### PR TITLE
feat(system): http-json rebuild reads current JSON (#3837)

### DIFF
--- a/docs/ai-generated/code-reviews/3837-http-json-rebuild-current-erlang.md
+++ b/docs/ai-generated/code-reviews/3837-http-json-rebuild-current-erlang.md
@@ -1,0 +1,40 @@
+# Erlang review — #3837 http-json rebuild reads current JSON
+
+**Branch:** `fix/issue-3837-http-json-rebuild-current`  
+**Date:** 2026-08-26  
+**Reviewer:** Erlang (pre-commit, independent of implementer)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for changed logic; portable `Path`/`Files` (no Unix-only roots); product-docs companion for operator-facing rebuild note; no incomplete rest/sitemanage adaptor cache (none present)
+
+## Summary
+
+`PSHttpJsonVirtualSiteSource` already re-reads local catalog bytes (`Files.readString`) and HTTP catalog bodies on every discover/load; `VirtualSiteConfigLoader` always opens `_config.yaml` from disk; `PSVirtualSiteBuildService.build` reloads config per invocation. This slice locks the no-stale-parse-cache contract in Javadoc (peer of sql-database #3780 / csv-filesystem #3708 / git-filesystem #3367), proves same-JVM JSON fixture / `_config.yaml` / loopback HTTP catalog edit → second build emits new HTML, and documents that operators rebuild after a JSON source edit without a CMS JVM restart and without file watchers.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Test I/O uses `@TempDir` + `Path.resolve` + `Files.writeString` / `readString`
+- [x] No Unix-only `/tmp` or Windows-only `C:\` hardcodes in new tests
+- [x] No raw OS `toString()` path equality assertions
+- [x] Line-ending sensitive checks use `contains` tokens, not whole-file `\n` equality
+- [x] Loopback `HttpServer` is in-process (127.0.0.1) — not a Unix-only path
+
+## Issues
+
+None (hard-gate).
+
+## Nits
+
+- Two nearly parallel `secondBuildAfterHttpJson…` tests (`PSVirtualSiteBuildServiceTest` factory wiring vs `PSHttpJsonVirtualSiteSourceTest` same-instance source). Acceptable as the SPI + assemble proofs matching CSV #3708 / SQL #3780.
+- Loopback rebuild test is extra vs the CSV/SQL peer (those have no HTTP catalog). Useful coverage; not sprawl.
+
+## C2 API shape
+
+Javadoc-only on existing public types; no `final`/`sealed` and no method/ctor signature change. Reverse-deps (`rest` / `sitemanage`) not required.
+
+## Build
+
+Standalone `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**.  
+Focused: `PSHttpJsonVirtualSiteSourceTest` Tests run: 24, Failures: 0, Skipped: 1 (Unix-only absolute catalog path). `PSVirtualSiteBuildServiceTest` Tests run: 13, Failures: 0. `VirtualSiteConfigLoaderTest` Tests run: 15, Failures: 0.  
+Module Surefire: Tests run: 2429, Failures: 0, Errors: 0, Skipped: 244.

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -39,11 +39,11 @@ For Git/filesystem, CSV/filesystem, SQL/database, or HTTP JSON Virtual Sites suc
   current Git/filesystem, CSV tree (`csv-filesystem`), H2 `SELECT` (`sql-database`), or HTTP
   JSON catalog (`http-json`: local fixture / loopback `http.url`). After
   `git pull`, a local Markdown edit, a CSV change, a `_config.yaml` change, a SQL
-  `queryFile` / `sql.query` change, an H2 row change, or a JSON catalog edit, run Build
-  (or Publish) again — no CMS restart. `sql-database` requires
-  `_config.yaml` with a `sql:` mapping (`jdbc:h2:mem:`; Oracle / MySQL / SQL Server URLs
-  return **400**). `http-json` requires `_config.yaml` (versions plus `http.url` or
-  `http.file`); `virtual.remoteUrl` is **400**.
+  `queryFile` / `sql.query` change, an H2 row change, or a JSON catalog / `_config.yaml`
+  edit, run Build (or Publish) again — no CMS restart. File watchers are not used.
+  `sql-database` requires `_config.yaml` with a `sql:` mapping (`jdbc:h2:mem:`; Oracle /
+  MySQL / SQL Server URLs return **400**). `http-json` requires `_config.yaml` (versions
+  plus `http.url` or `http.file`); `virtual.remoteUrl` is **400**.
 - **Publish** (`POST /sites/{nameOrId}/virtual/publish`) runs that build, then copies the
   assembled HTML/assets to the Site **filesystem publish location** (`IPSSite.root` / Site
   publishing root). Staging `_meta` files are not copied. Redirect HTML and `redirects.json`

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -240,10 +240,11 @@ Build succeeds, **Preview assembled site** streams last-build home HTML and
 4. Choose **Build Virtual Site**.
 5. After a `git pull` or a local Markdown/frontmatter edit on the host — or after the remote
    branch moves — or after a CSV file or `_config.yaml` change — or after the SQL
-   `_config.yaml`, `sql.queryFile`, `SELECT`, or H2 rows change — choose **Build Virtual
-   Site** again. The build re-reads the current tree (and re-fetches when a Git remote is
-   configured) — **do not restart the CMS** just to pick up those edits. There is no file
-   watcher; the next explicit build is the refresh.
+   `_config.yaml`, `sql.queryFile`, `SELECT`, or H2 rows change — or after an HTTP JSON
+   catalog (`pages.json` / `http.file` / loopback `http.url`) or `_config.yaml` change —
+   choose **Build Virtual Site** again. The build re-reads the current tree (and re-fetches
+   when a Git remote is configured) — **do not restart the CMS** just to pick up those
+   edits. There is no file watcher; the next explicit build is the refresh.
 6. Wait for the busy indicator, then review:
    - **Success** — pages written, absolute output path (default under
      `{install}/tmp/virtual-sites/{siteKey}` when no custom output is set).

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -303,6 +303,10 @@ Supply **one** of:
 
 Do not set both `http.url` and `http.file`. Catalogs larger than 2 MB fail closed. Each
 discover/load re-reads the current HTTP body or file bytes (no process-lifetime cache).
+After you edit the JSON catalog (`http.file` / default `pages.json` / loopback `http.url`
+body) or `_config.yaml` on the CMS host, run **Build Virtual Site** again (UI,
+`POST …/virtual/build`, or `PSVirtualSiteBuildMain … http-json`) — **no JVM restart**.
+File watchers are not used; the next explicit build is the refresh.
 
 JSON contract:
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -219,7 +219,9 @@ Each build re-reads current Markdown/frontmatter, CSV rows, `_config.yaml`, the
 sql-database `SELECT` (`sql.query` or current `sql.queryFile` plus H2 rows), and the
 http-json catalog (`http.url` / `http.file` or default `pages.json`) from
 `virtual.rootPath` (no CMS restart after `git pull`, a CSV/`_config.yaml` edit, a SQL
-query-file/`_config.yaml` or H2 row edit, a JSON catalog edit, or a local Markdown edit).
+query-file/`_config.yaml` or H2 row edit, a JSON catalog/`_config.yaml` edit, or a local
+Markdown edit). File watchers are not used; run **Build Virtual Site** again after those
+edits.
 The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind
 is Git, CSV, SQL, or HTTP JSON (never for traditional repository Sites). After a
 successful HTTP JSON Build, **Preview assembled site** opens last-build home HTML

--- a/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
@@ -26,12 +26,13 @@ import java.util.List;
  * Headless catalog: {@link PSHttpJsonVirtualSiteSource} ({@code http-json}). Future adapters
  * (object storage, …) implement this interface.
  *
- * <p>Filesystem and SQL implementations must read <em>current</em> source contents on every
- * {@link #discover} and {@link #load}. Process-lifetime parse caches that skip a file because
- * its path or mtime looks unchanged are not allowed — a second build in the same JVM (after
- * {@code git pull}, a CSV row edit, a local Markdown/frontmatter edit, a {@code _config.yaml}
- * or {@code sql.queryFile} edit, or an in-memory H2 row change) must see the new bytes. File
- * watchers are not required; the next explicit build is the refresh.
+ * <p>Filesystem, SQL, and HTTP JSON implementations must read <em>current</em> source contents
+ * on every {@link #discover} and {@link #load}. Process-lifetime parse caches that skip a file
+ * because its path or mtime looks unchanged are not allowed — a second build in the same JVM
+ * (after {@code git pull}, a CSV row edit, a local Markdown/frontmatter edit, a {@code
+ * _config.yaml} or {@code sql.queryFile} edit, an in-memory H2 row change, or an HTTP JSON
+ * catalog ({@code http.file} / {@code pages.json} / {@code http.url} body) edit) must see the
+ * new bytes. File watchers are not required; the next explicit build is the refresh.
  */
 public interface IPSVirtualSiteSource {
 

--- a/system/services/src/com/percussion/services/virtualsite/PSHttpJsonVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSHttpJsonVirtualSiteSource.java
@@ -58,7 +58,11 @@ import org.json.JSONObject;
  * site root.
  *
  * <p>Stateless: {@link #discover} and {@link #load} always re-read the current HTTP response or
- * file bytes. No catalog cache is kept on the instance or in statics.
+ * local catalog file bytes via {@link Files#readString}. No path/mtime parse cache or catalog
+ * cache is kept on the instance or in statics — a second build in the same JVM after a JSON
+ * fixture ({@code http.file} / default {@code pages.json}) or {@code _config.yaml} edit, or
+ * after a new HTTP catalog body, must see the new bytes. File watchers are not used; {@code
+ * _config.yaml} is reloaded by {@link PSVirtualSiteBuildService}, not this source.
  */
 public class PSHttpJsonVirtualSiteSource implements IPSVirtualSiteSource {
 

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
@@ -94,12 +94,14 @@ public class PSVirtualSiteBuildService {
    * Build a Virtual Site from a filesystem root into {@code outputRoot}.
    *
    * <p>Every invocation reloads {@code _config.yaml}, optional {@code _redirects.yaml}, and
-   * re-discovers and re-loads Markdown, CSV rows, or the current sql-database SELECT (inline
-   * {@code sql.query} or {@code sql.queryFile} bytes plus H2 rows) from the current tree, then
-   * overwrites emitted HTML. Missing {@code _redirects.yaml} is a no-op. The same service
-   * instance does not reuse parsed pages from a previous build — operators do not need a JVM
-   * restart after {@code git pull}, a CSV/{@code _config.yaml} edit, a local Markdown edit, a
-   * SQL query-file/{@code _config.yaml} edit, or an H2 row change.
+   * re-discovers and re-loads Markdown, CSV rows, the current sql-database SELECT (inline
+   * {@code sql.query} or {@code sql.queryFile} bytes plus H2 rows), or the current http-json
+   * catalog ({@code http.url} / {@code http.file} or default {@code pages.json}) from the
+   * current tree, then overwrites emitted HTML. Missing {@code _redirects.yaml} is a no-op. The
+   * same service instance does not reuse parsed pages from a previous build — operators do not
+   * need a JVM restart after {@code git pull}, a CSV/{@code _config.yaml} edit, a local
+   * Markdown edit, a SQL query-file/{@code _config.yaml} edit, an H2 row change, or an HTTP
+   * JSON catalog/{@code _config.yaml} edit.
    *
    * @param siteRoot source tree ({@code _config.yaml} required for git-filesystem and
    *     sql-database; optional for csv-filesystem)

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
@@ -39,7 +39,8 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
  *
  * <p>Stateless: each {@link #load} / {@link #loadOrDefault} reads the current file (or current
  * child directories). No process-lifetime YAML cache — a second build after a config edit sees
- * the new title/versions without a JVM restart.
+ * the new title/versions (and current {@code sql:} / {@code http:} mapping) without a JVM
+ * restart.
  */
 public final class VirtualSiteConfigLoader {
 

--- a/system/src/test/java/com/percussion/services/virtualsite/PSHttpJsonVirtualSiteSourceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSHttpJsonVirtualSiteSourceTest.java
@@ -19,6 +19,7 @@ package com.percussion.services.virtualsite;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,6 +33,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -229,6 +231,124 @@ class PSHttpJsonVirtualSiteSourceTest {
             VirtualSiteException.class,
             () -> new PSHttpJsonVirtualSiteSource().discover(config(root, null, "pages.json")));
     assertTrue(ex.getMessage().toLowerCase().contains("duplicate"), ex.getMessage());
+  }
+
+  @Test
+  void secondBuildAfterJsonAndConfigEditEmitsUpdatedHtmlWithoutRestart() throws Exception {
+    Path root = writeSite(tempDir.resolve("json-rebuild"), null, "pages.json");
+    writeHttpYaml(root, "First Site Title", "pages.json");
+    Files.writeString(
+        root.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${siteTitle}</h1><h2>${pageTitle}</h2>${content}</body></html>",
+        StandardCharsets.UTF_8);
+    Path catalog = root.resolve("pages.json");
+    Files.writeString(
+        catalog,
+        """
+        {"pages":[{"id":"live-home","path":"index.html","title":"First Title","body":"unique-token-AAA"}]}
+        """,
+        StandardCharsets.UTF_8);
+
+    Path out = tempDir.resolve("json-rebuild-out");
+    PSHttpJsonVirtualSiteSource source = new PSHttpJsonVirtualSiteSource();
+    PSVirtualSiteBuildService service =
+        new PSVirtualSiteBuildService(source, new PSInMemoryVirtualParticipantService());
+
+    PSVirtualSiteBuildResult first = service.build(root, out, "http-docs");
+    assertEquals(1, first.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String firstHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(firstHtml.contains("First Site Title"), firstHtml);
+    assertTrue(firstHtml.contains("First Title"), firstHtml);
+    assertTrue(firstHtml.contains("unique-token-AAA"), firstHtml);
+
+    Files.writeString(
+        catalog,
+        """
+        {"pages":[{"id":"live-home","path":"index.html","title":"Second Title","body":"unique-token-BBB"}]}
+        """,
+        StandardCharsets.UTF_8);
+    writeHttpYaml(root, "Second Site Title", "pages.json");
+
+    VirtualSiteConfig reloaded =
+        VirtualSiteConfigLoader.load(root, VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, "http-docs");
+    assertEquals("Second Site Title", reloaded.siteTitle());
+    VirtualItem loaded = source.load(reloaded, source.discover(reloaded).get(0));
+    assertEquals("Second Title", loaded.frontmatter().title());
+    assertTrue(loaded.markdownBody().contains("unique-token-BBB"), loaded.markdownBody());
+    assertFalse(loaded.markdownBody().contains("unique-token-AAA"), loaded.markdownBody());
+
+    PSVirtualSiteBuildResult second = service.build(root, out, "http-docs");
+    assertEquals(1, second.pageCount());
+    String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(secondHtml.contains("Second Site Title"), secondHtml);
+    assertTrue(secondHtml.contains("Second Title"), secondHtml);
+    assertTrue(secondHtml.contains("unique-token-BBB"), secondHtml);
+    assertFalse(secondHtml.contains("unique-token-AAA"), secondHtml);
+    assertFalse(secondHtml.contains("First Title"), secondHtml);
+    assertFalse(secondHtml.contains("First Site Title"), secondHtml);
+    assertNotEquals(firstHtml, secondHtml);
+  }
+
+  @Test
+  void secondBuildAfterLoopbackHttpCatalogEditEmitsUpdatedHtmlWithoutRestart() throws Exception {
+    AtomicReference<String> catalog =
+        new AtomicReference<>(
+            """
+            {"pages":[{"id":"live-home","path":"index.html","title":"First Title","body":"unique-token-AAA"}]}
+            """);
+    HttpServer server = loopbackServer();
+    try {
+      server.createContext(
+          "/pages.json",
+          exchange -> {
+            byte[] bytes = catalog.get().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+              os.write(bytes);
+            }
+          });
+      server.start();
+      String url = loopbackUrl(server, "/pages.json");
+      Path root = writeSite(tempDir.resolve("http-rebuild"), url, null);
+      writeHttpYamlWithUrl(root, "First Site Title", url);
+      Files.writeString(
+          root.resolve("_theme").resolve("page.html"),
+          "<html><body><h1>${siteTitle}</h1><h2>${pageTitle}</h2>${content}</body></html>",
+          StandardCharsets.UTF_8);
+
+      Path out = tempDir.resolve("http-rebuild-out");
+      PSVirtualSiteBuildService service =
+          PSVirtualSiteBuildService.forSourceType(VirtualSiteSourceType.HTTP_JSON);
+
+      PSVirtualSiteBuildResult first = service.build(root, out, "http-docs");
+      assertEquals(1, first.pageCount());
+      Path html = out.resolve("8.2").resolve("index.html");
+      assertTrue(Files.isRegularFile(html), "missing " + html);
+      String firstHtml = Files.readString(html, StandardCharsets.UTF_8);
+      assertTrue(firstHtml.contains("First Site Title"), firstHtml);
+      assertTrue(firstHtml.contains("unique-token-AAA"), firstHtml);
+
+      catalog.set(
+          """
+          {"pages":[{"id":"live-home","path":"index.html","title":"Second Title","body":"unique-token-BBB"}]}
+          """);
+      writeHttpYamlWithUrl(root, "Second Site Title", url);
+
+      PSVirtualSiteBuildResult second = service.build(root, out, "http-docs");
+      assertEquals(1, second.pageCount());
+      String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
+      assertTrue(secondHtml.contains("Second Site Title"), secondHtml);
+      assertTrue(secondHtml.contains("Second Title"), secondHtml);
+      assertTrue(secondHtml.contains("unique-token-BBB"), secondHtml);
+      assertFalse(secondHtml.contains("unique-token-AAA"), secondHtml);
+      assertFalse(secondHtml.contains("First Title"), secondHtml);
+      assertNotEquals(firstHtml, secondHtml);
+    } finally {
+      server.stop(0);
+    }
   }
 
   @Test
@@ -581,6 +701,47 @@ class PSHttpJsonVirtualSiteSourceTest {
             .formatted(httpBlock),
         StandardCharsets.UTF_8);
     return root;
+  }
+
+  private static void writeHttpYaml(Path root, String siteTitle, String file) throws Exception {
+    Files.writeString(
+        root.resolve("_config.yaml"),
+        """
+        site:
+          title: %s
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: "8.2"
+            default: true
+        theme:
+          layout: page.html
+        http:
+          file: %s
+        """
+            .formatted(siteTitle, file),
+        StandardCharsets.UTF_8);
+  }
+
+  private static void writeHttpYamlWithUrl(Path root, String siteTitle, String url)
+      throws Exception {
+    Files.writeString(
+        root.resolve("_config.yaml"),
+        """
+        site:
+          title: %s
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: "8.2"
+            default: true
+        theme:
+          layout: page.html
+        http:
+          url: "%s"
+        """
+            .formatted(siteTitle, url),
+        StandardCharsets.UTF_8);
   }
 
   private static VirtualSiteConfig config(Path root, String url, String file) {

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
@@ -373,6 +373,88 @@ class PSVirtualSiteBuildServiceTest {
   }
 
   @Test
+  void secondBuildAfterHttpJsonAndConfigEditEmitsUpdatedHtmlWithoutRestart() throws Exception {
+    Path siteRoot = tempDir.resolve("http-json-live-site");
+    Files.createDirectories(siteRoot.resolve("8.2"));
+    Files.createDirectories(siteRoot.resolve("_theme"));
+    Path configYaml = siteRoot.resolve("_config.yaml");
+    Path catalog = siteRoot.resolve("pages.json");
+    Files.writeString(
+        configYaml,
+        """
+        site:
+          title: First Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: "8.2"
+            default: true
+        theme:
+          layout: page.html
+        http:
+          file: pages.json
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        catalog,
+        """
+        {"pages":[{"id":"live-home","path":"index.html","title":"First Title","body":"unique-token-AAA"}]}
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        siteRoot.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${siteTitle}</h1><h2>${pageTitle}</h2>${content}</body></html>",
+        StandardCharsets.UTF_8);
+
+    Path out = tempDir.resolve("http-json-live-out");
+    PSVirtualSiteBuildService service =
+        PSVirtualSiteBuildService.forSourceType(VirtualSiteSourceType.HTTP_JSON);
+
+    PSVirtualSiteBuildResult first = service.build(siteRoot, out, "http-live");
+    assertEquals(1, first.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    String firstHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(firstHtml.contains("First Site Title"), firstHtml);
+    assertTrue(firstHtml.contains("First Title"), firstHtml);
+    assertTrue(firstHtml.contains("unique-token-AAA"), firstHtml);
+
+    Files.writeString(
+        catalog,
+        """
+        {"pages":[{"id":"live-home","path":"index.html","title":"Second Title","body":"unique-token-BBB"}]}
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        configYaml,
+        """
+        site:
+          title: Second Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: "8.2"
+            default: true
+        theme:
+          layout: page.html
+        http:
+          file: pages.json
+        """,
+        StandardCharsets.UTF_8);
+
+    PSVirtualSiteBuildResult second = service.build(siteRoot, out, "http-live");
+    assertEquals(1, second.pageCount());
+    String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(secondHtml.contains("Second Site Title"), secondHtml);
+    assertTrue(secondHtml.contains("Second Title"), secondHtml);
+    assertTrue(secondHtml.contains("unique-token-BBB"), secondHtml);
+    assertFalse(secondHtml.contains("unique-token-AAA"), secondHtml);
+    assertFalse(secondHtml.contains("First Title"), secondHtml);
+    assertFalse(secondHtml.contains("First Site Title"), secondHtml);
+    assertNotEquals(firstHtml, secondHtml);
+  }
+
+  @Test
   void linkReportListsProblemsWhenBrokenLinksPresent() throws Exception {
     Path siteRoot = tempDir.resolve("broken-site");
     Path versionDir = siteRoot.resolve("8.2");

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
@@ -236,6 +236,50 @@ class VirtualSiteConfigLoaderTest {
   }
 
   @Test
+  void secondLoadAfterHttpFileAndConfigEditSeesCurrentHttpWithoutCache() throws Exception {
+    Path root = tempDir.resolve("live-http-config");
+    Files.createDirectories(root);
+    Path yaml = root.resolve("_config.yaml");
+    Files.writeString(
+        yaml,
+        """
+        site:
+          title: HTTP First
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        http:
+          file: pages.json
+        """,
+        StandardCharsets.UTF_8);
+    VirtualSiteConfig first = VirtualSiteConfigLoader.load(root, null, "k");
+    assertEquals("HTTP First", first.siteTitle());
+    assertEquals("pages.json", first.http().file());
+    assertTrue(first.http().url() == null || first.http().url().isBlank());
+
+    Files.writeString(
+        yaml,
+        """
+        site:
+          title: HTTP Second
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        http:
+          file: catalog.json
+        """,
+        StandardCharsets.UTF_8);
+    VirtualSiteConfig second = VirtualSiteConfigLoader.load(root, null, "k");
+    assertEquals("HTTP Second", second.siteTitle());
+    assertEquals("catalog.json", second.http().file());
+    assertTrue(second.http().url() == null || second.http().url().isBlank());
+  }
+
+  @Test
   void nullRootFails() {
     assertThrows(
         VirtualSiteException.class,


### PR DESCRIPTION
## Summary

HTTP JSON Virtual Site **Build** always reads the **current** JSON catalog and `_config.yaml` (peer of sql-database #3780 / csv-filesystem #3708 / git-filesystem #3367).

`PSHttpJsonVirtualSiteSource` already re-reads local fixture bytes and HTTP catalog bodies on every discover/load (no path/mtime parse cache). This slice:

- Locks that contract in SPI / source / build Javadoc (no file watchers; `_config.yaml` reloaded per `PSVirtualSiteBuildService.build`).
- Proves same-JVM unit tests: edit JSON under `@TempDir` (and loopback catalog + `_config.yaml`) → second Build HTML changes.
- Documents the operator step: rebuild after a JSON source edit; **no JVM restart**.

Parent: #2678  
Fixes #3837

Out of scope: object-storage (#3838/#3839), secrets, `virtual.remoteUrl` on http-json.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` — module suite green.
2. Focused: `PSHttpJsonVirtualSiteSourceTest`, `PSVirtualSiteBuildServiceTest`, `VirtualSiteConfigLoaderTest` — second-build assertions (`unique-token-AAA` gone, `unique-token-BBB` present) without restarting the JVM.
3. Operator: edit `pages.json` / `_config.yaml` under `virtual.rootPath`, run **Build Virtual Site** again; assembled HTML updates; no CMS restart; no file watchers.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/virtual-sites.md` http-json section, `admin/sites.md` rebuild step, `admin/publishing.md`, `reference/site-config.md`)
- [x] **Unit / module tests** — same-JVM JSON/`_config.yaml`/loopback catalog edit → second Build HTML; `cd system && ../mvnw.cmd clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; Java SPI/build + operator docs)
- [x] **Build gates** — standalone `system` clean install (no skipTests); C2 N/A (Javadoc-only, no signature/`final`/`sealed` change)
- [x] **Cross-platform** — `@TempDir` + `Path` / `Files`; no Unix-only roots; OS-specific absolute catalog rejects stay behind `@EnabledOnOs`

### C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**. Surefire: Tests run: 2429, Failures: 0, Errors: 0, Skipped: 244. Focused: `PSHttpJsonVirtualSiteSourceTest` Tests run: 24, Failures: 0, Skipped: 1; `PSVirtualSiteBuildServiceTest` Tests run: 13, Failures: 0; `VirtualSiteConfigLoaderTest` Tests run: 15, Failures: 0.
- **downstream_checked:** none (C2 did not apply — no public/protected signature, `final`, or `sealed` change)

### C5 UI proof

N/A — no WebUI/Playwright surface in this slice.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
