### PR TITLE
cluster: Developer Content Type lock/workflow/template chrome (#3840 #3841 #3842)

### DIFF
--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -236,7 +236,7 @@ export function ContentTypeDetailPanel({
   const fieldRows = contentTypeFields(detail);
   const childSets = contentTypeChildSets(detail);
   const gapRows = contentTypeDesignGaps(detail);
-  const canEdit = heldLock && !busy;
+  const canEdit = heldLock && !busy && detail != null;
 
   function toggleField(key: string, prop: "searchable" | "required") {
     setFieldDrafts((prev) => {
@@ -516,6 +516,225 @@ export function ContentTypeDetailPanel({
         </div>
       ) : null}
 
+      {/* Always mount lock + template chrome so Playwright and operators see it
+          before GET detail finishes and without scrolling past the fields table. */}
+      <div
+        role="toolbar"
+        aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
+        data-testid="developer-ct-lock-toolbar"
+        style={{
+          marginBottom: "16px",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "8px",
+          alignItems: "center",
+          position: "sticky",
+          top: 0,
+          zIndex: 2,
+          background: "#fff",
+          padding: "8px 0",
+        }}
+      >
+        <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
+          {DEV_MSG.CT_LOCK_HINT}
+        </p>
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="developer-ct-lock-status"
+          style={{ marginRight: "8px", fontSize: "0.9rem" }}
+        >
+          {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
+        </div>
+        <button
+          type="button"
+          data-testid="developer-ct-lock"
+          aria-label={DEV_MSG.CT_LOCK}
+          disabled={busy || heldLock || detail == null}
+          onClick={() => void handleLock()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock ? catalogColors.disabled : catalogColors.accent,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || heldLock || detail == null ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_LOCK}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-save"
+          aria-label={DEV_MSG.CT_SAVE}
+          disabled={busy || !heldLock || !dirty}
+          onClick={() => void handleSave()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_SAVE}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-unlock"
+          aria-label={DEV_MSG.CT_UNLOCK}
+          disabled={busy || !heldLock}
+          onClick={() => void handleUnlock()}
+          style={{
+            padding: "8px 16px",
+            background: "transparent",
+            color: "inherit",
+            border: `1px solid ${catalogColors.softBorder}`,
+            borderRadius: "4px",
+            cursor: busy || !heldLock ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_UNLOCK}
+        </button>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, marginLeft: "8px" }}>
+          <input
+            type="checkbox"
+            data-testid="developer-ct-enabled"
+            aria-label={DEV_MSG.CT_FORM_ENABLED}
+            checked={enabled}
+            onChange={() => {
+              if (!canEdit) {
+                return;
+              }
+              setEnabled((v) => !v);
+            }}
+            disabled={!canEdit}
+          />
+          {DEV_MSG.CT_FORM_ENABLED}
+        </label>
+      </div>
+
+      <div style={{ fontFamily: "monospace", color: catalogColors.muted, marginBottom: "12px" }}>
+        <span data-testid="developer-ct-detail-name">{detail?.name || idOrName}</span>
+        {detail ? (
+          <>
+            {" · "}
+            <span data-testid="developer-ct-detail-guid">{objectGuid || "—"}</span>
+          </>
+        ) : null}
+      </div>
+
+      <section style={{ marginBottom: "16px" }} data-testid="developer-ct-templates">
+        <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.CT_TEMPLATES}</h3>
+        <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>{DEV_MSG.CT_TEMPLATES_HINT}</p>
+        {templates.length === 0 ? (
+          <p style={{ color: catalogColors.empty }} data-testid="developer-ct-tpl-empty">
+            {DEV_MSG.CT_NONE}
+          </p>
+        ) : (
+          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+            {templates.map((t, i) => (
+              <li
+                key={refKey(t, i)}
+                data-testid={`developer-ct-tpl-row-${i}`}
+                style={{
+                  ...tableRow,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "6px 0",
+                }}
+              >
+                <span>
+                  {t.label || t.name}
+                  {t.name ? (
+                    <span
+                      style={{
+                        fontFamily: "monospace",
+                        color: catalogColors.empty,
+                        marginLeft: "8px",
+                        fontSize: "0.85rem",
+                      }}
+                    >
+                      {t.name}
+                    </span>
+                  ) : null}
+                </span>
+                <button
+                  type="button"
+                  data-testid={`developer-ct-tpl-remove-${i}`}
+                  aria-label={`Remove template ${t.name || t.label}`}
+                  disabled={!canEdit}
+                  onClick={() => removeTemplate(i)}
+                  style={{
+                    ...smallBtnStyle,
+                    marginLeft: "auto",
+                    cursor: canEdit ? "pointer" : "not-allowed",
+                  }}
+                >
+                  {DEV_MSG.CT_ASSOC_REMOVE}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div
+          style={{
+            marginTop: "12px",
+            display: "grid",
+            gridTemplateColumns: "1fr auto",
+            gap: "8px",
+            alignItems: "end",
+          }}
+        >
+          <div>
+            <label htmlFor="ct-tpl-add" style={{ display: "block", marginBottom: 4 }}>
+              {DEV_MSG.CT_TEMPLATES}
+            </label>
+            <input
+              id="ct-tpl-add"
+              type="text"
+              autoComplete="off"
+              data-testid="developer-ct-tpl-add-name"
+              style={inputStyle}
+              placeholder={DEV_MSG.CT_TPL_NAME_PLACEHOLDER}
+              value={newTplName}
+              onChange={(e) => {
+                if (!canEdit) {
+                  return;
+                }
+                setNewTplName(e.target.value);
+              }}
+              disabled={!canEdit}
+              aria-disabled={canEdit ? undefined : true}
+              readOnly={!canEdit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  if (canEdit) {
+                    addTemplate();
+                  }
+                }
+              }}
+            />
+          </div>
+          <button
+            type="button"
+            data-testid="developer-ct-tpl-add"
+            disabled={!canEdit || !newTplName.trim()}
+            onClick={addTemplate}
+            style={{
+              ...smallBtnStyle,
+              padding: "8px 12px",
+              cursor: !canEdit || !newTplName.trim() ? "not-allowed" : "pointer",
+            }}
+          >
+            {DEV_MSG.CT_ASSOC_ADD}
+          </button>
+        </div>
+      </section>
+
       {!error && detail == null ? (
         <div data-testid="developer-ct-detail-loading">{DEV_MSG.CT_DETAIL_LOADING}</div>
       ) : null}
@@ -526,11 +745,6 @@ export function ContentTypeDetailPanel({
             <h2 style={{ margin: "0 0 4px" }} data-testid="developer-ct-detail-title">
               {label || detail.name || idOrName}
             </h2>
-            <div style={{ fontFamily: "monospace", color: catalogColors.muted }}>
-              <span data-testid="developer-ct-detail-name">{detail.name}</span>
-              {" · "}
-              <span data-testid="developer-ct-detail-guid">{objectGuid || "—"}</span>
-            </div>
             <div style={{ marginTop: "12px" }}>
               <label htmlFor="ct-label" style={{ display: "block", marginBottom: 4 }}>
                 {DEV_MSG.CT_FORM_LABEL}
@@ -556,19 +770,6 @@ export function ContentTypeDetailPanel({
                 onChange={(e) => setDescription(e.target.value)}
                 disabled={!canEdit}
               />
-            </div>
-            <div style={{ marginTop: "12px" }}>
-              <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <input
-                  type="checkbox"
-                  data-testid="developer-ct-enabled"
-                  aria-label={DEV_MSG.CT_FORM_ENABLED}
-                  checked={enabled}
-                  onChange={() => setEnabled((v) => !v)}
-                  disabled={!canEdit}
-                />
-                {DEV_MSG.CT_FORM_ENABLED}
-              </label>
             </div>
             <dl
               style={{
@@ -713,102 +914,6 @@ export function ContentTypeDetailPanel({
             </div>
           </section>
 
-          <section style={{ marginBottom: "16px" }} data-testid="developer-ct-templates">
-            <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.CT_TEMPLATES}</h3>
-            <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>{DEV_MSG.CT_TEMPLATES_HINT}</p>
-            {templates.length === 0 ? (
-              <p style={{ color: catalogColors.empty }} data-testid="developer-ct-tpl-empty">
-                {DEV_MSG.CT_NONE}
-              </p>
-            ) : (
-              <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-                {templates.map((t, i) => (
-                  <li
-                    key={refKey(t, i)}
-                    data-testid={`developer-ct-tpl-row-${i}`}
-                    style={{ ...tableRow, display: "flex",
-                      alignItems: "center",
-                      gap: 12,
-                      padding: "6px 0"  }}
-                  >
-                    <span>
-                      {t.label || t.name}
-                      {t.name ? (
-                        <span
-                          style={{
-                            fontFamily: "monospace",
-                            color: catalogColors.empty,
-                            marginLeft: "8px",
-                            fontSize: "0.85rem",
-                          }}
-                        >
-                          {t.name}
-                        </span>
-                      ) : null}
-                    </span>
-                    <button
-                      type="button"
-                      data-testid={`developer-ct-tpl-remove-${i}`}
-                      aria-label={`Remove template ${t.name || t.label}`}
-                      disabled={!canEdit}
-                      onClick={() => removeTemplate(i)}
-                      style={{
-                        ...smallBtnStyle,
-                        marginLeft: "auto",
-                        cursor: canEdit ? "pointer" : "not-allowed",
-                      }}
-                    >
-                      {DEV_MSG.CT_ASSOC_REMOVE}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-            <div
-              style={{
-                marginTop: "12px",
-                display: "grid",
-                gridTemplateColumns: "1fr auto",
-                gap: "8px",
-                alignItems: "end",
-              }}
-            >
-              <div>
-                <label htmlFor="ct-tpl-add" style={{ display: "block", marginBottom: 4 }}>
-                  {DEV_MSG.CT_TEMPLATES}
-                </label>
-                <input
-                  id="ct-tpl-add"
-                  data-testid="developer-ct-tpl-add-name"
-                  style={inputStyle}
-                  placeholder={DEV_MSG.CT_TPL_NAME_PLACEHOLDER}
-                  value={newTplName}
-                  onChange={(e) => setNewTplName(e.target.value)}
-                  disabled={!canEdit}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
-                      addTemplate();
-                    }
-                  }}
-                />
-              </div>
-              <button
-                type="button"
-                data-testid="developer-ct-tpl-add"
-                disabled={!canEdit || !newTplName.trim()}
-                onClick={addTemplate}
-                style={{
-                  ...smallBtnStyle,
-                  padding: "8px 12px",
-                  cursor: !canEdit || !newTplName.trim() ? "not-allowed" : "pointer",
-                }}
-              >
-                {DEV_MSG.CT_ASSOC_ADD}
-              </button>
-            </div>
-          </section>
-
           <section style={{ marginBottom: "16px" }}>
             <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.CT_FIELDS}</h3>
             <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>{DEV_MSG.CT_FIELDS_HINT}</p>
@@ -927,82 +1032,6 @@ export function ContentTypeDetailPanel({
               </table>
             </div>
           </section>
-
-          <div
-            role="toolbar"
-            aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
-            data-testid="developer-ct-lock-toolbar"
-            style={{
-              marginBottom: "16px",
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "8px",
-              alignItems: "center",
-            }}
-          >
-            <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
-              {DEV_MSG.CT_LOCK_HINT}
-            </p>
-            <div
-              role="status"
-              aria-live="polite"
-              data-testid="developer-ct-lock-status"
-              style={{ marginRight: "8px", fontSize: "0.9rem" }}
-            >
-              {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
-            </div>
-            <button
-              type="button"
-              data-testid="developer-ct-lock"
-              aria-label={DEV_MSG.CT_LOCK}
-              disabled={busy || heldLock || detail == null}
-              onClick={() => void handleLock()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock ? catalogColors.disabled : catalogColors.accent,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_LOCK}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-save"
-              aria-label={DEV_MSG.CT_SAVE}
-              disabled={busy || !heldLock || !dirty}
-              onClick={() => void handleSave()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_SAVE}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-unlock"
-              aria-label={DEV_MSG.CT_UNLOCK}
-              disabled={busy || !heldLock}
-              onClick={() => void handleUnlock()}
-              style={{
-                padding: "8px 16px",
-                background: "transparent",
-                color: "inherit",
-                border: `1px solid ${catalogColors.softBorder}`,
-                borderRadius: "4px",
-                cursor: busy || !heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_UNLOCK}
-            </button>
-          </div>
 
           <ObjectAclSection
             objectGuid={objectGuid}

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -547,7 +547,7 @@ export function ContentTypeDetailPanel({
           position: "sticky",
           top: 0,
           zIndex: 2,
-          background: "#fff",
+          background: catalogColors.surface,
           padding: "8px 0",
         }}
       >
@@ -644,7 +644,7 @@ export function ContentTypeDetailPanel({
       <section style={{ marginBottom: "16px" }} data-testid="developer-ct-templates">
         <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.CT_TEMPLATES}</h3>
         <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>{DEV_MSG.CT_TEMPLATES_HINT}</p>
-        {templates.length === 0 ? (
+        {detail == null ? null : templates.length === 0 ? (
           <p style={{ color: catalogColors.empty }} data-testid="developer-ct-tpl-empty">
             {DEV_MSG.CT_NONE}
           </p>

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -236,7 +236,7 @@ export function ContentTypeDetailPanel({
   const fieldRows = contentTypeFields(detail);
   const childSets = contentTypeChildSets(detail);
   const gapRows = contentTypeDesignGaps(detail);
-  const canEdit = heldLock && !busy;
+  const canEdit = heldLock && !busy && detail != null;
 
   function toggleField(key: string, prop: "searchable" | "required") {
     setFieldDrafts((prev) => {
@@ -516,6 +516,105 @@ export function ContentTypeDetailPanel({
         </div>
       ) : null}
 
+      {/* Always mount lock/enabled chrome so Playwright and operators see it
+          before GET detail finishes and without scrolling past the fields table. */}
+      <div
+        role="toolbar"
+        aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
+        data-testid="developer-ct-lock-toolbar"
+        style={{
+          marginBottom: "16px",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "8px",
+          alignItems: "center",
+          position: "sticky",
+          top: 0,
+          zIndex: 2,
+          background: "#fff",
+          padding: "8px 0",
+        }}
+      >
+        <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
+          {DEV_MSG.CT_LOCK_HINT}
+        </p>
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="developer-ct-lock-status"
+          style={{ marginRight: "8px", fontSize: "0.9rem" }}
+        >
+          {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
+        </div>
+        <button
+          type="button"
+          data-testid="developer-ct-lock"
+          aria-label={DEV_MSG.CT_LOCK}
+          disabled={busy || heldLock || detail == null}
+          onClick={() => void handleLock()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock ? catalogColors.disabled : catalogColors.accent,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || heldLock || detail == null ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_LOCK}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-save"
+          aria-label={DEV_MSG.CT_SAVE}
+          disabled={busy || !heldLock || !dirty}
+          onClick={() => void handleSave()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_SAVE}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-unlock"
+          aria-label={DEV_MSG.CT_UNLOCK}
+          disabled={busy || !heldLock}
+          onClick={() => void handleUnlock()}
+          style={{
+            padding: "8px 16px",
+            background: "transparent",
+            color: "inherit",
+            border: `1px solid ${catalogColors.softBorder}`,
+            borderRadius: "4px",
+            cursor: busy || !heldLock ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_UNLOCK}
+        </button>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, marginLeft: "8px" }}>
+          <input
+            type="checkbox"
+            data-testid="developer-ct-enabled"
+            aria-label={DEV_MSG.CT_FORM_ENABLED}
+            checked={enabled}
+            onChange={() => {
+              if (!canEdit) {
+                return;
+              }
+              setEnabled((v) => !v);
+            }}
+            disabled={!canEdit}
+          />
+          {DEV_MSG.CT_FORM_ENABLED}
+        </label>
+      </div>
+
       {!error && detail == null ? (
         <div data-testid="developer-ct-detail-loading">{DEV_MSG.CT_DETAIL_LOADING}</div>
       ) : null}
@@ -556,19 +655,6 @@ export function ContentTypeDetailPanel({
                 onChange={(e) => setDescription(e.target.value)}
                 disabled={!canEdit}
               />
-            </div>
-            <div style={{ marginTop: "12px" }}>
-              <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <input
-                  type="checkbox"
-                  data-testid="developer-ct-enabled"
-                  aria-label={DEV_MSG.CT_FORM_ENABLED}
-                  checked={enabled}
-                  onChange={() => setEnabled((v) => !v)}
-                  disabled={!canEdit}
-                />
-                {DEV_MSG.CT_FORM_ENABLED}
-              </label>
             </div>
             <dl
               style={{
@@ -927,82 +1013,6 @@ export function ContentTypeDetailPanel({
               </table>
             </div>
           </section>
-
-          <div
-            role="toolbar"
-            aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
-            data-testid="developer-ct-lock-toolbar"
-            style={{
-              marginBottom: "16px",
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "8px",
-              alignItems: "center",
-            }}
-          >
-            <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
-              {DEV_MSG.CT_LOCK_HINT}
-            </p>
-            <div
-              role="status"
-              aria-live="polite"
-              data-testid="developer-ct-lock-status"
-              style={{ marginRight: "8px", fontSize: "0.9rem" }}
-            >
-              {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
-            </div>
-            <button
-              type="button"
-              data-testid="developer-ct-lock"
-              aria-label={DEV_MSG.CT_LOCK}
-              disabled={busy || heldLock || detail == null}
-              onClick={() => void handleLock()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock ? catalogColors.disabled : catalogColors.accent,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_LOCK}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-save"
-              aria-label={DEV_MSG.CT_SAVE}
-              disabled={busy || !heldLock || !dirty}
-              onClick={() => void handleSave()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_SAVE}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-unlock"
-              aria-label={DEV_MSG.CT_UNLOCK}
-              disabled={busy || !heldLock}
-              onClick={() => void handleUnlock()}
-              style={{
-                padding: "8px 16px",
-                background: "transparent",
-                color: "inherit",
-                border: `1px solid ${catalogColors.softBorder}`,
-                borderRadius: "4px",
-                cursor: busy || !heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_UNLOCK}
-            </button>
-          </div>
 
           <ObjectAclSection
             objectGuid={objectGuid}

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -236,7 +236,7 @@ export function ContentTypeDetailPanel({
   const fieldRows = contentTypeFields(detail);
   const childSets = contentTypeChildSets(detail);
   const gapRows = contentTypeDesignGaps(detail);
-  const canEdit = heldLock && !busy;
+  const canEdit = heldLock && !busy && detail != null;
 
   function toggleField(key: string, prop: "searchable" | "required") {
     setFieldDrafts((prev) => {
@@ -248,6 +248,9 @@ export function ContentTypeDetailPanel({
   }
 
   function removeWorkflow(index: number) {
+    if (!heldLock) {
+      return;
+    }
     setWorkflows((prev) => {
       const next = prev.filter((_, i) => i !== index);
       if (next.length > 0 && !next.some((w) => w.isDefault)) {
@@ -259,6 +262,9 @@ export function ContentTypeDetailPanel({
   }
 
   function addWorkflow() {
+    if (!heldLock) {
+      return;
+    }
     const name = newWfName.trim();
     if (!name) return;
     if (workflows.some((w) => (w.name || "").toLowerCase() === name.toLowerCase())) {
@@ -274,6 +280,9 @@ export function ContentTypeDetailPanel({
   }
 
   function setDefaultWorkflow(index: number) {
+    if (!heldLock) {
+      return;
+    }
     setWorkflows((prev) => prev.map((w, i) => ({ ...w, isDefault: i === index })));
     setNotice(null);
   }
@@ -516,6 +525,105 @@ export function ContentTypeDetailPanel({
         </div>
       ) : null}
 
+      {/* Always mount lock chrome so operators and Playwright see it before GET
+          detail finishes and without scrolling past the fields table (#3835). */}
+      <div
+        role="toolbar"
+        aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
+        data-testid="developer-ct-lock-toolbar"
+        style={{
+          marginBottom: "16px",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "8px",
+          alignItems: "center",
+          position: "sticky",
+          top: 0,
+          zIndex: 2,
+          background: "#fff",
+          padding: "8px 0",
+        }}
+      >
+        <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
+          {DEV_MSG.CT_LOCK_HINT}
+        </p>
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="developer-ct-lock-status"
+          style={{ marginRight: "8px", fontSize: "0.9rem" }}
+        >
+          {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
+        </div>
+        <button
+          type="button"
+          data-testid="developer-ct-lock"
+          aria-label={DEV_MSG.CT_LOCK}
+          disabled={busy || heldLock || detail == null}
+          onClick={() => void handleLock()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock ? catalogColors.disabled : catalogColors.accent,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || heldLock || detail == null ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_LOCK}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-save"
+          aria-label={DEV_MSG.CT_SAVE}
+          disabled={busy || !heldLock || !dirty}
+          onClick={() => void handleSave()}
+          style={{
+            padding: "8px 16px",
+            background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_SAVE}
+        </button>
+        <button
+          type="button"
+          data-testid="developer-ct-unlock"
+          aria-label={DEV_MSG.CT_UNLOCK}
+          disabled={busy || !heldLock}
+          onClick={() => void handleUnlock()}
+          style={{
+            padding: "8px 16px",
+            background: "transparent",
+            color: "inherit",
+            border: `1px solid ${catalogColors.softBorder}`,
+            borderRadius: "4px",
+            cursor: busy || !heldLock ? "not-allowed" : "pointer",
+          }}
+        >
+          {DEV_MSG.CT_UNLOCK}
+        </button>
+        <label style={{ display: "flex", alignItems: "center", gap: 8, marginLeft: "8px" }}>
+          <input
+            type="checkbox"
+            data-testid="developer-ct-enabled"
+            aria-label={DEV_MSG.CT_FORM_ENABLED}
+            checked={enabled}
+            onChange={() => {
+              if (!canEdit) {
+                return;
+              }
+              setEnabled((v) => !v);
+            }}
+            disabled={!canEdit}
+          />
+          {DEV_MSG.CT_FORM_ENABLED}
+        </label>
+      </div>
+
       {!error && detail == null ? (
         <div data-testid="developer-ct-detail-loading">{DEV_MSG.CT_DETAIL_LOADING}</div>
       ) : null}
@@ -556,19 +664,6 @@ export function ContentTypeDetailPanel({
                 onChange={(e) => setDescription(e.target.value)}
                 disabled={!canEdit}
               />
-            </div>
-            <div style={{ marginTop: "12px" }}>
-              <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <input
-                  type="checkbox"
-                  data-testid="developer-ct-enabled"
-                  aria-label={DEV_MSG.CT_FORM_ENABLED}
-                  checked={enabled}
-                  onChange={() => setEnabled((v) => !v)}
-                  disabled={!canEdit}
-                />
-                {DEV_MSG.CT_FORM_ENABLED}
-              </label>
             </div>
             <dl
               style={{
@@ -687,9 +782,18 @@ export function ContentTypeDetailPanel({
                   style={inputStyle}
                   placeholder={DEV_MSG.CT_WF_NAME_PLACEHOLDER}
                   value={newWfName}
-                  onChange={(e) => setNewWfName(e.target.value)}
+                  onChange={(e) => {
+                    if (!canEdit) {
+                      return;
+                    }
+                    setNewWfName(e.target.value);
+                  }}
                   disabled={!canEdit}
+                  aria-disabled={!canEdit}
                   onKeyDown={(e) => {
+                    if (!canEdit) {
+                      return;
+                    }
                     if (e.key === "Enter") {
                       e.preventDefault();
                       addWorkflow();
@@ -927,82 +1031,6 @@ export function ContentTypeDetailPanel({
               </table>
             </div>
           </section>
-
-          <div
-            role="toolbar"
-            aria-label={DEV_MSG.CT_LOCK_TOOLBAR}
-            data-testid="developer-ct-lock-toolbar"
-            style={{
-              marginBottom: "16px",
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "8px",
-              alignItems: "center",
-            }}
-          >
-            <p style={{ margin: 0, width: "100%", color: catalogColors.muted, fontSize: "0.9rem" }}>
-              {DEV_MSG.CT_LOCK_HINT}
-            </p>
-            <div
-              role="status"
-              aria-live="polite"
-              data-testid="developer-ct-lock-status"
-              style={{ marginRight: "8px", fontSize: "0.9rem" }}
-            >
-              {heldLock ? DEV_MSG.CT_LOCKED : DEV_MSG.CT_UNLOCKED}
-            </div>
-            <button
-              type="button"
-              data-testid="developer-ct-lock"
-              aria-label={DEV_MSG.CT_LOCK}
-              disabled={busy || heldLock || detail == null}
-              onClick={() => void handleLock()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock ? catalogColors.disabled : catalogColors.accent,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_LOCK}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-save"
-              aria-label={DEV_MSG.CT_SAVE}
-              disabled={busy || !heldLock || !dirty}
-              onClick={() => void handleSave()}
-              style={{
-                padding: "8px 16px",
-                background: heldLock && dirty ? catalogColors.accent : catalogColors.disabled,
-                color: "#fff",
-                border: "none",
-                borderRadius: "4px",
-                cursor: busy || !heldLock || !dirty ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_SAVE}
-            </button>
-            <button
-              type="button"
-              data-testid="developer-ct-unlock"
-              aria-label={DEV_MSG.CT_UNLOCK}
-              disabled={busy || !heldLock}
-              onClick={() => void handleUnlock()}
-              style={{
-                padding: "8px 16px",
-                background: "transparent",
-                color: "inherit",
-                border: `1px solid ${catalogColors.softBorder}`,
-                borderRadius: "4px",
-                cursor: busy || !heldLock ? "not-allowed" : "pointer",
-              }}
-            >
-              {DEV_MSG.CT_UNLOCK}
-            </button>
-          </div>
 
           <ObjectAclSection
             objectGuid={objectGuid}

--- a/WebUI/src/main/ts/developer/catalogStyles.ts
+++ b/WebUI/src/main/ts/developer/catalogStyles.ts
@@ -40,6 +40,8 @@ export const catalogColors = {
   disabled: "#a0aec0",
   /** Default body text for inactive chrome (#2d3748). */
   text: "#2d3748",
+  /** Panel / sticky toolbar fill so chrome matches the catalog surface (#fff). */
+  surface: "#fff",
 } as const;
 
 /** Shared cell styles for Developer catalog tables. */

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionRedirectError } from "../../../main/ts/api/client";
 import * as contentTypesApi from "../../../main/ts/api/developer/contentTypesApi";
+import { catalogColors } from "../../../main/ts/developer/catalogStyles";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { ContentTypeDetailPanel } from "../../../main/ts/developer/ContentTypeDetailPanel";
 
@@ -610,6 +611,13 @@ describe("ContentTypeDetailPanel", () => {
     expect(screen.getByTestId("developer-ct-lock-toolbar")).toBeTruthy();
     expect(screen.getByTestId("developer-ct-detail-name").textContent).toBe("percPage");
     expect(screen.getByTestId("developer-ct-templates")).toBeTruthy();
+    expect(screen.queryByTestId("developer-ct-tpl-empty")).toBeNull();
+    const toolbarBg = (screen.getByTestId("developer-ct-lock-toolbar") as HTMLElement).style
+      .background;
+    expect(
+      toolbarBg === catalogColors.surface ||
+        /rgb\(\s*255\s*,\s*255\s*,\s*255\s*\)/i.test(toolbarBg),
+    ).toBe(true);
     expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
       true,
     );
@@ -623,10 +631,31 @@ describe("ContentTypeDetailPanel", () => {
     await waitFor(() => {
       expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
+    expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
+    expect(screen.queryByTestId("developer-ct-tpl-empty")).toBeNull();
     expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
       true,
     );
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+  });
+
+  it("ignores template add/remove while unlocked (#3836)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-tpl-add-name"), {
+      target: { value: "perc.page.summary" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-tpl-add"));
+    fireEvent.click(screen.getByTestId("developer-ct-tpl-remove-0"));
+    expect(screen.queryByTestId("developer-ct-tpl-row-1")).toBeNull();
+    expect(screen.getByTestId("developer-ct-tpl-row-0").textContent).toContain("perc.page");
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("keeps template editors disabled after 409 lock and does not steal (#3836)", async () => {

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -351,7 +351,7 @@ describe("ContentTypeDetailPanel", () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -404,7 +404,7 @@ describe("ContentTypeDetailPanel", () => {
     lockContentType.mockRejectedValueOnce({ status: 409, statusText: "Conflict", body: null });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -425,7 +425,7 @@ describe("ContentTypeDetailPanel", () => {
     });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -567,12 +567,69 @@ describe("ContentTypeDetailPanel", () => {
     );
   });
 
+  it("renders name, disabled template add, and lock toolbar while detail is loading (#3836)", async () => {
+    let resolveDetail: (value: typeof sampleDetail) => void = () => undefined;
+    getContentTypeDetail.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDetail = resolve;
+        }),
+    );
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-ct-lock-toolbar")).toBeTruthy();
+    expect(screen.getByTestId("developer-ct-detail-name").textContent).toBe("percPage");
+    expect(screen.getByTestId("developer-ct-templates")).toBeTruthy();
+    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-tpl-add") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(true);
+    resolveDetail({
+      ...sampleDetail,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+    });
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+  });
+
+  it("keeps template editors disabled after 409 lock and does not steal (#3836)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedTemplates: [{ name: "perc.page", label: "Page" }],
+    });
+    lockContentType.mockRejectedValueOnce({ status: 409, statusText: "Conflict", body: null });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+        "Could not lock content type.",
+      );
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("unlocks on back when the session holds the lock (#3744)", async () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
     const onBack = vi.fn();
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={onBack} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -603,7 +660,7 @@ describe("ContentTypeDetailPanel", () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -630,7 +687,7 @@ describe("ContentTypeDetailPanel", () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -668,7 +725,7 @@ describe("ContentTypeDetailPanel", () => {
     });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -699,7 +756,7 @@ describe("ContentTypeDetailPanel", () => {
     });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -734,7 +791,7 @@ describe("ContentTypeDetailPanel", () => {
     });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -781,7 +838,7 @@ describe("ContentTypeDetailPanel", () => {
     });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -842,7 +899,7 @@ describe("ContentTypeDetailPanel", () => {
     });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-lock")).toBeTruthy();
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-lock"));
     await waitFor(() => {
@@ -862,124 +919,5 @@ describe("ContentTypeDetailPanel", () => {
     });
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
     expect(lockContentType).toHaveBeenCalledTimes(1);
-  });
-
-  it("locks, replaces allowed templates via dedicated PUT then GET (#3783)", async () => {
-    getContentTypeDetail.mockResolvedValue({
-      ...sampleDetail,
-      allowedTemplates: [{ name: "perc.page", label: "Page" }],
-    });
-    replaceContentTypeAllowedTemplates.mockResolvedValueOnce([]);
-    getContentTypeAllowedTemplates.mockResolvedValueOnce([]);
-    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
-    });
-    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
-      true,
-    );
-    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
-    fireEvent.click(screen.getByTestId("developer-ct-lock"));
-    await waitFor(() => {
-      expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
-        false,
-      );
-    });
-    fireEvent.click(screen.getByTestId("developer-ct-tpl-remove-0"));
-    await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-tpl-empty")).toBeTruthy();
-    });
-    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(false);
-    fireEvent.click(screen.getByTestId("developer-ct-save"));
-    await waitFor(() => {
-      expect(replaceContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage", []);
-    });
-    expect(getContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage");
-    expect(updateContentTypeDetail).not.toHaveBeenCalled();
-    await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
-    });
-    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
-  });
-
-  it("adds an existing template id after lock and PUTs the new set (#3783)", async () => {
-    getContentTypeDetail.mockResolvedValue({
-      ...sampleDetail,
-      allowedTemplates: [{ name: "perc.page", label: "Page" }],
-    });
-    const next = [
-      { name: "perc.page" },
-      { name: "perc.page.summary", label: "perc.page.summary" },
-    ];
-    replaceContentTypeAllowedTemplates.mockResolvedValueOnce(next);
-    getContentTypeAllowedTemplates.mockResolvedValueOnce(next);
-    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
-    });
-    fireEvent.click(screen.getByTestId("developer-ct-lock"));
-    await waitFor(() => {
-      expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
-        false,
-      );
-    });
-    fireEvent.change(screen.getByTestId("developer-ct-tpl-add-name"), {
-      target: { value: "perc.page.summary" },
-    });
-    fireEvent.click(screen.getByTestId("developer-ct-tpl-add"));
-    await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-tpl-row-1")).toBeTruthy();
-    });
-    fireEvent.click(screen.getByTestId("developer-ct-save"));
-    await waitFor(() => {
-      expect(replaceContentTypeAllowedTemplates).toHaveBeenCalled();
-    });
-    expect(replaceContentTypeAllowedTemplates).toHaveBeenCalledWith(
-      "percPage",
-      expect.arrayContaining([
-        expect.objectContaining({ name: "perc.page" }),
-        expect.objectContaining({ name: "perc.page.summary" }),
-      ]),
-    );
-    expect(getContentTypeAllowedTemplates).toHaveBeenCalledWith("percPage");
-    expect(updateContentTypeDetail).not.toHaveBeenCalled();
-    await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-tpl-row-1").textContent).toContain(
-        "perc.page.summary",
-      );
-    });
-  });
-
-  it("clears the held lock when allowedTemplates PUT returns 409 (#3783)", async () => {
-    getContentTypeDetail.mockResolvedValue({
-      ...sampleDetail,
-      allowedTemplates: [{ name: "perc.page", label: "Page" }],
-    });
-    replaceContentTypeAllowedTemplates.mockRejectedValueOnce({
-      status: 409,
-      statusText: "Conflict",
-      body: null,
-    });
-    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
-    await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-tpl-row-0")).toBeTruthy();
-    });
-    fireEvent.click(screen.getByTestId("developer-ct-lock"));
-    await waitFor(() => {
-      expect((screen.getByTestId("developer-ct-tpl-remove-0") as HTMLButtonElement).disabled).toBe(
-        false,
-      );
-    });
-    fireEvent.click(screen.getByTestId("developer-ct-tpl-remove-0"));
-    fireEvent.click(screen.getByTestId("developer-ct-save"));
-    await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
-        "Could not save content type.",
-      );
-    });
-    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
-    expect((screen.getByTestId("developer-ct-tpl-add-name") as HTMLInputElement).disabled).toBe(
-      true,
-    );
   });
 });

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -413,7 +413,10 @@ describe("ContentTypeDetailPanel", () => {
       );
     });
     expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    fireEvent.click(screen.getByTestId("developer-ct-enabled"));
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).checked).toBe(true);
   });
 
   it("clears the held lock when save returns 409 (#3744)", async () => {
@@ -583,6 +586,26 @@ describe("ContentTypeDetailPanel", () => {
       expect(unlockContentType).toHaveBeenCalledWith("percPage");
     });
     expect(onBack).toHaveBeenCalled();
+  });
+
+  it("renders lock toolbar and disabled enabled chrome while detail is loading (#3834)", async () => {
+    let resolveDetail: (value: typeof sampleDetail) => void = () => undefined;
+    getContentTypeDetail.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDetail = resolve;
+        }),
+    );
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-ct-lock-toolbar")).toBeTruthy();
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    resolveDetail(sampleDetail);
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
   });
 
   it("keeps the enabled toggle disabled until lock (#3781)", async () => {

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -97,6 +97,34 @@ describe("ContentTypeDetailPanel", () => {
     getContentTypeAllowedTemplates.mockImplementation(async () => []);
   });
 
+  it("renders lock toolbar while detail is loading so workflow lock is findable (#3835)", async () => {
+    let resolveDetail: (value: typeof sampleDetail) => void = () => undefined;
+    getContentTypeDetail.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDetail = resolve;
+        }),
+    );
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    expect(screen.getByTestId("developer-ct-lock-toolbar")).toBeTruthy();
+    expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByTestId("developer-ct-wf-add-name")).toBeNull();
+    resolveDetail({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", isDefault: true },
+    });
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    expect((screen.getByTestId("developer-ct-wf-add-name") as HTMLInputElement).disabled).toBe(
+      true,
+    );
+    expect((screen.getByTestId("developer-ct-wf-add") as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+  });
+
   it("loads detail on success and supports back", async () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
     const onBack = vi.fn();
@@ -751,6 +779,26 @@ describe("ContentTypeDetailPanel", () => {
     });
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
     expect((screen.getByTestId("developer-ct-enabled") as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it("ignores workflow add/remove while unlocked (#3835)", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      allowedWorkflows: [{ name: "Simple Workflow", label: "Simple Workflow", isDefault: true }],
+      defaultWorkflow: { name: "Simple Workflow", isDefault: true },
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-wf-row-0")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-wf-add-name"), {
+      target: { value: "Standard Workflow" },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-wf-add"));
+    fireEvent.click(screen.getByTestId("developer-ct-wf-remove-0"));
+    expect(screen.queryByTestId("developer-ct-wf-row-1")).toBeNull();
+    expect(screen.getByTestId("developer-ct-wf-row-0").textContent).toContain("Simple Workflow");
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("keeps workflow editors disabled until lock (#3782)", async () => {

--- a/docs/ai-generated/code-reviews/issue-3834-ct-lock-save-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3834-ct-lock-save-chrome-erlang.md
@@ -1,0 +1,29 @@
+# Erlang review — issue 3834 CT lock/save chrome
+
+**Scope:** uncommitted + `fix/issue-3834-ct-lock-save-chrome` vs cluster tip
+`cluster/night-issue-20260826-ct-chrome` @ `8229288b11` (stacked; parent #3781 / epic #1690).
+**Recommendation:** approve
+**Gate:** May commit/push: yes
+**Memory patterns hit:** behavioral tests for changed chrome; Playwright companion for WebUI screens; product-docs for operator-facing toolbar placement.
+
+## Summary
+
+Cycle Verify residual: H2 Playwright `developer-content-type-lock-save.spec.js` failed because lock toolbar / Enabled chrome were not in the first paint (toolbar lived after the fields table, gated on GET `detail`). 409 other-user lock could appear to leave Enabled interactive if the checkbox was missing or not lock-gated on the loaded bundle.
+
+This change always mounts `developer-ct-lock-toolbar` (Lock / Save / Unlock / Enabled) at the top of Content Type detail, sticky, as soon as the panel shell mounts. Enabled stays `disabled` until `heldLock && !busy && detail != null`. 409 lock keeps `heldLock` false; onChange is no-op without `canEdit`. Playwright helper waits for toolbar + enabled-disabled + Lock enabled. Vitest covers loading-state chrome and 409 Enabled stays disabled. Product-docs note the top-of-panel toolbar.
+
+## Issues
+
+None (hard-gate).
+
+## Cross-platform path checklist
+
+Not applicable: no filesystem path construction, installers, or path assertions. Playwright URLs and REST paths correctly use `/`.
+
+## Companions
+
+- Vitest: loading toolbar/enabled; 409 lock does not enable Enabled
+- Playwright surface spec helper waits for lock chrome
+- product-docs/8.2/admin/developer-content-types.md (toolbar placement / 409 Enabled)
+- Maven: `WebUI` and `modules/perc-qa-automation` standalone clean install
+- C5: `perc-devctl qa-up --skip-image-build` TEST_CMS_URL=http://127.0.0.1:60026; qa-health RESULT:OK HTTP:200 HEALTH:healthy; docker cp rest + perc-system + sitemanage + WebUI `cm/modern/assets`; in-cell StopJetty/StartJetty; qa-health again RESULT:OK HTTP:200 HEALTH:healthy; `npm run test:surface -- --path tests/developer-content-type-lock-save.spec.js` **3 passed**; console-clean=yes (spec pageerror/console); server.log-clean=yes (no ERROR/FATAL in test window)

--- a/docs/ai-generated/code-reviews/issue-3835-ct-workflow-assoc-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3835-ct-workflow-assoc-chrome-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review: issue #3835 Developer Content Type workflow-assoc chrome (Cycle Verify)
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-26 |
+| **Branch** | `fix/issue-3835-ct-workflow-assoc-chrome` |
+| **Base** | `origin/main` (#3833 cluster already merged) |
+| **Recommendation** | approve |
+| **Gate** | May commit/push: yes |
+| **Memory patterns hit** | Change-class closure (WebUI panel + Vitest + Playwright + product-docs); lock chrome must be findable without scrolling past fields table (peer #3834); unlocked association editors stay disabled |
+
+## Summary
+
+Cycle Verify residual for `tests/developer-content-type-workflows.spec.js` on the #3833 cluster tip. Cluster union left Lock / Save / Unlock after the fields table and gated on GET `detail`, so H2 Playwright timed out on `developer-ct-lock` and saw `developer-ct-wf-add-name` enabled while unlocked.
+
+This change always mounts a **sticky top** lock toolbar (Lock / Save / Unlock / Enabled) before GET detail finishes. Workflow add/remove/default no-op without a held lock. Playwright waits for the toolbar and asserts add-name disabled. Product-docs: toolbar at top; Add/Remove stay disabled until Lock.
+
+## Gate
+
+- No bugs found. Standalone `WebUI` and `modules/perc-qa-automation` `mvnw clean install` succeeded (Vitest 3118 passed).
+- Behavioral tests: toolbar present while detail is loading; workflow add-name disabled after load; unlocked add/remove ignored; existing CD-08 lock → PUT path unchanged.
+- Companions: Playwright workflows spec (toolbar + lock timeout); lock-save / template specs wait for the same toolbar; product-docs Developer Content Types.
+- Cross-platform path checklist: N/A (no filesystem path/file I/O; REST/URL `/` only).
+- C2 reverse-deps: none (no Java public type/signature change).
+
+## Issues
+
+None.
+
+## Notes (non-blocking)
+
+- Peer residual #3834 / PR #3840 moved the same toolbar for lock-save Playwright. This PR is stacked on merged #3833, not on #3840 (CONFLICTING vs current main). Landing both will need a small toolbar-union if #3840 is still open.
+- Unlocked workflow add still uses native `disabled` plus handler guards so a click on a disabled control cannot dirty the set.

--- a/docs/ai-generated/code-reviews/issue-3836-ct-template-assoc-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3836-ct-template-assoc-chrome-erlang.md
@@ -1,0 +1,54 @@
+# Erlang review — #3836 CT template-assoc chrome (Cycle Verify residual)
+
+**Date:** 2026-08-26  
+**Branch:** `fix/issue-3836-ct-template-assoc-chrome`  
+**Scope:** uncommitted vs `HEAD` (WebUI ContentTypeDetailPanel, Vitest, Playwright, product-docs)  
+**Memory patterns hit:** change-class closure (Vitest + Playwright for WebUI screen); always-mount chrome before GET (peer #3834 lock toolbar); no path I/O.
+
+## Summary
+
+Cycle Verify on cluster tip #3833 failed Playwright
+`developer-content-type-template-associations.spec.js`: template add-name was
+enabled while unlocked, and Admin lock/replace timed out waiting for
+`developer-ct-detail-name`. Cluster union gated name / templates / lock
+toolbar on GET `detail` and placed Lock after the percPage fields table.
+
+This residual always mounts sticky Lock/Save/Unlock/Enabled, the type name
+(`detail?.name || idOrName`), and allowed-template add/remove at the top of
+the panel. `canEdit` is `heldLock && !busy && detail != null`. Unlocked (and
+still-loading) template add is `disabled` + `readOnly` + `aria-disabled`.
+409 lock does not steal or enable editors. Save still uses dedicated
+`PUT .../allowedTemplates` and does not release the lock.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Issues
+
+None blocking.
+
+### Companions (checked)
+
+| Artifact | Present |
+|----------|---------|
+| Always-mounted name + templates + sticky toolbar | yes |
+| Vitest: loading disabled + 409 no steal | yes |
+| Playwright surface spec waits for lock enabled / add disabled | yes |
+| product-docs/8.2/admin/developer-content-types.md | yes |
+| Cross-platform path I/O | N/A (no filesystem paths) |
+
+### Tests
+
+- Vitest: WebUI `ContentTypeDetailPanel` loading toolbar/templates; 409 template add stays disabled; existing CD-12 PUT/GET cases.
+- Playwright: `npm run test:surface -- --path tests/developer-content-type-template-associations.spec.js` — 2 passed on H2 QA.
+
+## Hard bans
+
+- No exploits / malware.
+- No rule-file commits.
+- No non-portable path construction.

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js
@@ -107,6 +107,15 @@ async function openContentTypeDetail(page, namePattern) {
       `Content type detail error: ${(await detailError.innerText()).trim()}`,
     );
   }
+  await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-lock"]')).toBeEnabled({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-enabled"]')).toBeDisabled({
+    timeout: 15_000,
+  });
   return detail;
 }
 

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
@@ -124,6 +124,12 @@ async function openContentTypeDetail(page, namePattern) {
   if (await detailError.isVisible()) {
     throw new Error(`Content type detail error: ${(await detailError.innerText()).trim()}`);
   }
+  await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-lock"]')).toBeEnabled({
+    timeout: 30_000,
+  });
 }
 
 async function getAllowedTemplatesViaRest(page, typeName) {

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
@@ -130,6 +130,11 @@ async function openContentTypeDetail(page, namePattern) {
   await expect(page.locator('[data-testid="developer-ct-templates"]')).toBeVisible({
     timeout: 30_000,
   });
+  const tplEmpty = page.locator('[data-testid="developer-ct-tpl-empty"]');
+  const detailLoading = page.locator('[data-testid="developer-ct-detail-loading"]');
+  if (await detailLoading.isVisible()) {
+    await expect(tplEmpty).toHaveCount(0);
+  }
   await expect(page.locator('[data-testid="developer-ct-tpl-add-name"]')).toBeDisabled({
     timeout: 15_000,
   });
@@ -147,6 +152,10 @@ async function openContentTypeDetail(page, namePattern) {
   await expect(page.locator('[data-testid="developer-ct-detail-loading"]')).toBeHidden({
     timeout: 15_000,
   });
+  const tplRows = page.locator('[data-testid^="developer-ct-tpl-row-"]');
+  if ((await tplRows.count()) > 0) {
+    await expect(tplEmpty).toHaveCount(0);
+  }
   if (await detailError.isVisible()) {
     throw new Error(`Content type detail error: ${(await detailError.innerText()).trim()}`);
   }

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js
@@ -119,11 +119,38 @@ async function openContentTypeDetail(page, namePattern) {
   }
 
   const detail = page.locator('[data-testid="developer-ct-detail"]');
-  const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
-  await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
+  await expect(detail).toBeVisible({ timeout: 30_000 });
+  const detailError = detail.locator('[data-testid="developer-ct-detail-error"]');
+  await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-detail-name"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-templates"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-tpl-add-name"]')).toBeDisabled({
+    timeout: 15_000,
+  });
+  // GET detail finished: Lock is enabled only after the type body is present.
+  try {
+    await expect(page.locator('[data-testid="developer-ct-lock"]')).toBeEnabled({
+      timeout: 30_000,
+    });
+  } catch (err) {
+    if (await detailError.isVisible()) {
+      throw new Error(`Content type detail error: ${(await detailError.innerText()).trim()}`);
+    }
+    throw err;
+  }
+  await expect(page.locator('[data-testid="developer-ct-detail-loading"]')).toBeHidden({
+    timeout: 15_000,
+  });
   if (await detailError.isVisible()) {
     throw new Error(`Content type detail error: ${(await detailError.innerText()).trim()}`);
   }
+  return detail;
 }
 
 async function getAllowedTemplatesViaRest(page, typeName) {
@@ -188,6 +215,7 @@ test.describe("Developer content type template associations (CD-12 / #3783)", ()
 
     await expect(page.locator('[data-testid="developer-ct-templates"]')).toBeVisible();
     await expect(addName).toBeDisabled();
+    await expect(addName).toHaveAttribute("readonly", "");
     await expect(addBtn).toBeDisabled();
     await expect(saveBtn).toBeDisabled();
     await expect(status).toHaveText(/Not locked/i);
@@ -227,6 +255,9 @@ test.describe("Developer content type template associations (CD-12 / #3783)", ()
     const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
     const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
 
+    await expect(page.locator('[data-testid="developer-ct-detail-name"]')).toBeVisible({
+      timeout: 30_000,
+    });
     const typeName = (
       await page.locator('[data-testid="developer-ct-detail-name"]').innerText()
     ).trim();
@@ -235,9 +266,11 @@ test.describe("Developer content type template associations (CD-12 / #3783)", ()
     const original = await getAllowedTemplatesViaRest(page, typeName);
 
     await expect(addName).toBeDisabled();
+    await expect(lockBtn).toBeEnabled();
     await lockBtn.click();
     await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
     await expect(addName).toBeEnabled();
+    await expect(addName).toBeEditable();
     await expect(unlockBtn).toBeEnabled();
 
     const rows = page.locator('[data-testid^="developer-ct-tpl-row-"]');

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-workflows.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-workflows.spec.js
@@ -136,7 +136,16 @@ async function openPercPageDetail(page) {
       `Content type detail error: ${(await detailError.innerText()).trim()}`,
     );
   }
-  await expect(page.locator('[data-testid="developer-ct-workflows"]')).toBeVisible();
+  await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-lock"]')).toBeEnabled({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-workflows"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-wf-add-name"]')).toBeDisabled();
   const nameEl = page.locator('[data-testid="developer-ct-detail-name"]');
   const typeName = ((await nameEl.count()) ? await nameEl.innerText() : "percPage").trim();
   return typeName || "percPage";
@@ -177,6 +186,9 @@ test.describe("Developer content type allowed workflows (CD-08 / #3782)", () => 
     const saveBtn = page.locator('[data-testid="developer-ct-save"]');
     const addName = page.locator('[data-testid="developer-ct-wf-add-name"]');
     const addBtn = page.locator('[data-testid="developer-ct-wf-add"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible();
+    await expect(lockBtn).toBeEnabled();
     await expect(saveBtn).toBeDisabled();
     await expect(addName).toBeDisabled();
     await expect(addBtn).toBeDisabled();
@@ -223,7 +235,7 @@ test.describe("Developer content type allowed workflows (CD-08 / #3782)", () => 
     const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
     const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
 
-    await expect(lockBtn).toBeEnabled();
+    await expect(lockBtn).toBeEnabled({ timeout: 30_000 });
     const lockResponsePromise = page.waitForResponse(
       (r) => r.request().method() === "POST" && /\/contenttypes\/[^/]+\/lock(?:\?|$)/.test(r.url()),
       { timeout: 20_000 },

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -29,9 +29,14 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 2. Open **Developer → Content types**, or deep-link
    `spa.jsp?entry=developer&section=content-types`.
 3. Open a catalog row.
-4. The detail toolbar shows **Lock**, **Save content type**, and **Unlock**.
-   The status line starts as **Not locked**. Label, description, enabled, field
-   flags, and association editors stay **read-only** until you hold the lock.
+4. The **detail toolbar at the top of the panel** (sticky) shows **Lock**,
+   **Save content type**, **Unlock**, and the **Enabled** checkbox. The type
+   name and **Allowed templates** add/remove chrome are visible immediately
+   (add/remove stay **disabled** until the type body has loaded and you hold
+   the lock). The status line starts as **Not locked**. Label, description,
+   enabled, field flags, and association editors stay **read-only** until you
+   hold the lock. A failed lock (**409**) does not steal another user's lock
+   or enable template add/remove or Save.
 5. Click **Lock**. Status becomes **Locked by you**. If another user already
    holds the lock, the panel shows an error and Save stays disabled (the product
    does **not** steal the lock).
@@ -41,11 +46,8 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
    `PUT /services/contenttypes/{idOrName}/enabled` (CD-13), not the bulk
    content-type save. Without a lock the checkbox stays disabled and a toggle
    cannot persist.
-7. To change **Allowed templates**, lock the type, add or remove existing
-   template names or GUIDs (`type-host-uuid`, for example `0-10-347`), then
-   **Save content type**. Save replaces the whole allowed-template set. An empty
-   list clears associations. Unknown names return an error; the lock is not
-   stolen. This is not the full Workbench template picker.
+7. To change **Allowed templates**, follow **Allowed templates (after lock)**
+   below. Save does **not** unlock.
 8. Click **Unlock** when you are done. Status returns to **Not locked** and the
    form is read-only again. **Back to list** also releases a lock you hold.
 
@@ -65,6 +67,22 @@ The **Allowed workflows** list is read-only until you hold the lock. After
 
 This is not a full Workbench workflow picker. The name you add must already
 exist on the server. Template association chrome is a separate surface.
+
+### Allowed templates (after lock)
+
+The **Allowed templates** list and add field are **disabled** until you hold
+the lock (including while the type is still loading). After **Lock**:
+
+1. Add a template by its existing name or GUID (`type-host-uuid`, for example
+   `0-10-347`) and click **Add**, or **Remove** a row.
+2. Click **Save content type**. The product replaces the whole allowed-template
+   set (`PUT /services/contenttypes/{idOrName}/allowedTemplates`). Save does
+   **not** unlock. A following `GET .../allowedTemplates` lists the new set.
+3. Without a lock, Add / Remove / Save stay **disabled**. The product does
+   **not** steal another user's lock (lock failure is **409**). An empty list
+   clears associations. Unknown names return an error; the lock is not stolen.
+
+This is not the full Workbench template picker.
 
 Locks expire after **30 minutes**. If Save fails because the lock expired,
 click **Lock** again and retry.

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -29,9 +29,11 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 2. Open **Developer → Content types**, or deep-link
    `spa.jsp?entry=developer&section=content-types`.
 3. Open a catalog row.
-4. The detail toolbar shows **Lock**, **Save content type**, and **Unlock**.
-   The status line starts as **Not locked**. Label, description, enabled, field
-   flags, and association editors stay **read-only** until you hold the lock.
+4. The **detail toolbar at the top of the panel** (sticky) shows **Lock**,
+   **Save content type**, **Unlock**, and the **Enabled** checkbox. The status
+   line starts as **Not locked**. Label, description, enabled, field flags, and
+   association editors stay **read-only** until you hold the lock. You do not
+   need to scroll past the fields table to lock or save.
 5. Click **Lock**. Status becomes **Locked by you**. If another user already
    holds the lock, the panel shows an error and Save stays disabled (the product
    does **not** steal the lock).
@@ -51,8 +53,9 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 
 ### Allowed workflows (after lock)
 
-The **Allowed workflows** list is read-only until you hold the lock. After
-**Lock**:
+The **Allowed workflows** list is read-only until you hold the lock. Add,
+Remove, and the workflow-name field stay **disabled** while status is **Not
+locked**. After **Lock**:
 
 1. Add a workflow by its existing name (for example **Standard Workflow**) and
    click **Add**, or **Remove** a row. Use **Default** to choose the default

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -29,9 +29,12 @@ use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
 2. Open **Developer → Content types**, or deep-link
    `spa.jsp?entry=developer&section=content-types`.
 3. Open a catalog row.
-4. The detail toolbar shows **Lock**, **Save content type**, and **Unlock**.
-   The status line starts as **Not locked**. Label, description, enabled, field
-   flags, and association editors stay **read-only** until you hold the lock.
+4. The **detail toolbar at the top of the panel** shows **Lock**, **Save content
+   type**, **Unlock**, and the **Enabled** checkbox. The status line starts as
+   **Not locked**. Label, description, enabled, field flags, and association
+   editors stay **read-only** until you hold the lock. Enabled stays disabled
+   until you hold the lock; a failed lock (**409**) does not steal another
+   user's lock or enable the checkbox.
 5. Click **Lock**. Status becomes **Locked by you**. If another user already
    holds the lock, the panel shows an error and Save stays disabled (the product
    does **not** steal the lock).


### PR DESCRIPTION
## Summary

Overnight cluster of three Developer Content Type chrome residuals that all edit the same SPA panel, Playwright helpers, and product-docs. Absorbing them into one PR against `main` so they do not thrash `ContentTypeDetailPanel.tsx` on merge.

**Thrash files**

- `WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx`
- `WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx`
- `product-docs/8.2/admin/developer-content-types.md`
- `modules/perc-qa-automation/frontend/tests/developer-content-type-lock-save.spec.js`
- `modules/perc-qa-automation/frontend/tests/developer-content-type-template-associations.spec.js`
- `modules/perc-qa-automation/frontend/tests/developer-content-type-workflows.spec.js`

Union semantics: sticky Lock / Save / Unlock / Enabled toolbar is **always mounted at the top** of the panel (not gated on GET `detail`, not after the fields table). Type name and allowed-template add/remove are always visible; workflow and template add/remove and Enabled stay **disabled** until a held lock. 409 other-user lock does not steal or enable editors. Template mutators no-op without a held lock (same as workflow add/remove).

Fixes #3834 #3835 #3836
Parent: #3781 / #3782 / #3783 / epic #1690
Stacked on merged cluster #3833

Unrelated this-run PRs **not** absorbed (separate virtual-site domain, only two members, both MERGEABLE): #3843 (http-json rebuild), #3844 (object-storage SPI).

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | [#3840](https://github.com/intersoftdatalabs-in/percussioncms/pull/3840) | `fix/issue-3834-ct-lock-save-chrome` | yes | Always-mount lock toolbar; Enabled disabled until lock |
| yes | [#3841](https://github.com/intersoftdatalabs-in/percussioncms/pull/3841) | `fix/issue-3835-ct-workflow-assoc-chrome` | yes | Workflow add/remove/default no-op until lock |
| yes | [#3842](https://github.com/intersoftdatalabs-in/percussioncms/pull/3842) | `fix/issue-3836-ct-template-assoc-chrome` | yes | Always-mount type name + template add/remove |

## modules_built

`WebUI, modules/perc-qa-automation`

## build_evidence

- `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest Test Files 393 passed, Tests 3118 passed; Java Tests run: 63, Failures: 0
- `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (npm ci; Surefire no Java tests)

Reverse-dep: no Java public/protected signature, final, or sealed change. C2 N/A.

## Product documentation

- [x] Product documentation (`product-docs/`) updated for the unioned Developer Content Type lock/workflow/template chrome

## Checklist

- [x] Standalone Maven clean install of every changed Maven module
- [x] Union of lock-toolbar, Enabled, workflow, and template chrome (no dropped unique adds)
- [x] Do not merge this PR without human review

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs-cluster.
