### PR TITLE
fix(system): leftover servlet/WebDAV IPS*Errors to typed ErrorCodes (#3848)

### DIFF
--- a/deployer/src/test/java/com/percussion/webdav/test/PSWebdavConfigTest.java
+++ b/deployer/src/test/java/com/percussion/webdav/test/PSWebdavConfigTest.java
@@ -18,7 +18,7 @@ package com.percussion.webdav.test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 import com.percussion.webdav.objectstore.IPSRxWebDavDTD;
 import com.percussion.webdav.objectstore.PSWebdavConfigDef;
@@ -175,7 +175,11 @@ public class PSWebdavConfigTest {
     } catch (PSWebdavException e) {
       expectedEx = e;
     }
-    assertEquals(IPSWebdavErrors.FIELDNAME_CANNOT_BE_EMPTY_OR_MISSING, expectedEx.getErrorCode());
+    assertEquals(
+        WebdavErrorCodes.FIELDNAME_CANNOT_BE_EMPTY_OR_MISSING.numericCode(),
+        expectedEx.getErrorCode());
+    assertSame(WebdavErrorCodes.FIELDNAME_CANNOT_BE_EMPTY_OR_MISSING, expectedEx.getTypedErrorCode());
+    assertFalse(expectedEx.isAuditable());
   }
 
   /**
@@ -191,7 +195,10 @@ public class PSWebdavConfigTest {
     } catch (PSWebdavException e) {
       expectedEx = e;
     }
-    assertEquals(IPSWebdavErrors.MISSING_REQUIRED_PROPERTY, expectedEx.getErrorCode());
+    assertEquals(
+        WebdavErrorCodes.MISSING_REQUIRED_PROPERTY.numericCode(), expectedEx.getErrorCode());
+    assertSame(WebdavErrorCodes.MISSING_REQUIRED_PROPERTY, expectedEx.getTypedErrorCode());
+    assertFalse(expectedEx.isAuditable());
   }
 
   /**
@@ -207,7 +214,10 @@ public class PSWebdavConfigTest {
     } catch (PSWebdavException e) {
       expectedEx = e;
     }
-    assertEquals(IPSWebdavErrors.DUPLICATE_CONTENTTYPE_NAMES, expectedEx.getErrorCode());
+    assertEquals(
+        WebdavErrorCodes.DUPLICATE_CONTENTTYPE_NAMES.numericCode(), expectedEx.getErrorCode());
+    assertSame(WebdavErrorCodes.DUPLICATE_CONTENTTYPE_NAMES, expectedEx.getTypedErrorCode());
+    assertFalse(expectedEx.isAuditable());
   }
 
   /**
@@ -223,7 +233,11 @@ public class PSWebdavConfigTest {
     } catch (PSWebdavException e) {
       expectedEx = e;
     }
-    assertEquals(IPSWebdavErrors.CANNOT_HAVE_DUPLICATE_PROPERTIES, expectedEx.getErrorCode());
+    assertEquals(
+        WebdavErrorCodes.CANNOT_HAVE_DUPLICATE_PROPERTIES.numericCode(),
+        expectedEx.getErrorCode());
+    assertSame(WebdavErrorCodes.CANNOT_HAVE_DUPLICATE_PROPERTIES, expectedEx.getTypedErrorCode());
+    assertFalse(expectedEx.isAuditable());
   }
 
   /**
@@ -239,7 +253,9 @@ public class PSWebdavConfigTest {
     } catch (PSWebdavException e) {
       expectedEx = e;
     }
-    assertEquals(IPSWebdavErrors.MIMETYPES_REQUIRED, expectedEx.getErrorCode());
+    assertEquals(WebdavErrorCodes.MIMETYPES_REQUIRED.numericCode(), expectedEx.getErrorCode());
+    assertSame(WebdavErrorCodes.MIMETYPES_REQUIRED, expectedEx.getTypedErrorCode());
+    assertFalse(expectedEx.isAuditable());
   }
 
   /**
@@ -255,7 +271,12 @@ public class PSWebdavConfigTest {
     } catch (PSWebdavException e) {
       expectedEx = e;
     }
-    assertEquals(IPSWebdavErrors.CAN_ONLY_HAVE_ONE_DEFAULT_CONTENTTYPE, expectedEx.getErrorCode());
+    assertEquals(
+        WebdavErrorCodes.CAN_ONLY_HAVE_ONE_DEFAULT_CONTENTTYPE.numericCode(),
+        expectedEx.getErrorCode());
+    assertSame(
+        WebdavErrorCodes.CAN_ONLY_HAVE_ONE_DEFAULT_CONTENTTYPE, expectedEx.getTypedErrorCode());
+    assertFalse(expectedEx.isAuditable());
   }
 
   /**

--- a/docs/ai-generated/code-reviews/3848-servlet-webdav-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3848-servlet-webdav-errorcodes-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review — #3848 system/servlet WebDAV leftover IPS*Errors typed ErrorCodes
+
+**Date:** 2026-08-26  
+**Branch:** `fix/issue-3848-servlet-webdav-errorcodes`  
+**Base:** `origin/main`  
+**Reviewer:** Erlang (pre-commit, independent of implementer)
+
+## Summary
+
+Parent #2616 leftover slice. Convert leftover `system/servlet` production `IPS*Errors` call-sites (hooks + WebDAV methods/objectstore, plus `IPSRemoteErrors` in `PSWebdavMethod`) to typed `ServletErrorCodes` / `WebdavErrorCodes` / `RemoteErrorCodes`. Added `IPSErrorCode` constructors on `PSServletException`, `PSWebdavException`, and `PSRemoteException`. Residual allow-list shrunk by those 17 servlet paths. Dual-write skip tests cover non-auditable leftover catalogs.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: present (typed construction, `PSMethodFactory` unsupported-method throw, missing WebDAV config file throw, deployer config expected codes, dual-write skip)
+- Cross-platform paths: pass — missing-config test uses `Path.of(System.getProperty("java.io.tmpdir"), …)` (no hardcoded `/` or `/tmp`)
+- Change-class companions: exception typed ctors + production retype + allow-list shrink + dual-write tests + deployer assertion update
+- May commit/push: **yes** (module `clean install` evidence recorded)
+
+## Issues
+
+None.
+
+## Notes
+
+- Servlet hooks still throw `jakarta.servlet.ServletException` with formatted bundle strings; they now format via `PSConnectionFactory.formatMessage(IPSErrorCode, Object[])`. Numeric codes and message lookup are unchanged.
+- `PSWebdavException(IPSErrorCode, Object, int)` matches the legacy `(int, Object, int)` overload so `Object[]` status-code call sites keep treating the array as a single argument.
+- C2: constructors are additive. Only subclass of `PSServletException` is `PSWebdavException`. No `new PSWebdavException() {` / `new PSServletException() {` sites. Reverse-dep `deployer` standalone `clean install` green (config tests compile against typed throws).
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); cross-platform temp path.

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/ServletWebdavResidualErrorCodesDualWriteTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/ServletWebdavResidualErrorCodesDualWriteTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intsof.percussioncms.auditlog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.RemoteErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
+import com.intsof.percussioncms.auditlog.sink.CapturingAuditLogSink;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Dual-write skip coverage for leftover servlet-hook / WebDAV catalog codes (#3848). Every leftover
+ * in this slice is non-auditable operational / protocol noise.
+ */
+class ServletWebdavResidualErrorCodesDualWriteTest {
+
+  @BeforeEach
+  void rebootstrap() {
+    LegacyErrorCodeRegistry.clearForTests();
+    LegacyErrorCodeRegistry.bootstrap();
+  }
+
+  @Test
+  void leftoverServletCodesSkipDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    for (ServletErrorCodes code : ServletErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      assertSame(code, LegacyErrorCodeRegistry.find(code.numericCode()).orElseThrow());
+      AuditLogId id =
+          LegacyErrorCodeRegistry.logIfAuditable(
+              svc, code.numericCode(), AuditContext.builder().actor("jdoe").build());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED, id, code.name());
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void leftoverWebdavCodesSkipDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    WebdavErrorCodes[] leftovers = {
+      WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
+      WebdavErrorCodes.XML_INVALID_FORMAT,
+      WebdavErrorCodes.XML_ELEMENT_CANNOT_BE_EMPTY,
+      WebdavErrorCodes.XML_FAILED_CREATE_DOC_FROM_CONTENT,
+      WebdavErrorCodes.UNSUPPORTED_METHOD,
+      WebdavErrorCodes.MIMETYPES_REQUIRED,
+      WebdavErrorCodes.CANNOT_HAVE_DUPLICATE_PROPERTIES,
+      WebdavErrorCodes.MISSING_REQUIRED_PROPERTY,
+      WebdavErrorCodes.CAN_ONLY_HAVE_ONE_DEFAULT_CONTENTTYPE,
+      WebdavErrorCodes.IO_EXCEPTION_OCCURED,
+      WebdavErrorCodes.SAX_EXCEPTION_OCCURED,
+      WebdavErrorCodes.FILE_DOES_NOT_EXIST,
+      WebdavErrorCodes.DUPLICATE_CONTENTTYPE_NAMES,
+      WebdavErrorCodes.RESOURCE_NOT_FIND,
+      WebdavErrorCodes.HEADER_MISSING,
+      WebdavErrorCodes.FORBIDDEN_SRC_TARGET_SAME,
+      WebdavErrorCodes.METHOD_FAIL_CANNOT_OVERWRITE,
+      WebdavErrorCodes.ITEMFIELD_NOT_EXIST,
+      WebdavErrorCodes.LOCKSCOPE_NOT_ALLOWED,
+      WebdavErrorCodes.LOCKTYPE_NOT_ALLOWED,
+      WebdavErrorCodes.FIELDNAME_CANNOT_BE_EMPTY_OR_MISSING,
+      WebdavErrorCodes.CONTENTTYPE_NOT_CONFIGURED,
+      WebdavErrorCodes.UNKNOWN_BODY_IN_MKCOL_REQ,
+      WebdavErrorCodes.MALFORMED_URL_FROM_HEADER,
+      WebdavErrorCodes.NO_PUBLIC_AUTO_TRANSITION,
+      WebdavErrorCodes.NO_QE_AUTO_TRANSITION
+    };
+
+    for (WebdavErrorCodes code : leftovers) {
+      assertFalse(code.isAuditable(), code.name());
+      assertSame(code, LegacyErrorCodeRegistry.find(code.numericCode()).orElseThrow());
+      AuditLogId id =
+          LegacyErrorCodeRegistry.logIfAuditable(
+              svc, code.numericCode(), AuditContext.builder().actor("jdoe").build());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED, id, code.name());
+    }
+    assertTrue(sink.records().isEmpty());
+  }
+
+  @Test
+  void leftoverRemoteUnexpectedErrorSkipsDualWrite() {
+    CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+    DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+
+    assertFalse(RemoteErrorCodes.REMOTE_UNEXPECTED_ERROR.isAuditable());
+    AuditLogId id =
+        LegacyErrorCodeRegistry.logIfAuditable(
+            svc,
+            RemoteErrorCodes.REMOTE_UNEXPECTED_ERROR.numericCode(),
+            AuditContext.builder().actor("jdoe").build());
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, id);
+    assertTrue(sink.records().isEmpty());
+  }
+}

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -10,6 +10,7 @@
 #   #3740 deployer server/handlers + server/dependencies
 #   #3741 DCE/ContentUI/TableFactory leftover call sites
 #   #3770 leftover nav/sfp/workflow extension modules
+#   #3848 leftover system/servlet hooks + WebDAV
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -119,23 +120,6 @@ system/services/src/com/percussion/services/ui/PSUiException.java
 system/services/src/com/percussion/services/ui/impl/PSUiService.java
 system/services/src/com/percussion/services/workflow/PSWorkflowException.java
 system/services/src/com/percussion/services/workflow/impl/PSWorkflowService.java
-system/servlet/src/com/percussion/hooks/PSConnectionFactory.java
-system/servlet/src/com/percussion/hooks/PSServletBase.java
-system/servlet/src/com/percussion/hooks/servlet/RhythmyxServlet.java
-system/servlet/src/com/percussion/webdav/PSWebdavServlet.java
-system/servlet/src/com/percussion/webdav/method/PSCopyMethod.java
-system/servlet/src/com/percussion/webdav/method/PSDeleteMethod.java
-system/servlet/src/com/percussion/webdav/method/PSLockMethod.java
-system/servlet/src/com/percussion/webdav/method/PSMethodFactory.java
-system/servlet/src/com/percussion/webdav/method/PSMkcolMethod.java
-system/servlet/src/com/percussion/webdav/method/PSPropFindMethod.java
-system/servlet/src/com/percussion/webdav/method/PSPropPatchMethod.java
-system/servlet/src/com/percussion/webdav/method/PSUnlockMethod.java
-system/servlet/src/com/percussion/webdav/method/PSWebdavMethod.java
-system/servlet/src/com/percussion/webdav/method/PSWebdavUtils.java
-system/servlet/src/com/percussion/webdav/objectstore/PSPropertyFieldNameMapping.java
-system/servlet/src/com/percussion/webdav/objectstore/PSWebdavConfigDef.java
-system/servlet/src/com/percussion/webdav/objectstore/PSWebdavContentType.java
 system/src/main/java/com/percussion/cms/PSApplicationBuilder.java
 system/src/main/java/com/percussion/cms/PSChoiceBuilder.java
 system/src/main/java/com/percussion/cms/PSCompleteChildDocumentBuilder.java

--- a/system/servlet/src/com/percussion/hooks/PSConnectionFactory.java
+++ b/system/servlet/src/com/percussion/hooks/PSConnectionFactory.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.hooks;
 
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.hooks.servlet.RhythmyxServlet;
 
 import java.io.IOException;
@@ -113,7 +115,7 @@ public class PSConnectionFactory
             strPort
          };
          throw new ServletException(
-            formatMessage(IPSServletErrors.INVALID_PORT_NUMBER, args));
+            formatMessage(ServletErrorCodes.INVALID_PORT_NUMBER, args));
       }
       catch (UnknownHostException e)
       {
@@ -124,7 +126,7 @@ public class PSConnectionFactory
             e.getLocalizedMessage()
          };
          throw new ServletException(
-            formatMessage(IPSServletErrors.CONNECTION_ERROR, args));
+            formatMessage(ServletErrorCodes.CONNECTION_ERROR, args));
       }
    }
    
@@ -244,6 +246,20 @@ public class PSConnectionFactory
          return message;
       
       return MessageFormat.format(message, args);
+   }
+
+   /**
+    * Formats the message for a catalogued {@link IPSErrorCode}.
+    *
+    * @param code catalogued error code, never {@code null}
+    * @param args the message arguments, may be {@code null} or empty
+    * @return the formatted message string, never {@code null}
+    */
+   public static String formatMessage(IPSErrorCode code, Object[] args)
+   {
+      if (code == null)
+         throw new IllegalArgumentException("code may not be null");
+      return formatMessage(code.numericCode(), args);
    }
 
    /**

--- a/system/servlet/src/com/percussion/hooks/PSServletBase.java
+++ b/system/servlet/src/com/percussion/hooks/PSServletBase.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.hooks;
 
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -44,14 +45,14 @@ public class PSServletBase extends HttpServlet
          getVersionResources().getString("buildId")
       };
       String version = PSConnectionFactory.formatMessage(
-         IPSServletErrors.VERSION_STRING, versionArgs);
+         ServletErrorCodes.VERSION_STRING, versionArgs);
 
       Object[] args =
       {
          version
       };
       return PSConnectionFactory.formatMessage(
-         IPSServletErrors.SERVLET_INFORMATION, args);
+         ServletErrorCodes.SERVLET_INFORMATION, args);
    }
 
    /**

--- a/system/servlet/src/com/percussion/hooks/PSServletException.java
+++ b/system/servlet/src/com/percussion/hooks/PSServletException.java
@@ -17,6 +17,7 @@
 package com.percussion.hooks;
 
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.error.PSStandaloneException;
 
@@ -53,6 +54,30 @@ public class PSServletException extends PSStandaloneException
    public PSServletException(int msgCode)
    {
       super(msgCode);
+   }
+
+   /**
+    * @see com.percussion.error.PSStandaloneException#PSStandaloneException(IPSErrorCode)
+    */
+   public PSServletException(IPSErrorCode code)
+   {
+      super(code);
+   }
+
+   /**
+    * @see com.percussion.error.PSStandaloneException#PSStandaloneException(IPSErrorCode, Object)
+    */
+   public PSServletException(IPSErrorCode code, Object singleArg)
+   {
+      super(code, singleArg);
+   }
+
+   /**
+    * @see com.percussion.error.PSStandaloneException#PSStandaloneException(IPSErrorCode, Object[])
+    */
+   public PSServletException(IPSErrorCode code, Object[] arrayArgs)
+   {
+      super(code, arrayArgs);
    }
 
    /**

--- a/system/servlet/src/com/percussion/hooks/servlet/RhythmyxServlet.java
+++ b/system/servlet/src/com/percussion/hooks/servlet/RhythmyxServlet.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.hooks.servlet;
 
-import com.percussion.hooks.IPSServletErrors;
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
 import com.percussion.hooks.PSConnectionFactory;
 import com.percussion.hooks.PSServletBase;
 import com.percussion.security.xml.PSSecureXMLUtils;
@@ -144,7 +144,7 @@ public class RhythmyxServlet extends PSServletBase
    {
       if ((req == null) || (resp == null))
          throw new ServletException(PSConnectionFactory.formatMessage(
-            IPSServletErrors.INVALID_REQUEST_PARAMETERS, null));
+            ServletErrorCodes.INVALID_REQUEST_PARAMETERS, null));
 
       httpProcessRequest(req, resp);
    }
@@ -164,7 +164,7 @@ public class RhythmyxServlet extends PSServletBase
    {
       if ((req == null) || (resp == null))
          throw new ServletException(PSConnectionFactory.formatMessage(
-            IPSServletErrors.INVALID_REQUEST_PARAMETERS, null));
+            ServletErrorCodes.INVALID_REQUEST_PARAMETERS, null));
 
       httpProcessRequest(req, resp);
    }
@@ -182,7 +182,7 @@ public class RhythmyxServlet extends PSServletBase
       Socket sock = m_connFactory.getConnection(m_connFactory.useSSL());
       if (sock == null)
          throw new ServletException(PSConnectionFactory.formatMessage(
-            IPSServletErrors.CONNECTION_FAILURE, null));
+            ServletErrorCodes.CONNECTION_FAILURE, null));
       
       return sock;
    }
@@ -200,7 +200,7 @@ public class RhythmyxServlet extends PSServletBase
    {
       if (m_connFactory == null)
          throw new ServletException(PSConnectionFactory.formatMessage(
-            IPSServletErrors.SERVLET_DESTROYED, null));
+            ServletErrorCodes.SERVLET_DESTROYED, null));
 
       String rhythmyxRoles = getRhythmyxRoles(req);
       
@@ -411,7 +411,7 @@ public class RhythmyxServlet extends PSServletBase
             sTemp
          };
          throw new ServletException(PSConnectionFactory.formatMessage(
-            IPSServletErrors.INVALID_STATUS_CODE, args));
+            ServletErrorCodes.INVALID_STATUS_CODE, args));
       }
 
       return statusCode;

--- a/system/servlet/src/com/percussion/webdav/PSWebdavServlet.java
+++ b/system/servlet/src/com/percussion/webdav/PSWebdavServlet.java
@@ -19,7 +19,7 @@ package com.percussion.webdav;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.hooks.PSServletBase;
 import com.percussion.servlet_utils.servlet.PSServletUtils;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 import com.percussion.webdav.method.PSMethodFactory;
 import com.percussion.webdav.method.PSWebdavMethod;
@@ -133,7 +133,7 @@ public class PSWebdavServlet extends PSServletBase
          return in;
       }catch (IOException e)
       {
-         throw new PSWebdavException(IPSWebdavErrors.FILE_DOES_NOT_EXIST,
+         throw new PSWebdavException(WebdavErrorCodes.FILE_DOES_NOT_EXIST,
             filename);
       }
 

--- a/system/servlet/src/com/percussion/webdav/error/PSWebdavException.java
+++ b/system/servlet/src/com/percussion/webdav/error/PSWebdavException.java
@@ -18,6 +18,7 @@
 package com.percussion.webdav.error;
 
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.error.PSStandaloneException;
 import com.percussion.hooks.PSServletException;
@@ -55,6 +56,40 @@ public class PSWebdavException extends PSServletException
    public PSWebdavException(int msgCode)
    {
       super(msgCode);
+   }
+
+   /**
+    * Typed construction from a catalogued {@link IPSErrorCode} (e.g. {@code
+    * WebdavErrorCodes}).
+    */
+   public PSWebdavException(IPSErrorCode code)
+   {
+      super(code);
+   }
+
+   /**
+    * Typed construction with a single message argument.
+    */
+   public PSWebdavException(IPSErrorCode code, Object singleArg)
+   {
+      super(code, singleArg);
+   }
+
+   /**
+    * Typed construction with a single message argument and HTTP/WebDAV status.
+    */
+   public PSWebdavException(IPSErrorCode code, Object singleArg, int statusCode)
+   {
+      super(code, singleArg);
+      setStatusCode(statusCode);
+   }
+
+   /**
+    * Typed construction with message arguments.
+    */
+   public PSWebdavException(IPSErrorCode code, Object[] arrayArgs)
+   {
+      super(code, arrayArgs);
    }
 
    // see com.percussion.error.PSStandaloneException(PSException)

--- a/system/servlet/src/com/percussion/webdav/method/PSCopyMethod.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSCopyMethod.java
@@ -43,7 +43,7 @@ import com.percussion.error.PSException;
 import com.percussion.util.PSCharSets;
 import com.percussion.webdav.PSWebdavServlet;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 
 /**
@@ -84,7 +84,7 @@ public class PSCopyMethod extends PSWebdavMethod
 
       if (destination == null || destination.trim().length() == 0)
       {
-         throw new PSWebdavException(IPSWebdavErrors.HEADER_MISSING,
+         throw new PSWebdavException(WebdavErrorCodes.HEADER_MISSING,
             H_DESTINATION, PSWebdavStatus.SC_BAD_REQUEST);
       }
 
@@ -100,7 +100,7 @@ public class PSCopyMethod extends PSWebdavMethod
       catch (MalformedURLException e)
       {
          String[] args = {destination, H_DESTINATION};
-         throw new PSWebdavException(IPSWebdavErrors.MALFORMED_URL_FROM_HEADER,
+         throw new PSWebdavException(WebdavErrorCodes.MALFORMED_URL_FROM_HEADER,
                args, PSWebdavStatus.SC_BAD_REQUEST);
       }
       catch (UnsupportedEncodingException e)
@@ -122,7 +122,7 @@ public class PSCopyMethod extends PSWebdavMethod
       {
          String[] args = { m_sourcePath, getRequest().getMethod()};
          throw new PSWebdavException(
-            IPSWebdavErrors.FORBIDDEN_SRC_TARGET_SAME,
+            WebdavErrorCodes.FORBIDDEN_SRC_TARGET_SAME,
             args,
             PSWebdavStatus.SC_FORBIDDEN);
       }
@@ -136,7 +136,7 @@ public class PSCopyMethod extends PSWebdavMethod
       else if (! isOverwrite())
       {   // if request does not specify overwrite, fail with 412 status code
           throw new PSWebdavException(
-             IPSWebdavErrors.METHOD_FAIL_CANNOT_OVERWRITE,
+             WebdavErrorCodes.METHOD_FAIL_CANNOT_OVERWRITE,
              m_targetPath,
              PSWebdavStatus.SC_PRECONDITION_FAILED);
       }

--- a/system/servlet/src/com/percussion/webdav/method/PSDeleteMethod.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSDeleteMethod.java
@@ -22,7 +22,7 @@ import com.percussion.cms.objectstore.client.PSRemoteException;
 import com.percussion.system.utils.PSWorkflowInfo;
 import com.percussion.webdav.PSWebdavServlet;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 
 import java.io.IOException;
@@ -72,7 +72,7 @@ public class PSDeleteMethod extends PSWebdavMethod
       if (compSummary == null)
       {
          throw new PSWebdavException(
-            IPSWebdavErrors.RESOURCE_NOT_FIND,
+            WebdavErrorCodes.RESOURCE_NOT_FIND,
             compPath,
             PSWebdavStatus.SC_NOT_FOUND);
       }

--- a/system/servlet/src/com/percussion/webdav/method/PSLockMethod.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSLockMethod.java
@@ -32,7 +32,7 @@ import com.percussion.system.utils.IPSHtmlParameters;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.webdav.PSWebdavServlet;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 import com.percussion.webdav.objectstore.PSWebdavContentType;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -361,7 +361,7 @@ public class PSLockMethod extends PSWebdavMethod
                   Integer.valueOf(locator.getId()),
                   Integer.valueOf(locator.getRevision()) };
             throw new PSWebdavException(
-                  IPSWebdavErrors.CONTENTTYPE_NOT_CONFIGURED, args,
+                  WebdavErrorCodes.CONTENTTYPE_NOT_CONFIGURED, args,
                   PSWebdavStatus.SC_PRECONDITION_FAILED);
          }
          PSItemField field = item.getFieldByName(contentType.getOwnerField());
@@ -505,14 +505,14 @@ public class PSLockMethod extends PSWebdavMethod
          if (exclusiveEl == null)
          {
             throw new PSWebdavException(
-                  IPSWebdavErrors.XML_ELEMENT_CANNOT_BE_EMPTY, E_LOCKSCOPE,
+                  WebdavErrorCodes.XML_ELEMENT_CANNOT_BE_EMPTY, E_LOCKSCOPE,
                   PSWebdavStatus.SC_BAD_REQUEST);
          }
          String scopeName = PSXMLDomUtil.getUnqualifiedNodeName(exclusiveEl);
          if (!scopeName.equalsIgnoreCase(E_EXCLUSIVE))
          {
             String[] args = { scopeName, E_EXCLUSIVE };
-            throw new PSWebdavException(IPSWebdavErrors.LOCKSCOPE_NOT_ALLOWED,
+            throw new PSWebdavException(WebdavErrorCodes.LOCKSCOPE_NOT_ALLOWED,
                   args, PSWebdavStatus.SC_FORBIDDEN);
          }
 
@@ -521,7 +521,7 @@ public class PSLockMethod extends PSWebdavMethod
          if (typeEl == null)
          {
             throw new PSWebdavException(
-                  IPSWebdavErrors.XML_ELEMENT_CANNOT_BE_EMPTY, E_LOCKTYPE,
+                  WebdavErrorCodes.XML_ELEMENT_CANNOT_BE_EMPTY, E_LOCKTYPE,
                   PSWebdavStatus.SC_BAD_REQUEST);
          }
 
@@ -529,7 +529,7 @@ public class PSLockMethod extends PSWebdavMethod
          if (!typeName.equalsIgnoreCase(E_WRITE))
          {
             String[] args = { typeName, E_WRITE };
-            throw new PSWebdavException(IPSWebdavErrors.LOCKTYPE_NOT_ALLOWED,
+            throw new PSWebdavException(WebdavErrorCodes.LOCKTYPE_NOT_ALLOWED,
                   args, PSWebdavStatus.SC_FORBIDDEN);
          }
 

--- a/system/servlet/src/com/percussion/webdav/method/PSMethodFactory.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSMethodFactory.java
@@ -18,7 +18,7 @@ package com.percussion.webdav.method;
 
 import com.percussion.webdav.PSWebdavServlet;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -106,7 +106,7 @@ public class PSMethodFactory
       }
 
       PSWebdavException e = new PSWebdavException(
-         IPSWebdavErrors.UNSUPPORTED_METHOD, name);
+         WebdavErrorCodes.UNSUPPORTED_METHOD, name);
       e.setStatusCode(PSWebdavStatus.SC_METHOD_NOT_ALLOWED);
       
       throw e;

--- a/system/servlet/src/com/percussion/webdav/method/PSMkcolMethod.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSMkcolMethod.java
@@ -25,7 +25,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.webdav.PSWebdavServlet;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 
 
@@ -63,7 +63,7 @@ public class PSMkcolMethod extends PSWebdavMethod
             if (s.trim().length() > 0)
             {
                Object[] args = {s};
-               throw new PSWebdavException(IPSWebdavErrors.UNKNOWN_BODY_IN_MKCOL_REQ,
+               throw new PSWebdavException(WebdavErrorCodes.UNKNOWN_BODY_IN_MKCOL_REQ,
                      args, PSWebdavStatus.SC_UNSUPPORTED_MEDIA_TYPE);
             }
          }
@@ -71,7 +71,7 @@ public class PSMkcolMethod extends PSWebdavMethod
       catch (Exception e)  // this should not happen, in case it does, we don't
       {                    // care the content, just set the correct status
          Object[] args = {"...unknown..."};
-         throw new PSWebdavException(IPSWebdavErrors.UNKNOWN_BODY_IN_MKCOL_REQ,
+         throw new PSWebdavException(WebdavErrorCodes.UNKNOWN_BODY_IN_MKCOL_REQ,
                args, PSWebdavStatus.SC_UNSUPPORTED_MEDIA_TYPE);
       }
       

--- a/system/servlet/src/com/percussion/webdav/method/PSPropFindMethod.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSPropFindMethod.java
@@ -31,7 +31,7 @@ import com.percussion.util.PSXMLDomUtil;
 import com.percussion.utils.spring.PSUrlHandlerMapping;
 import com.percussion.webdav.PSWebdavServlet;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 import com.percussion.webdav.objectstore.PSDateProperty;
 import com.percussion.webdav.objectstore.PSPropertyFieldNameMapping;
@@ -127,7 +127,7 @@ public class PSPropFindMethod extends PSWebdavMethod
             else // unknown element
             {
                throw new PSWebdavException(
-                  IPSWebdavErrors.XML_INVALID_FORMAT,
+                  WebdavErrorCodes.XML_INVALID_FORMAT,
                   E_PROPFIND,
                   PSWebdavStatus.SC_BAD_REQUEST);
             }
@@ -283,7 +283,7 @@ public class PSPropFindMethod extends PSWebdavMethod
             comp = new ComponentStatus(summary, ct, uri);
          else // the item is an unsupported content type
             throw new PSWebdavException(
-               IPSWebdavErrors.RESOURCE_NOT_FIND,
+               WebdavErrorCodes.RESOURCE_NOT_FIND,
                compPath,
                PSWebdavStatus.SC_NOT_FOUND);
       }

--- a/system/servlet/src/com/percussion/webdav/method/PSPropPatchMethod.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSPropPatchMethod.java
@@ -19,7 +19,7 @@ import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.webdav.PSWebdavServlet;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 
@@ -64,7 +64,7 @@ public class PSPropPatchMethod extends PSWebdavMethod
          if (root == null)
          {
             throw new PSWebdavException(
-               IPSWebdavErrors.XML_INVALID_FORMAT,
+               WebdavErrorCodes.XML_INVALID_FORMAT,
                E_PROPERTYUPDATE,
                PSWebdavStatus.SC_BAD_REQUEST);
          }
@@ -74,7 +74,7 @@ public class PSPropPatchMethod extends PSWebdavMethod
          if (childEl == null)
          {
             throw new PSWebdavException(
-               IPSWebdavErrors.XML_ELEMENT_CANNOT_BE_EMPTY,
+               WebdavErrorCodes.XML_ELEMENT_CANNOT_BE_EMPTY,
                E_PROPERTYUPDATE,
                PSWebdavStatus.SC_BAD_REQUEST);
          }
@@ -92,7 +92,7 @@ public class PSPropPatchMethod extends PSWebdavMethod
             else
             {
                throw new PSWebdavException(
-                  IPSWebdavErrors.XML_INVALID_FORMAT,
+                  WebdavErrorCodes.XML_INVALID_FORMAT,
                   E_PROPERTYUPDATE,
                   PSWebdavStatus.SC_BAD_REQUEST);
             }

--- a/system/servlet/src/com/percussion/webdav/method/PSUnlockMethod.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSUnlockMethod.java
@@ -24,7 +24,7 @@ import com.percussion.cms.objectstore.ws.PSClientItem;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.webdav.PSWebdavServlet;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 import com.percussion.webdav.objectstore.PSWebdavContentType;
 
@@ -94,7 +94,7 @@ public class PSUnlockMethod extends PSWebdavMethod
          Object[] args = { new Long(id), compSummary.getName(),
                Integer.valueOf(locator.getId()), Integer.valueOf(locator.getRevision()) };
          throw new PSWebdavException(
-               IPSWebdavErrors.CONTENTTYPE_NOT_CONFIGURED, args,
+               WebdavErrorCodes.CONTENTTYPE_NOT_CONFIGURED, args,
                PSWebdavStatus.SC_PRECONDITION_FAILED);
       }
       try

--- a/system/servlet/src/com/percussion/webdav/method/PSWebdavMethod.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSWebdavMethod.java
@@ -20,7 +20,7 @@ package com.percussion.webdav.method;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.cms.objectstore.PSRelationshipProcessorProxy;
-import com.percussion.cms.objectstore.client.IPSRemoteErrors;
+import com.intsof.percussioncms.auditlog.codes.RemoteErrorCodes;
 import com.percussion.cms.objectstore.client.PSRemoteAgent;
 import com.percussion.cms.objectstore.client.PSRemoteException;
 import com.percussion.design.objectstore.PSLocator;
@@ -34,7 +34,7 @@ import com.percussion.util.servlet.PSServletRequester;
 import com.percussion.webdav.IPSWebdavConstants;
 import com.percussion.webdav.PSWebdavServlet;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 import com.percussion.webdav.objectstore.PSWebdavConfig;
 import com.percussion.xml.PSXmlDocumentBuilder;
@@ -372,7 +372,7 @@ public abstract class PSWebdavMethod
                log.debug(PSExceptionUtils.getDebugMessageForLog(e));
                
                throw new PSWebdavException(
-                  IPSWebdavErrors.XML_FAILED_CREATE_DOC_FROM_CONTENT,
+                  WebdavErrorCodes.XML_FAILED_CREATE_DOC_FROM_CONTENT,
                   e.getLocalizedMessage(),
                   PSWebdavStatus.SC_BAD_REQUEST);
             }
@@ -442,7 +442,7 @@ public abstract class PSWebdavMethod
          catch (Exception e)
          {
             throw new PSRemoteException(
-                  IPSRemoteErrors.REMOTE_UNEXPECTED_ERROR,
+                  RemoteErrorCodes.REMOTE_UNEXPECTED_ERROR,
                   e.toString());
          }
          return ms_workflowInstance;
@@ -760,7 +760,7 @@ public abstract class PSWebdavMethod
          if (parentSummary == null) // the parent component may not exists 
          {
             throw new PSWebdavException(
-               IPSWebdavErrors.RESOURCE_NOT_FIND, 
+               WebdavErrorCodes.RESOURCE_NOT_FIND, 
                parentPath, 
                PSWebdavStatus.SC_CONFLICT);
          }
@@ -768,7 +768,7 @@ public abstract class PSWebdavMethod
       else // there is no parent path
       {
          throw new PSWebdavException(
-            IPSWebdavErrors.RESOURCE_NOT_FIND, 
+            WebdavErrorCodes.RESOURCE_NOT_FIND, 
             compPath, 
             PSWebdavStatus.SC_CONFLICT);
       }

--- a/system/servlet/src/com/percussion/webdav/method/PSWebdavUtils.java
+++ b/system/servlet/src/com/percussion/webdav/method/PSWebdavUtils.java
@@ -36,7 +36,7 @@ import com.percussion.util.IPSRemoteRequester;
 import com.percussion.utils.spring.PSUrlHandlerMapping;
 import com.percussion.webdav.IPSWebdavConstants;
 import com.percussion.webdav.PSWebdavStatus;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 import com.percussion.webdav.objectstore.PSWebdavConfig;
 import org.apache.commons.lang3.StringUtils;
@@ -228,7 +228,7 @@ public class PSWebdavUtils
          if (summary == null)
          {
             throw new PSWebdavException(
-               IPSWebdavErrors.RESOURCE_NOT_FIND,
+               WebdavErrorCodes.RESOURCE_NOT_FIND,
                path,
                PSWebdavStatus.SC_NOT_FOUND);
          }
@@ -340,7 +340,7 @@ public class PSWebdavUtils
             String.valueOf(item.getContentId()),
             String.valueOf(item.getContentTypeId())
          };
-         throw new PSWebdavException(IPSWebdavErrors.ITEMFIELD_NOT_EXIST, args);
+         throw new PSWebdavException(WebdavErrorCodes.ITEMFIELD_NOT_EXIST, args);
       }
       else
       {
@@ -641,7 +641,7 @@ public class PSWebdavUtils
 
          if (transitionId == null)
             throw new PSWebdavException(
-                  IPSWebdavErrors.NO_PUBLIC_AUTO_TRANSITION);
+                  WebdavErrorCodes.NO_PUBLIC_AUTO_TRANSITION);
          
          remoteAgent.transitionItem(getLocator(summary, httpRequest),
                transitionId, WEBDAV_AUTO_COMMENT);
@@ -724,7 +724,7 @@ public class PSWebdavUtils
                .getPublicValidTokens(), true);
 
          if (transitionId == null)
-            throw new PSWebdavException(IPSWebdavErrors.NO_QE_AUTO_TRANSITION);
+            throw new PSWebdavException(WebdavErrorCodes.NO_QE_AUTO_TRANSITION);
 
          PSLocator locator = PSWebdavUtils.getLocator(summary, httpRequest);
          remoteAgent.transitionItem(locator, transitionId, null);

--- a/system/servlet/src/com/percussion/webdav/objectstore/PSPropertyFieldNameMapping.java
+++ b/system/servlet/src/com/percussion/webdav/objectstore/PSPropertyFieldNameMapping.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 
 import org.w3c.dom.Document;
@@ -141,7 +141,7 @@ public class PSPropertyFieldNameMapping extends PSWebdavComponent
       if(propName.trim().length() == 0)
          handleValidationExceptions(
             new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
                new Object[] {IPSRxWebDavDTD.ATTR_NAME, getNodeName()}));
 
 
@@ -165,7 +165,7 @@ public class PSPropertyFieldNameMapping extends PSWebdavComponent
          if(fieldName.trim().length() == 0)
             handleValidationExceptions(
                new PSWebdavException(
-                  IPSWebdavErrors.FIELDNAME_CANNOT_BE_EMPTY_OR_MISSING,
+                  WebdavErrorCodes.FIELDNAME_CANNOT_BE_EMPTY_OR_MISSING,
                   propName));
 
          m_propertyName = propName;

--- a/system/servlet/src/com/percussion/webdav/objectstore/PSWebdavConfigDef.java
+++ b/system/servlet/src/com/percussion/webdav/objectstore/PSWebdavConfigDef.java
@@ -36,7 +36,7 @@ import org.xml.sax.SAXException;
 
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 import com.percussion.xml.PSXmlDocumentBuilder;
 
@@ -102,7 +102,7 @@ public class PSWebdavConfigDef extends PSWebdavComponent
          throw new IllegalArgumentException("File cannot be null.");
       // Does the specified file actually exist?
       if (!xmlfile.exists() || !xmlfile.isFile())
-         throw new PSWebdavException(IPSWebdavErrors.FILE_DOES_NOT_EXIST,
+         throw new PSWebdavException(WebdavErrorCodes.FILE_DOES_NOT_EXIST,
                xmlfile.getAbsolutePath());
 
       try( FileInputStream in = new FileInputStream(xmlfile)){
@@ -114,14 +114,14 @@ public class PSWebdavConfigDef extends PSWebdavComponent
       {
          log.error(ie.getMessage());
          log.debug(ie.getMessage(), ie);
-         throw new PSWebdavException(IPSWebdavErrors.IO_EXCEPTION_OCCURED, ie
+         throw new PSWebdavException(WebdavErrorCodes.IO_EXCEPTION_OCCURED, ie
                .getMessage());
       }
       catch (SAXException se)
       {
          log.error(se.getMessage());
          log.debug(se.getMessage(), se);
-         throw new PSWebdavException(IPSWebdavErrors.SAX_EXCEPTION_OCCURED, se
+         throw new PSWebdavException(WebdavErrorCodes.SAX_EXCEPTION_OCCURED, se
                .getMessage());
       }
    }
@@ -183,14 +183,14 @@ public class PSWebdavConfigDef extends PSWebdavComponent
       {
          log.error(ie.getMessage());
          log.debug(ie.getMessage(), ie);
-         throw new PSWebdavException(IPSWebdavErrors.IO_EXCEPTION_OCCURED, ie
+         throw new PSWebdavException(WebdavErrorCodes.IO_EXCEPTION_OCCURED, ie
                .getMessage());
       }
       catch (SAXException se)
       {
          log.error(se.getMessage());
          log.debug(se.getMessage(), se);
-         throw new PSWebdavException(IPSWebdavErrors.SAX_EXCEPTION_OCCURED, se
+         throw new PSWebdavException(WebdavErrorCodes.SAX_EXCEPTION_OCCURED, se
                .getMessage());
       }
    }
@@ -469,22 +469,22 @@ public class PSWebdavConfigDef extends PSWebdavComponent
       // Validate that the required attributes are set
       if (rootPath == null || rootPath.trim().length() == 0)
          handleValidationExceptions(new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED, new Object[] {
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED, new Object[] {
                      IPSRxWebDavDTD.ATTR_ROOT, getNodeName() }));
 
       if (community == null || community.trim().length() == 0)
          handleValidationExceptions(new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED, new Object[] {
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED, new Object[] {
                      IPSRxWebDavDTD.ATTR_COMMUNITY_NAME, getNodeName() }));
 
       if (communityId == null || communityId.trim().length() == 0)
          handleValidationExceptions(new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED, new Object[] {
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED, new Object[] {
                      IPSRxWebDavDTD.ATTR_COMMUNITY_ID, getNodeName() }));
 
       if (locale == null || locale.trim().length() == 0)
          handleValidationExceptions(new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED, new Object[] {
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED, new Object[] {
                      IPSRxWebDavDTD.ATTR_LOCALE, getNodeName() }));
 
       if (deleteAs != null
@@ -529,7 +529,7 @@ public class PSWebdavConfigDef extends PSWebdavComponent
          if (typeNames.contains(ct.getName()))
          {
             handleValidationExceptions(new PSWebdavException(
-                  IPSWebdavErrors.DUPLICATE_CONTENTTYPE_NAMES, ct.getName()));
+                  WebdavErrorCodes.DUPLICATE_CONTENTTYPE_NAMES, ct.getName()));
          }
          typeNames.add(ct.getName());
          if (ct.isDefault())
@@ -537,7 +537,7 @@ public class PSWebdavConfigDef extends PSWebdavComponent
             if (gotDefault)
             {
                handleValidationExceptions(new PSWebdavException(
-                     IPSWebdavErrors.CAN_ONLY_HAVE_ONE_DEFAULT_CONTENTTYPE));
+                     WebdavErrorCodes.CAN_ONLY_HAVE_ONE_DEFAULT_CONTENTTYPE));
             }
             gotDefault = true;
          }

--- a/system/servlet/src/com/percussion/webdav/objectstore/PSWebdavContentType.java
+++ b/system/servlet/src/com/percussion/webdav/objectstore/PSWebdavContentType.java
@@ -19,7 +19,7 @@ package com.percussion.webdav.objectstore;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.util.PSXMLDomUtil;
 import com.percussion.webdav.IPSWebdavConstants;
-import com.percussion.webdav.error.IPSWebdavErrors;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
 import com.percussion.webdav.error.PSWebdavException;
 
 import java.util.ArrayList;
@@ -343,7 +343,7 @@ public class PSWebdavContentType
          {
             handleValidationExceptions(
                new PSWebdavException(
-                  IPSWebdavErrors.CANNOT_HAVE_DUPLICATE_PROPERTIES));
+                  WebdavErrorCodes.CANNOT_HAVE_DUPLICATE_PROPERTIES));
          }
          addPropertyFieldMapping(mapping);
 
@@ -355,25 +355,25 @@ public class PSWebdavContentType
       if(name.trim().length() == 0)
          handleValidationExceptions(
             new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
                new Object[] {IPSRxWebDavDTD.ATTR_NAME, getNodeName()}));
 
       if(id.trim().length() == 0)
          handleValidationExceptions(
             new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
                new Object[] {IPSRxWebDavDTD.ATTR_ID, getNodeName()}));
 
       if(contentfield.trim().length() == 0)
          handleValidationExceptions(
             new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
                new Object[] {IPSRxWebDavDTD.ATTR_CONTENTFIELD, getNodeName()}));
 
       if(ownerfield.trim().length() == 0)
          handleValidationExceptions(
             new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
                new Object[] {IPSRxWebDavDTD.ATTR_OWNERFIELD, getNodeName()}));
 
       validateRequiredProperties(name);
@@ -382,7 +382,7 @@ public class PSWebdavContentType
       if(!def && m_mimetypes.isEmpty())
          handleValidationExceptions(
             new PSWebdavException(
-               IPSWebdavErrors.MIMETYPES_REQUIRED));
+               WebdavErrorCodes.MIMETYPES_REQUIRED));
 
       try
       {
@@ -392,7 +392,7 @@ public class PSWebdavContentType
       {
          handleValidationExceptions(
             new PSWebdavException(
-               IPSWebdavErrors.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
+               WebdavErrorCodes.XML_ATTRIBUTE_MUST_BE_SPECIFIED,
                new Object[] {IPSRxWebDavDTD.ATTR_ID, getNodeName()}));
       }
       
@@ -461,7 +461,7 @@ public class PSWebdavContentType
             
             handleValidationExceptions(
                new PSWebdavException(
-                  IPSWebdavErrors.MISSING_REQUIRED_PROPERTY,
+                  WebdavErrorCodes.MISSING_REQUIRED_PROPERTY,
                   new Object[] {required[i], name}));      
          }
       }

--- a/system/src/main/java/com/percussion/cms/objectstore/client/PSRemoteException.java
+++ b/system/src/main/java/com/percussion/cms/objectstore/client/PSRemoteException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cms.objectstore.client;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /** Exceptions of this type will be thrown from the Remote Agent */
@@ -41,6 +42,35 @@ public class PSRemoteException extends PSException {
    */
   public PSRemoteException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction from a catalogued {@link IPSErrorCode} (e.g. {@code RemoteErrorCodes}).
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSRemoteException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSRemoteException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSRemoteException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /**

--- a/system/src/test/java/com/percussion/hooks/PSServletHookTypedErrorCodeSliceTest.java
+++ b/system/src/test/java/com/percussion/hooks/PSServletHookTypedErrorCodeSliceTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.hooks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.ServletErrorCodes;
+import com.percussion.error.IPSErrorCode;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3848 (parent #2616): leftover servlet-hook production call sites use typed {@link
+ * ServletErrorCodes} (not bare {@code IPSServletErrors} ints). Catalog codes are non-auditable.
+ */
+@Tag("UnitTest")
+public class PSServletHookTypedErrorCodeSliceTest {
+
+  @Test
+  public void invalidPortFormatMessageUsesTypedCatalogCode() {
+    String msg =
+        PSConnectionFactory.formatMessage(
+            ServletErrorCodes.INVALID_PORT_NUMBER, new Object[] {"not-a-port"});
+    assertTrue(msg.contains("not-a-port"));
+    assertEquals(10152, ServletErrorCodes.INVALID_PORT_NUMBER.numericCode());
+    assertFalse(ServletErrorCodes.INVALID_PORT_NUMBER.isAuditable());
+  }
+
+  @Test
+  public void connectionFailureFormatMessageUsesTypedCatalogCode() {
+    String msg = PSConnectionFactory.formatMessage(ServletErrorCodes.CONNECTION_FAILURE, null);
+    assertFalse(msg.isBlank());
+    assertEquals(10155, ServletErrorCodes.CONNECTION_FAILURE.numericCode());
+    assertFalse(ServletErrorCodes.CONNECTION_FAILURE.isAuditable());
+  }
+
+  @Test
+  public void typedServletExceptionRetainsNonAuditableCode() {
+    Object[] args = {"9999x"};
+    PSServletException ex =
+        new PSServletException(ServletErrorCodes.INVALID_PORT_NUMBER, args);
+    assertEquals(ServletErrorCodes.INVALID_PORT_NUMBER.numericCode(), ex.getErrorCode());
+    assertSame(ServletErrorCodes.INVALID_PORT_NUMBER, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void typedServletExceptionNoArgCtorRetainsCode() {
+    PSServletException ex = new PSServletException(ServletErrorCodes.SERVLET_DESTROYED);
+    assertEquals(ServletErrorCodes.SERVLET_DESTROYED.numericCode(), ex.getErrorCode());
+    assertSame(ServletErrorCodes.SERVLET_DESTROYED, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void typedConstructorsRejectNullCode() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSServletException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PSConnectionFactory.formatMessage((IPSErrorCode) null, null));
+  }
+}

--- a/system/src/test/java/com/percussion/webdav/PSWebdavTypedErrorCodeSliceTest.java
+++ b/system/src/test/java/com/percussion/webdav/PSWebdavTypedErrorCodeSliceTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.webdav;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.intsof.percussioncms.auditlog.codes.RemoteErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.WebdavErrorCodes;
+import com.percussion.cms.objectstore.client.PSRemoteException;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.webdav.error.PSWebdavException;
+import com.percussion.webdav.method.PSMethodFactory;
+import com.percussion.webdav.objectstore.PSWebdavConfigDef;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3848 (parent #2616): leftover WebDAV production throw sites use typed {@link
+ * WebdavErrorCodes} via IPSErrorCode-aware {@link PSWebdavException} constructors — not bare {@code
+ * IPSWebdavErrors} ints. Catalog codes are non-auditable.
+ */
+@Tag("UnitTest")
+public class PSWebdavTypedErrorCodeSliceTest {
+
+  @Test
+  public void unsupportedMethodThrowsTypedNonAuditableException() {
+    HttpServletRequest req = mock(HttpServletRequest.class);
+    HttpServletResponse resp = mock(HttpServletResponse.class);
+    PSWebdavServlet servlet = mock(PSWebdavServlet.class);
+
+    PSWebdavException ex =
+        assertThrows(
+            PSWebdavException.class,
+            () -> PSMethodFactory.createMethod("TRACE", req, resp, servlet));
+    assertEquals(WebdavErrorCodes.UNSUPPORTED_METHOD.numericCode(), ex.getErrorCode());
+    assertSame(WebdavErrorCodes.UNSUPPORTED_METHOD, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+    assertEquals(PSWebdavStatus.SC_METHOD_NOT_ALLOWED, ex.getStatusCode());
+  }
+
+  @Test
+  public void missingConfigFileThrowsTypedNonAuditableException() {
+    Path missing =
+        Path.of(System.getProperty("java.io.tmpdir"), "percussion-webdav-missing-config.xml");
+    PSWebdavException ex =
+        assertThrows(PSWebdavException.class, () -> new PSWebdavConfigDef(missing.toFile()));
+    assertEquals(WebdavErrorCodes.FILE_DOES_NOT_EXIST.numericCode(), ex.getErrorCode());
+    assertSame(WebdavErrorCodes.FILE_DOES_NOT_EXIST, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void headerMissingCtorRetainsTypedCodeAndStatus() {
+    PSWebdavException ex =
+        new PSWebdavException(
+            WebdavErrorCodes.HEADER_MISSING, "Destination", PSWebdavStatus.SC_BAD_REQUEST);
+    assertEquals(WebdavErrorCodes.HEADER_MISSING.numericCode(), ex.getErrorCode());
+    assertSame(WebdavErrorCodes.HEADER_MISSING, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+    assertEquals(PSWebdavStatus.SC_BAD_REQUEST, ex.getStatusCode());
+  }
+
+  @Test
+  public void typedConstructorRejectsNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSWebdavException((IPSErrorCode) null));
+  }
+
+  @Test
+  public void remoteUnexpectedErrorRetainsTypedNonAuditableCode() {
+    PSRemoteException ex =
+        new PSRemoteException(RemoteErrorCodes.REMOTE_UNEXPECTED_ERROR, "timeout");
+    assertEquals(RemoteErrorCodes.REMOTE_UNEXPECTED_ERROR.numericCode(), ex.getErrorCode());
+    assertSame(RemoteErrorCodes.REMOTE_UNEXPECTED_ERROR, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+}


### PR DESCRIPTION
## Summary

Parent #2616 leftover slice (#3848). Retype leftover **perc-system servlet/WebDAV** production `IPS*Errors` call-sites to typed `ServletErrorCodes` / `WebdavErrorCodes` / `RemoteErrorCodes`. Dual-write skip tests cover non-auditable leftover catalogs. Residual allow-list shrunk for those 17 servlet paths.

Hooks format messages via `PSConnectionFactory.formatMessage(IPSErrorCode, …)`. WebDAV throws `PSWebdavException` with typed constructors. `PSWebdavMethod` leftover `IPSRemoteErrors` converted so the allow-list row could be removed.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3848
Partial #2616

## Test plan

1. `cd modules/perc-auditlog && ../../mvnw.cmd clean install`
2. `cd system && ../mvnw.cmd clean install`
3. `cd deployer && ../mvnw.cmd clean install`
4. `python scripts/verify-no-bare-ipserrors.py` — PASS (servlet paths no longer residual)
5. No live WebDAV soak (out of scope)

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal error-catalog retype; numeric codes and operator-visible messages unchanged
- [x] **Unit / module tests** — behavioral tests for typed throws / formatMessage / dual-write skip; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when `final`/API shape changes
- [x] **Cross-platform** — missing-config test uses `Path.of(System.getProperty("java.io.tmpdir"), …)`

### C3 evidence

- **modules_built:** `modules/perc-auditlog`, `system`, `deployer`
- **build_evidence:**
  - `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 307, Failures: 0; `ServletWebdavResidualErrorCodesDualWriteTest` 3 tests
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2387, Failures: 0; `PSServletHookTypedErrorCodeSliceTest` 5 tests; `PSWebdavTypedErrorCodeSliceTest` 5 tests
  - `cd deployer && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 306, Failures: 0, Skipped: 19; `PSWebdavConfigTest` 13 tests
  - `python scripts/verify-no-bare-ipserrors.py` → PASS
- **downstream_checked:** C2 additive constructors only (not `final`/signature-breaking). Grep: no anonymous `new PSWebdavException() {` / `new PSServletException() {`; only subclass is `PSWebdavException extends PSServletException`. Reverse-dep `deployer` standalone clean install green (tests compile against typed throws).
- **C5 UI proof:** N/A (pure Java backend error-catalog retype; no WebUI/Playwright surface)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
