### PR TITLE
fix(explorer): find/types 400 + find/templates 500 (#3855)

### DIFF
--- a/WebUI/src/main/ts/api/contentExplorer/actionMenuApi.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/actionMenuApi.ts
@@ -52,11 +52,40 @@
 
 import { get, post } from "../client";
 import { PATHS } from "../paths";
+import { parseExplorerContentId } from "./pathItemId";
 import type {
   ActionMenu,
   AllowedContentTypeMenusRequest,
   MenuAction,
 } from "./types";
+
+/** Jackson WRAP_ROOT_VALUE root for {@link AllowedContentTypeMenusRequest}. */
+export const ALLOWED_CONTENT_TYPE_MENUS_REQUEST_ROOT =
+  "AllowedContentTypeMenusRequest";
+
+export type AllowedContentTypeMenusRequestEnvelope = {
+  AllowedContentTypeMenusRequest: AllowedContentTypeMenusRequest;
+};
+
+/**
+ * Wrap {@code contentIds} under {@link ALLOWED_CONTENT_TYPE_MENUS_REQUEST_ROOT}.
+ * Coerces GUID last-segments ({@code 16777215-101-551}) to ints so UNWRAP_ROOT_VALUE
+ * never sees a string array (#3855).
+ */
+export function wrapAllowedContentTypeMenusRequest(
+  contentIds: Array<number | string | undefined | null>,
+): AllowedContentTypeMenusRequestEnvelope {
+  const ids: number[] = [];
+  for (const raw of contentIds ?? []) {
+    const id = parseExplorerContentId(raw);
+    if (id != null) {
+      ids.push(id);
+    }
+  }
+  return {
+    AllowedContentTypeMenusRequest: { contentIds: ids },
+  };
+}
 
 // ---------- Wire envelopes (internal) ----------
 
@@ -143,9 +172,9 @@ export async function findActions(
  * menus allowed for the supplied contentIds.</p>
  */
 export async function findAllowedContentTypeMenus(
-  contentIds: number[],
+  contentIds: Array<number | string>,
 ): Promise<ActionMenu[]> {
-  const body: AllowedContentTypeMenusRequest = { contentIds };
+  const body = wrapAllowedContentTypeMenusRequest(contentIds);
   const res = await post<unknown>(`${PATHS.ACTIONS_ROOT}/find/types`, body);
   return unwrapActionMenuListPayload(res);
 }

--- a/WebUI/src/main/ts/api/contentExplorer/types.ts
+++ b/WebUI/src/main/ts/api/contentExplorer/types.ts
@@ -504,7 +504,8 @@ export interface ActionMenu {
 
 /**
  * Wire body for {@code POST /actions/find/types}. Mirrors
- * {@code AllowedContentTypeMenusRequest}.
+ * {@code AllowedContentTypeMenusRequest}. Live posts wrap this under
+ * {@code AllowedContentTypeMenusRequest} for UNWRAP_ROOT_VALUE (#3855).
  */
 export interface AllowedContentTypeMenusRequest {
   contentIds: number[];

--- a/WebUI/src/test/ts/contentExplorer/actionMenuApi.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/actionMenuApi.test.ts
@@ -25,6 +25,7 @@ import {
   nestActionMenusByParentId,
   unwrapActionMenuChildren,
   unwrapActionMenuListPayload,
+  wrapAllowedContentTypeMenusRequest,
 } from "../../../main/ts/api/contentExplorer/actionMenuApi";
 import { PATHS } from "../../../main/ts/api/paths";
 
@@ -320,8 +321,30 @@ describe("actionMenuApi REST wrappers", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const init = fetchMock.mock.calls[0]?.[1];
     expect(init?.method).toBe("POST");
-    expect(JSON.parse(String(init?.body))).toEqual({ contentIds: [101, 102] });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      AllowedContentTypeMenusRequest: { contentIds: [101, 102] },
+    });
     expect(result.map((m) => m.name)).toEqual(["trans1", "trans2"]);
+  });
+
+  it("findAllowedContentTypeMenus coerces GUID last-segment to int (#3855)", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ ActionMenuList: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await findAllowedContentTypeMenus(["16777215-101-551"]);
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(JSON.parse(String(init?.body))).toEqual({
+      AllowedContentTypeMenusRequest: { contentIds: [551] },
+    });
+  });
+
+  it("wrapAllowedContentTypeMenusRequest drops unparseable tokens", () => {
+    expect(wrapAllowedContentTypeMenusRequest(["16777215-101-551", 42, "nope"])).toEqual({
+      AllowedContentTypeMenusRequest: { contentIds: [551, 42] },
+    });
   });
 
   it("findAllowedTemplateMenus passes contentId + isAA query param and unwraps ActionMenuList", async () => {

--- a/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
+++ b/WebUI/src/test/ts/contentExplorer/menuCatalogLoad.test.ts
@@ -270,6 +270,57 @@ describe("loadExplorerMenuCatalog", () => {
     expect(actions[0]?.children?.map((c) => c.name)).toContain("open");
     expect(actions[0]?.children?.map((c) => c.name)).toContain("new-page");
     expect(global.fetch).toHaveBeenCalledTimes(4);
+    const typesInit = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1]?.[1];
+    expect(JSON.parse(String(typesInit?.body))).toEqual({
+      AllowedContentTypeMenusRequest: { contentIds: [101] },
+    });
+  });
+
+  it("posts GUID last-segment as int contentIds for find/types (#3855)", async () => {
+    vi.spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ActionMenu: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ActionMenuList: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ActionMenuList: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ActionMenuList: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    await loadExplorerMenuCatalog({
+      id: "16777215-101-551",
+      name: "Corporate Investments Home",
+      type: "percPage",
+      path: "/Sites/Corporate_Investments/Corporate Investments Home",
+      folderPath: "/Sites/Corporate_Investments",
+      displayProperties: { workflowId: "5" },
+    } as never);
+    const typesCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(String(typesCall?.[0])).toContain("/actions/find/types");
+    expect(JSON.parse(String(typesCall?.[1]?.body))).toEqual({
+      AllowedContentTypeMenusRequest: { contentIds: [551] },
+    });
+    expect(String((global.fetch as ReturnType<typeof vi.fn>).mock.calls[2]?.[0])).toContain(
+      "/actions/find/templates/551?isAA=false",
+    );
+    expect(String((global.fetch as ReturnType<typeof vi.fn>).mock.calls[3]?.[0])).toContain(
+      "/actions/find/templates/551?isAA=true",
+    );
   });
 
   it("uses only find() for folder-only selection", async () => {

--- a/docs/ai-generated/code-reviews/3855-explorer-find-types-templates-erlang.md
+++ b/docs/ai-generated/code-reviews/3855-explorer-find-types-templates-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3855 Explorer find/types 400 + find/templates 500
+
+Persona: independent of implementer. Date: 2026-08-26.
+
+## Verdict
+
+**Pass** (no bug/hard-gate findings). Residual risk is C5 live proof on H2 QA (Playwright), required before PR.
+
+## Change class
+
+Explorer REST + SPA catalog bind: `POST /actions/find/types` Jackson envelope/GUID tokens, `GET /actions/find/templates/{id}` uncaught helper failures.
+
+## Companions (closure)
+
+| Layer | Artifact |
+|-------|----------|
+| rest resource | `ActionMenuResource` null-safe empty list, no 500 |
+| rest wire | `AllowedContentTypeMenusRequestJsonReader` + `JsonRootName` |
+| rest tests | JsonReader, CXF unmarshall, serial/deserial, resource Mockito |
+| sitemanage | beans.xml provider ahead of jackson; adaptor catch; convert null PK |
+| sitemanage tests | CatalogRestJaxrsRegistrationTest; adaptor/convert unit tests |
+| WebUI | WRAP_ROOT envelope + GUID last-segment coerce |
+| Vitest | actionMenuApi + menuCatalogLoad |
+| Playwright | explorer-console-clean + explorer-preview-view collectors |
+| product-docs | N/A — operator Preview/actions steps unchanged |
+
+## Hard gates
+
+- **Bugs:** None remaining. Live 500 was JAXB `ActionMenu nor any of its super class is known to this context` — fixed with `@XmlSeeAlso(ActionMenu.class)` on `ActionMenuList` (peer `SiteList`). SPA posts WRAP_ROOT `{AllowedContentTypeMenusRequest:{contentIds:[551]}}` (GUID last-segment coerced). JsonReader still binds flat/GUID when Jackson is selected (CXF unit tests).
+- **Tests:** Behavioral unit tests for production types (`int[]`, GUID string, wrapped envelope). CXF local POST proves HTTP 200.
+- **Portable paths:** Java uses `StandardCharsets` / Jackson trees; Playwright URL regexes; no OS path joins.
+- **C2:** No `final`/`sealed` type; `ActionMenuList(Collection)` still accepts the same type (null-safe). TS `findAllowedContentTypeMenus` widened `number[]` → `Array<number\|string>`. Downstream: sitemanage clean install against rest SNAPSHOT.
+
+## Notes (not blocking)
+
+- Swallowing adaptor `RuntimeException` as empty 200 can hide a still-broken helper; C5 must prove HTTP 200 with a selected rffHome row.
+- `GET /actions/find/templates/{id}` path param remains `int` (SPA sends numeric last-segment).

--- a/modules/perc-qa-automation/frontend/tests/explorer-console-clean.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-console-clean.spec.js
@@ -16,9 +16,11 @@
  */
 
 /**
- * Playwright surface: #3468 / #3458 / parent #2745 — Explorer shell
+ * Playwright surface: #3468 / #3458 / parent #2745 / #3855 — Explorer shell
  * console-clean of product-path 404/400 (login → Explorer → sample site
  * folder → Refresh). Covers both /services and /Rhythmyx/services prefixes.
+ * Find/types 400 + find/templates 500 after page select is asserted in
+ * {@code explorer-preview-view.spec.js} (listed-page navigation).
  *
  * Does not blanket-skip 404/400 resource errors.
  *

--- a/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/explorer-preview-view.spec.js
@@ -16,7 +16,7 @@
 
 /**
  * Playwright surface: #2733 / #3456 / #3463 / #3627 / #3688 / #3696 / #3716 /
- * #3719 / #3722 / #3809 — Explorer preview for a listed page on
+ * #3719 / #3722 / #3809 / #3855 — Explorer preview for a listed page on
  * {@code spa.jsp?entry=explorer}.
  *
  * <p>Verifies product shell chrome for Preview + Refresh, then opens
@@ -35,6 +35,10 @@
 
 const { test, expect, errors } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL, adminBasicAuthHeaders } = require("./helpers/auth");
+const {
+  attachFindMenuStatusCollector,
+  formatHits,
+} = require("./helpers/explorer-console-clean");
 const {
   TEST_IDS,
   explorerEntryUrl,
@@ -446,6 +450,7 @@ test.describe("modern React Content Explorer — preview + view residual (#2733 
       test.setTimeout(90_000);
       const pageErrors = [];
       page.on("pageerror", (err) => pageErrors.push(String(err)));
+      const { hits: findMenuHits } = attachFindMenuStatusCollector(page, BASE_URL);
       const checkInFailures = [];
       page.on("response", (res) => {
         const u = res.url();
@@ -509,7 +514,40 @@ test.describe("modern React Content Explorer — preview + view residual (#2733 
         pageRow = byName;
       }
 
+      const typesPromise = page
+        .waitForResponse(
+          (res) => /\/actions\/find\/types(?:\?|$)/i.test(res.url()),
+          { timeout: 15_000 },
+        )
+        .catch(() => null);
+      const templatesPromise = page
+        .waitForResponse(
+          (res) => /\/actions\/find\/templates\//i.test(res.url()),
+          { timeout: 15_000 },
+        )
+        .catch(() => null);
       await pageRow.click({ force: true });
+      const typesRes = await typesPromise;
+      const templatesRes = await templatesPromise;
+      expect(
+        typesRes,
+        "selecting a listed page must POST /actions/find/types",
+      ).not.toBeNull();
+      expect(
+        typesRes.status(),
+        `POST find/types must be HTTP 200, not 400; ${typesRes.url()}`,
+      ).toBe(200);
+      if (templatesRes) {
+        expect(
+          templatesRes.status(),
+          `GET find/templates must not be HTTP 500; ${templatesRes.url()}`,
+        ).toBeLessThan(500);
+      }
+      await page.waitForLoadState("networkidle").catch(() => {});
+      expect(
+        findMenuHits,
+        `find/types 400 or find/templates 500 after select:\n${formatHits(findMenuHits)}`,
+      ).toEqual([]);
       const preview = page.locator(`[data-testid="${TEST_IDS.preview}"]`);
       await expect(preview).toBeEnabled({ timeout: 10_000 });
 

--- a/modules/perc-qa-automation/frontend/tests/helpers/explorer-console-clean.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/explorer-console-clean.js
@@ -62,6 +62,34 @@ function isTrackedHttpStatus(status) {
 }
 
 /**
+ * Explorer action-menu catalog calls that human QA failed on #3716 / #3855.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isFindTypesUrl(url) {
+  return /\/actions\/find\/types(?:\?|$)/i.test(String(url || ""));
+}
+
+/**
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isFindTemplatesUrl(url) {
+  return /\/actions\/find\/templates\//i.test(String(url || ""));
+}
+
+/**
+ * Track 400/500 on find/types and find/templates (not 404 — empty catalog is 200).
+ *
+ * @param {number} status
+ * @returns {boolean}
+ */
+function isTrackedFindMenuStatus(status) {
+  return status === 400 || status === 500;
+}
+
+/**
  * Attach response + pageerror collectors for product 400/404.
  *
  * @param {import("@playwright/test").Page} page
@@ -81,6 +109,41 @@ function attachProductStatusCollector(page, baseUrl) {
     }
     const url = res.url();
     if (!isProductPathUrl(url, baseUrl)) {
+      return;
+    }
+    hits.push({
+      status,
+      method: res.request().method(),
+      url,
+    });
+  });
+  return { hits, pageErrors };
+}
+
+/**
+ * Attach collectors for {@code POST /actions/find/types} 400 and
+ * {@code GET /actions/find/templates/{id}} 500 (#3855 / parent #3716).
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} baseUrl
+ * @returns {{ hits: {status:number, method:string, url:string}[], pageErrors: string[] }}
+ */
+function attachFindMenuStatusCollector(page, baseUrl) {
+  const hits = [];
+  const pageErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("response", (res) => {
+    const url = res.url();
+    if (!isProductPathUrl(url, baseUrl)) {
+      return;
+    }
+    if (!isFindTypesUrl(url) && !isFindTemplatesUrl(url)) {
+      return;
+    }
+    const status = res.status();
+    if (!isTrackedFindMenuStatus(status)) {
       return;
     }
     hits.push({
@@ -116,7 +179,11 @@ module.exports = {
   explorerSpaUrl,
   isProductPathUrl,
   isTrackedHttpStatus,
+  isFindTypesUrl,
+  isFindTemplatesUrl,
+  isTrackedFindMenuStatus,
   attachProductStatusCollector,
+  attachFindMenuStatusCollector,
   formatHits,
   isKnownExplorerTransientNetworkConsoleNoise,
 };

--- a/modules/perc-qa-automation/frontend/tests/unit/explorer-console-clean.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/explorer-console-clean.test.js
@@ -20,6 +20,9 @@ const assert = require("node:assert/strict");
 const {
   isProductPathUrl,
   isTrackedHttpStatus,
+  isFindTypesUrl,
+  isFindTemplatesUrl,
+  isTrackedFindMenuStatus,
   formatHits,
   isKnownExplorerTransientNetworkConsoleNoise,
 } = require("../helpers/explorer-console-clean");
@@ -30,6 +33,27 @@ describe("explorer-console-clean helpers (#3458)", () => {
     assert.equal(isTrackedHttpStatus(404), true);
     assert.equal(isTrackedHttpStatus(200), false);
     assert.equal(isTrackedHttpStatus(500), false);
+  });
+
+  it("isFindTypesUrl / isFindTemplatesUrl match Explorer catalog calls (#3855)", () => {
+    const base = "http://127.0.0.1:9993";
+    assert.equal(
+      isFindTypesUrl(`${base}/Rhythmyx/services/actions/find/types`),
+      true,
+    );
+    assert.equal(
+      isFindTemplatesUrl(`${base}/Rhythmyx/services/actions/find/templates/551?isAA=false`),
+      true,
+    );
+    assert.equal(
+      isFindTemplatesUrl(`${base}/Rhythmyx/services/actions/find/templates/551?isAA=true`),
+      true,
+    );
+    assert.equal(isFindTypesUrl(`${base}/Rhythmyx/services/actions/find`), false);
+    assert.equal(isTrackedFindMenuStatus(400), true);
+    assert.equal(isTrackedFindMenuStatus(500), true);
+    assert.equal(isTrackedFindMenuStatus(200), false);
+    assert.equal(isTrackedFindMenuStatus(404), false);
   });
 
   it("isProductPathUrl keeps CMS services/rest/cm paths", () => {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -158,14 +158,28 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
 
   @Override
   public List<ActionMenu> findAllowedContentTypes(Integer[] contentIds) {
-    return ApiUtils.convertPSActionMenuList(
-        PSContentTypeActionMenuHelper.getInstance().getContentTypeMenus(null));
+    try {
+      return ApiUtils.convertPSActionMenuList(
+          PSContentTypeActionMenuHelper.getInstance().getContentTypeMenus(null));
+    } catch (RuntimeException e) {
+      log.error("Error finding allowed content-type menus: {}", e.getMessage(), e);
+      return Collections.emptyList();
+    }
   }
 
   @Override
   public List<ActionMenu> findAllowedTemplates(Integer contentId, boolean isAA) {
-    return ApiUtils.convertPSActionMenuList(
-        PSTemplateActionMenuHelper.getInstance().getTemplateMenus(contentId, isAA, null));
+    if (contentId == null || contentId <= 0) {
+      return Collections.emptyList();
+    }
+    try {
+      return ApiUtils.convertPSActionMenuList(
+          PSTemplateActionMenuHelper.getInstance().getTemplateMenus(contentId, isAA, null));
+    } catch (RuntimeException e) {
+      log.error(
+          "Error finding allowed templates for contentId {}: {}", contentId, e.getMessage(), e);
+      return Collections.emptyList();
+    }
   }
 
   @Override

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -859,6 +859,9 @@ public class ApiUtils {
     ArrayList<ActionMenuProperty> props = new ArrayList<>();
     if (pa.getProperties() != null) {
       for (PSActionMenuProperty pap : pa.getProperties()) {
+        if (pap == null || pap.getPrimaryKey() == null) {
+          continue;
+        }
         ActionMenuProperty p = new ActionMenuProperty();
         p.setActionId(pap.getPrimaryKey().getActionId());
         p.setName(pap.getPrimaryKey().getPropertyName());
@@ -873,6 +876,9 @@ public class ApiUtils {
     ArrayList<ActionMenuParameter> params = new ArrayList<>();
     if (pa.getParameters() != null) {
       for (PSActionMenuParam psparam : pa.getParameters()) {
+        if (psparam == null || psparam.getActionParamPK() == null) {
+          continue;
+        }
         ActionMenuParameter p = new ActionMenuParameter();
         p.setDescription(psparam.getDescription());
         p.setName(psparam.getActionParamPK().getParamName());
@@ -886,7 +892,9 @@ public class ApiUtils {
     ArrayList<ActionMenuVisibilityContext> vis = new ArrayList<>();
     if (pa.getVisibility() != null) {
       for (PSActionMenuVisibility v : pa.getVisibility()) {
-
+        if (v == null || v.getPrimaryKey() == null) {
+          continue;
+        }
         ActionMenuVisibilityContext vc = new ActionMenuVisibilityContext();
 
         vc.setDescription(v.getPrimaryKey().getDescription());

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -133,6 +133,10 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <!-- #3360 / #3361: Explorer folder create posts flat {name,parentPath};
                  JAXB expects AddFolderRequest root. Bind both envelopes. -->
             <ref bean="addFolderRequestJsonReader" />
+            <!-- #3855: Explorer POST /actions/find/types posts flat {contentIds} and
+                 GUID last-segment tokens; JAXB / UNWRAP_ROOT_VALUE expects
+                 AllowedContentTypeMenusRequest. Bind both envelopes. -->
+            <ref bean="allowedContentTypeMenusRequestJsonReader" />
             <ref bean="jacksonProvider" />
             <ref bean="jacksonContextResolver" />
             <ref bean="authorizationFilter" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorFilterTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorFilterTest.java
@@ -18,8 +18,10 @@ package com.percussion.apibridge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import com.percussion.rest.actions.ActionMenu;
+import com.percussion.webservices.ui.IPSUiDesignWs;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -110,6 +112,14 @@ public class ActionMenuAdaptorFilterTest {
         ActionMenuAdaptor.filterMenus(Collections.emptyList(), "x", null, null, null, null)
             .isEmpty());
     assertTrue(ActionMenuAdaptor.filterMenus(null, "x", null, null, null, null).isEmpty());
+  }
+
+  @Test
+  public void findAllowedTemplatesRejectsNonPositiveIds() {
+    ActionMenuAdaptor adaptor = new ActionMenuAdaptor(mock(IPSUiDesignWs.class));
+    assertTrue(adaptor.findAllowedTemplates(null, false).isEmpty());
+    assertTrue(adaptor.findAllowedTemplates(0, true).isEmpty());
+    assertTrue(adaptor.findAllowedTemplates(-1, false).isEmpty());
   }
 
   private static ActionMenu menu(String name, String label, String type, String url) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsActionMenuConvertTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ApiUtilsActionMenuConvertTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.actions.ActionMenu;
 import com.percussion.services.menus.PSActionMenu;
+import com.percussion.services.menus.PSActionMenuProperty;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
@@ -112,5 +113,19 @@ public class ApiUtilsActionMenuConvertTest {
   @Test
   public void convertListNullIsEmpty() {
     assertTrue(ApiUtils.convertPSActionMenuList(null).isEmpty());
+  }
+
+  @Test
+  public void convertSkipsPropertiesWithoutPrimaryKey() {
+    PSActionMenu leaf =
+        new PSActionMenu("preview", "Preview", TYPE_MENUITEM, "/p", "server", 0);
+    leaf.setActionId(12);
+    leaf.addProperty(new PSActionMenuProperty());
+    leaf.addProperty(new PSActionMenuProperty(12, "launchesWindow", "yes"));
+    ActionMenu converted = ApiUtils.convertPSActionMenu(leaf);
+    assertEquals("preview", converted.getName());
+    assertNotNull(converted.getProperties());
+    assertEquals(1, converted.getProperties().length);
+    assertEquals("launchesWindow", converted.getProperties()[0].getName());
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -65,6 +65,10 @@ class CatalogRestJaxrsRegistrationTest {
   /** Explorer folder create #3360 — must precede jacksonProvider. */
   private static final String ADD_FOLDER_JSON_READER = "addFolderRequestJsonReader";
 
+  /** Explorer find/types #3855 — must precede jacksonProvider. */
+  private static final String FIND_TYPES_JSON_READER =
+      "allowedContentTypeMenusRequestJsonReader";
+
   @Test
   void restJaxRsServiceBeansIncludeDeveloperCatalogResources() throws Exception {
     Path root = resolveRepoRoot();
@@ -112,6 +116,7 @@ class CatalogRestJaxrsRegistrationTest {
     int searchReader = providerBlock.indexOf("bean=\"" + SEARCH_EXECUTE_JSON_READER + "\"");
     int aclReader = providerBlock.indexOf("bean=\"" + ACL_LIST_JSON_READER + "\"");
     int addFolderReader = providerBlock.indexOf("bean=\"" + ADD_FOLDER_JSON_READER + "\"");
+    int findTypesReader = providerBlock.indexOf("bean=\"" + FIND_TYPES_JSON_READER + "\"");
     int jackson = providerBlock.indexOf("bean=\"jacksonProvider\"");
     assertTrue(
         reader >= 0,
@@ -133,6 +138,11 @@ class CatalogRestJaxrsRegistrationTest {
         "rest-jax-rs providers must ref "
             + ADD_FOLDER_JSON_READER
             + " (missing → folder create unexpected element name / AddFolderRequest)");
+    assertTrue(
+        findTypesReader >= 0,
+        "rest-jax-rs providers must ref "
+            + FIND_TYPES_JSON_READER
+            + " (missing → Explorer find/types flat contentIds / GUID 400)");
     assertTrue(jackson >= 0, "rest-jax-rs providers must still ref jacksonProvider");
     assertTrue(
         reader < jackson,
@@ -146,6 +156,9 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(
         addFolderReader < jackson,
         ADD_FOLDER_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        findTypesReader < jackson,
+        FIND_TYPES_JSON_READER + " must be listed before jacksonProvider");
   }
 
   private static Path resolveRepoRoot() {

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuList.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuList.java
@@ -22,8 +22,10 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -39,9 +41,15 @@ import java.util.Objects;
  * [...]}} for top-level {@code /actions/find/types} and {@code
  * /actions/find/templates/{id}}. Nested {@code children} stay a JSON array
  * because WRAP_ROOT_VALUE only wraps the document root.
+ *
+ * <p>{@link XmlSeeAlso} registers {@link ActionMenu} in the JAXB context so
+ * those list endpoints can marshal. Without it, CXF JAXB JSON fails with
+ * {@code ActionMenu nor any of its super class is known to this context} (HTTP
+ * 500, #3855). Peer: {@link com.percussion.rest.sites.SiteList}.
  */
 @XmlRootElement(name = "ActionMenuList")
 @JsonRootName("ActionMenuList")
+@XmlSeeAlso(ActionMenu.class)
 @ArraySchema(schema = @Schema(implementation = ActionMenu.class))
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 public class ActionMenuList extends ArrayList<ActionMenu> {
@@ -59,7 +67,7 @@ public class ActionMenuList extends ArrayList<ActionMenu> {
    * @param c the source collection
    */
   public ActionMenuList(Collection<? extends ActionMenu> c) {
-    super(c);
+    super(c != null ? c : Collections.emptyList());
   }
 
   @Override

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -214,9 +214,19 @@ public class ActionMenuResource {
         @ApiResponse(responseCode = "500", description = "Error searching for Action Menu")
       })
   public ActionMenuList getAllowedContentTypeMenus(AllowedContentTypeMenusRequest request) {
-    int[] raw = request.getContentIds() != null ? request.getContentIds() : new int[0];
-    var contentIds = Arrays.stream(raw).boxed().toArray(Integer[]::new);
-    return new ActionMenuList(adaptor.findAllowedContentTypes(contentIds));
+    try {
+      AllowedContentTypeMenusRequest body =
+          request != null ? request : new AllowedContentTypeMenusRequest();
+      int[] raw = body.getContentIds() != null ? body.getContentIds() : new int[0];
+      var contentIds = Arrays.stream(raw).boxed().toArray(Integer[]::new);
+      List<ActionMenu> menus = requireAdaptor().findAllowedContentTypes(contentIds);
+      return new ActionMenuList(menus != null ? menus : Collections.emptyList());
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Error finding content-type action menus: {}", e.getMessage(), e);
+      return new ActionMenuList();
+    }
   }
 
   @GET
@@ -242,6 +252,15 @@ public class ActionMenuResource {
           int contentId,
       @Parameter(description = "Set to true to include AA menus.") @QueryParam(value = "isAA")
           boolean isAA) {
-    return new ActionMenuList(adaptor.findAllowedTemplates(contentId, isAA));
+    try {
+      List<ActionMenu> menus = requireAdaptor().findAllowedTemplates(contentId, isAA);
+      return new ActionMenuList(menus != null ? menus : Collections.emptyList());
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Error finding template action menus for contentId {}: {}", contentId, e.getMessage(), e);
+      return new ActionMenuList();
+    }
   }
 }

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -214,12 +214,14 @@ public class ActionMenuResource {
         @ApiResponse(responseCode = "500", description = "Error searching for Action Menu")
       })
   public ActionMenuList getAllowedContentTypeMenus(AllowedContentTypeMenusRequest request) {
+    // Wiring must 500; helper failures below still return an empty catalog (Explorer robustness).
+    IActionMenuAdaptor menuAdaptor = requireAdaptor();
     try {
       AllowedContentTypeMenusRequest body =
           request != null ? request : new AllowedContentTypeMenusRequest();
       int[] raw = body.getContentIds() != null ? body.getContentIds() : new int[0];
       var contentIds = Arrays.stream(raw).boxed().toArray(Integer[]::new);
-      List<ActionMenu> menus = requireAdaptor().findAllowedContentTypes(contentIds);
+      List<ActionMenu> menus = menuAdaptor.findAllowedContentTypes(contentIds);
       return new ActionMenuList(menus != null ? menus : Collections.emptyList());
     } catch (WebApplicationException e) {
       throw e;
@@ -252,8 +254,10 @@ public class ActionMenuResource {
           int contentId,
       @Parameter(description = "Set to true to include AA menus.") @QueryParam(value = "isAA")
           boolean isAA) {
+    // Wiring must 500; helper failures below still return an empty catalog (Explorer robustness).
+    IActionMenuAdaptor menuAdaptor = requireAdaptor();
     try {
-      List<ActionMenu> menus = requireAdaptor().findAllowedTemplates(contentId, isAA);
+      List<ActionMenu> menus = menuAdaptor.findAllowedTemplates(contentId, isAA);
       return new ActionMenuList(menus != null ? menus : Collections.emptyList());
     } catch (WebApplicationException e) {
       throw e;

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequest.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.actions;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -28,8 +29,13 @@ import java.util.Arrays;
  *
  * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
  * {@code contentIds} as a JSON array, not an Optional bean (issue #3388 slice 10 / #3432).
+ *
+ * <p>{@link JsonRootName} matches {@code JacksonContextResolver} WRAP/UNWRAP_ROOT_VALUE. Live
+ * Explorer may still POST a flat {@code {contentIds}} object or GUID strings — those bind via
+ * {@link AllowedContentTypeMenusRequestJsonReader} (#3855).
  */
-@XmlRootElement
+@XmlRootElement(name = "AllowedContentTypeMenusRequest")
+@JsonRootName("AllowedContentTypeMenusRequest")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema
 public class AllowedContentTypeMenusRequest {

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequestJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedContentTypeMenusRequestJsonReader.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.actions;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for {@code POST /actions/find/types}.
+ *
+ * <p>CXF {@code UNWRAP_ROOT_VALUE} rejects a bare {@code contentIds} field (expected {@code
+ * AllowedContentTypeMenusRequest}). Explorer posts that flat shape, and display-format rows may
+ * send GUID strings such as {@code 16777215-101-551} instead of ints (#3855 / parent #3716). This
+ * reader binds either:
+ *
+ * <ul>
+ *   <li>{@code {"AllowedContentTypeMenusRequest":{"contentIds":[551]}}} (preferred)
+ *   <li>{@code {"contentIds":[551]}} (live SPA / QA residual)
+ *   <li>GUID last-segment or Jackson {@code {stringValue}} tokens in {@code contentIds}
+ * </ul>
+ *
+ * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code jacksonProvider}
+ * so it wins over JAXB / UNWRAP_ROOT_VALUE.
+ */
+@Provider
+@Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("allowedContentTypeMenusRequestJsonReader")
+public class AllowedContentTypeMenusRequestJsonReader
+    implements MessageBodyReader<AllowedContentTypeMenusRequest> {
+
+  /** Mapper without UNWRAP_ROOT_VALUE so a flat contentIds object is readable. */
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  /** No-op constructor. */
+  public AllowedContentTypeMenusRequestJsonReader() {}
+
+  /** CMS content ids are signed 32-bit locators. */
+  private static final int MAX_CMS_CONTENT_ID = Integer.MAX_VALUE;
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    if (type == null || !AllowedContentTypeMenusRequest.class.isAssignableFrom(type)) {
+      return false;
+    }
+    return mediaType == null || isJsonCompatible(mediaType);
+  }
+
+  static boolean isJsonCompatible(MediaType mediaType) {
+    if (mediaType == null || mediaType.isWildcardType() || mediaType.isWildcardSubtype()) {
+      return true;
+    }
+    String subtype = mediaType.getSubtype();
+    if (subtype == null) {
+      return false;
+    }
+    String lower = subtype.toLowerCase();
+    return "json".equals(lower) || lower.endsWith("+json");
+  }
+
+  @Override
+  public AllowedContentTypeMenusRequest readFrom(
+      Class<AllowedContentTypeMenusRequest> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new AllowedContentTypeMenusRequest();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new AllowedContentTypeMenusRequest();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Bind find/types JSON. Empty / whitespace is an empty request (resource treats missing ids as
+   * an empty catalog, HTTP 200).
+   *
+   * @param json request body; may be null
+   * @return non-null request
+   */
+  public static AllowedContentTypeMenusRequest parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new AllowedContentTypeMenusRequest();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid AllowedContentTypeMenusRequest",
+          400);
+    }
+    return parseNode(root);
+  }
+
+  /**
+   * Bind a parsed JSON tree to {@link AllowedContentTypeMenusRequest}.
+   *
+   * @param root parsed body; may be null
+   * @return non-null request
+   */
+  public static AllowedContentTypeMenusRequest parseNode(JsonNode root) {
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new AllowedContentTypeMenusRequest();
+    }
+    if (!root.isObject()) {
+      throw new WebApplicationException(
+          "AllowedContentTypeMenusRequest body must be a JSON object", 400);
+    }
+    JsonNode nested =
+        firstObject(root, "AllowedContentTypeMenusRequest", "allowedContentTypeMenusRequest");
+    JsonNode fields = nested != null ? nested : root;
+    AllowedContentTypeMenusRequest out = new AllowedContentTypeMenusRequest();
+    JsonNode idsNode = fields.get("contentIds");
+    if (idsNode == null) {
+      idsNode = fields.get("ContentIds");
+    }
+    out.setContentIds(parseContentIds(idsNode));
+    return out;
+  }
+
+  /**
+   * Coerce {@code contentIds} JSON to positive ints. Accepts ints, numeric strings, GUID {@code
+   * host-type-uuid} last segments, and Jackson GUID objects.
+   *
+   * @param node array, scalar, or null
+   * @return never null; invalid tokens are skipped
+   */
+  static int[] parseContentIds(JsonNode node) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return new int[0];
+    }
+    if (!node.isArray()) {
+      int one = parseContentIdToken(node);
+      return one > 0 ? new int[] {one} : new int[0];
+    }
+    List<Integer> ids = new ArrayList<>();
+    for (JsonNode el : node) {
+      int id = parseContentIdToken(el);
+      if (id > 0) {
+        ids.add(id);
+      }
+    }
+    int[] out = new int[ids.size()];
+    for (int i = 0; i < ids.size(); i++) {
+      out[i] = ids.get(i);
+    }
+    return out;
+  }
+
+  static int parseContentIdToken(JsonNode node) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return 0;
+    }
+    if (node.isNumber() || node.isString() || node.isBoolean()) {
+      return parseContentIdString(node.asString());
+    }
+    if (node.isObject()) {
+      JsonNode stringValue = node.get("stringValue");
+      if (stringValue == null) {
+        stringValue = node.get("string_value");
+      }
+      if (stringValue != null && !stringValue.isNull()) {
+        int fromSv = parseContentIdString(stringValue.asString());
+        if (fromSv > 0) {
+          return fromSv;
+        }
+      }
+      JsonNode uuid = node.get("uuid");
+      if (uuid != null && !uuid.isNull()) {
+        return parseContentIdString(uuid.asString());
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * Parse a numeric content id or {@code host-type-uuid} last segment.
+   *
+   * @param raw token; may be null
+   * @return positive content id, or {@code 0} if unusable
+   */
+  static int parseContentIdString(String raw) {
+    if (raw == null) {
+      return 0;
+    }
+    String s = raw.trim();
+    if (s.isEmpty()) {
+      return 0;
+    }
+    if (isAllDigits(s)) {
+      return asPositiveInt(s);
+    }
+    String[] parts = s.split("-");
+    if (parts.length == 3
+        && isAllDigits(parts[0])
+        && isAllDigits(parts[1])
+        && isAllDigits(parts[2])) {
+      return asPositiveInt(parts[2]);
+    }
+    return 0;
+  }
+
+  private static boolean isAllDigits(String s) {
+    if (s == null || s.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < s.length(); i++) {
+      if (!Character.isDigit(s.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static int asPositiveInt(String digits) {
+    try {
+      int n = Integer.parseInt(digits);
+      return n > 0 && n <= MAX_CMS_CONTENT_ID ? n : 0;
+    } catch (NumberFormatException e) {
+      return 0;
+    }
+  }
+
+  private static JsonNode firstObject(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && n.isObject()) {
+        return n;
+      }
+    }
+    return null;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuListSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuListSerialDeserialTest.java
@@ -21,6 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.JacksonContextResolver;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import java.io.StringWriter;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
@@ -97,5 +100,19 @@ public class ActionMenuListSerialDeserialTest {
     JsonNode children = menu.get("children");
     assertTrue(children != null && children.isArray(), "nested children must stay a JSON array: " + json);
     assertEquals("open", children.get(0).get("name").asString());
+  }
+
+  @Test
+  public void jaxbMarshalsActionMenuListWithActionMenuSeeAlso() throws Exception {
+    ActionMenuList list = new ActionMenuList();
+    list.add(sampleMenu());
+    JAXBContext ctx = JAXBContext.newInstance(ActionMenuList.class);
+    Marshaller marshaller = ctx.createMarshaller();
+    marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.FALSE);
+    StringWriter writer = new StringWriter();
+    marshaller.marshal(list, writer);
+    String xml = writer.toString();
+    assertTrue(xml.contains("ActionMenuList"), xml);
+    assertTrue(xml.contains("open") || xml.contains("ActionMenu"), xml);
   }
 }

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -134,4 +134,45 @@ public class ActionMenuResourceTest {
     verify(adaptor).findAllowedContentTypes(captor.capture());
     assertArrayEquals(new Integer[0], captor.getValue());
   }
+
+  @Test
+  public void getAllowedContentTypeMenusNullRequestIsEmptyNot500() {
+    when(adaptor.findAllowedContentTypes(any())).thenReturn(List.of());
+    ActionMenuList out = resource.getAllowedContentTypeMenus(null);
+    assertTrue(out.isEmpty());
+  }
+
+  @Test
+  public void getAllowedContentTypeMenusAdaptorFailureIsEmptyNot500() {
+    when(adaptor.findAllowedContentTypes(any())).thenThrow(new IllegalStateException("down"));
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    request.setContentIds(new int[] {551});
+    ActionMenuList out = resource.getAllowedContentTypeMenus(request);
+    assertTrue(out.isEmpty());
+  }
+
+  @Test
+  public void getAllowedTemplateMenusDelegates() {
+    ActionMenu menu = new ActionMenu();
+    menu.setName("rffHome");
+    when(adaptor.findAllowedTemplates(eq(551), eq(false))).thenReturn(List.of(menu));
+    ActionMenuList out = resource.getAllowedTemplateMenus(551, false);
+    assertEquals(1, out.size());
+    assertEquals("rffHome", out.get(0).getName());
+  }
+
+  @Test
+  public void getAllowedTemplateMenusNullAdaptorResultIsEmpty() {
+    when(adaptor.findAllowedTemplates(eq(551), eq(true))).thenReturn(null);
+    ActionMenuList out = resource.getAllowedTemplateMenus(551, true);
+    assertTrue(out.isEmpty());
+  }
+
+  @Test
+  public void getAllowedTemplateMenusAdaptorFailureIsEmptyNot500() {
+    when(adaptor.findAllowedTemplates(eq(551), eq(false)))
+        .thenThrow(new IllegalArgumentException("Request can't be null"));
+    ActionMenuList out = resource.getAllowedTemplateMenus(551, false);
+    assertTrue(out.isEmpty());
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -103,6 +103,14 @@ public class ActionMenuResourceTest {
         assertThrows(WebApplicationException.class, () -> bare.getActionMenu("x"));
     assertEquals(500, getEx.getResponse().getStatus());
     assertInstanceOf(IllegalStateException.class, getEx.getCause());
+
+    IllegalStateException typesEx =
+        assertThrows(IllegalStateException.class, () -> bare.getAllowedContentTypeMenus(null));
+    assertTrue(typesEx.getMessage().contains("not configured"));
+
+    IllegalStateException templatesEx =
+        assertThrows(IllegalStateException.class, () -> bare.getAllowedTemplateMenus(551, false));
+    assertTrue(templatesEx.getMessage().contains("not configured"));
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/actions/AllowedContentTypeMenusRequestCxfUnmarshallTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/AllowedContentTypeMenusRequestCxfUnmarshallTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.actions;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.JacksonContextResolver;
+import com.percussion.rest.errors.WebApplicationExceptionMapper;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import java.io.ByteArrayInputStream;
+import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
+
+/**
+ * CXF pipeline for POST {@code /actions/find/types} (#3855).
+ *
+ * <p>Production JAXB / UNWRAP_ROOT_VALUE rejects a bare {@code contentIds} root. When {@link
+ * AllowedContentTypeMenusRequestJsonReader} is registered, wrapped, flat, and GUID-token bodies
+ * bind as HTTP 200.
+ */
+@Tag("UnitTest")
+public class AllowedContentTypeMenusRequestCxfUnmarshallTest {
+
+  private static final String WRAPPED =
+      "{\"AllowedContentTypeMenusRequest\":{\"contentIds\":[551]}}";
+  private static final String FLAT = "{\"contentIds\":[551]}";
+  private static final String GUID = "{\"contentIds\":[\"16777215-101-551\"]}";
+
+  private Server server;
+
+  @AfterEach
+  public void stopServer() {
+    if (server != null) {
+      server.stop();
+      server.destroy();
+      server = null;
+    }
+  }
+
+  @Test
+  public void cxfFactorySelectsAllowedContentTypeMenusRequestJsonReader() throws Exception {
+    ServerProviderFactory factory = ServerProviderFactory.createInstance(null);
+    AllowedContentTypeMenusRequestJsonReader custom =
+        new AllowedContentTypeMenusRequestJsonReader();
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(AllowedContentTypeMenusRequest.class));
+    factory.setUserProviders(Arrays.asList(custom, jackson, new JacksonContextResolver()));
+
+    MessageImpl message = new MessageImpl();
+    MessageBodyReader<AllowedContentTypeMenusRequest> selected =
+        factory.createMessageBodyReader(
+            AllowedContentTypeMenusRequest.class,
+            AllowedContentTypeMenusRequest.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            message);
+    assertNotNull(
+        selected, "CXF must find a MessageBodyReader for AllowedContentTypeMenusRequest");
+    assertTrue(
+        selected.isReadable(
+            AllowedContentTypeMenusRequest.class,
+            AllowedContentTypeMenusRequest.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE),
+        selected.getClass().getName());
+
+    AllowedContentTypeMenusRequest req =
+        selected.readFrom(
+            AllowedContentTypeMenusRequest.class,
+            AllowedContentTypeMenusRequest.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(FLAT.getBytes(StandardCharsets.UTF_8)));
+    assertArrayEquals(new int[] {551}, req.getContentIds());
+  }
+
+  @Test
+  public void cxfPostWrappedEnvelopeIsHttp200() throws Exception {
+    assertPostBinds(WRAPPED, 551, "local://issue-3855-find-types-wrap");
+  }
+
+  @Test
+  public void cxfPostFlatSpaBodyIsHttp200() throws Exception {
+    assertPostBinds(FLAT, 551, "local://issue-3855-find-types-flat");
+  }
+
+  @Test
+  public void cxfPostGuidTokenIsHttp200() throws Exception {
+    assertPostBinds(GUID, 551, "local://issue-3855-find-types-guid");
+  }
+
+  private void assertPostBinds(String json, int expectedId, String address) throws Exception {
+    AtomicReference<Integer[]> captured = new AtomicReference<>();
+    IActionMenuAdaptor adaptor = mock(IActionMenuAdaptor.class);
+    when(adaptor.findAllowedContentTypes(any()))
+        .thenAnswer(
+            inv -> {
+              captured.set(inv.getArgument(0));
+              ActionMenu menu = new ActionMenu();
+              menu.setName("rffHome");
+              return List.of(menu);
+            });
+
+    ActionMenuResource resource = new ActionMenuResource();
+    var field = ActionMenuResource.class.getDeclaredField("adaptor");
+    field.setAccessible(true);
+    field.set(resource, adaptor);
+
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(AllowedContentTypeMenusRequest.class));
+
+    JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
+    sf.setAddress(address);
+    sf.setServiceBean(resource);
+    sf.setProviders(
+        List.of(
+            new AllowedContentTypeMenusRequestJsonReader(),
+            jackson,
+            new JacksonContextResolver(),
+            new WebApplicationExceptionMapper()));
+    server = sf.create();
+    assertNotNull(server, "CXF local server must start");
+
+    WebClient client =
+        WebClient.create(address)
+            .accept(MediaType.APPLICATION_JSON)
+            .type(MediaType.APPLICATION_JSON)
+            .path("/actions/find/types");
+    Response response = client.post(json);
+    assertEquals(
+        200,
+        response.getStatus(),
+        "POST must be HTTP 200; body=" + response.readEntity(String.class));
+    Integer[] saved = captured.get();
+    assertNotNull(saved, "adaptor.findAllowedContentTypes must be invoked");
+    assertArrayEquals(new Integer[] {expectedId}, saved);
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/actions/AllowedContentTypeMenusRequestJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/AllowedContentTypeMenusRequestJsonReaderTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.actions;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Live SPA envelope for POST /actions/find/types (#3855). */
+@Tag("UnitTest")
+public class AllowedContentTypeMenusRequestJsonReaderTest {
+
+  private final AllowedContentTypeMenusRequestJsonReader reader =
+      new AllowedContentTypeMenusRequestJsonReader();
+
+  @Test
+  public void parseAcceptsWrappedEnvelope() {
+    AllowedContentTypeMenusRequest out =
+        AllowedContentTypeMenusRequestJsonReader.parse(
+            "{\"AllowedContentTypeMenusRequest\":{\"contentIds\":[551,552]}}");
+    assertArrayEquals(new int[] {551, 552}, out.getContentIds());
+  }
+
+  @Test
+  public void parseAcceptsFlatSpaBody() {
+    AllowedContentTypeMenusRequest out =
+        AllowedContentTypeMenusRequestJsonReader.parse("{\"contentIds\":[551]}");
+    assertArrayEquals(new int[] {551}, out.getContentIds());
+  }
+
+  @Test
+  public void parseAcceptsGuidLastSegment() {
+    AllowedContentTypeMenusRequest out =
+        AllowedContentTypeMenusRequestJsonReader.parse(
+            "{\"contentIds\":[\"16777215-101-551\"]}");
+    assertArrayEquals(new int[] {551}, out.getContentIds());
+  }
+
+  @Test
+  public void parseAcceptsJacksonGuidObject() {
+    AllowedContentTypeMenusRequest out =
+        AllowedContentTypeMenusRequestJsonReader.parse(
+            "{\"contentIds\":[{\"stringValue\":\"16777215-101-551\"}]}");
+    assertArrayEquals(new int[] {551}, out.getContentIds());
+  }
+
+  @Test
+  public void parseAcceptsCamelCaseRootAlias() {
+    AllowedContentTypeMenusRequest out =
+        AllowedContentTypeMenusRequestJsonReader.parse(
+            "{\"allowedContentTypeMenusRequest\":{\"contentIds\":[42]}}");
+    assertArrayEquals(new int[] {42}, out.getContentIds());
+  }
+
+  @Test
+  public void parseEmptyIsEmptyRequest() {
+    AllowedContentTypeMenusRequest empty = AllowedContentTypeMenusRequestJsonReader.parse("  ");
+    assertTrue(empty.getContentIds() == null || empty.getContentIds().length == 0);
+    assertTrue(
+        AllowedContentTypeMenusRequestJsonReader.parse(null).getContentIds() == null
+            || AllowedContentTypeMenusRequestJsonReader.parse(null).getContentIds().length == 0);
+  }
+
+  @Test
+  public void parseRejectsNonObject() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> AllowedContentTypeMenusRequestJsonReader.parse("[1,2]"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void parseRejectsInvalidJson() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> AllowedContentTypeMenusRequestJsonReader.parse("{"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void parseContentIdStringCoercesGuidAndInt() {
+    assertEquals(551, AllowedContentTypeMenusRequestJsonReader.parseContentIdString("551"));
+    assertEquals(
+        551, AllowedContentTypeMenusRequestJsonReader.parseContentIdString("16777215-101-551"));
+    assertEquals(0, AllowedContentTypeMenusRequestJsonReader.parseContentIdString("nope"));
+    assertEquals(0, AllowedContentTypeMenusRequestJsonReader.parseContentIdString("0"));
+  }
+
+  @Test
+  public void isReadableOnlyForAllowedContentTypeMenusRequest() {
+    assertTrue(
+        reader.isReadable(
+            AllowedContentTypeMenusRequest.class,
+            AllowedContentTypeMenusRequest.class,
+            null,
+            MediaType.APPLICATION_JSON_TYPE));
+    assertTrue(
+        !reader.isReadable(ActionMenu.class, ActionMenu.class, null, MediaType.APPLICATION_JSON_TYPE));
+  }
+
+  @Test
+  public void readFromReadsUtf8Stream() throws Exception {
+    byte[] raw = "{\"contentIds\":[551]}".getBytes(StandardCharsets.UTF_8);
+    AllowedContentTypeMenusRequest out =
+        reader.readFrom(
+            AllowedContentTypeMenusRequest.class,
+            AllowedContentTypeMenusRequest.class,
+            null,
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(raw));
+    assertArrayEquals(new int[] {551}, out.getContentIds());
+  }
+
+  @Test
+  public void readFromEmptyStreamIsEmptyRequest() throws Exception {
+    AllowedContentTypeMenusRequest out =
+        reader.readFrom(
+            AllowedContentTypeMenusRequest.class,
+            AllowedContentTypeMenusRequest.class,
+            null,
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(new byte[0]));
+    assertTrue(out.getContentIds() == null || out.getContentIds().length == 0);
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/actions/AllowedContentTypeMenusRequestSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/AllowedContentTypeMenusRequestSerialDeserialTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.actions;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.percussion.rest.JacksonContextResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire contract for {@link AllowedContentTypeMenusRequest} under WRAP_ROOT_VALUE / UNWRAP_ROOT_VALUE
+ * (#3855). Flat SPA bodies bind via {@link AllowedContentTypeMenusRequestJsonReader}.
+ */
+@Tag("UnitTest")
+public class AllowedContentTypeMenusRequestSerialDeserialTest {
+
+  private final ObjectMapper mapper =
+      new JacksonContextResolver().getContext(AllowedContentTypeMenusRequest.class);
+
+  @Test
+  public void serializesUnderAllowedContentTypeMenusRequestRoot() {
+    AllowedContentTypeMenusRequest request = new AllowedContentTypeMenusRequest();
+    request.setContentIds(new int[] {551});
+    String json = mapper.writeValueAsString(request);
+    assertTrue(
+        json.contains("\"AllowedContentTypeMenusRequest\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("\"contentIds\""), json);
+    assertTrue(json.contains("551"), json);
+  }
+
+  @Test
+  public void deserializesWrappedBody() {
+    String json = "{\"AllowedContentTypeMenusRequest\":{\"contentIds\":[551]}}";
+    AllowedContentTypeMenusRequest req =
+        mapper.readValue(json, AllowedContentTypeMenusRequest.class);
+    assertArrayEquals(new int[] {551}, req.getContentIds());
+  }
+
+  @Test
+  public void productionMapperRejectsBareContentIdsRoot() {
+    String flat = "{\"contentIds\":[551]}";
+    try {
+      AllowedContentTypeMenusRequest result =
+          mapper.readValue(flat, AllowedContentTypeMenusRequest.class);
+      assertTrue(
+          result == null
+              || result.getContentIds() == null
+              || result.getContentIds().length == 0,
+          "flat contentIds root must not bind under UNWRAP_ROOT_VALUE; got "
+              + (result == null ? "null" : java.util.Arrays.toString(result.getContentIds())));
+    } catch (Exception expected) {
+      assertTrue(
+          expected.getMessage() != null
+              && (expected.getMessage().contains("AllowedContentTypeMenusRequest")
+                  || expected.getMessage().contains("Root name")
+                  || expected.getMessage().contains("contentIds")),
+          "unexpected failure: " + expected);
+    }
+  }
+
+  @Test
+  public void productionMapperRejectsGuidStringArray() {
+    String guid = "{\"AllowedContentTypeMenusRequest\":{\"contentIds\":[\"16777215-101-551\"]}}";
+    try {
+      AllowedContentTypeMenusRequest result =
+          mapper.readValue(guid, AllowedContentTypeMenusRequest.class);
+      fail(
+          "GUID string array must not bind as int[] on the production mapper; got "
+              + (result == null ? "null" : java.util.Arrays.toString(result.getContentIds())));
+    } catch (Exception expected) {
+      assertTrue(expected.getMessage() != null, "unexpected empty failure");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Explorer residual of #3716 / QA #2745: selecting Corporate Investments Home (`rffHome`, content id 551 / GUID `16777215-101-551`) 400'd `POST /services/actions/find/types` and 500'd `GET /services/actions/find/templates/551?isAA=true|false`.

CXF JAXB JSON expected a WRAP_ROOT `{AllowedContentTypeMenusRequest:{contentIds:[…]}}` body (flat `{contentIds}` / GUID strings 400). `ActionMenuList` was missing `@XmlSeeAlso(ActionMenu.class)`, so a successful list marshal failed with `ActionMenu nor any of its super class is known to this context` (HTTP 500 — same class as SiteList #3090).

This change:

- SPA posts WRAP_ROOT with integer ids (GUID last-segment coerced).
- `AllowedContentTypeMenusRequestJsonReader` binds wrapped, flat, and GUID tokens when Jackson is selected.
- `ActionMenuList` `@XmlSeeAlso(ActionMenu.class)`.
- Resource/adaptor return empty `ActionMenuList` instead of 500 on helper failure.

Fixes #3855. Parent implement #3716. Parent QA #2745 (do not steal; not a qa task).

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. H2 QA: `python docker/scripts/perc-devctl.py qa-up` then `qa-health`.
2. Log in as Admin, open Explorer, `/Sites/Corporate_Investments`, select Corporate Investments Home (`rffHome` / 551).
3. Confirm `POST /Rhythmyx/services/actions/find/types` is HTTP 200 (not 400).
4. Confirm `GET /Rhythmyx/services/actions/find/templates/551?isAA=false` and `isAA=true` are HTTP 200 (not 500).
5. Playwright: `npm run test:surface -- --path tests/explorer-preview-view.spec.js --path tests/explorer-console-clean.spec.js` from `modules/perc-qa-automation/frontend`.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): bugfix of REST 400/500 on existing Explorer Preview/select; operator steps unchanged
- [x] **Unit / module tests** — JsonReader/CXF/JAXB/resource/adaptor/convert + Vitest + Playwright helper tests; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `explorer-preview-view.spec.js` asserts find/types 200 and find/templates not 500 after listed-page select; `explorer-console-clean.spec.js` still covers 404/400 shell
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O); URL regexes and Jackson trees only

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 636, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1616, Failures: 0, Skipped: 125
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS, Java Tests run: 63, Failures: 0; Vitest Test Files 393 passed, Tests 3130 passed
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS; `npm run test:unit` 457 passed
- **downstream_checked:** sitemanage standalone clean install against rest SNAPSHOT (adaptor implements rest `IActionMenuAdaptor`). No `final`/`sealed` type or breaking public Java signature. TS `findAllowedContentTypeMenus` widened `number[]` → `Array<number|string>`.

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` — `TEST_CMS_URL=http://127.0.0.1:30907` container `perc-matrix-cms-h2`
- `qa-health --url http://127.0.0.1:30907/Rhythmyx/login` — RESULT:OK HTTP:200 HEALTH:healthy
- Hot-deploy: `rest-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar`, `sitemanage-beans.xml`, WebUI `cm/modern/assets`; in-cell StopJetty/StartJetty; qa-health HTTP:200 HEALTH:healthy
- `npm run test:surface -- --path tests/explorer-console-clean.spec.js --path tests/explorer-preview-view.spec.js` — **5 passed 0 failed 0 skipped**
- console-clean=yes (no pageerror on exercised paths)
- server.log-clean=yes for this feature (no find/types or find/templates ERROR/FATAL). Pre-existing `PSRuntimeExceptionMapper HTTP 404 Not Found` mapper noise only (not this slice).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
