### PR TITLE
fix(utils): leftover IPS*Errors typed ErrorCodes (#3859)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3859-utils-typed-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3859-utils-typed-errorcodes-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review: issue #3859 utils leftover IPS*Errors typed ErrorCodes
+
+- **Branch:** `fix/issue-3859-utils-typed-errorcodes`
+- **Base:** `origin/main`
+- **Date:** 2026-08-26
+- **Reviewer:** Erlang (independent of implementer)
+- **Recommendation:** approve
+- **Gate:** May commit/push: yes
+- **Memory patterns hit:** missing behavioral tests; incomplete change-class closure; non-portable path joins; tests that only grep source strings
+
+## Summary
+
+Retypes eleven leftover `modules/utils` production `IPS*Errors` sites to utils-local `IPSErrorCode` peers (`UtilErrorCode`, `XmlErrorCode`, `JBossErrorCode`) matching perc-auditlog catalogs. Utils cannot depend on `audit-log` (circular Maven graph). Allow-list rows for those exact paths are removed. Tests exercise production exception types (`PSRuntimeException`, `PSException`, `PSInvalidXmlException`, `PSMissingApplicationPolicyException`) and assert `isAuditable() == false`.
+
+## Issues
+
+None blocking.
+
+### Cross-platform path checklist
+
+- [x] No new `".../" +` filesystem path construction in production (XML/URL `/` only where already domain)
+- [x] Tests use `Path.of` / `Files` / JUnit `@TempDir` (not `/tmp` or `C:\`)
+- [x] HttpServer binds loopback + ephemeral port
+- [x] Line-ending sensitive assertions not used
+
+## Notes (non-blocking)
+
+- `PSXmlTreeWalker.getLowestLevelElement` still wraps the typed `PSInvalidXmlException` in `RuntimeException(message)` (pre-existing). Test asserts typed construction plus message equality.
+- `PSRuntimeException` gained typed constructors and `getTypedErrorCode()` / `isAuditable()` delegates. Existing subclasses compile (added API, type not `final`).
+- perc-auditlog enums were not grown; dual-write skip is asserted on utils-local peers (`isAuditable() == false`).

--- a/modules/utils/src/main/java/com/percussion/error/PSRuntimeException.java
+++ b/modules/utils/src/main/java/com/percussion/error/PSRuntimeException.java
@@ -75,6 +75,48 @@ public class PSRuntimeException extends RuntimeException implements IPSException
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSRuntimeException(IPSErrorCode code) {
+    this(code, (Object[]) null);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSRuntimeException(IPSErrorCode code, Object singleArg) {
+    this(code, singleArg == null ? null : new Object[] {singleArg});
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSRuntimeException(IPSErrorCode code, Object[] arrayArgs) {
+    super();
+    m_exception = new PSException(code, arrayArgs);
+  }
+
+  /**
+   * Typed construction with message arguments and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   * @param cause causal throwable; may be {@code null}
+   */
+  public PSRuntimeException(IPSErrorCode code, Object[] arrayArgs, Throwable cause) {
+    super(cause);
+    m_exception = new PSException(code, arrayArgs, cause);
+  }
+
+  /**
    * Returns the localized detail message of this exception.
    *
    * @param locale the locale to generate the message in
@@ -122,6 +164,22 @@ public class PSRuntimeException extends RuntimeException implements IPSException
    */
   public int getErrorCode() {
     return m_exception.getErrorCode();
+  }
+
+  /**
+   * Typed error code when constructed via {@link #PSRuntimeException(IPSErrorCode)} (or overloads);
+   * otherwise {@code null} for legacy int construction.
+   */
+  public IPSErrorCode getTypedErrorCode() {
+    return m_exception.getTypedErrorCode();
+  }
+
+  /**
+   * Whether dual-write should consider this exception auditable. Prefer the typed code when
+   * present; legacy int construction returns {@code false}.
+   */
+  public boolean isAuditable() {
+    return m_exception.isAuditable();
   }
 
   /**

--- a/modules/utils/src/main/java/com/percussion/util/PSBase64Decoder.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSBase64Decoder.java
@@ -74,7 +74,7 @@ public class PSBase64Decoder {
       else return new String(decoded);
     } catch (UnsupportedEncodingException e) {
       throw new PSRuntimeException(
-          IPSUtilErrors.BASE64_ENCODING_EXCEPTION, new Object[] {in, e.toString()});
+          UtilErrorCode.BASE64_ENCODING_EXCEPTION, new Object[] {in, e.toString()});
     }
   }
 

--- a/modules/utils/src/main/java/com/percussion/util/PSBase64Encoder.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSBase64Encoder.java
@@ -98,7 +98,7 @@ public class PSBase64Encoder {
         source = in.getBytes(encoding);
       } catch (UnsupportedEncodingException e) {
         throw new PSRuntimeException(
-            IPSUtilErrors.BASE64_ENCODING_EXCEPTION, new Object[] {in, e.toString()});
+            UtilErrorCode.BASE64_ENCODING_EXCEPTION, new Object[] {in, e.toString()});
       }
     }
 

--- a/modules/utils/src/main/java/com/percussion/util/PSHttpConnection.java
+++ b/modules/utils/src/main/java/com/percussion/util/PSHttpConnection.java
@@ -322,7 +322,7 @@ public class PSHttpConnection {
           // Make sure received all the data if specified "Content-Length"
           if ((contentLength > 0) && (long) contentLength != readData) {
             String[] args = {"" + readData, "" + contentLength};
-            throw new PSException(IPSUtilErrors.RECEIVE_DATA_ERROR, args);
+            throw new PSException(UtilErrorCode.RECEIVE_DATA_ERROR, args);
           }
 
           byte[] byteData = os.toByteArray();
@@ -344,13 +344,13 @@ public class PSHttpConnection {
           // then throw exception with error code and message
           if (respCode >= 400) {
             String[] args = {Integer.toString(respCode), msg};
-            throw new PSException(IPSUtilErrors.POST_DATA_ERROR, args);
+            throw new PSException(UtilErrorCode.POST_DATA_ERROR, args);
           }
         }
         return msg;
       }
     } catch (IOException | NumberFormatException | PSException e) {
-      throw new PSException(IPSUtilErrors.POST_DATA_ERROR, PSExceptionUtils.getMessageForLog(e));
+      throw new PSException(UtilErrorCode.POST_DATA_ERROR, PSExceptionUtils.getMessageForLog(e));
     }
   }
 
@@ -397,7 +397,7 @@ public class PSHttpConnection {
       // Make sure received all the data if specified "Content-Length"
       if ((contentLength > 0) && contentLength != readData) {
         String[] args = {"" + readData, "" + contentLength};
-        throw new PSException(IPSUtilErrors.RECEIVE_DATA_ERROR, args);
+        throw new PSException(UtilErrorCode.RECEIVE_DATA_ERROR, args);
       }
 
       // Get the character-set for the received data
@@ -418,7 +418,7 @@ public class PSHttpConnection {
       // then throw exception with error code and message
       if (respCode >= 400) {
         String[] args = {Integer.toString(respCode), msg};
-        throw new PSException(IPSUtilErrors.POST_DATA_ERROR, args);
+        throw new PSException(UtilErrorCode.POST_DATA_ERROR, args);
       }
     } finally {
       // don't call connection.disconnect() as this will not allow keep-alive

--- a/modules/utils/src/main/java/com/percussion/util/UtilErrorCode.java
+++ b/modules/utils/src/main/java/com/percussion/util/UtilErrorCode.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.util;
+
+import com.percussion.error.IPSErrorCode;
+
+/**
+ * Utils-local typed peers for leftover {@link IPSUtilErrors} production sites (#3859 / parent
+ * #2616).
+ *
+ * <p>Modules that depend on {@code audit-log} should prefer {@code
+ * com.intsof.percussioncms.auditlog.codes.UtilErrorCodes}. Utils cannot depend on {@code
+ * audit-log} ({@code audit-log} depends on utils), so these {@link IPSErrorCode} values carry the
+ * same numeric codes and non-auditable policy for typed {@link
+ * com.percussion.error.PSException} construction without a circular Maven dependency.
+ *
+ * <p>Numeric codes are identical to the legacy {@link IPSUtilErrors} ints and to the matching
+ * {@code UtilErrorCodes} enum constants.
+ */
+public enum UtilErrorCode implements IPSErrorCode {
+
+  /** Peer of {@link IPSUtilErrors#BASE64_ENCODING_EXCEPTION} / UtilErrorCodes same. */
+  BASE64_ENCODING_EXCEPTION(IPSUtilErrors.BASE64_ENCODING_EXCEPTION),
+
+  /** Peer of {@link IPSUtilErrors#BASE64_DECODING_EXCEPTION} / UtilErrorCodes same. */
+  BASE64_DECODING_EXCEPTION(IPSUtilErrors.BASE64_DECODING_EXCEPTION),
+
+  /** Peer of {@link IPSUtilErrors#COLLECTION_CLASS_NOT_FOUND} / UtilErrorCodes same. */
+  COLLECTION_CLASS_NOT_FOUND(IPSUtilErrors.COLLECTION_CLASS_NOT_FOUND),
+
+  /** Peer of {@link IPSUtilErrors#PURGABLE_TEMP_DIR_IS_FILE} / UtilErrorCodes same. */
+  PURGABLE_TEMP_DIR_IS_FILE(IPSUtilErrors.PURGABLE_TEMP_DIR_IS_FILE),
+
+  /** Peer of {@link IPSUtilErrors#RECEIVE_DATA_ERROR} / UtilErrorCodes same. */
+  RECEIVE_DATA_ERROR(IPSUtilErrors.RECEIVE_DATA_ERROR),
+
+  /** Peer of {@link IPSUtilErrors#POST_DATA_ERROR} / UtilErrorCodes same. */
+  POST_DATA_ERROR(IPSUtilErrors.POST_DATA_ERROR);
+
+  private final int numericCode;
+
+  UtilErrorCode(int numericCode) {
+    this.numericCode = numericCode;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return false;
+  }
+}

--- a/modules/utils/src/main/java/com/percussion/utils/container/PSAbstractXmlConnectors.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/PSAbstractXmlConnectors.java
@@ -18,8 +18,8 @@
 package com.percussion.utils.container;
 
 import com.percussion.utils.tomcat.PSTomcatConnector;
-import com.percussion.utils.xml.IPSXmlErrors;
 import com.percussion.utils.xml.PSInvalidXmlException;
+import com.percussion.utils.xml.XmlErrorCode;
 import com.percussion.utils.xml.PSXmlUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -125,7 +125,7 @@ public abstract class PSAbstractXmlConnectors extends PSAbstractConnectors imple
     PSXmlTreeWalker tree = new PSXmlTreeWalker(curDoc);
     Element root = (Element) tree.getCurrent();
     if (root == null || !root.getNodeName().equals(SERVER_NODE_NAME))
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, SERVER_NODE_NAME);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, SERVER_NODE_NAME);
     copyAttributes(root, newServerEl);
 
     // create a new service element
@@ -136,7 +136,7 @@ public abstract class PSAbstractXmlConnectors extends PSAbstractConnectors imple
     Element serviceEl =
         tree.getNextElement(SERVICE_NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (serviceEl == null)
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, SERVICE_NODE_NAME);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, SERVICE_NODE_NAME);
     copyAttributes(serviceEl, newServiceEl);
 
     // append new connector list
@@ -181,12 +181,12 @@ public abstract class PSAbstractXmlConnectors extends PSAbstractConnectors imple
     PSXmlTreeWalker tree = new PSXmlTreeWalker(doc);
     Element root = (Element) tree.getCurrent();
     if (root == null || !root.getNodeName().equals(SERVER_NODE_NAME))
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, SERVER_NODE_NAME);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, SERVER_NODE_NAME);
 
     Element serviceEl =
         tree.getNextElement(SERVICE_NODE_NAME, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (serviceEl == null)
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, SERVICE_NODE_NAME);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, SERVICE_NODE_NAME);
 
     int firstFlag =
         PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN | PSXmlTreeWalker.GET_NEXT_RESET_CURRENT;

--- a/modules/utils/src/main/java/com/percussion/utils/container/PSMissingApplicationPolicyException.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/PSMissingApplicationPolicyException.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.utils.container;
 
-import com.percussion.utils.container.jboss.IPSJBossErrors;
+import com.percussion.utils.container.jboss.JBossErrorCode;
 import com.percussion.utils.exceptions.PSBaseException;
 import org.apache.commons.lang3.StringUtils;
 
@@ -34,7 +34,7 @@ public class PSMissingApplicationPolicyException extends PSBaseException {
    *     <code>null</code> or empty.
    */
   public PSMissingApplicationPolicyException(String policyName, String fileName) {
-    super(IPSJBossErrors.APP_POLICY_ELEMENT_MISSING, policyName, fileName);
+    super(JBossErrorCode.APP_POLICY_ELEMENT_MISSING, policyName, fileName);
 
     if (StringUtils.isBlank(policyName))
       throw new IllegalArgumentException("policyName may not be null or empty");

--- a/modules/utils/src/main/java/com/percussion/utils/container/PSSecureCredentials.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/PSSecureCredentials.java
@@ -18,8 +18,8 @@
 package com.percussion.utils.container;
 
 import com.percussion.legacy.security.deprecated.PSLegacyEncrypter;
-import com.percussion.utils.xml.IPSXmlErrors;
 import com.percussion.utils.xml.PSInvalidXmlException;
+import com.percussion.utils.xml.XmlErrorCode;
 import com.percussion.utils.xml.PSXmlUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -121,7 +121,7 @@ public class PSSecureCredentials {
     String policyName = getName(source);
     if (StringUtils.isBlank(policyName))
       throw new PSInvalidXmlException(
-          IPSXmlErrors.XML_ELEMENT_INVALID_ATTR,
+          XmlErrorCode.XML_ELEMENT_INVALID_ATTR,
           new Object[] {APP_POLICY_NODE_NAME, NAME_ATTR, policyName});
     m_securityDomain = policyName;
 
@@ -129,16 +129,16 @@ public class PSSecureCredentials {
 
     Element authEl = tree.getNextElement(AUTHENTICATION, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (authEl == null)
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, AUTHENTICATION);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, AUTHENTICATION);
 
     Element loginModEl = tree.getNextElement(LOGIN_MODULE, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (loginModEl == null)
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, LOGIN_MODULE);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, LOGIN_MODULE);
 
     Element moduleOptionEl =
         tree.getNextElement(MODULE_OPTION, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (moduleOptionEl == null)
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, MODULE_OPTION);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, MODULE_OPTION);
     boolean foundPassword = false;
     while (moduleOptionEl != null) {
       String nameAttr = getName(moduleOptionEl);
@@ -159,15 +159,15 @@ public class PSSecureCredentials {
     // make sure we got user name, dsname, and at least empty pwd.
     if (m_userId == null) {
       throw new PSInvalidXmlException(
-          IPSXmlErrors.XML_ELEMENT_ATTR_INVALID_VAL,
+          XmlErrorCode.XML_ELEMENT_ATTR_INVALID_VAL,
           new Object[] {MODULE_OPTION, NAME_ATTR, USERNAME_ATTR_VAL, "null"});
     } else if (!foundPassword) {
       throw new PSInvalidXmlException(
-          IPSXmlErrors.XML_ELEMENT_ATTR_INVALID_VAL,
+          XmlErrorCode.XML_ELEMENT_ATTR_INVALID_VAL,
           new Object[] {MODULE_OPTION, NAME_ATTR, PASSWORD_ATTR_VAL, ""});
     } else if (m_securityDomain == null) {
       throw new PSInvalidXmlException(
-          IPSXmlErrors.XML_ELEMENT_ATTR_INVALID_VAL,
+          XmlErrorCode.XML_ELEMENT_ATTR_INVALID_VAL,
           new Object[] {MODULE_OPTION, NAME_ATTR, MANAGED_CONN_FACTORY_ATTR_VAL, "null"});
     }
   }

--- a/modules/utils/src/main/java/com/percussion/utils/container/jboss/JBossErrorCode.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/jboss/JBossErrorCode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.container.jboss;
+
+import com.percussion.error.IPSErrorCode;
+
+/**
+ * Utils-local typed peer for leftover {@link IPSJBossErrors} production sites (#3859 / parent
+ * #2616).
+ *
+ * <p>Modules that depend on {@code audit-log} should prefer {@code
+ * com.intsof.percussioncms.auditlog.codes.JBossErrorCodes}. Utils cannot depend on {@code
+ * audit-log} ({@code audit-log} depends on utils), so this {@link IPSErrorCode} carries the same
+ * numeric code and non-auditable policy without a circular Maven dependency.
+ *
+ * <p>Numeric code is identical to {@link IPSJBossErrors#APP_POLICY_ELEMENT_MISSING} and to {@code
+ * JBossErrorCodes.APP_POLICY_ELEMENT_MISSING}.
+ */
+public enum JBossErrorCode implements IPSErrorCode {
+
+  /** Peer of {@link IPSJBossErrors#APP_POLICY_ELEMENT_MISSING} / JBossErrorCodes same. */
+  APP_POLICY_ELEMENT_MISSING(IPSJBossErrors.APP_POLICY_ELEMENT_MISSING);
+
+  private final int numericCode;
+
+  JBossErrorCode(int numericCode) {
+    this.numericCode = numericCode;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return false;
+  }
+}

--- a/modules/utils/src/main/java/com/percussion/utils/container/jboss/PSJBossJndiDatasource.java
+++ b/modules/utils/src/main/java/com/percussion/utils/container/jboss/PSJBossJndiDatasource.java
@@ -20,8 +20,8 @@ package com.percussion.utils.container.jboss;
 import com.percussion.utils.container.IPSJndiDatasource;
 import com.percussion.utils.container.PSJndiDatasourceImpl;
 import com.percussion.utils.jdbc.PSJdbcUtils;
-import com.percussion.utils.xml.IPSXmlErrors;
 import com.percussion.utils.xml.PSInvalidXmlException;
+import com.percussion.utils.xml.XmlErrorCode;
 import com.percussion.utils.xml.PSXmlUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -153,7 +153,7 @@ public class PSJBossJndiDatasource extends PSJndiDatasourceImpl
     walker.setCurrent(source);
     element = walker.getNextElement(METADATA, firstFlag);
     if (element == null)
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, METADATA);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, METADATA);
   }
 
   /**
@@ -355,7 +355,7 @@ public class PSJBossJndiDatasource extends PSJndiDatasourceImpl
       intVal = Integer.parseInt(val);
     } catch (NumberFormatException e) {
       throw new PSInvalidXmlException(
-          IPSXmlErrors.XML_ELEMENT_INVALID_VALUE, new String[] {name, val});
+          XmlErrorCode.XML_ELEMENT_INVALID_VALUE, new Object[] {name, val});
     }
 
     return intVal;

--- a/modules/utils/src/main/java/com/percussion/utils/spring/PSSpringBeanUtils.java
+++ b/modules/utils/src/main/java/com/percussion/utils/spring/PSSpringBeanUtils.java
@@ -18,8 +18,8 @@ package com.percussion.utils.spring;
 
 import com.percussion.utils.jdbc.PSDatasourceConfig;
 import com.percussion.utils.jdbc.PSDatasourceResolver;
-import com.percussion.utils.xml.IPSXmlErrors;
 import com.percussion.utils.xml.PSInvalidXmlException;
+import com.percussion.utils.xml.XmlErrorCode;
 import com.percussion.utils.xml.PSXmlUtils;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
@@ -65,7 +65,7 @@ public class PSSpringBeanUtils {
       args[1] = e.getLocalizedMessage();
       args[2] = PSXmlDocumentBuilder.toString(data);
 
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_RESTORE_ERROR, args, e);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_RESTORE_ERROR, args, e);
     }
   }
 
@@ -237,11 +237,11 @@ public class PSSpringBeanUtils {
 
     Element nextPropEl = tree.getNextElement(BEAN_PROPERTY, flag);
     if (nextPropEl == null) {
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, BEAN_PROPERTY);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, BEAN_PROPERTY);
     } else if (!name.equals(getBeanPropertyName(nextPropEl))) {
       throw new PSInvalidXmlException(
-          IPSXmlErrors.XML_ELEMENT_INVALID_ATTR,
-          new String[] {BEAN_PROPERTY, BEAN_PROP_NAME_ATTR, name});
+          XmlErrorCode.XML_ELEMENT_INVALID_ATTR,
+          new Object[] {BEAN_PROPERTY, BEAN_PROP_NAME_ATTR, name});
     }
 
     return nextPropEl;
@@ -297,7 +297,7 @@ public class PSSpringBeanUtils {
     PSXmlTreeWalker tree = new PSXmlTreeWalker(source);
     Element mapEl = tree.getNextElement(BEAN_PROP_VAL_MAP, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
     if (mapEl == null)
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, BEAN_PROP_VAL_MAP);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, BEAN_PROP_VAL_MAP);
 
     Element entryEl =
         tree.getNextElement(BEAN_PROP_VAL_MAP_ENTRY, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
@@ -311,7 +311,7 @@ public class PSSpringBeanUtils {
             tree.getNextElement(BEAN_PROP_VAL_MAP_VAL, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
 
         if (valEl == null)
-          throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, BEAN_PROP_VAL_MAP_VAL);
+          throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, BEAN_PROP_VAL_MAP_VAL);
 
         value = PSXmlUtils.getElementData(valEl, BEAN_PROP_VAL_MAP_VAL, true);
       }
@@ -346,7 +346,7 @@ public class PSSpringBeanUtils {
       Element listEl =
           tree.getNextElement(BEAN_PROP_VAL_LIST, PSXmlTreeWalker.GET_NEXT_ALLOW_CHILDREN);
       if (listEl == null)
-        throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, BEAN_PROP_VAL_LIST);
+        throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, BEAN_PROP_VAL_LIST);
     } else {
       tree.setCurrent(curEl);
       flags = PSXmlTreeWalker.GET_NEXT_ALLOW_SIBLINGS;
@@ -371,7 +371,7 @@ public class PSSpringBeanUtils {
     while (entryEl != null) {
       if (!entryEl.getNodeName().equals(IPSBeanConfig.BEAN_NODE_NAME)) {
         throw new PSInvalidXmlException(
-            IPSXmlErrors.XML_ELEMENT_MISSING, IPSBeanConfig.BEAN_NODE_NAME);
+            XmlErrorCode.XML_ELEMENT_MISSING, IPSBeanConfig.BEAN_NODE_NAME);
       }
 
       list.add(createBean(getClassName(entryEl), entryEl));
@@ -443,14 +443,14 @@ public class PSSpringBeanUtils {
     test = getBeanName(source);
     if (!beanName.equals(test))
       throw new PSInvalidXmlException(
-          IPSXmlErrors.XML_ELEMENT_INVALID_ATTR,
-          new String[] {IPSBeanConfig.BEAN_NODE_NAME, BEAN_ID_ATTR, test});
+          XmlErrorCode.XML_ELEMENT_INVALID_ATTR,
+          new Object[] {IPSBeanConfig.BEAN_NODE_NAME, BEAN_ID_ATTR, test});
 
     test = getClassName(source);
     if (!className.equals(test))
       throw new PSInvalidXmlException(
-          IPSXmlErrors.XML_ELEMENT_INVALID_ATTR,
-          new String[] {IPSBeanConfig.BEAN_NODE_NAME, BEAN_CLASSNAME_ATTR, test});
+          XmlErrorCode.XML_ELEMENT_INVALID_ATTR,
+          new Object[] {IPSBeanConfig.BEAN_NODE_NAME, BEAN_CLASSNAME_ATTR, test});
   }
 
   private static String mapMovedClasses(String className) {

--- a/modules/utils/src/main/java/com/percussion/utils/spring/PSSpringConfiguration.java
+++ b/modules/utils/src/main/java/com/percussion/utils/spring/PSSpringConfiguration.java
@@ -17,8 +17,8 @@
 
 package com.percussion.utils.spring;
 
-import com.percussion.utils.xml.IPSXmlErrors;
 import com.percussion.utils.xml.PSInvalidXmlException;
+import com.percussion.utils.xml.XmlErrorCode;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.io.File;
@@ -88,7 +88,7 @@ public class PSSpringConfiguration {
     PSXmlTreeWalker tree = new PSXmlTreeWalker(doc);
     Element root = (Element) tree.getCurrent();
     if (!BEANS.equals(root.getNodeName())) {
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, BEANS);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, BEANS);
     }
 
     m_beanDataMap = new LinkedHashMap<String, PSBeanData>();

--- a/modules/utils/src/main/java/com/percussion/utils/xml/PSXmlUtils.java
+++ b/modules/utils/src/main/java/com/percussion/utils/xml/PSXmlUtils.java
@@ -50,7 +50,7 @@ public class PSXmlUtils {
 
     if (source == null) {
       if (required) {
-        throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_MISSING, name);
+        throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_MISSING, name);
       }
 
       return null;
@@ -59,7 +59,7 @@ public class PSXmlUtils {
     data = PSXmlTreeWalker.getElementData(source);
     if (required && StringUtils.isEmpty(data)) {
       throw new PSInvalidXmlException(
-          IPSXmlErrors.XML_ELEMENT_INVALID_VALUE, new String[] {name, data});
+          XmlErrorCode.XML_ELEMENT_INVALID_VALUE, new Object[] {name, data});
     }
 
     return data;
@@ -85,7 +85,7 @@ public class PSXmlUtils {
     String val = el.getAttribute(name);
     if (required && (val == null || val.trim().length() == 0)) {
       Object[] args = {el.getNodeName(), name, val};
-      throw new PSInvalidXmlException(IPSXmlErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSInvalidXmlException(XmlErrorCode.XML_ELEMENT_INVALID_ATTR, args);
     }
     return (val == null) ? "" : val;
   }

--- a/modules/utils/src/main/java/com/percussion/utils/xml/XmlErrorCode.java
+++ b/modules/utils/src/main/java/com/percussion/utils/xml/XmlErrorCode.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.utils.xml;
+
+import com.percussion.error.IPSErrorCode;
+
+/**
+ * Utils-local typed peers for leftover {@link IPSXmlErrors} production sites (#3859 / parent
+ * #2616).
+ *
+ * <p>Modules that depend on {@code audit-log} should prefer {@code
+ * com.intsof.percussioncms.auditlog.codes.XmlErrorCodes}. Utils cannot depend on {@code
+ * audit-log} ({@code audit-log} depends on utils), so these {@link IPSErrorCode} values carry the
+ * same package-local numeric codes and non-auditable policy for typed {@link
+ * PSInvalidXmlException} construction without a circular Maven dependency.
+ *
+ * <p>Numeric codes are identical to the legacy {@link IPSXmlErrors} ints ({@code 1–6}) and to the
+ * matching {@code XmlErrorCodes} enum constants.
+ */
+public enum XmlErrorCode implements IPSErrorCode {
+
+  /** Peer of {@link IPSXmlErrors#XML_ELEMENT_MISSING} / XmlErrorCodes same. */
+  XML_ELEMENT_MISSING(IPSXmlErrors.XML_ELEMENT_MISSING),
+
+  /** Peer of {@link IPSXmlErrors#XML_ELEMENT_INVALID_VALUE} / XmlErrorCodes same. */
+  XML_ELEMENT_INVALID_VALUE(IPSXmlErrors.XML_ELEMENT_INVALID_VALUE),
+
+  /** Peer of {@link IPSXmlErrors#XML_TWO_ROOT_ELEMENTS} / XmlErrorCodes same. */
+  XML_TWO_ROOT_ELEMENTS(IPSXmlErrors.XML_TWO_ROOT_ELEMENTS),
+
+  /** Peer of {@link IPSXmlErrors#XML_ELEMENT_INVALID_ATTR} / XmlErrorCodes same. */
+  XML_ELEMENT_INVALID_ATTR(IPSXmlErrors.XML_ELEMENT_INVALID_ATTR),
+
+  /** Peer of {@link IPSXmlErrors#XML_ELEMENT_ATTR_INVALID_VAL} / XmlErrorCodes same. */
+  XML_ELEMENT_ATTR_INVALID_VAL(IPSXmlErrors.XML_ELEMENT_ATTR_INVALID_VAL),
+
+  /** Peer of {@link IPSXmlErrors#XML_RESTORE_ERROR} / XmlErrorCodes same. */
+  XML_RESTORE_ERROR(IPSXmlErrors.XML_RESTORE_ERROR);
+
+  private final int numericCode;
+
+  XmlErrorCode(int numericCode) {
+    this.numericCode = numericCode;
+  }
+
+  @Override
+  public int numericCode() {
+    return numericCode;
+  }
+
+  @Override
+  public boolean isAuditable() {
+    return false;
+  }
+}

--- a/modules/utils/src/main/java/com/percussion/xml/PSXmlTreeWalker.java
+++ b/modules/utils/src/main/java/com/percussion/xml/PSXmlTreeWalker.java
@@ -19,8 +19,8 @@ package com.percussion.xml;
 
 import com.percussion.security.xml.PSSecureXMLUtils;
 import com.percussion.utils.tools.IPSUtilsConstants;
-import com.percussion.utils.xml.IPSXmlErrors;
 import com.percussion.utils.xml.PSInvalidXmlException;
+import com.percussion.utils.xml.XmlErrorCode;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -848,7 +848,7 @@ public class PSXmlTreeWalker implements Serializable {
           if (newBase == null) { // there are elements in different trees here!?
             Object[] args = {getRootNodeName(baseElement), getRootNodeName(el)};
             PSInvalidXmlException ex =
-                new PSInvalidXmlException(IPSXmlErrors.XML_TWO_ROOT_ELEMENTS, args);
+                new PSInvalidXmlException(XmlErrorCode.XML_TWO_ROOT_ELEMENTS, args);
             throw new RuntimeException(ex.getLocalizedMessage());
           }
 

--- a/modules/utils/src/test/java/com/percussion/error/PSExceptionTypedErrorCodeTest.java
+++ b/modules/utils/src/test/java/com/percussion/error/PSExceptionTypedErrorCodeTest.java
@@ -99,6 +99,20 @@ class PSExceptionTypedErrorCodeTest {
   }
 
   @Test
+  void runtimeExceptionTypedCtorSetsNumericAndRetainsCode() {
+    PSRuntimeException ex = new PSRuntimeException(SAMPLE, new Object[] {"in", "detail"});
+    assertEquals(2011, ex.getErrorCode());
+    assertSame(SAMPLE, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void runtimeExceptionTypedCtorRejectsNullCode() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSRuntimeException((IPSErrorCode) null));
+  }
+
+  @Test
   void typedSingleArgCtorRejectsNullCode() {
     assertThrows(
         IllegalArgumentException.class, () -> new PSException((IPSErrorCode) null, "arg"));

--- a/modules/utils/src/test/java/com/percussion/error/PSUtilsLeftoverErrorCodesSliceTest.java
+++ b/modules/utils/src/test/java/com/percussion/error/PSUtilsLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.error;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.util.PSBase64Decoder;
+import com.percussion.util.PSBase64Encoder;
+import com.percussion.util.PSHttpConnection;
+import com.percussion.util.UtilErrorCode;
+import com.percussion.utils.container.PSJBossConnectors;
+import com.percussion.utils.container.PSMissingApplicationPolicyException;
+import com.percussion.utils.container.PSSecureCredentials;
+import com.percussion.utils.container.jboss.IPSJBossErrors;
+import com.percussion.utils.container.jboss.JBossErrorCode;
+import com.percussion.utils.container.jboss.PSJBossJndiDatasource;
+import com.percussion.utils.spring.IPSBeanConfig;
+import com.percussion.utils.spring.PSSpringBeanUtils;
+import com.percussion.utils.spring.PSSpringConfiguration;
+import com.percussion.utils.xml.IPSXmlErrors;
+import com.percussion.utils.xml.PSInvalidXmlException;
+import com.percussion.utils.xml.PSXmlUtils;
+import com.percussion.utils.xml.XmlErrorCode;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import com.percussion.xml.PSXmlTreeWalker;
+import com.sun.net.httpserver.HttpServer;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #3859 (parent #2616): leftover {@code modules/utils} production sites throw typed {@code
+ * *ErrorCode} peers (utils-local {@link IPSErrorCode} matching perc-auditlog catalogs) — not bare
+ * {@code IPS*Errors} ints. Dual-write is skipped ({@code isAuditable() == false}).
+ */
+@Tag("UnitTest")
+class PSUtilsLeftoverErrorCodesSliceTest {
+
+  @TempDir Path tempDir;
+
+  @Test
+  void utilErrorCodePeersMatchLegacyIntsAndSkipDualWrite() {
+    assertEquals(
+        com.percussion.util.IPSUtilErrors.BASE64_ENCODING_EXCEPTION,
+        UtilErrorCode.BASE64_ENCODING_EXCEPTION.numericCode());
+    assertEquals(
+        com.percussion.util.IPSUtilErrors.RECEIVE_DATA_ERROR,
+        UtilErrorCode.RECEIVE_DATA_ERROR.numericCode());
+    assertEquals(
+        com.percussion.util.IPSUtilErrors.POST_DATA_ERROR,
+        UtilErrorCode.POST_DATA_ERROR.numericCode());
+    for (UtilErrorCode code : UtilErrorCode.values()) {
+      assertFalse(code.isAuditable(), code.name());
+    }
+  }
+
+  @Test
+  void xmlAndJbossErrorCodePeersMatchLegacyIntsAndSkipDualWrite() {
+    assertEquals(IPSXmlErrors.XML_ELEMENT_MISSING, XmlErrorCode.XML_ELEMENT_MISSING.numericCode());
+    assertEquals(
+        IPSXmlErrors.XML_ELEMENT_INVALID_VALUE,
+        XmlErrorCode.XML_ELEMENT_INVALID_VALUE.numericCode());
+    assertEquals(
+        IPSXmlErrors.XML_TWO_ROOT_ELEMENTS, XmlErrorCode.XML_TWO_ROOT_ELEMENTS.numericCode());
+    assertEquals(
+        IPSXmlErrors.XML_ELEMENT_INVALID_ATTR, XmlErrorCode.XML_ELEMENT_INVALID_ATTR.numericCode());
+    assertEquals(
+        IPSXmlErrors.XML_ELEMENT_ATTR_INVALID_VAL,
+        XmlErrorCode.XML_ELEMENT_ATTR_INVALID_VAL.numericCode());
+    assertEquals(IPSXmlErrors.XML_RESTORE_ERROR, XmlErrorCode.XML_RESTORE_ERROR.numericCode());
+    assertEquals(
+        IPSJBossErrors.APP_POLICY_ELEMENT_MISSING,
+        JBossErrorCode.APP_POLICY_ELEMENT_MISSING.numericCode());
+    for (XmlErrorCode code : XmlErrorCode.values()) {
+      assertFalse(code.isAuditable(), code.name());
+    }
+    assertFalse(JBossErrorCode.APP_POLICY_ELEMENT_MISSING.isAuditable());
+  }
+
+  @Test
+  void base64EncoderAndDecoderThrowTypedNonAuditableRuntimeException() {
+    PSRuntimeException encodeEx =
+        assertThrows(
+            PSRuntimeException.class, () -> PSBase64Encoder.encode("payload", "not-a-charset"));
+    assertSame(UtilErrorCode.BASE64_ENCODING_EXCEPTION, encodeEx.getTypedErrorCode());
+    assertEquals(
+        UtilErrorCode.BASE64_ENCODING_EXCEPTION.numericCode(), encodeEx.getErrorCode());
+    assertFalse(encodeEx.isAuditable());
+
+    PSRuntimeException decodeEx =
+        assertThrows(
+            PSRuntimeException.class, () -> PSBase64Decoder.decode("YQ==", "not-a-charset"));
+    assertSame(UtilErrorCode.BASE64_ENCODING_EXCEPTION, decodeEx.getTypedErrorCode());
+    assertFalse(decodeEx.isAuditable());
+  }
+
+  @Test
+  void runtimeExceptionTypedCtorRejectsNullCode() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSRuntimeException((IPSErrorCode) null));
+  }
+
+  @Test
+  void httpGetJsonHttpErrorUsesTypedPostDataError() throws Exception {
+    HttpServer server =
+        HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    server.createContext(
+        "/json",
+        exchange -> {
+          byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+          exchange.sendResponseHeaders(400, body.length);
+          exchange.getResponseBody().write(body);
+          exchange.close();
+        });
+    server.start();
+    try {
+      int port = server.getAddress().getPort();
+      URL url =
+          URI.create("http://127.0.0.1:" + port + "/json?pssessionid=sid").toURL();
+      PSHttpConnection conn = new PSHttpConnection(url, "sid");
+      PSException ex = assertThrows(PSException.class, () -> conn.getJSON(url));
+      assertSame(UtilErrorCode.POST_DATA_ERROR, ex.getTypedErrorCode());
+      assertEquals(UtilErrorCode.POST_DATA_ERROR.numericCode(), ex.getErrorCode());
+      assertFalse(ex.isAuditable());
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void xmlUtilsMissingAndInvalidUseTypedCodes() throws Exception {
+    PSInvalidXmlException missing =
+        assertThrows(
+            PSInvalidXmlException.class, () -> PSXmlUtils.getElementData(null, "title", true));
+    assertSame(XmlErrorCode.XML_ELEMENT_MISSING, missing.getTypedErrorCode());
+    assertFalse(missing.isAuditable());
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element empty = PSXmlDocumentBuilder.createRoot(doc, "title");
+    PSInvalidXmlException invalidValue =
+        assertThrows(
+            PSInvalidXmlException.class, () -> PSXmlUtils.getElementData(empty, "title", true));
+    assertSame(XmlErrorCode.XML_ELEMENT_INVALID_VALUE, invalidValue.getTypedErrorCode());
+
+    Document attrDoc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(attrDoc, "Root");
+    PSInvalidXmlException invalidAttr =
+        assertThrows(
+            PSInvalidXmlException.class, () -> PSXmlUtils.checkAttribute(root, "req", true));
+    assertSame(XmlErrorCode.XML_ELEMENT_INVALID_ATTR, invalidAttr.getTypedErrorCode());
+    assertFalse(invalidAttr.isAuditable());
+  }
+
+  @Test
+  void missingApplicationPolicyUsesTypedJbossCode() {
+    PSMissingApplicationPolicyException ex =
+        new PSMissingApplicationPolicyException("rx.policy", "login-config.xml");
+    assertSame(JBossErrorCode.APP_POLICY_ELEMENT_MISSING, ex.getTypedErrorCode());
+    assertEquals(
+        JBossErrorCode.APP_POLICY_ELEMENT_MISSING.numericCode(), ex.getErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void secureCredentialsXmlErrorsUseTypedCodes() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element unnamed = doc.createElement(PSSecureCredentials.APP_POLICY_NODE_NAME);
+    PSInvalidXmlException invalidAttr =
+        assertThrows(PSInvalidXmlException.class, () -> new PSSecureCredentials(unnamed));
+    assertSame(XmlErrorCode.XML_ELEMENT_INVALID_ATTR, invalidAttr.getTypedErrorCode());
+
+    Element named = doc.createElement(PSSecureCredentials.APP_POLICY_NODE_NAME);
+    named.setAttribute("name", "rx.datasource.jdbc_rx");
+    PSInvalidXmlException missingAuth =
+        assertThrows(PSInvalidXmlException.class, () -> new PSSecureCredentials(named));
+    assertSame(XmlErrorCode.XML_ELEMENT_MISSING, missingAuth.getTypedErrorCode());
+    assertFalse(missingAuth.isAuditable());
+  }
+
+  @Test
+  void jbossDatasourceXmlErrorsUseTypedCodes() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element empty = doc.createElement(PSJBossJndiDatasource.DATASOURCE_NODE_NAME);
+    PSInvalidXmlException missingName =
+        assertThrows(PSInvalidXmlException.class, () -> new PSJBossJndiDatasource(empty));
+    assertSame(XmlErrorCode.XML_ELEMENT_MISSING, missingName.getTypedErrorCode());
+
+    Element source = doc.createElement(PSJBossJndiDatasource.DATASOURCE_NODE_NAME);
+    appendChild(doc, source, "jndi-name", "jdbc/x");
+    appendChild(doc, source, "connection-url", "jdbc:jtds:sqlserver://host:1433");
+    appendChild(doc, source, "driver-class", "net.sourceforge.jtds.jdbc.Driver");
+    appendChild(doc, source, "min-pool-size", "not-an-int");
+    PSInvalidXmlException invalidInt =
+        assertThrows(PSInvalidXmlException.class, () -> new PSJBossJndiDatasource(source));
+    assertSame(XmlErrorCode.XML_ELEMENT_INVALID_VALUE, invalidInt.getTypedErrorCode());
+    assertFalse(invalidInt.isAuditable());
+  }
+
+  @Test
+  void jbossDatasourceMissingMetadataUsesTypedCode() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element source = doc.createElement(PSJBossJndiDatasource.DATASOURCE_NODE_NAME);
+    appendChild(doc, source, "jndi-name", "jdbc/x");
+    appendChild(doc, source, "connection-url", "jdbc:jtds:sqlserver://host:1433");
+    appendChild(doc, source, "driver-class", "net.sourceforge.jtds.jdbc.Driver");
+    appendChild(doc, source, "min-pool-size", "1");
+    appendChild(doc, source, "max-pool-size", "10");
+    appendChild(doc, source, "idle-timeout-minutes", "15");
+    PSInvalidXmlException missingMeta =
+        assertThrows(PSInvalidXmlException.class, () -> new PSJBossJndiDatasource(source));
+    assertSame(XmlErrorCode.XML_ELEMENT_MISSING, missingMeta.getTypedErrorCode());
+  }
+
+  @Test
+  void xmlConnectorsMissingServerRootUsesTypedCode() throws Exception {
+    Path deployer =
+        tempDir.resolve(
+            Path.of("AppServer", "server", "rx", "deploy", "jboss-web.deployer"));
+    Files.createDirectories(deployer);
+    Files.writeString(deployer.resolve("server.xml"), "<NotServer/>");
+
+    PSJBossConnectors connectors = new PSJBossConnectors(tempDir.toFile());
+    RuntimeException wrap = assertThrows(RuntimeException.class, connectors::load);
+    assertTrue(wrap.getCause() instanceof PSInvalidXmlException);
+    PSInvalidXmlException ex = (PSInvalidXmlException) wrap.getCause();
+    assertSame(XmlErrorCode.XML_ELEMENT_MISSING, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void springConfigurationWrongRootUsesTypedCode() throws Exception {
+    Path config = tempDir.resolve("not-beans.xml");
+    Files.writeString(config, "<notbeans/>");
+    PSInvalidXmlException ex =
+        assertThrows(
+            PSInvalidXmlException.class, () -> new PSSpringConfiguration(config.toFile()));
+    assertSame(XmlErrorCode.XML_ELEMENT_MISSING, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void springBeanUtilsRestoreAndMissingPropertyUseTypedCodes() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element bean = PSXmlDocumentBuilder.createRoot(doc, IPSBeanConfig.BEAN_NODE_NAME);
+    bean.setAttribute("id", "x");
+    bean.setAttribute("class", "java.lang.String");
+
+    PSInvalidXmlException restore =
+        assertThrows(
+            PSInvalidXmlException.class,
+            () -> PSSpringBeanUtils.createBean("java.lang.String", bean));
+    assertSame(XmlErrorCode.XML_RESTORE_ERROR, restore.getTypedErrorCode());
+    assertFalse(restore.isAuditable());
+
+    PSInvalidXmlException missingProp =
+        assertThrows(
+            PSInvalidXmlException.class,
+            () -> PSSpringBeanUtils.getNextPropertyElement(bean, null, "missing"));
+    assertSame(XmlErrorCode.XML_ELEMENT_MISSING, missingProp.getTypedErrorCode());
+  }
+
+  @Test
+  void springBeanUtilsValidateRootUsesTypedInvalidAttr() throws Exception {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element bean = PSXmlDocumentBuilder.createRoot(doc, IPSBeanConfig.BEAN_NODE_NAME);
+    bean.setAttribute("id", "actual");
+    bean.setAttribute("class", "com.example.Actual");
+    PSInvalidXmlException ex =
+        assertThrows(
+            PSInvalidXmlException.class,
+            () ->
+                PSSpringBeanUtils.validateBeanRootElement(
+                    "expected", "com.example.Expected", bean));
+    assertSame(XmlErrorCode.XML_ELEMENT_INVALID_ATTR, ex.getTypedErrorCode());
+  }
+
+  @Test
+  void xmlTreeWalkerTwoRootsConstructsTypedInvalidXmlThenRuntimeException() {
+    List<String> twoTrees = Arrays.asList("alpha/child", "beta/child");
+    RuntimeException ex =
+        assertThrows(
+            RuntimeException.class, () -> PSXmlTreeWalker.getLowestLevelElement(twoTrees));
+    PSInvalidXmlException typed =
+        new PSInvalidXmlException(XmlErrorCode.XML_TWO_ROOT_ELEMENTS, new Object[] {"alpha", "beta"});
+    assertSame(XmlErrorCode.XML_TWO_ROOT_ELEMENTS, typed.getTypedErrorCode());
+    assertFalse(typed.isAuditable());
+    assertEquals(typed.getLocalizedMessage(), ex.getMessage());
+  }
+
+  private static void appendChild(Document doc, Element parent, String name, String value) {
+    Element child = doc.createElement(name);
+    child.appendChild(doc.createTextNode(value));
+    parent.appendChild(child);
+  }
+}

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -9,6 +9,7 @@
 #   #3740 deployer server/handlers + server/dependencies
 #   #3741 DCE/ContentUI/TableFactory leftover call sites
 #   #3770 leftover nav/sfp/workflow extension modules
+#   #3859 leftover modules/utils production call sites
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -43,17 +44,6 @@ modules/perc-toolkit/src/main/java/com/percussion/pso/jexl/PSOSlotTools.java
 modules/perc-toolkit/src/main/java/com/percussion/pso/relationshipbuilder/exit/PSAbstractBuildRelationshipsExtension.java
 modules/segmentation-rx/src/main/java/com/percussion/soln/relationshipbuilder/exit/PSAbstractBuildRelationshipsExtension.java
 modules/servletutils/src/main/java/com/percussion/servlet_utils/tomcat/PSTomcatUtils.java
-modules/utils/src/main/java/com/percussion/util/PSBase64Decoder.java
-modules/utils/src/main/java/com/percussion/util/PSBase64Encoder.java
-modules/utils/src/main/java/com/percussion/util/PSHttpConnection.java
-modules/utils/src/main/java/com/percussion/utils/container/PSAbstractXmlConnectors.java
-modules/utils/src/main/java/com/percussion/utils/container/PSMissingApplicationPolicyException.java
-modules/utils/src/main/java/com/percussion/utils/container/PSSecureCredentials.java
-modules/utils/src/main/java/com/percussion/utils/container/jboss/PSJBossJndiDatasource.java
-modules/utils/src/main/java/com/percussion/utils/spring/PSSpringBeanUtils.java
-modules/utils/src/main/java/com/percussion/utils/spring/PSSpringConfiguration.java
-modules/utils/src/main/java/com/percussion/utils/xml/PSXmlUtils.java
-modules/utils/src/main/java/com/percussion/xml/PSXmlTreeWalker.java
 system/Testing/Extensions/src/com/percussion/extensions/testing/PSMakeCERequest.java
 system/Testing/Extensions/src/com/percussion/extensions/testing/PSSortDocData.java
 system/Testing/Extensions/src/com/percussion/extensions/testing/TestMakeInternalRequest.java


### PR DESCRIPTION
## Summary

Parent #2616 leftover slice #3859. Retype the 11 remaining `modules/utils` production `IPS*Errors` call sites to typed `IPSErrorCode` peers. Utils cannot depend on `perc-auditlog` (circular Maven graph), so this PR adds utils-local catalogs matching the existing perc-auditlog enums:

- `UtilErrorCode` (peer of `UtilErrorCodes` / `IPSUtilErrors`)
- `XmlErrorCode` (peer of `XmlErrorCodes` / `IPSXmlErrors` 1–6)
- `JBossErrorCode` (peer of `JBossErrorCodes` / `IPSJBossErrors`)

All leftover codes are non-auditable (`isAuditable() == false`). `PSRuntimeException` gains typed constructors plus `getTypedErrorCode()` / `isAuditable()` delegates. `scripts/ipserrors-residual-allowlist.txt` shrinks for those exact eleven paths only.

Does **not** touch `system/business` (#3860), `system/webservices` (#3861), or the `system/src/main` mega-tree.

Fixes #3859  
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/utils && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 411, Failures: 0, Errors: 0, Skipped: 9 (pre-existing skips). Slice test `PSUtilsLeftoverErrorCodesSliceTest` 15 tests.
2. `python scripts/verify-no-bare-ipserrors.py` — PASS (no new bare production `IPS*Errors` sites).
3. Reviewer: confirm allow-list no longer lists the eleven `modules/utils` production files.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal error-code retype / tech-debt; no operator, admin, integrator, or end-user surface change
- [x] **Unit / module tests** — behavioral tests for typed exception construction and leftover production throw sites; standalone utils `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests)
- [x] **Cross-platform** — tests use `Path` / `Files` / `@TempDir` and loopback `HttpServer`; no OS-specific path joins

### C3 evidence

- **modules_built:** `modules/utils`
- **build_evidence:** `cd modules/utils && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 411, Failures: 0, Errors: 0, Skipped: 9. No new compiler varargs/Xlint warnings (String[]→Object[] for typed varargs).
- **downstream_checked:** C2 added constructors/methods on `PSRuntimeException` (not `final`; existing signatures unchanged). Grep: `extends PSRuntimeException` in utils/system/sitemanage; no `new PSRuntimeException() {` anonymous subclasses. Reverse-dep rebuild not required.

### C5 UI proof

N/A — Java backend error-code retype; no UI surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
