### PR TITLE
feat(system): object-storage Virtual Site rebuild reads current keys (#3880)

### DIFF
--- a/docs/ai-generated/code-reviews/3880-object-storage-rebuild-current-erlang.md
+++ b/docs/ai-generated/code-reviews/3880-object-storage-rebuild-current-erlang.md
@@ -1,0 +1,43 @@
+# Erlang review — #3880 object-storage rebuild reads current object keys
+
+**Branch:** `fix/issue-3880-object-storage-rebuild-current`  
+**Date:** 2026-08-27  
+**Reviewer:** Erlang (pre-commit, independent of implementer)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for changed logic; portable `Path`/`Files` (no Unix-only roots); product-docs companion for operator-facing rebuild note; no incomplete rest/sitemanage adaptor cache (none present)
+
+## Summary
+
+`PSObjectStorageVirtualSiteSource` already `Files.readString`s Markdown / HTML / JSON object keys on every discover/load (no path/mtime parse cache). `VirtualSiteConfigLoader` always opens `_config.yaml` from disk (including `objects.keys`). `PSVirtualSiteBuildService.build` reloads config then re-discovers. This slice locks that no-stale-parse-cache contract (Javadoc), proves same-JVM object-key / `_config.yaml` Path/Files edit→rebuild emits new HTML, and documents the operator rebuild path (no JVM restart; no file watchers).
+
+Peer: http-json rebuild #3837 / sql-database #3780 / csv-filesystem #3708 / git-filesystem #3367. Parent epic: #2678.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Test I/O uses `@TempDir` + `Path.resolve` + `Files.writeString` / `readString`
+- [x] No Unix-only `/tmp` or Windows-only `C:\` hardcodes in new tests
+- [x] No raw OS `toString()` path equality assertions
+- [x] Line-ending sensitive checks use `contains` tokens, not whole-file `\n` equality
+- [x] Object keys in YAML use logical `/` (URI-style keys), not OS separators
+
+## Issues
+
+None (hard-gate).
+
+## Nits
+
+- Two nearly parallel `secondBuildAfterObject…` tests (`PSVirtualSiteBuildServiceTest` factory wiring vs `PSObjectStorageVirtualSiteSourceTest` same-instance source). Acceptable as the SPI + assemble proofs matching HTTP JSON #3837 / CSV #3708 / SQL #3780.
+- Factory test also proves `_config.yaml` `objects.keys` is honored on the second build (`pageCount` 2→1). Extra vs peers; useful, not sprawl.
+
+## C2 API shape
+
+Javadoc-only on existing public types; no `final`/`sealed` and no method/ctor signature change. Reverse-deps (`rest` / `sitemanage`) not required.
+
+## Build
+
+Standalone `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**.  
+Focused: `PSObjectStorageVirtualSiteSourceTest` Tests run: 18, Failures: 0, Skipped: 1 (Unix-only absolute key). `PSVirtualSiteBuildServiceTest` Tests run: 14, Failures: 0. `VirtualSiteConfigLoaderTest` Tests run: 17, Failures: 0.  
+Module Surefire: Tests run: 2489, Failures: 0, Errors: 0, Skipped: 245.  
+Product-docs: `scripts\ci-smoke-product-docs.bat` → **OK** (24 pages).

--- a/product-docs/8.2/admin/publishing.md
+++ b/product-docs/8.2/admin/publishing.md
@@ -41,7 +41,8 @@ For Git/filesystem, CSV/filesystem, SQL/database, or HTTP JSON Virtual Sites suc
   (`object-storage`: Markdown / HTML / JSON under a local `rootPath`). After
   `git pull`, a local Markdown edit, a CSV change, a `_config.yaml` change, a SQL
   `queryFile` / `sql.query` change, an H2 row change, a JSON catalog / `_config.yaml`
-  edit, or an object-key edit, run Build (or Publish) again — no CMS restart. File
+  edit, or an object-storage Markdown / HTML / JSON key or `_config.yaml`
+  (`objects.keys`) edit, run Build (or Publish) again — no CMS restart. File
   watchers are not used. `sql-database` requires `_config.yaml` with a `sql:` mapping
   (`jdbc:h2:mem:`; Oracle / MySQL / SQL Server URLs return **400**). `http-json` requires
   `_config.yaml` (versions plus `http.url` or `http.file`); `virtual.remoteUrl` is **400**.

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -266,7 +266,8 @@ integrators can REST-publish).
    branch moves — or after a CSV file or `_config.yaml` change — or after the SQL
    `_config.yaml`, `sql.queryFile`, `SELECT`, or H2 rows change — or after an HTTP JSON
    catalog (`pages.json` / `http.file` / loopback `http.url`) or `_config.yaml` change —
-   or after an object-storage blob / `_config.yaml` change —
+   or after an object-storage Markdown / HTML / JSON object key or `_config.yaml`
+   (`objects.keys` or site title) change —
    choose **Build Virtual Site** again. The build re-reads the current tree (and re-fetches
    when a Git remote is configured) — **do not restart the CMS** just to pick up those
    edits. There is no file watcher; the next explicit build is the refresh.

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -411,7 +411,10 @@ Page identity:
 JSON catalog fields match HTTP JSON (`path` optional ⇒ `{version}/{id}.html`; `order`;
 `version`). Missing `id`/`title`, duplicate ids, unsafe keys, or objects larger than 2 MB
 fail closed (`VirtualSiteException`). Each discover/load re-reads current file bytes (no
-process-lifetime cache).
+process-lifetime cache). After you edit a Markdown, HTML, or JSON object key or
+`_config.yaml` (`objects.keys` or site title) on the CMS host, run **Build Virtual Site**
+again (UI, `POST …/virtual/build`, or `PSVirtualSiteBuildMain … object-storage`) — **no JVM
+restart**. File watchers are not used; the next explicit build is the refresh.
 
 Example `_config.yaml` fragment (optional key list):
 

--- a/product-docs/8.2/reference/site-config.md
+++ b/product-docs/8.2/reference/site-config.md
@@ -226,10 +226,11 @@ the output root) without failing the HTTP status when the build itself succeeds.
 Each build re-reads current Markdown/frontmatter, CSV rows, `_config.yaml`, the
 sql-database `SELECT` (`sql.query` or current `sql.queryFile` plus H2 rows), the
 http-json catalog (`http.url` / `http.file` or default `pages.json`), and object-storage
-blobs (Markdown / HTML / JSON keys) from `virtual.rootPath` (no CMS restart after `git
-pull`, a CSV/`_config.yaml` edit, a SQL query-file/`_config.yaml` or H2 row edit, a JSON
-catalog/`_config.yaml` edit, an object-key edit, or a local Markdown edit). File watchers
-are not used; run **Build Virtual Site** again after those edits.
+Markdown / HTML / JSON keys (and current `objects.keys`) from `virtual.rootPath` (no CMS
+restart after `git pull`, a CSV/`_config.yaml` edit, a SQL query-file/`_config.yaml` or H2
+row edit, a JSON catalog/`_config.yaml` edit, an object-key / `_config.yaml` edit, or a
+local Markdown edit). File watchers are not used; run **Build Virtual Site** again after
+those edits.
 The Developer Sites UI exposes this operation as **Build Virtual Site** when source kind
 is Git, CSV, SQL, HTTP JSON, or Object storage (never for traditional repository Sites).
 **Object storage** hides Preview and Publish chrome. After a

--- a/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/IPSVirtualSiteSource.java
@@ -26,13 +26,15 @@ import java.util.List;
  * Headless catalog: {@link PSHttpJsonVirtualSiteSource} ({@code http-json}). Local object-key
  * bucket: {@link PSObjectStorageVirtualSiteSource} ({@code object-storage}).
  *
- * <p>Filesystem, SQL, and HTTP JSON implementations must read <em>current</em> source contents
- * on every {@link #discover} and {@link #load}. Process-lifetime parse caches that skip a file
- * because its path or mtime looks unchanged are not allowed — a second build in the same JVM
- * (after {@code git pull}, a CSV row edit, a local Markdown/frontmatter edit, a {@code
- * _config.yaml} or {@code sql.queryFile} edit, an in-memory H2 row change, or an HTTP JSON
- * catalog ({@code http.file} / {@code pages.json} / {@code http.url} body) edit) must see the
- * new bytes. File watchers are not required; the next explicit build is the refresh.
+ * <p>Filesystem, SQL, HTTP JSON, and object-storage implementations must read
+ * <em>current</em> source contents on every {@link #discover} and {@link #load}.
+ * Process-lifetime parse caches that skip a file because its path or mtime looks unchanged
+ * are not allowed — a second build in the same JVM (after {@code git pull}, a CSV row edit, a
+ * local Markdown/frontmatter edit, a {@code _config.yaml} or {@code sql.queryFile} edit, an
+ * in-memory H2 row change, an HTTP JSON catalog ({@code http.file} / {@code pages.json} /
+ * {@code http.url} body) edit, or an object-storage Markdown/HTML/JSON key or {@code
+ * objects.keys} edit) must see the new bytes. File watchers are not required; the next
+ * explicit build is the refresh.
  */
 public interface IPSVirtualSiteSource {
 

--- a/system/services/src/com/percussion/services/virtualsite/PSObjectStorageVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSObjectStorageVirtualSiteSource.java
@@ -49,8 +49,12 @@ import org.json.JSONObject;
  *
  * <p>No cloud SDK, access keys, or network. Git remotes are not used.
  *
- * <p>Stateless: {@link #discover} and {@link #load} always re-read current file bytes. No
- * path/mtime parse cache is kept on the instance or in statics.
+ * <p>Stateless: {@link #discover} and {@link #load} always re-read current file bytes via
+ * {@link Files#readString}. No path/mtime parse cache is kept on the instance or in statics
+ * — a second build in the same JVM after a Markdown, HTML, or JSON object-key edit or a
+ * {@code _config.yaml} (site title / {@code objects.keys}) edit must see the new bytes. File
+ * watchers are not used; {@code _config.yaml} is reloaded by {@link
+ * PSVirtualSiteBuildService}, not this source.
  */
 public class PSObjectStorageVirtualSiteSource implements IPSVirtualSiteSource {
 

--- a/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSVirtualSiteBuildService.java
@@ -101,7 +101,8 @@ public class PSVirtualSiteBuildService {
    * The same service instance does not reuse parsed pages from a previous build — operators do
    * not need a JVM restart after {@code git pull}, a CSV/{@code _config.yaml} edit, a local
    * Markdown edit, a SQL query-file/{@code _config.yaml} edit, an H2 row change, an HTTP JSON
-   * catalog/{@code _config.yaml} edit, or an object-storage blob/{@code _config.yaml} edit.
+   * catalog/{@code _config.yaml} edit, or an object-storage Markdown/HTML/JSON key/{@code
+   * _config.yaml} ({@code objects.keys}) edit.
    *
    * @param siteRoot source tree ({@code _config.yaml} required for git-filesystem and
    *     sql-database; optional for csv-filesystem)

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfigLoader.java
@@ -40,8 +40,8 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
  *
  * <p>Stateless: each {@link #load} / {@link #loadOrDefault} reads the current file (or current
  * child directories). No process-lifetime YAML cache — a second build after a config edit sees
- * the new title/versions (and current {@code sql:} / {@code http:} mapping) without a JVM
- * restart.
+ * the new title/versions (and current {@code sql:} / {@code http:} / {@code objects:} mapping)
+ * without a JVM restart.
  */
 public final class VirtualSiteConfigLoader {
 

--- a/system/src/test/java/com/percussion/services/virtualsite/PSObjectStorageVirtualSiteSourceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSObjectStorageVirtualSiteSourceTest.java
@@ -19,6 +19,7 @@ package com.percussion.services.virtualsite;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -302,6 +303,124 @@ class PSObjectStorageVirtualSiteSourceTest {
   }
 
   @Test
+  void secondBuildAfterObjectKeyAndConfigEditEmitsUpdatedHtmlWithoutRestart() throws Exception {
+    Path root = writeSite(tempDir.resolve("obj-rebuild"), null);
+    Files.writeString(
+        root.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${siteTitle}</h1><h2>${pageTitle}</h2>${content}</body></html>",
+        StandardCharsets.UTF_8);
+    writeObjYaml(root, "First Site Title", null);
+    Path md = root.resolve("8.2").resolve("index.md");
+    Path htmlKey = root.resolve("8.2").resolve("install.html");
+    Path json = root.resolve("8.2").resolve("pages.json");
+    Files.writeString(
+        md,
+        """
+        ---
+        id: live-home
+        title: First Title
+        ---
+        unique-token-AAA-md
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        htmlKey,
+        "<html><head><title>First Install</title></head><body>unique-token-AAA-html</body></html>",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        json,
+        """
+        {"pages":[{"id":"plain","title":"First Catalog","body":"unique-token-AAA-json"}]}
+        """,
+        StandardCharsets.UTF_8);
+
+    Path out = tempDir.resolve("obj-rebuild-out");
+    PSObjectStorageVirtualSiteSource source = new PSObjectStorageVirtualSiteSource();
+    PSVirtualSiteBuildService service =
+        new PSVirtualSiteBuildService(source, new PSInMemoryVirtualParticipantService());
+
+    PSVirtualSiteBuildResult first = service.build(root, out, "obj-docs");
+    assertEquals(3, first.pageCount());
+    Path homeHtml = out.resolve("8.2").resolve("index.html");
+    Path installHtml = out.resolve("8.2").resolve("install.html");
+    Path catalogHtml = out.resolve("8.2").resolve("plain.html");
+    assertTrue(Files.isRegularFile(homeHtml), "missing " + homeHtml);
+    assertTrue(Files.isRegularFile(installHtml), "missing " + installHtml);
+    assertTrue(Files.isRegularFile(catalogHtml), "missing " + catalogHtml);
+    String firstHome = Files.readString(homeHtml, StandardCharsets.UTF_8);
+    String firstInstall = Files.readString(installHtml, StandardCharsets.UTF_8);
+    String firstCatalog = Files.readString(catalogHtml, StandardCharsets.UTF_8);
+    assertTrue(firstHome.contains("First Site Title"), firstHome);
+    assertTrue(firstHome.contains("First Title"), firstHome);
+    assertTrue(firstHome.contains("unique-token-AAA-md"), firstHome);
+    assertTrue(firstInstall.contains("First Install"), firstInstall);
+    assertTrue(firstInstall.contains("unique-token-AAA-html"), firstInstall);
+    assertTrue(firstCatalog.contains("First Catalog"), firstCatalog);
+    assertTrue(firstCatalog.contains("unique-token-AAA-json"), firstCatalog);
+
+    Files.writeString(
+        md,
+        """
+        ---
+        id: live-home
+        title: Second Title
+        ---
+        unique-token-BBB-md
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        htmlKey,
+        "<html><head><title>Second Install</title></head><body>unique-token-BBB-html</body></html>",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        json,
+        """
+        {"pages":[{"id":"plain","title":"Second Catalog","body":"unique-token-BBB-json"}]}
+        """,
+        StandardCharsets.UTF_8);
+    writeObjYaml(root, "Second Site Title", null);
+
+    VirtualSiteConfig reloaded =
+        VirtualSiteConfigLoader.load(root, VirtualSiteConfigLoader.DEFAULT_CONFIG_FILE, "obj-docs");
+    assertEquals("Second Site Title", reloaded.siteTitle());
+    List<VirtualItemRef> refs = source.discover(reloaded);
+    assertEquals(3, refs.size());
+    VirtualItem loadedMd = source.load(reloaded, findRef(refs, "live-home"));
+    assertEquals("Second Title", loadedMd.frontmatter().title());
+    assertTrue(loadedMd.markdownBody().contains("unique-token-BBB-md"), loadedMd.markdownBody());
+    assertFalse(loadedMd.markdownBody().contains("unique-token-AAA-md"), loadedMd.markdownBody());
+    VirtualItem loadedHtml = source.load(reloaded, findRef(refs, "install"));
+    assertEquals("Second Install", loadedHtml.frontmatter().title());
+    assertTrue(
+        loadedHtml.markdownBody().contains("unique-token-BBB-html"), loadedHtml.markdownBody());
+    VirtualItem loadedJson = source.load(reloaded, findRef(refs, "plain"));
+    assertEquals("Second Catalog", loadedJson.frontmatter().title());
+    assertTrue(
+        loadedJson.markdownBody().contains("unique-token-BBB-json"), loadedJson.markdownBody());
+
+    PSVirtualSiteBuildResult second = service.build(root, out, "obj-docs");
+    assertEquals(3, second.pageCount());
+    String secondHome = Files.readString(homeHtml, StandardCharsets.UTF_8);
+    String secondInstall = Files.readString(installHtml, StandardCharsets.UTF_8);
+    String secondCatalog = Files.readString(catalogHtml, StandardCharsets.UTF_8);
+    assertTrue(secondHome.contains("Second Site Title"), secondHome);
+    assertTrue(secondHome.contains("Second Title"), secondHome);
+    assertTrue(secondHome.contains("unique-token-BBB-md"), secondHome);
+    assertFalse(secondHome.contains("unique-token-AAA-md"), secondHome);
+    assertFalse(secondHome.contains("First Title"), secondHome);
+    assertFalse(secondHome.contains("First Site Title"), secondHome);
+    assertTrue(secondInstall.contains("Second Install"), secondInstall);
+    assertTrue(secondInstall.contains("unique-token-BBB-html"), secondInstall);
+    assertFalse(secondInstall.contains("unique-token-AAA-html"), secondInstall);
+    assertTrue(secondCatalog.contains("Second Catalog"), secondCatalog);
+    assertTrue(secondCatalog.contains("unique-token-BBB-json"), secondCatalog);
+    assertFalse(secondCatalog.contains("unique-token-AAA-json"), secondCatalog);
+    assertNotEquals(firstHome, secondHome);
+    assertNotEquals(firstInstall, secondInstall);
+    assertNotEquals(firstCatalog, secondCatalog);
+  }
+
+  @Test
   void skipsThemeAndDotFiles() throws Exception {
     Path root = writeSite(tempDir.resolve("skip-hidden"), null);
     Files.writeString(
@@ -479,6 +598,12 @@ class PSObjectStorageVirtualSiteSourceTest {
   private static Path writeSite(Path root, List<String> keys) throws Exception {
     Files.createDirectories(root.resolve("8.2"));
     Files.createDirectories(root.resolve("_theme"));
+    writeObjYaml(root, "Object Docs", keys);
+    return root;
+  }
+
+  private static void writeObjYaml(Path root, String siteTitle, List<String> keys)
+      throws Exception {
     String objectsBlock = "";
     if (keys != null && !keys.isEmpty()) {
       StringBuilder sb = new StringBuilder("objects:\n  keys:\n");
@@ -491,7 +616,7 @@ class PSObjectStorageVirtualSiteSourceTest {
         root.resolve("_config.yaml"),
         """
         site:
-          title: Object Docs
+          title: %s
         versions:
           - id: "8.2"
             label: "8.2"
@@ -501,9 +626,15 @@ class PSObjectStorageVirtualSiteSourceTest {
           layout: page.html
         %s
         """
-            .formatted(objectsBlock),
+            .formatted(siteTitle, objectsBlock),
         StandardCharsets.UTF_8);
-    return root;
+  }
+
+  private static VirtualItemRef findRef(List<VirtualItemRef> refs, String id) {
+    return refs.stream()
+        .filter(r -> id.equals(r.id()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("missing ref " + id + " in " + refs));
   }
 
   private static VirtualSiteConfig config(Path root, List<String> keys) {

--- a/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSVirtualSiteBuildServiceTest.java
@@ -455,6 +455,110 @@ class PSVirtualSiteBuildServiceTest {
   }
 
   @Test
+  void secondBuildAfterObjectStorageKeyAndConfigEditEmitsUpdatedHtmlWithoutRestart()
+      throws Exception {
+    Path siteRoot = tempDir.resolve("obj-live-site");
+    Path versionDir = siteRoot.resolve("8.2");
+    Files.createDirectories(versionDir);
+    Files.createDirectories(siteRoot.resolve("_theme"));
+    Path configYaml = siteRoot.resolve("_config.yaml");
+    Files.writeString(
+        configYaml,
+        """
+        site:
+          title: First Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: "8.2"
+            default: true
+        theme:
+          layout: page.html
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        siteRoot.resolve("_theme").resolve("page.html"),
+        "<html><body><h1>${siteTitle}</h1><h2>${pageTitle}</h2>${content}</body></html>",
+        StandardCharsets.UTF_8);
+    Path indexMd = versionDir.resolve("index.md");
+    Path extraMd = versionDir.resolve("extra.md");
+    Files.writeString(
+        indexMd,
+        """
+        ---
+        id: live-home
+        title: First Title
+        ---
+        unique-token-AAA
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        extraMd,
+        """
+        ---
+        id: extra
+        title: Extra Page
+        ---
+        unique-token-EXTRA
+        """,
+        StandardCharsets.UTF_8);
+
+    Path out = tempDir.resolve("obj-live-out");
+    PSVirtualSiteBuildService service =
+        PSVirtualSiteBuildService.forSourceType(VirtualSiteSourceType.OBJECT_STORAGE);
+
+    PSVirtualSiteBuildResult first = service.build(siteRoot, out, "obj-live");
+    assertEquals(2, first.pageCount());
+    Path html = out.resolve("8.2").resolve("index.html");
+    Path extraHtml = out.resolve("8.2").resolve("extra.html");
+    assertTrue(Files.isRegularFile(html), "missing " + html);
+    assertTrue(Files.isRegularFile(extraHtml), "missing " + extraHtml);
+    String firstHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(firstHtml.contains("First Site Title"), firstHtml);
+    assertTrue(firstHtml.contains("First Title"), firstHtml);
+    assertTrue(firstHtml.contains("unique-token-AAA"), firstHtml);
+
+    Files.writeString(
+        indexMd,
+        """
+        ---
+        id: live-home
+        title: Second Title
+        ---
+        unique-token-BBB
+        """,
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        configYaml,
+        """
+        site:
+          title: Second Site Title
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: "8.2"
+            default: true
+        theme:
+          layout: page.html
+        objects:
+          keys:
+            - 8.2/index.md
+        """,
+        StandardCharsets.UTF_8);
+
+    PSVirtualSiteBuildResult second = service.build(siteRoot, out, "obj-live");
+    assertEquals(1, second.pageCount());
+    String secondHtml = Files.readString(html, StandardCharsets.UTF_8);
+    assertTrue(secondHtml.contains("Second Site Title"), secondHtml);
+    assertTrue(secondHtml.contains("Second Title"), secondHtml);
+    assertTrue(secondHtml.contains("unique-token-BBB"), secondHtml);
+    assertFalse(secondHtml.contains("unique-token-AAA"), secondHtml);
+    assertFalse(secondHtml.contains("First Title"), secondHtml);
+    assertFalse(secondHtml.contains("First Site Title"), secondHtml);
+    assertNotEquals(firstHtml, secondHtml);
+  }
+
+  @Test
   void linkReportListsProblemsWhenBrokenLinksPresent() throws Exception {
     Path siteRoot = tempDir.resolve("broken-site");
     Path versionDir = siteRoot.resolve("8.2");

--- a/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/VirtualSiteConfigLoaderTest.java
@@ -305,6 +305,58 @@ class VirtualSiteConfigLoaderTest {
   }
 
   @Test
+  void secondLoadAfterObjectsKeysAndConfigEditSeesCurrentObjectsWithoutCache() throws Exception {
+    Path root = tempDir.resolve("live-objects-config");
+    Files.createDirectories(root);
+    Path yaml = root.resolve("_config.yaml");
+    Files.writeString(
+        yaml,
+        """
+        site:
+          title: Objects First
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        objects:
+          keys:
+            - 8.2/index.md
+        """,
+        StandardCharsets.UTF_8);
+    VirtualSiteConfig first = VirtualSiteConfigLoader.load(root, null, "k");
+    assertEquals("Objects First", first.siteTitle());
+    assertTrue(first.objects().hasKeys());
+    assertEquals(1, first.objects().keys().size());
+    assertEquals("8.2/index.md", first.objects().keys().get(0));
+
+    Files.writeString(
+        yaml,
+        """
+        site:
+          title: Objects Second
+        versions:
+          - id: "8.2"
+            label: "8.2"
+            path: 8.2
+            default: true
+        objects:
+          keys:
+            - 8.2/index.md
+            - 8.2/install.html
+            - 8.2/pages.json
+        """,
+        StandardCharsets.UTF_8);
+    VirtualSiteConfig second = VirtualSiteConfigLoader.load(root, null, "k");
+    assertEquals("Objects Second", second.siteTitle());
+    assertTrue(second.objects().hasKeys());
+    assertEquals(3, second.objects().keys().size());
+    assertEquals("8.2/index.md", second.objects().keys().get(0));
+    assertEquals("8.2/install.html", second.objects().keys().get(1));
+    assertEquals("8.2/pages.json", second.objects().keys().get(2));
+  }
+
+  @Test
   void nullRootFails() {
     assertThrows(
         VirtualSiteException.class,


### PR DESCRIPTION
## Summary

Object-storage Virtual Site **Build** always re-reads the current Markdown / HTML / JSON object keys and `_config.yaml` (`objects.keys` / site title). Operators editing keys on the CMS host do **not** need a JVM restart; there are no file watchers — the next explicit Build is the refresh.

Locks the no-stale-parse-cache contract on `PSObjectStorageVirtualSiteSource` / `PSVirtualSiteBuildService` / `VirtualSiteConfigLoader` (peer of http-json #3837 / sql-database #3780 / csv-filesystem #3708 / git-filesystem #3367). Same-JVM two-build tests after Path/Files edits emit updated HTML.

Fixes #3880. Parent: #2678.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2489, Failures: 0).
2. Focused: `PSObjectStorageVirtualSiteSourceTest` (18/0/1), `PSVirtualSiteBuildServiceTest` (14/0), `VirtualSiteConfigLoaderTest` (17/0).
3. Review the same-JVM tests: edit Markdown/HTML/JSON keys and `_config.yaml`, second `build()` on the same service instance emits new tokens / titles; factory path honors `objects.keys` (`pageCount` 2→1).
4. `scripts\ci-smoke-product-docs.bat` — OK (24 pages). Confirm 8.2 operator notes: rebuild after object-key / `_config.yaml` edit; no JVM restart; no file watchers.
5. No AWS/remoteUrl/secrets in this slice.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/virtual-sites.md`, `admin/sites.md`, `admin/publishing.md`, `reference/site-config.md`)
- [x] **Unit / module tests** — same-JVM two-build + loader `objects.keys` reload tests; `system` standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone `cd system && ../mvnw.cmd clean install` (no skipTests)
- [x] **Cross-platform** — `@TempDir` + `Path` / `Files`; logical `/` object keys; no Unix-only roots

### C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: 2489, Failures: 0, Errors: 0, Skipped: 245. Focused: `PSObjectStorageVirtualSiteSourceTest` Tests run: 18, Failures: 0, Skipped: 1; `PSVirtualSiteBuildServiceTest` Tests run: 14, Failures: 0; `VirtualSiteConfigLoaderTest` Tests run: 17, Failures: 0. Product-docs: `scripts\ci-smoke-product-docs.bat` → OK (24 pages).
- **downstream_checked:** none (C2 did not apply — Javadoc-only; no `final`/`sealed` and no method/ctor signature change)

### C5 UI proof

N/A — Java SPI/build + product-docs only; no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
