### PR TITLE
fix(system): leftover cms handlers IPS*Errors typed ErrorCodes (#3883)

### DIFF
--- a/docs/ai-generated/code-reviews/3883-cms-handlers-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3883-cms-handlers-errorcodes-erlang.md
@@ -1,0 +1,26 @@
+# Erlang review — #3883 system/src/main cms handlers leftover IPS*Errors
+
+**Scope:** uncommitted branch `fix/issue-3883-cms-handlers-errorcodes` vs `origin/main`  
+**Memory patterns hit:** typed `*ErrorCodes` + `IPSErrorCode` constructors; dual-write skip for `isAuditable()==false`; additive constructors (C2); do not delete `IPS*Errors` interfaces; PathItem-owned folder/community denials stay auditable; SQL_EXCEPTION_WRAPPER 1002 collides with `ServerErrorCodes.RAW_DUMP`.  
+**Cross-platform path checklist:** N/A (no new filesystem path joins; HTTP status ints and catalog codes only).
+
+## Summary
+
+Parent #2616 leftover slice: sixteen `system/src/main/java/com/percussion/cms/handlers` production `IPS*Errors` call-sites now construct typed `CmsErrorCodes` / `ServerErrorCodes` / `DataErrorCodes` / `HttpErrorCodes` / `PathItemErrorCodes`. Additive `IPSErrorCode` constructors on `PSDataExtractionException` (utils), `PSServerConfigException`, `PSUnsupportedConversionException`, `PSInternalRequestCallException` (cause overload), and the AA handler local `PSRequestException`. Residual allow-list shrunk by those exact 16 paths. Dual-write skip tests cover leftover non-auditable catalog codes; folder/community denials remain auditable. HTTP status sites use `.numericCode()`. No product UI/config surface.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None.
+
+### Notes (non-blocking)
+
+- `IPSCmsErrors.SQL_EXCEPTION_WRAPPER` (1002) is mapped to `ServerErrorCodes.RAW_DUMP` per the CmsErrorCodes collision comment; numeric contract is unchanged.
+- cms builders (#3882) and cms objectstore (#3884) remain on the allow-list by design.

--- a/modules/utils/src/main/java/com/percussion/data/PSDataExtractionException.java
+++ b/modules/utils/src/main/java/com/percussion/data/PSDataExtractionException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.data;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -56,6 +57,35 @@ public class PSDataExtractionException extends PSException {
    */
   public PSDataExtractionException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSDataExtractionException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSDataExtractionException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSDataExtractionException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 
   /**

--- a/modules/utils/src/test/java/com/percussion/error/PSExceptionTypedErrorCodeTest.java
+++ b/modules/utils/src/test/java/com/percussion/error/PSExceptionTypedErrorCodeTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.data.PSDataExtractionException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import org.junit.jupiter.api.Test;
 
@@ -204,5 +205,25 @@ class PSExceptionTypedErrorCodeTest {
     assertEquals(2011, ex.getErrorCode());
     assertSame(SAMPLE, ex.getTypedErrorCode());
     assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  void dataExtractionExceptionTypedCtors() {
+    PSDataExtractionException noArgs = new PSDataExtractionException(SAMPLE);
+    assertEquals(2011, noArgs.getErrorCode());
+    assertSame(SAMPLE, noArgs.getTypedErrorCode());
+    assertFalse(noArgs.isAuditable());
+
+    PSDataExtractionException single = new PSDataExtractionException(SAMPLE, "redirect");
+    assertSame(SAMPLE, single.getTypedErrorCode());
+    assertEquals("redirect", single.getErrorArguments()[0]);
+
+    Object[] args = {"field", "transform"};
+    PSDataExtractionException array = new PSDataExtractionException(SAMPLE, args);
+    assertSame(SAMPLE, array.getTypedErrorCode());
+    assertEquals(args, array.getErrorArguments());
+
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSDataExtractionException((IPSErrorCode) null));
   }
 }

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -12,6 +12,7 @@
 #   #3860 system/business delivery leftover call sites
 #   #3859 leftover modules/utils production call sites
 #   #3861 leftover system/webservices SOAP/ws call sites
+#   #3883 leftover system/src/main cms handlers
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -67,22 +68,6 @@ system/src/main/java/com/percussion/cms/PSSingleValueBuilder.java
 system/src/main/java/com/percussion/cms/PSSummaryEditorDocumentBuilder.java
 system/src/main/java/com/percussion/cms/PSTableValueBuilder.java
 system/src/main/java/com/percussion/cms/PSValidateModifyStep.java
-system/src/main/java/com/percussion/cms/handlers/PSActiveAssemblyRequestHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSBinaryCommandHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSCloneCommandHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSCloneHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSCommandHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSConditionalCloneHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSContentEditorHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSCopyHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSEditCommandHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSGlobalTemplateUpdateHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSModifyCommandHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSPreviewCommandHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSQueryCommandHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSRelationshipCommandHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSSearchCommandHandler.java
-system/src/main/java/com/percussion/cms/handlers/PSWorkflowCommandHandler.java
 system/src/main/java/com/percussion/cms/objectstore/PSActiveAssemblyProcessorProxy.java
 system/src/main/java/com/percussion/cms/objectstore/PSDbComponent.java
 system/src/main/java/com/percussion/cms/objectstore/PSDbComponentList.java

--- a/system/src/main/java/com/percussion/cms/handlers/PSActiveAssemblyRequestHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSActiveAssemblyRequestHandler.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cms.handlers;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSActiveAssemblerHandlerRequest;
 import com.percussion.cms.objectstore.PSDependentSet;
@@ -24,6 +24,7 @@ import com.percussion.cms.objectstore.server.PSActiveAssemblerProcessor;
 import com.percussion.conn.PSServerException;
 import com.percussion.design.objectstore.PSLocator;
 import com.percussion.design.objectstore.PSRelationshipConfig;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.error.PSStandaloneException;
 import com.percussion.server.IPSLoadableRequestHandler;
@@ -108,27 +109,27 @@ public class PSActiveAssemblyRequestHandler implements IPSLoadableRequestHandler
             deleteForActiveAssembler(processor, requestDoc.getOwner(), requestDoc.getDependents());
           } else {
             // unknown command
-            throw new PSCmsException(IPSCmsErrors.UNKNOWN_AA_COMMAND, command);
+            throw new PSCmsException(CmsErrorCodes.UNKNOWN_AA_COMMAND, command);
           }
         } else {
           if (command.equals(AA_REL_LOOKUP)) {
             processAaRelationshipLookup(request);
           } else {
             // unknown command
-            throw new PSCmsException(IPSCmsErrors.UNKNOWN_AA_COMMAND, command);
+            throw new PSCmsException(CmsErrorCodes.UNKNOWN_AA_COMMAND, command);
           }
         }
       } else {
         // missing command or input document parameter
         String requiredParams = IPSHtmlParameters.SYS_COMMAND + ", " + INPUT_DOC;
-        throw new PSCmsException(IPSCmsErrors.MISSING_AA_PARAMETER, requiredParams);
+        throw new PSCmsException(CmsErrorCodes.MISSING_AA_PARAMETER, requiredParams);
       }
     } catch (Exception e) {
       // create error response
       PSRequestException exception = null;
       if (e instanceof PSException) exception = new PSRequestException((PSException) e);
       else {
-        exception = new PSRequestException(IPSCmsErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        exception = new PSRequestException(CmsErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
 
       respDoc = PSXmlDocumentBuilder.createXmlDocument();
@@ -183,6 +184,16 @@ public class PSActiveAssemblyRequestHandler implements IPSLoadableRequestHandler
     // see base class for description
     public PSRequestException(int msgCode, Object singleArg) {
       super(msgCode, singleArg);
+    }
+
+    /**
+     * Typed construction with a single message argument.
+     *
+     * @param code catalogued error code, never {@code null}
+     * @param singleArg the argument to use as the sole argument in the error message
+     */
+    public PSRequestException(IPSErrorCode code, Object singleArg) {
+      super(code, singleArg);
     }
 
     // see base class for description

--- a/system/src/main/java/com/percussion/cms/handlers/PSBinaryCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSBinaryCommandHandler.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.data.IPSInternalResultHandler;
 import com.percussion.data.PSExecutionData;
@@ -57,8 +59,6 @@ import com.percussion.extension.PSExtensionException;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.security.error.PSExceptionUtils;
-import com.percussion.server.IPSHttpErrors;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSResponse;
@@ -138,7 +138,7 @@ public class PSBinaryCommandHandler extends PSCommandHandler
         // Get the mime content and set on response of the request.
         PSMimeContentResult mimeContent = rh.getMimeContent(resultData, false);
         PSResponse resp = req.getResponse();
-        if (mimeContent == null) resp.setStatus(IPSHttpErrors.HTTP_NO_CONTENT);
+        if (mimeContent == null) resp.setStatus(HttpErrorCodes.HTTP_NO_CONTENT.numericCode());
         else {
           resp.setContent(
               mimeContent.getContent(), mimeContent.getContentLength(), mimeContent.getMimeType());
@@ -162,7 +162,7 @@ public class PSBinaryCommandHandler extends PSCommandHandler
         errorCode = e.getErrorCode();
         errorArgs = e.getErrorArguments();
       } else {
-        errorCode = IPSServerErrors.RAW_DUMP;
+        errorCode = ServerErrorCodes.RAW_DUMP.numericCode();
         errorArgs = new Object[] {getExceptionText(t)};
       }
 
@@ -531,7 +531,7 @@ public class PSBinaryCommandHandler extends PSCommandHandler
        * resource map.
        */
       if (m_resourceMap.containsKey(submitName))
-        throw new PSSystemValidationException(IPSServerErrors.CE_DUPLICATE_SUBMIT_NAME, submitName);
+        throw new PSSystemValidationException(ServerErrorCodes.CE_DUPLICATE_SUBMIT_NAME, submitName);
       else m_resourceMap.put(submitName.toLowerCase(), dataset.getName());
 
       return dataset;

--- a/system/src/main/java/com/percussion/cms/handlers/PSCloneCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSCloneCommandHandler.java
@@ -17,10 +17,11 @@
 
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSRelationshipFilter;
 import com.percussion.cms.objectstore.server.PSRelationshipDbProcessor;
-import com.percussion.data.IPSDataErrors;
 import com.percussion.data.IPSInternalRequestHandler;
 import com.percussion.data.PSExecutionData;
 import com.percussion.data.PSInternalRequestCallException;
@@ -37,7 +38,6 @@ import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSRequest;
@@ -138,7 +138,7 @@ public class PSCloneCommandHandler extends PSCommandHandler {
         errorCode = e.getErrorCode();
         errorArgs = e.getErrorArguments();
       } else {
-        errorCode = IPSServerErrors.RAW_DUMP;
+        errorCode = ServerErrorCodes.RAW_DUMP.numericCode();
         errorArgs = new Object[] {getExceptionText(t)};
       }
 
@@ -202,10 +202,10 @@ public class PSCloneCommandHandler extends PSCommandHandler {
     strRevisionId = request.getParameter(m_revisionIdParamName);
     if (strContentId == null) {
       Object[] args = {m_contentIdParamName, "null"};
-      throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+      throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
     } else if (strRevisionId == null) {
       Object[] args = {m_revisionIdParamName, "null"};
-      throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+      throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
     }
 
     int contentId;
@@ -214,14 +214,14 @@ public class PSCloneCommandHandler extends PSCommandHandler {
       contentId = Integer.parseInt(strContentId);
     } catch (NumberFormatException e) {
       Object[] args = {m_contentIdParamName, strContentId};
-      throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+      throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
     }
 
     try {
       revisionId = Integer.parseInt(strRevisionId);
     } catch (NumberFormatException e) {
       Object[] args = {m_revisionIdParamName, strRevisionId};
-      throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+      throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
     }
 
     // create new ids
@@ -273,7 +273,7 @@ public class PSCloneCommandHandler extends PSCommandHandler {
       throw new PSInternalRequestCallException(e.getErrorCode(), e.getErrorArguments());
     } catch (Exception e) {
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
     } finally {
       if (execData != null) execData.release();
     }

--- a/system/src/main/java/com/percussion/cms/handlers/PSCloneHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSCloneHandler.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.data.PSContentItemStatusExtractor;
 import com.percussion.data.PSExecutionData;
 import com.percussion.data.PSRuleListEvaluator;
@@ -29,7 +30,6 @@ import com.percussion.design.objectstore.PSProcessCheck;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.PSExtensionException;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.config.PSConfigManager;
 import com.percussion.server.config.PSServerConfigException;
 import java.io.IOException;
@@ -76,7 +76,7 @@ public abstract class PSCloneHandler implements IPSCloneHandler {
             null);
     m_config = configs.getConfig(config);
     if (m_config == null)
-      throw new PSServerConfigException(IPSServerErrors.UNKNOWN_CLONEHANDLER_CONFIGURATION, config);
+      throw new PSServerConfigException(ServerErrorCodes.UNKNOWN_CLONEHANDLER_CONFIGURATION, config);
   }
 
   /** see IPSCloneHandler for description */

--- a/system/src/main/java/com/percussion/cms/handlers/PSCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSCommandHandler.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.IPSEditorChangeListener;
 import com.percussion.cms.PSCmsException;
@@ -65,7 +66,6 @@ import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.extension.PSParameterMismatchException;
 import com.percussion.security.utils.PSRedirectValidation;
 import com.percussion.server.IPSInternalRequest;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
@@ -301,7 +301,7 @@ public abstract class PSCommandHandler extends PSDataHandler {
     Iterator requests = appFlow.getRedirects(commandName);
 
     if (requests == null || !requests.hasNext())
-      throw new PSSystemValidationException(IPSServerErrors.CE_MISSING_REDIRECTS, commandName);
+      throw new PSSystemValidationException(ServerErrorCodes.CE_MISSING_REDIRECTS, commandName);
 
     while (requests.hasNext()) {
       PSConditionalRequest request = (PSConditionalRequest) requests.next();
@@ -329,7 +329,7 @@ public abstract class PSCommandHandler extends PSDataHandler {
 
     // create the redirect url
     String url = getRedirectURL(data);
-    if (url == null) throw new PSDataExtractionException(IPSServerErrors.CE_NO_REDIRECT_URL);
+    if (url == null) throw new PSDataExtractionException(ServerErrorCodes.CE_NO_REDIRECT_URL);
 
     sendRedirect(data, processUrlReplacementParameters(url, data));
   }
@@ -650,7 +650,7 @@ public abstract class PSCommandHandler extends PSDataHandler {
 
     if (null == fieldSet) {
       throw new PSSystemValidationException(
-          IPSServerErrors.CE_MISSING_FIELDSET, dispMapper.getFieldSetRef());
+          ServerErrorCodes.CE_MISSING_FIELDSET, dispMapper.getFieldSetRef());
     }
 
     Iterator mappings = dispMapper.iterator();

--- a/system/src/main/java/com/percussion/cms/handlers/PSConditionalCloneHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSConditionalCloneHandler.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.cms.handlers;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.cms.objectstore.PSRelationshipFilter;
@@ -147,7 +147,7 @@ public class PSConditionalCloneHandler extends PSCloneHandler {
           if (!PSCms.canWriteToFolders(new PSRequestContext(data.getRequest()))) {
             // user must have write access
             throw new PSAuthorizationException(
-                IPSCmsErrors.FOLDER_PERMISSION_DENIED, new String[] {});
+                PathItemErrorCodes.FOLDER_PERMISSION_DENIED, new String[] {});
           }
         }
 

--- a/system/src/main/java/com/percussion/cms/handlers/PSContentEditorHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSContentEditorHandler.java
@@ -17,6 +17,7 @@
 
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.IPSEditorChangeListener;
 import com.percussion.cms.IPSRelationshipChangeListener;
@@ -71,7 +72,6 @@ import com.percussion.security.PSAuthorizationException;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSInternalRequest;
 import com.percussion.server.IPSRequestHandler;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSRequest;
@@ -149,12 +149,12 @@ public class PSContentEditorHandler
      * already have been logged by the server and displayed on the console.
      */
     if (null == m_systemDef) {
-      throw new PSSystemValidationException(IPSServerErrors.CE_SYSTEM_DEF_INVALID);
+      throw new PSSystemValidationException(ServerErrorCodes.CE_SYSTEM_DEF_INVALID);
     }
 
     if (null == m_sharedDef) {
       // must have at least one group
-      throw new PSSystemValidationException(IPSServerErrors.CE_SHARED_DEF_INVALID);
+      throw new PSSystemValidationException(ServerErrorCodes.CE_SHARED_DEF_INVALID);
     }
 
     PSContentEditorPipe cePipe = (PSContentEditorPipe) ce.getPipe();
@@ -844,12 +844,12 @@ public class PSContentEditorHandler
     Object[] args = {fieldName, m_dataSet.getName(), m_appHandler.getName()};
     if (PSServer.requireUniqueFieldNames()) {
       // throw error
-      throw new PSSystemValidationException(IPSServerErrors.CE_DUPLICATE_FIELD_NAME_ERROR, args);
+      throw new PSSystemValidationException(ServerErrorCodes.CE_DUPLICATE_FIELD_NAME_ERROR, args);
     } else {
       // just write a warning to console and log
       PSLogManager.write(
           new PSLogServerWarning(
-              IPSServerErrors.CE_DUPLICATE_FIELD_NAME_WARNING, args, true, SUBSYSTEM_NAME));
+              ServerErrorCodes.CE_DUPLICATE_FIELD_NAME_WARNING.numericCode(), args, true, SUBSYSTEM_NAME));
     }
   }
 
@@ -868,7 +868,7 @@ public class PSContentEditorHandler
     Object[] args = {colName, fields, m_dataSet.getName(), m_appHandler.getName()};
     PSLogManager.write(
         new PSLogServerWarning(
-            IPSServerErrors.CE_DUPLICATE_COL_NAME_WARNING, args, true, SUBSYSTEM_NAME));
+            ServerErrorCodes.CE_DUPLICATE_COL_NAME_WARNING.numericCode(), args, true, SUBSYSTEM_NAME));
   }
 
   /**
@@ -893,7 +893,7 @@ public class PSContentEditorHandler
           int id = ids.next().intValue();
           if (id == defaultWfId)
             throw new PSSystemValidationException(
-                IPSServerErrors.CE_DEFAULT_WF_EXCLUDED, Integer.toString(id));
+                ServerErrorCodes.CE_DEFAULT_WF_EXCLUDED, Integer.toString(id));
         }
       } else {
         // make sure the default IS in the included list
@@ -905,7 +905,7 @@ public class PSContentEditorHandler
         }
         if (!found)
           throw new PSSystemValidationException(
-              IPSServerErrors.CE_DEFAULT_WF_NOT_INLUDED, Integer.toString(id));
+              ServerErrorCodes.CE_DEFAULT_WF_NOT_INLUDED, Integer.toString(id));
       }
     }
   }

--- a/system/src/main/java/com/percussion/cms/handlers/PSCopyHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSCopyHandler.java
@@ -17,7 +17,8 @@
 
 package com.percussion.cms.handlers;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSApplicationBuilder;
 import com.percussion.cms.PSChoiceBuilder;
@@ -60,7 +61,6 @@ import com.percussion.error.PSNotFoundException;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.security.error.PSExceptionUtils;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSInternalRequest;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
@@ -408,7 +408,7 @@ class PSCopyHandler implements IPSCopyHandler {
               communityId
             };
         PSAuthorizationException e =
-            new PSAuthorizationException(IPSCmsErrors.CONTENT_TYPE_NOT_VISIBLE_BY_COMMUNITY, args);
+            new PSAuthorizationException(PathItemErrorCodes.CONTENT_TYPE_NOT_VISIBLE_BY_COMMUNITY, args);
         throw e;
       }
     } catch (PSInvalidContentTypeException e) {
@@ -492,7 +492,7 @@ class PSCopyHandler implements IPSCopyHandler {
 
     if (fieldSet == null)
       throw new PSSystemValidationException(
-          IPSServerErrors.CE_MISSING_FIELDSET, mapper.getFieldSetRef());
+          ServerErrorCodes.CE_MISSING_FIELDSET, mapper.getFieldSetRef());
 
     // create list of system mappings to process later
     Map systemMappings = new HashMap();
@@ -546,7 +546,7 @@ class PSCopyHandler implements IPSCopyHandler {
             label = mapping.getUISet().getLabel().getText();
           String[] args = {fieldRef, label};
 
-          throw new PSSystemValidationException(IPSServerErrors.CE_MISSING_FIELD, args);
+          throw new PSSystemValidationException(ServerErrorCodes.CE_MISSING_FIELD, args);
         }
       }
 
@@ -658,7 +658,7 @@ class PSCopyHandler implements IPSCopyHandler {
         String tableAlias = beCol.getTable().getAlias();
         PSBackEndTable beTable = (PSBackEndTable) m_beTables.get(tableAlias.toLowerCase());
         if (beTable == null) {
-          throw new PSSystemValidationException(IPSServerErrors.CE_MISSING_TABLE, tableAlias);
+          throw new PSSystemValidationException(ServerErrorCodes.CE_MISSING_TABLE, tableAlias);
         }
         beCol.setTable(beTable);
 
@@ -684,7 +684,7 @@ class PSCopyHandler implements IPSCopyHandler {
           ((PSBackEndTable) tables.get(1)).getAlias()
         };
         throw new PSSystemValidationException(
-            IPSServerErrors.CE_MULTIPLE_TABLES_NOT_SUPPORTED, args);
+            ServerErrorCodes.CE_MULTIPLE_TABLES_NOT_SUPPORTED, args);
       }
 
       // add keys to both mappers and create selkeys for query
@@ -819,7 +819,7 @@ class PSCopyHandler implements IPSCopyHandler {
 
     if (!parentRowSelected) {
       Object[] args = {String.valueOf(contentId), String.valueOf(revisionId)};
-      throw new PSNotFoundException(IPSServerErrors.CE_COPY_REVISION_NOT_FOUND, args);
+      throw new PSNotFoundException(ServerErrorCodes.CE_COPY_REVISION_NOT_FOUND, args);
     }
 
     // run binary queries and add file info to appropriate rows

--- a/system/src/main/java/com/percussion/cms/handlers/PSEditCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSEditCommandHandler.java
@@ -17,6 +17,7 @@
 
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSApplicationBuilder;
 import com.percussion.cms.PSCompleteChildDocumentBuilder;
@@ -43,7 +44,6 @@ import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
@@ -96,7 +96,7 @@ public class PSEditCommandHandler extends PSQueryCommandHandler {
     PSContentEditorPipe pipe = (PSContentEditorPipe) ce.getPipe();
     if (null == pipe) {
       String[] args = {ce.getName(), ah.getApplicationDefinition().getName()};
-      throw new PSSystemValidationException(IPSServerErrors.APP_NO_QUERY_PIPES_IN_DATASET, args);
+      throw new PSSystemValidationException(ServerErrorCodes.APP_NO_QUERY_PIPES_IN_DATASET, args);
     }
     PSDisplayMapper dispMapper = pipe.getMapper().getUIDefinition().getDisplayMapper();
 
@@ -113,7 +113,7 @@ public class PSEditCommandHandler extends PSQueryCommandHandler {
     URL url;
     try {
       if (null == ce.getRequestor()) {
-        throw new PSSystemValidationException(IPSServerErrors.CE_MISSING_REQUESTOR, ce.getName());
+        throw new PSSystemValidationException(ServerErrorCodes.CE_MISSING_REQUESTOR, ce.getName());
       }
       if (PSServer.getProperty("requestBehindProxy", "false").equalsIgnoreCase("true")) {
         url =
@@ -132,7 +132,7 @@ public class PSEditCommandHandler extends PSQueryCommandHandler {
                 ah.getFullRequestRoot() + "/" + ce.getRequestor().getRequestPage() + ".html");
       }
     } catch (MalformedURLException mue) {
-      throw new PSSystemValidationException(IPSServerErrors.RAW_DUMP, mue.getLocalizedMessage());
+      throw new PSSystemValidationException(ServerErrorCodes.RAW_DUMP, mue.getLocalizedMessage());
     }
 
     rowCtx.setPageInfoMap(m_pageInfo);
@@ -432,7 +432,7 @@ public class PSEditCommandHandler extends PSQueryCommandHandler {
     PSPageInfo info = (PSPageInfo) pageInfo.get(key);
     if (null == info) {
       String[] args = {"page", key.toString()};
-      throw new PSNotFoundException(IPSServerErrors.CE_MISSING_PAGEMAP_ENTRY, args);
+      throw new PSNotFoundException(ServerErrorCodes.CE_MISSING_PAGEMAP_ENTRY, args);
     }
     info.setBuilder(builder);
   }
@@ -565,7 +565,7 @@ public class PSEditCommandHandler extends PSQueryCommandHandler {
         PSDisplayMapper childMapper = mapping.getDisplayMapper();
         if (null == childMapper) {
           String[] args = {fields.getName(), fs.getName()};
-          throw new PSSystemValidationException(IPSServerErrors.CE_MISSING_CHILDMAPPER, args);
+          throw new PSSystemValidationException(ServerErrorCodes.CE_MISSING_CHILDMAPPER, args);
         }
         if (PSFieldSet.TYPE_COMPLEX_CHILD == fs.getType()) {
           /* we need to add a page for the summary editor and recursively

--- a/system/src/main/java/com/percussion/cms/handlers/PSGlobalTemplateUpdateHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSGlobalTemplateUpdateHandler.java
@@ -16,16 +16,16 @@
  */
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.PSCmsException;
 import com.percussion.fastforward.globaltemplate.PSGlobalTemplate;
 import com.percussion.fastforward.globaltemplate.PSGlobalTemplateException;
 import com.percussion.fastforward.globaltemplate.PSRxGlobals;
 import com.percussion.security.error.PSExceptionUtils;
 import com.percussion.server.IPSHandlerStateListener;
-import com.percussion.server.IPSHttpErrors;
 import com.percussion.server.IPSLoadableRequestHandler;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSHandlerStateEvent;
 import com.percussion.server.PSRequest;
@@ -204,7 +204,7 @@ public class PSGlobalTemplateUpdateHandler
       resp.setContent(fis, file.length(), "text/plain");
     } catch (FileNotFoundException e) {
       resp.setIsErrorResponse(true);
-      resp.setStatus(IPSHttpErrors.HTTP_NOT_FOUND, PSExceptionUtils.getMessageForLog(e));
+      resp.setStatus(HttpErrorCodes.HTTP_NOT_FOUND.numericCode(), PSExceptionUtils.getMessageForLog(e));
     }
   }
 
@@ -392,7 +392,7 @@ public class PSGlobalTemplateUpdateHandler
       templates = assembly.findAllTemplates();
     } catch (PSAssemblyException e) {
       throw new PSCmsException(
-          IPSServerErrors.UNEXPECTED_EXCEPTION_CONSOLE, e.getLocalizedMessage());
+          ServerErrorCodes.UNEXPECTED_EXCEPTION_CONSOLE, e.getLocalizedMessage());
     }
 
     for (IPSAssemblyTemplate template : templates) {

--- a/system/src/main/java/com/percussion/cms/handlers/PSModifyCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSModifyCommandHandler.java
@@ -16,6 +16,8 @@
  */
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSApplicationBuilder;
 import com.percussion.cms.PSChildDeletePlanBuilder;
@@ -37,7 +39,6 @@ import com.percussion.cms.PSSimpleChildDeletePlanBuilder;
 import com.percussion.cms.PSSimpleChildInsertPlanBuilder;
 import com.percussion.cms.PSSingleValueBuilder;
 import com.percussion.cms.PSUpdatePlanBuilder;
-import com.percussion.data.IPSDataErrors;
 import com.percussion.data.IPSInternalResultHandler;
 import com.percussion.data.PSConditionalEvaluator;
 import com.percussion.data.PSConversionException;
@@ -76,7 +77,6 @@ import com.percussion.i18n.PSI18nUtils;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.security.utils.PSRedirectValidation;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSPageCache;
@@ -155,7 +155,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
       String[] args = {
         IPSConstants.HIDDEN_CONTROL_PARAM_NAME, "InitParam is empty or missing from system def"
       };
-      throw new PSSystemValidationException(IPSServerErrors.CE_INVALID_PARAM, args);
+      throw new PSSystemValidationException(ServerErrorCodes.CE_INVALID_PARAM, args);
     }
 
     // get the app we will use and add the datasets we need
@@ -193,7 +193,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
         buf.append(next.getLocalizedMessage());
         next = next.getNextException();
       }
-      throw new PSSystemValidationException(IPSServerErrors.CE_SQL_ERRORS, buf.toString());
+      throw new PSSystemValidationException(ServerErrorCodes.CE_SQL_ERRORS, buf.toString());
     }
   }
 
@@ -347,7 +347,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
       } else {
         // throw exception
         Object[] args = {PSContentEditorHandler.CHILD_ID_PARAM_NAME, strId};
-        throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+        throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
       }
     }
 
@@ -413,7 +413,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
     // generating change events
     if (modifyPlan == null && planType != PSModifyPlan.TYPE_DELETE_ITEM) {
       Object[] args = {PSContentEditorHandler.CHILD_ID_PARAM_NAME, strId};
-      throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+      throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
     }
 
     Boolean isModifyParent = (Boolean) m_modifyParent.get();
@@ -684,7 +684,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
         errorCode = e.getErrorCode();
         errorArgs = e.getErrorArguments();
       } else {
-        errorCode = IPSServerErrors.RAW_DUMP;
+        errorCode = ServerErrorCodes.RAW_DUMP.numericCode();
         errorArgs = new Object[] {getExceptionText(t)};
       }
 
@@ -726,10 +726,10 @@ public class PSModifyCommandHandler extends PSCommandHandler {
         } catch (Exception e) {
           Object[] args = {name, errMsg + e.getLocalizedMessage()};
           if (e instanceof PSDataExtractionException) {
-            throw new PSDataExtractionException(IPSServerErrors.FIELD_TRANSFORM_ERROR, args);
+            throw new PSDataExtractionException(ServerErrorCodes.FIELD_TRANSFORM_ERROR, args);
           }
 
-          throw new PSConversionException(IPSServerErrors.FIELD_TRANSFORM_ERROR, args);
+          throw new PSConversionException(ServerErrorCodes.FIELD_TRANSFORM_ERROR, args);
         }
       }
     }
@@ -828,7 +828,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
       }
     } catch (MalformedURLException e) {
       // should never happen
-      throw new PSDataExtractionException(IPSServerErrors.CE_NO_REDIRECT_URL);
+      throw new PSDataExtractionException(ServerErrorCodes.CE_NO_REDIRECT_URL);
     }
   }
 
@@ -977,7 +977,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
       throw new PSInternalRequestCallException(e.getErrorCode(), e.getErrorArguments(), e);
     } catch (Exception e) {
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e), e);
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e), e);
     }
   }
 
@@ -1212,7 +1212,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
       planType = PSModifyPlan.TYPE_UPDATE_SEQUENCE;
     } else {
       Object[] args = {m_internalApp.getRequestTypeHtmlParamName(), dbActionType};
-      throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+      throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
     }
 
     return planType;
@@ -1311,7 +1311,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
       if (mapper == null) {
         // throw exception
         Object[] args = {PSContentEditorHandler.CHILD_ID_PARAM_NAME, strChildId};
-        throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+        throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
       }
       childId = mapper.getId();
     }
@@ -1334,21 +1334,21 @@ public class PSModifyCommandHandler extends PSCommandHandler {
 
         if (strContentId != null) {
           Object[] args = {contentIdParamName, strContentId};
-          throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+          throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
         } else if (strRevisionId != null) {
           Object[] args = {revisionIdParamName, strRevisionId};
-          throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+          throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
         }
       } else {
         if (strContentId == null) {
           Object[] args = {contentIdParamName, "null"};
-          throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+          throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
         } else if (strRevisionId == null) {
           Object[] args = {revisionIdParamName, "null"};
-          throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+          throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
         } else if (strChildRowId != null) {
           Object[] args = {childRowIdParamName, strChildRowId};
-          throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+          throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
         }
       }
     } else if (planType == PSModifyPlan.TYPE_UPDATE_PLAN
@@ -1358,13 +1358,13 @@ public class PSModifyCommandHandler extends PSCommandHandler {
       // should have all required keys
       if (strContentId == null) {
         Object[] args = {contentIdParamName, "null"};
-        throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+        throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
       } else if (strRevisionId == null && planType != PSModifyPlan.TYPE_DELETE_ITEM) {
         Object[] args = {revisionIdParamName, "null"};
-        throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+        throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
       } else if (!isParent && strChildRowId == null) {
         Object[] args = {childRowIdParamName, "null"};
-        throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+        throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
       }
     }
 
@@ -1439,7 +1439,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
           if (planType == PSModifyPlan.TYPE_UPDATE_SEQUENCE) {
             if (!fieldSet.isSequencingSupported()) {
               Object[] args = {m_internalApp.getRequestTypeHtmlParamName(), dbActionType};
-              throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+              throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
             }
 
             // determine resequencing values
@@ -1476,7 +1476,7 @@ public class PSModifyCommandHandler extends PSCommandHandler {
         }
 
         Object[] args = {param, value};
-        throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+        throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
       }
     }
   }

--- a/system/src/main/java/com/percussion/cms/handlers/PSPreviewCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSPreviewCommandHandler.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSEditorDocumentBuilder;
 import com.percussion.cms.PSEditorDocumentContext;
@@ -32,7 +33,6 @@ import com.percussion.design.objectstore.PSSystemValidationException;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.extension.PSExtensionException;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSRequest;
 import com.percussion.system.utils.IPSHtmlParameters;
@@ -96,7 +96,7 @@ public class PSPreviewCommandHandler extends PSQueryCommandHandler {
     PSContentEditorPipe pipe = (PSContentEditorPipe) ce.getPipe();
     if (null == pipe) {
       String[] args = {ce.getName(), ah.getApplicationDefinition().getName()};
-      throw new PSSystemValidationException(IPSServerErrors.APP_NO_QUERY_PIPES_IN_DATASET, args);
+      throw new PSSystemValidationException(ServerErrorCodes.APP_NO_QUERY_PIPES_IN_DATASET, args);
     }
     PSDisplayMapper dispMapper = pipe.getMapper().getUIDefinition().getDisplayMapper();
 
@@ -125,7 +125,7 @@ public class PSPreviewCommandHandler extends PSQueryCommandHandler {
       throws PSDataExtractionException {
     // can't preview a new document
     if (isNewDoc) {
-      throw new PSDataExtractionException(IPSServerErrors.CE_CANT_PREVIEW_NEWDOC);
+      throw new PSDataExtractionException(ServerErrorCodes.CE_CANT_PREVIEW_NEWDOC);
     }
 
     return m_editHandler.getAppList(id, data, false);

--- a/system/src/main/java/com/percussion/cms/handlers/PSQueryCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSQueryCommandHandler.java
@@ -16,11 +16,13 @@
  */
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.PSContentEditorWalker;
 import com.percussion.cms.PSEditorDocumentBuilder;
 import com.percussion.cms.PSPageInfo;
 import com.percussion.content.IPSMimeContentTypes;
-import com.percussion.data.IPSDataErrors;
 import com.percussion.data.IPSDataExtractor;
 import com.percussion.data.IPSInternalResultHandler;
 import com.percussion.data.PSConditionalUrlEvaluator;
@@ -53,8 +55,6 @@ import com.percussion.extension.PSParameterMismatchException;
 import com.percussion.log.PSLogError;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
-import com.percussion.server.IPSHttpErrors;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSPageCache;
@@ -202,7 +202,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
     if (PSRequest.PAGE_TYPE_UNKNOWN == req.getRequestPageType()) {
       String pageExt = req.getRequestPageExtension();
       throw new PSUnsupportedConversionException(
-          IPSDataErrors.HTML_CONV_EXT_NOT_SUPPORTED, pageExt);
+          DataErrorCodes.HTML_CONV_EXT_NOT_SUPPORTED, pageExt);
     }
 
     // run any pre-processing extensions
@@ -253,7 +253,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
     int pageId = getPageId(data);
     PSEditorDocumentBuilder builder = getDocumentBuilder(pageId, data);
     if (null == builder) {
-      throw new PSNotFoundException(IPSServerErrors.CE_INVALID_PAGEID, Integer.toString(pageId));
+      throw new PSNotFoundException(ServerErrorCodes.CE_INVALID_PAGEID, Integer.toString(pageId));
     }
 
     return builder;
@@ -336,7 +336,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
            * The page probably timed out and was removed from the
            * cache. Return an error.
            */
-          resp.setStatus(IPSHttpErrors.HTTP_NOT_FOUND);
+          resp.setStatus(HttpErrorCodes.HTTP_NOT_FOUND.numericCode());
           return;
         } else {
           /*
@@ -348,7 +348,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
         }
 
         // Request is successful but we are serving an error page
-        resp.setStatus(IPSHttpErrors.HTTP_INTERNAL_SERVER_ERROR);
+        resp.setStatus(HttpErrorCodes.HTTP_INTERNAL_SERVER_ERROR.numericCode());
         stylesheet = req.getParameter(PSContentEditorHandler.USE_STYLESHEET);
       }
 
@@ -370,7 +370,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
           PSStyleSheetMerger merger = PSStyleSheetMerger.getMerger(mergeStylesheet);
           if (!(merger instanceof PSXslStyleSheetMerger)) {
             throw new PSConversionException(
-                IPSServerErrors.CE_UNSUPPORTED_MERGER, mergeStylesheet.toString());
+                ServerErrorCodes.CE_UNSUPPORTED_MERGER, mergeStylesheet.toString());
           }
           PSXslStyleSheetMerger xslMerger = (PSXslStyleSheetMerger) merger;
 
@@ -384,7 +384,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
             xslMerger.merge(req, resultDoc, out, mergeStylesheet);
           } catch (PSConversionException e) {
             PSServerLogHandler.logException(XSL_PARSER_ERROR_STRING + urlPath, e);
-            resp.setStatus(IPSHttpErrors.HTTP_INTERNAL_SERVER_ERROR, XSL_PARSER_ERROR_STRING);
+            resp.setStatus(HttpErrorCodes.HTTP_INTERNAL_SERVER_ERROR.numericCode(), XSL_PARSER_ERROR_STRING);
             return;
           }
           if (out != null) {
@@ -401,7 +401,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
         }
       } else if (PSRequest.PAGE_TYPE_JSON == req.getRequestPageType()) {
         if (resultDoc == null) {
-          resp.setStatus(IPSHttpErrors.HTTP_NOT_FOUND);
+          resp.setStatus(HttpErrorCodes.HTTP_NOT_FOUND.numericCode());
         } else {
           String json = PSXmlDocumentJsonCodec.toJson(resultDoc);
           byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
@@ -456,7 +456,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
         errorCode = e.getErrorCode();
         errorArgs = e.getErrorArguments();
       } else {
-        errorCode = IPSServerErrors.RAW_DUMP;
+        errorCode = ServerErrorCodes.RAW_DUMP.numericCode();
         errorArgs = new Object[] {getExceptionText(t)};
       }
 
@@ -514,7 +514,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
       throw new PSInternalRequestCallException(e.getErrorCode(), e.getErrorArguments());
     } catch (Exception e) {
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
     } finally {
       cleanup(null, resultSetCleanupList, execDataCleanupList);
     }
@@ -544,7 +544,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
       throw new PSInternalRequestCallException(e.getErrorCode(), e.getErrorArguments());
     } catch (SQLException e) {
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
     } finally {
       cleanup(data, resultSetCleanupList, execDataCleanupList);
     }
@@ -599,7 +599,7 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
       throw new PSInternalRequestCallException(e.getErrorCode(), e.getErrorArguments());
     } catch (Exception e) {
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
     } finally {
       cleanup(data, resultSetCleanupList, execDataCleanupList);
     }
@@ -802,10 +802,10 @@ public abstract class PSQueryCommandHandler extends PSCommandHandler
       } catch (Exception e) {
         Object[] args = {name, errMsg + e.getLocalizedMessage()};
         if (e instanceof PSDataExtractionException) {
-          throw new PSDataExtractionException(IPSServerErrors.FIELD_TRANSFORM_ERROR, args);
+          throw new PSDataExtractionException(ServerErrorCodes.FIELD_TRANSFORM_ERROR, args);
         }
 
-        throw new PSConversionException(IPSServerErrors.FIELD_TRANSFORM_ERROR, args);
+        throw new PSConversionException(ServerErrorCodes.FIELD_TRANSFORM_ERROR, args);
       }
     }
     data.setInputDocument(null);

--- a/system/src/main/java/com/percussion/cms/handlers/PSRelationshipCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSRelationshipCommandHandler.java
@@ -17,7 +17,9 @@
 
 package com.percussion.cms.handlers;
 
-import com.percussion.cms.IPSCmsErrors;
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSRelationshipChangeListener;
 import com.percussion.cms.PSApplicationBuilder;
 import com.percussion.cms.PSCmsException;
@@ -26,7 +28,6 @@ import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.cms.objectstore.PSRelationshipFilter;
 import com.percussion.cms.objectstore.server.PSRelationshipDbProcessor;
 import com.percussion.cms.objectstore.server.PSRelationshipProcessor;
-import com.percussion.data.IPSDataErrors;
 import com.percussion.data.IPSDataExtractor;
 import com.percussion.data.PSDataExtractionException;
 import com.percussion.data.PSDataExtractorFactory;
@@ -63,7 +64,6 @@ import com.percussion.relationship.PSCloneAlreadyExistsException;
 import com.percussion.relationship.PSCloneLocator;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSRequest;
@@ -170,7 +170,7 @@ public class PSRelationshipCommandHandler extends PSCommandHandler
       PSRelationshipConfig config = ms_configs.getConfig(relationshipType);
       if (config == null) {
         throw new PSServerConfigException(
-            IPSServerErrors.UNKNOWN_RELATIONSHIP_CONFIGURATION, relationshipType);
+            ServerErrorCodes.UNKNOWN_RELATIONSHIP_CONFIGURATION, relationshipType);
       }
 
       PSRelationshipDbProcessor processor = PSRelationshipDbProcessor.getInstance();
@@ -230,7 +230,7 @@ public class PSRelationshipCommandHandler extends PSCommandHandler
         errorCode = e.getErrorCode();
         errorArgs = e.getErrorArguments();
       } else {
-        errorCode = IPSServerErrors.RAW_DUMP;
+        errorCode = ServerErrorCodes.RAW_DUMP.numericCode();
         errorArgs = new Object[] {getExceptionText(t)};
       }
 
@@ -282,7 +282,7 @@ public class PSRelationshipCommandHandler extends PSCommandHandler
       throw new PSInternalRequestCallException(e.getErrorCode(), e.getErrorArguments());
     } catch (Throwable t) {
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(t));
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(t));
     } finally {
       if (execData != null) execData.release();
     }
@@ -491,7 +491,7 @@ public class PSRelationshipCommandHandler extends PSCommandHandler
       return PSIdGenerator.getNextId("RXRELATEDCONTENT");
     } catch (SQLException e) {
       throw new PSCmsException(
-          IPSCmsErrors.ID_GENERATOR_FAILED, PSSqlException.getFormattedExceptionText(e));
+          CmsErrorCodes.ID_GENERATOR_FAILED, PSSqlException.getFormattedExceptionText(e));
     }
   }
 
@@ -514,11 +514,11 @@ public class PSRelationshipCommandHandler extends PSCommandHandler
     String param = request.getParameter(name);
     if (param == null) {
       Object[] args = {name, "null"};
-      throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+      throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
     }
     if (param.trim().length() == 0) {
       Object[] args = {name, "empty"};
-      throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+      throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
     }
 
     return param;
@@ -548,7 +548,7 @@ public class PSRelationshipCommandHandler extends PSCommandHandler
       paramInt = Integer.parseInt(param);
     } catch (NumberFormatException e) {
       Object[] args = {name, param};
-      throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+      throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
     }
 
     return paramInt;
@@ -576,7 +576,7 @@ public class PSRelationshipCommandHandler extends PSCommandHandler
       PSRelationshipConfig config = ms_configs.getConfig(relationshipType);
       if (config == null) {
         throw new PSServerConfigException(
-            IPSServerErrors.UNKNOWN_RELATIONSHIP_CONFIGURATION, relationshipType);
+            ServerErrorCodes.UNKNOWN_RELATIONSHIP_CONFIGURATION, relationshipType);
       }
 
       int contentid = getParameterInt(request, IPSHtmlParameters.SYS_CONTENTID);
@@ -642,10 +642,10 @@ public class PSRelationshipCommandHandler extends PSCommandHandler
         }
       }
     } catch (IOException e) {
-      throw new PSCmsException(IPSCmsErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+      throw new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
     } catch (SQLException e) {
       throw new PSCmsException(
-          IPSCmsErrors.SQL_EXCEPTION_WRAPPER, PSStandaloneException.formatSqlException(e));
+          ServerErrorCodes.RAW_DUMP, PSStandaloneException.formatSqlException(e));
     } catch (PSException e) {
       throw new PSCmsException(e);
     }
@@ -892,7 +892,7 @@ public class PSRelationshipCommandHandler extends PSCommandHandler
          */
         PSRelationship originatingRelationship = data.getOriginatingRelationship();
         if (originatingRelationship == null)
-          throw new PSCmsException(IPSCmsErrors.NO_ORIGINATING_RELATIONSHIP);
+          throw new PSCmsException(CmsErrorCodes.NO_ORIGINATING_RELATIONSHIP);
 
         relationships.add(originatingRelationship);
       } else {

--- a/system/src/main/java/com/percussion/cms/handlers/PSSearchCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSSearchCommandHandler.java
@@ -17,10 +17,11 @@
 
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.objectstore.PSCmsObject;
 import com.percussion.conn.PSServerException;
-import com.percussion.data.IPSDataErrors;
 import com.percussion.data.IPSInternalResultHandler;
 import com.percussion.data.IPSResultSetDataFilter;
 import com.percussion.data.PSExecutionData;
@@ -71,7 +72,6 @@ import com.percussion.search.objectstore.PSWSSearchParams;
 import com.percussion.search.objectstore.PSWSSearchRequest;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSInternalRequest;
 import com.percussion.server.PSRequest;
@@ -165,7 +165,7 @@ public class PSSearchCommandHandler extends PSCommandHandler
       return data;
     } catch (Exception e) {
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
     } finally {
       cleanup(data, execDataCleanupList);
     }
@@ -223,10 +223,10 @@ public class PSSearchCommandHandler extends PSCommandHandler
       return executeSearchRequest(request, execDataCleanupList);
     } catch (PSUnsupportedConversionException e) {
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
     } catch (PSSystemValidationException e) {
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e));
     } catch (PSUnknownNodeTypeException e) {
       throw new PSInternalRequestCallException(e.getErrorCode(), e.getErrorArguments());
     } finally {
@@ -281,7 +281,7 @@ public class PSSearchCommandHandler extends PSCommandHandler
     if (PSRequest.PAGE_TYPE_UNKNOWN == req.getRequestPageType()) {
       String pageExt = req.getRequestPageExtension();
       throw new PSUnsupportedConversionException(
-          IPSDataErrors.HTML_CONV_EXT_NOT_SUPPORTED, pageExt);
+          DataErrorCodes.HTML_CONV_EXT_NOT_SUPPORTED, pageExt);
     }
 
     Document doc;
@@ -1260,9 +1260,9 @@ public class PSSearchCommandHandler extends PSCommandHandler
       try {
         driver = PSConnectionHelper.getConnectionDetail(null).getDriver();
       } catch (NamingException e) {
-        throw new PSServerException(IPSServerErrors.RAW_DUMP, e.getLocalizedMessage());
+        throw new PSServerException(ServerErrorCodes.RAW_DUMP, e.getLocalizedMessage());
       } catch (SQLException e) {
-        throw new PSServerException(IPSServerErrors.RAW_DUMP, e.getLocalizedMessage());
+        throw new PSServerException(ServerErrorCodes.RAW_DUMP, e.getLocalizedMessage());
       }
       if (driver.startsWith(PSJdbcUtils.ORACLE_PRIMARY)) {
         PSBackEndTable table = new PSBackEndTable(IPSConstants.CONTENT_STATUS_TABLE);

--- a/system/src/main/java/com/percussion/cms/handlers/PSWorkflowCommandHandler.java
+++ b/system/src/main/java/com/percussion/cms/handlers/PSWorkflowCommandHandler.java
@@ -17,6 +17,8 @@
 
 package com.percussion.cms.handlers;
 
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 
 import com.intsof.percussioncms.auditlog.AuditOutcome;
@@ -32,7 +34,6 @@ import com.percussion.cms.PSSystemMapping;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.cms.objectstore.server.PSInlineLinkProcessor;
 import com.percussion.cms.objectstore.server.PSRelationshipEffectProcessor;
-import com.percussion.data.IPSDataErrors;
 import com.percussion.data.IPSInternalRequestHandler;
 import com.percussion.data.PSDataExtractionException;
 import com.percussion.data.PSErrorCollector;
@@ -62,7 +63,6 @@ import com.percussion.relationship.PSRejectTransition;
 import com.percussion.security.PSAuthenticationFailedException;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.security.error.PSExceptionUtils;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSApplicationHandler;
 import com.percussion.server.PSPageCache;
 import com.percussion.server.PSRequest;
@@ -224,7 +224,7 @@ public class PSWorkflowCommandHandler extends PSCommandHandler {
         errorCode = e.getErrorCode();
         errorArgs = e.getErrorArguments();
       } else {
-        errorCode = IPSServerErrors.RAW_DUMP;
+        errorCode = ServerErrorCodes.RAW_DUMP.numericCode();
         errorArgs = new Object[] {getExceptionText(t)};
       }
 
@@ -365,7 +365,7 @@ public class PSWorkflowCommandHandler extends PSCommandHandler {
     } catch (Exception e) {
       ms_logger.error(PSExceptionUtils.getMessageForLog(e));
       throw new PSInternalRequestCallException(
-          IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e), e);
+          DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, getExceptionText(e), e);
     }
   }
 
@@ -655,7 +655,7 @@ public class PSWorkflowCommandHandler extends PSCommandHandler {
         String paramName = (strContentId != null ? contentIdParam : revisionIdParam);
         String paramVal = (paramName.equals(contentIdParam) ? strContentId : strRevision);
         Object[] args = {paramName, paramVal == null ? "null" : paramVal};
-        throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+        throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
       }
 
       int baseRevision = wfCtx.getBaseRevisionNum();
@@ -763,7 +763,7 @@ public class PSWorkflowCommandHandler extends PSCommandHandler {
       if (redirect) sendRedirect(data, completeUrl.toExternalForm());
     } catch (MalformedURLException e) {
       // should never happen
-      throw new PSDataExtractionException(IPSServerErrors.CE_NO_REDIRECT_URL);
+      throw new PSDataExtractionException(ServerErrorCodes.CE_NO_REDIRECT_URL);
     }
   }
 
@@ -968,7 +968,7 @@ public class PSWorkflowCommandHandler extends PSCommandHandler {
         loc = new PSLocator(strContentId);
       } catch (Exception e) {
         Object[] args = {contentIdParam, strContentId == null ? "null" : strContentId};
-        throw new PSRequestValidationException(IPSServerErrors.CE_MODIFY_INVALID_PARAM, args);
+        throw new PSRequestValidationException(ServerErrorCodes.CE_MODIFY_INVALID_PARAM, args);
       }
 
       IPSCmsObjectMgr cms = PSCmsObjectMgrLocator.getObjectManager();

--- a/system/src/main/java/com/percussion/data/PSInternalRequestCallException.java
+++ b/system/src/main/java/com/percussion/data/PSInternalRequestCallException.java
@@ -109,6 +109,19 @@ public class PSInternalRequestCallException extends PSConversionException {
   }
 
   /**
+   * Typed construction with a single message argument and cause (matches the legacy {@code (int,
+   * String, Exception)} constructor used by cms command handlers).
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   * @param exception the original exception, may be {@code null}
+   */
+  public PSInternalRequestCallException(
+      IPSErrorCode code, String singleArg, Exception exception) {
+    super(code, exception, singleArg);
+  }
+
+  /**
    * Construct an exception for messages taking an array of arguments. Be sure to store the
    * arguments in the correct order in the array, where {0} in the string is array element 0, etc.
    *

--- a/system/src/main/java/com/percussion/data/PSUnsupportedConversionException.java
+++ b/system/src/main/java/com/percussion/data/PSUnsupportedConversionException.java
@@ -17,6 +17,8 @@
 
 package com.percussion.data;
 
+import com.percussion.error.IPSErrorCode;
+
 /**
  * PSUnsupportedConversionException is thrown to indicate that the requested conversion is not
  * supported by the converter. This will usually happen when the extension specified in the request
@@ -55,5 +57,34 @@ public class PSUnsupportedConversionException extends PSConversionException {
    */
   public PSUnsupportedConversionException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSUnsupportedConversionException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSUnsupportedConversionException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSUnsupportedConversionException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 }

--- a/system/src/main/java/com/percussion/server/config/PSServerConfigException.java
+++ b/system/src/main/java/com/percussion/server/config/PSServerConfigException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.server.config;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -48,5 +49,34 @@ public class PSServerConfigException extends PSException {
    */
   public PSServerConfigException(int msgCode) {
     super(msgCode);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSServerConfigException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg the argument to use as the sole argument in the error message
+   */
+  public PSServerConfigException(IPSErrorCode code, Object singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs the array of arguments to use as the arguments in the error message
+   */
+  public PSServerConfigException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
   }
 }

--- a/system/src/test/java/com/percussion/cms/handlers/PSCmsHandlersTypedErrorCodeSliceTest.java
+++ b/system/src/test/java/com/percussion/cms/handlers/PSCmsHandlersTypedErrorCodeSliceTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.cms.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.CmsErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.PathItemErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.cms.IPSCmsErrors;
+import com.percussion.cms.PSCmsException;
+import com.percussion.conn.PSServerException;
+import com.percussion.data.IPSDataErrors;
+import com.percussion.data.PSConversionException;
+import com.percussion.data.PSDataExtractionException;
+import com.percussion.data.PSInternalRequestCallException;
+import com.percussion.data.PSUnsupportedConversionException;
+import com.percussion.design.objectstore.PSSystemValidationException;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.error.PSNotFoundException;
+import com.percussion.security.PSAuthorizationException;
+import com.percussion.server.IPSHttpErrors;
+import com.percussion.server.IPSServerErrors;
+import com.percussion.server.PSRequestValidationException;
+import com.percussion.server.config.PSServerConfigException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3883 (parent #2616 leftover): {@code com.percussion.cms.handlers} production sites throw
+ * typed {@code *ErrorCodes} via IPSErrorCode-aware constructors — not bare {@code IPS*Errors}
+ * ints. Dual-write skip is {@code isAuditable()==false} on leftover operational catalog codes.
+ */
+@Tag("UnitTest")
+public class PSCmsHandlersTypedErrorCodeSliceTest {
+
+  @Test
+  public void leftoverOperationalCodesSkipDualWrite() {
+    leftoverNonAuditable(
+        new PSCmsException(CmsErrorCodes.UNKNOWN_AA_COMMAND, "insert"),
+        CmsErrorCodes.UNKNOWN_AA_COMMAND);
+    leftoverNonAuditable(
+        new PSCmsException(CmsErrorCodes.MISSING_AA_PARAMETER, "sys_command, inputdoc"),
+        CmsErrorCodes.MISSING_AA_PARAMETER);
+    leftoverNonAuditable(
+        new PSCmsException(CmsErrorCodes.UNEXPECTED_ERROR, "boom"), CmsErrorCodes.UNEXPECTED_ERROR);
+    leftoverNonAuditable(
+        new PSCmsException(CmsErrorCodes.NO_ORIGINATING_RELATIONSHIP),
+        CmsErrorCodes.NO_ORIGINATING_RELATIONSHIP);
+    leftoverNonAuditable(
+        new PSCmsException(CmsErrorCodes.ID_GENERATOR_FAILED, "sql text"),
+        CmsErrorCodes.ID_GENERATOR_FAILED);
+    leftoverNonAuditable(
+        new PSRequestValidationException(
+            ServerErrorCodes.CE_MODIFY_INVALID_PARAM, new Object[] {"sys_contentid"}),
+        ServerErrorCodes.CE_MODIFY_INVALID_PARAM);
+    leftoverNonAuditable(
+        new PSSystemValidationException(ServerErrorCodes.CE_SYSTEM_DEF_INVALID),
+        ServerErrorCodes.CE_SYSTEM_DEF_INVALID);
+    leftoverNonAuditable(
+        new PSDataExtractionException(ServerErrorCodes.CE_NO_REDIRECT_URL),
+        ServerErrorCodes.CE_NO_REDIRECT_URL);
+    leftoverNonAuditable(
+        new PSConversionException(ServerErrorCodes.FIELD_TRANSFORM_ERROR, new Object[] {"body"}),
+        ServerErrorCodes.FIELD_TRANSFORM_ERROR);
+    leftoverNonAuditable(
+        new PSUnsupportedConversionException(DataErrorCodes.HTML_CONV_EXT_NOT_SUPPORTED, ".bin"),
+        DataErrorCodes.HTML_CONV_EXT_NOT_SUPPORTED);
+    leftoverNonAuditable(
+        new PSInternalRequestCallException(
+            DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION, "sys_cePreview"),
+        DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION);
+    leftoverNonAuditable(
+        new PSInternalRequestCallException(
+            DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION,
+            "sys_ceModify",
+            new IllegalStateException("nested")),
+        DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION);
+    leftoverNonAuditable(
+        new PSNotFoundException(ServerErrorCodes.CE_INVALID_PAGEID, "7"),
+        ServerErrorCodes.CE_INVALID_PAGEID);
+    leftoverNonAuditable(
+        new PSServerException(ServerErrorCodes.RAW_DUMP, "stack"), ServerErrorCodes.RAW_DUMP);
+    leftoverNonAuditable(
+        new PSServerConfigException(
+            ServerErrorCodes.UNKNOWN_CLONEHANDLER_CONFIGURATION, "standard"),
+        ServerErrorCodes.UNKNOWN_CLONEHANDLER_CONFIGURATION);
+    leftoverNonAuditable(
+        new PSCmsException(
+            ServerErrorCodes.RAW_DUMP, "formatted sql"),
+        ServerErrorCodes.RAW_DUMP);
+  }
+
+  @Test
+  public void folderAndCommunityDenialsRetainTypedAuditableCodes() {
+    PSAuthorizationException denied =
+        new PSAuthorizationException(
+            PathItemErrorCodes.FOLDER_PERMISSION_DENIED, new String[] {});
+    assertEquals(
+        PathItemErrorCodes.FOLDER_PERMISSION_DENIED.numericCode(), denied.getErrorCode());
+    assertSame(PathItemErrorCodes.FOLDER_PERMISSION_DENIED, denied.getTypedErrorCode());
+    assertTrue(denied.isAuditable());
+    assertEquals(IPSCmsErrors.FOLDER_PERMISSION_DENIED, denied.getErrorCode());
+
+    Object[] args = {"item-1", "1", "page", "community-2"};
+    PSAuthorizationException hidden =
+        new PSAuthorizationException(
+            PathItemErrorCodes.CONTENT_TYPE_NOT_VISIBLE_BY_COMMUNITY, args);
+    assertSame(
+        PathItemErrorCodes.CONTENT_TYPE_NOT_VISIBLE_BY_COMMUNITY, hidden.getTypedErrorCode());
+    assertTrue(hidden.isAuditable());
+    assertEquals(IPSCmsErrors.CONTENT_TYPE_NOT_VISIBLE_BY_COMMUNITY, hidden.getErrorCode());
+  }
+
+  @Test
+  public void leftoverNumericCodesMatchLegacyIpsErrors() {
+    assertEquals(IPSCmsErrors.UNKNOWN_AA_COMMAND, CmsErrorCodes.UNKNOWN_AA_COMMAND.numericCode());
+    assertEquals(
+        IPSCmsErrors.MISSING_AA_PARAMETER, CmsErrorCodes.MISSING_AA_PARAMETER.numericCode());
+    assertEquals(IPSCmsErrors.UNEXPECTED_ERROR, CmsErrorCodes.UNEXPECTED_ERROR.numericCode());
+    assertEquals(
+        IPSCmsErrors.NO_ORIGINATING_RELATIONSHIP,
+        CmsErrorCodes.NO_ORIGINATING_RELATIONSHIP.numericCode());
+    assertEquals(
+        IPSCmsErrors.ID_GENERATOR_FAILED, CmsErrorCodes.ID_GENERATOR_FAILED.numericCode());
+    assertEquals(
+        IPSCmsErrors.SQL_EXCEPTION_WRAPPER, ServerErrorCodes.RAW_DUMP.numericCode());
+    assertEquals(
+        IPSCmsErrors.FOLDER_PERMISSION_DENIED,
+        PathItemErrorCodes.FOLDER_PERMISSION_DENIED.numericCode());
+    assertEquals(
+        IPSCmsErrors.CONTENT_TYPE_NOT_VISIBLE_BY_COMMUNITY,
+        PathItemErrorCodes.CONTENT_TYPE_NOT_VISIBLE_BY_COMMUNITY.numericCode());
+    assertEquals(IPSServerErrors.RAW_DUMP, ServerErrorCodes.RAW_DUMP.numericCode());
+    assertEquals(
+        IPSServerErrors.CE_MODIFY_INVALID_PARAM,
+        ServerErrorCodes.CE_MODIFY_INVALID_PARAM.numericCode());
+    assertEquals(
+        IPSServerErrors.CE_NO_REDIRECT_URL, ServerErrorCodes.CE_NO_REDIRECT_URL.numericCode());
+    assertEquals(
+        IPSServerErrors.FIELD_TRANSFORM_ERROR,
+        ServerErrorCodes.FIELD_TRANSFORM_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.UNKNOWN_CLONEHANDLER_CONFIGURATION,
+        ServerErrorCodes.UNKNOWN_CLONEHANDLER_CONFIGURATION.numericCode());
+    assertEquals(
+        IPSDataErrors.INTERNAL_REQUEST_CALL_EXCEPTION,
+        DataErrorCodes.INTERNAL_REQUEST_CALL_EXCEPTION.numericCode());
+    assertEquals(
+        IPSDataErrors.HTML_CONV_EXT_NOT_SUPPORTED,
+        DataErrorCodes.HTML_CONV_EXT_NOT_SUPPORTED.numericCode());
+    assertEquals(IPSHttpErrors.HTTP_NO_CONTENT, HttpErrorCodes.HTTP_NO_CONTENT.numericCode());
+    assertEquals(IPSHttpErrors.HTTP_NOT_FOUND, HttpErrorCodes.HTTP_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSHttpErrors.HTTP_INTERNAL_SERVER_ERROR,
+        HttpErrorCodes.HTTP_INTERNAL_SERVER_ERROR.numericCode());
+    assertFalse(HttpErrorCodes.HTTP_NOT_FOUND.isAuditable());
+    assertFalse(ServerErrorCodes.RAW_DUMP.isAuditable());
+  }
+
+  @Test
+  public void typedConstructorsRejectNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSCmsException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSRequestValidationException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSSystemValidationException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSDataExtractionException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSUnsupportedConversionException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSInternalRequestCallException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSServerConfigException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSServerException((IPSErrorCode) null));
+  }
+
+  private static void leftoverNonAuditable(com.percussion.error.PSException ex, IPSErrorCode expected) {
+    assertEquals(expected.numericCode(), ex.getErrorCode(), expected.toString());
+    assertSame(expected, ex.getTypedErrorCode(), expected.toString());
+    assertFalse(ex.isAuditable(), expected.toString());
+    assertFalse(expected.isAuditable(), expected.toString());
+  }
+}


### PR DESCRIPTION
## Summary

Parent leftover of #2616: retype listed `system/src/main` `com.percussion.cms.handlers` production `IPS*Errors` call-sites to typed `*ErrorCodes` (`CmsErrorCodes`, `ServerErrorCodes`, `DataErrorCodes`, `HttpErrorCodes`, `PathItemErrorCodes`). Additive `IPSErrorCode` constructors on `PSDataExtractionException` (utils), `PSServerConfigException`, `PSUnsupportedConversionException`, `PSInternalRequestCallException` (cause overload), and the AA handler local `PSRequestException`.

`IPSCmsErrors.SQL_EXCEPTION_WRAPPER` (1002) maps to `ServerErrorCodes.RAW_DUMP` per the CmsErrorCodes collision comment. HTTP status sites use `.numericCode()`. Folder/community denials stay on auditable `PathItemErrorCodes`. Residual allow-list shrunk by those exact 16 handler paths. Dual-write skip tests cover leftover non-auditable catalog codes.

Fixes #3883
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/utils && ../../mvnw.cmd clean install` (JDK 21) — BUILD SUCCESS
2. `cd system && ../mvnw.cmd clean install` (JDK 21) — BUILD SUCCESS
3. Confirm `PSCmsHandlersTypedErrorCodeSliceTest` (4 tests) and `PSExceptionTypedErrorCodeTest` data-extraction ctor test green
4. `python scripts/verify-no-bare-ipserrors.py` — PASS; `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 17 passed

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal leftover `IPS*Errors` → typed `*ErrorCodes` retype; no operator/UI/API/config change
- [x] **Unit / module tests** — `PSCmsHandlersTypedErrorCodeSliceTest` asserts exact production exception types + dual-write skip via `isAuditable()`; utils typed ctor test for `PSDataExtractionException`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone `cd modules/utils && ../../mvnw.cmd clean install` then `cd system && ../mvnw.cmd clean install` (no skipTests); C2 additive constructors only
- [x] **Cross-platform** — N/A (no path/file I/O); test args are dummy strings

### C3 evidence

- **modules_built:** `modules/utils`, `system`
- **build_evidence:** `cd modules/utils && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (Total time 29.435 s). Tests run: 412, Failures: 0, Errors: 0, Skipped: 9. `PSExceptionTypedErrorCodeTest` Tests run: 19, Failures: 0. `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (Total time 01:47). Tests run: 2438, Failures: 0, Errors: 0, Skipped: 242. New: `PSCmsHandlersTypedErrorCodeSliceTest` Tests run: 4, Failures: 0. Freeze gate PASS; pytest 17 passed. No new warnings attributable to this change (pre-existing javadoc/raw-type/undeclared-dep noise).
- **downstream_checked:** C2 additive `IPSErrorCode` constructors only (not `final`/`sealed`, no signature removal). Grep `extends PSDataExtractionException` / `extends PSServerConfigException` / `extends PSInternalRequestCallException` / `extends PSUnsupportedConversionException` and `new <Type>() {` → none. No reverse-dep rebuild required beyond system consuming the installed utils SNAPSHOT.

### C5 UI proof

N/A — Java backend leftover retype, zero UI surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.