### PR TITLE
fix(sitemanage): persist CT itemExits PUT after lock (#3905)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3905-itemexits-persist-put-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3905-itemexits-persist-put-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — #3905 CD-09 itemExits persist PUT after lock
+
+**Date:** 2026-08-27  
+**Branch:** `fix/issue-3905-itemexits-persist-put`  
+**Scope:** sitemanage `ContentTypeAdaptor.applyItemExits` / SAVE_FAILED surfacing, rest OpenAPI 400 text, Playwright persist spec, product-docs  
+**Memory patterns hit:** change-class closure (adaptor tests with production types + Playwright); CE pipe `setInputDataExtensions` UOE; SAVE_FAILED error map as 400 when validation.
+
+## Summary
+
+PUT `/contenttypes/{id}/itemExits` after a held lock no longer calls `PSPipe.setInputDataExtensions` on `PSContentEditorPipe` (percPage UOE). Unchanged GET rows reuse cloned `PSConditionalExit` objects (apply-when / param types). `PSErrorsException` error-map text is included in the thrown message; SAVE_FAILED that looks like design validation / wrong extension interface is `IllegalArgumentException` (HTTP 400). `saveContentTypes` must not treat a null lock version as create (`-1`) — that deleted existing node defs on failure. Playwright persist uses `sys_cleanReservedHtmlClasses` + `sys_title` (item-level IPSItemInputTransformer), not field UDF `sys_ToUpperCase`. H2 C5: 2 passed.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+## Issues
+
+None blocking.
+
+### Companions (checked)
+
+| Artifact | Present |
+|----------|---------|
+| sitemanage adaptor apply/save | yes |
+| Unit tests (`PSContentEditorPipe`, `PSErrorsException`, `PSConditionalExit`) | yes (18 in `ContentTypeAdaptorItemExitsTest`) |
+| Playwright `developer-content-type-item-exits.spec.js` | yes (REST persist + 409) |
+| product-docs 8.2 admin + REST | yes |
+| SPA chrome | out of scope (#3901) |
+
+### Notes
+
+- Cross-platform path checklist: N/A (REST URL `/` only; Playwright uses `page.request` + `encodeURIComponent`).
+- `isValidationSaveFailure` sniffs error-map text (`does not implement`, `validation`, …), not content-type names.
+- `ContentTypeDesignLockException` is an `IllegalStateException`; rethrow catch is `IllegalStateException | IllegalArgumentException | WebApplicationException`.

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-item-exits.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-item-exits.spec.js
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Content Type item-level exits persist (CD-09 / #3905 / leftover #3902).
+ *
+ * After a held design lock, PUT /contenttypes/{id}/itemExits must persist
+ * reconstructed GET rows plus a valid item-level input translation (IPSItemInputTransformer).
+ * Field UDFs such as sys_ToUpperCase are not valid at item-level.
+ * Unlocked PUT is 409. Pipe pre/post exits are omitted so percPage is unchanged.
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/developer-content-type-item-exits.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+/** Item-level IPSItemInputTransformer present on H2 sample types — not sys_ToUpperCase. */
+const SAMPLE_FQN = "Java/global/percussion/content/sys_cleanReservedHtmlClasses";
+const SAMPLE_PARAM = "sys_title";
+const SAMPLE_TYPES = ["percRawHtmlAsset", "percPage", "percFileAsset"];
+
+function unwrapItemExits(payload) {
+  if (payload == null || typeof payload !== "object") {
+    return {
+      inputTranslations: [],
+      outputTranslations: [],
+      validations: [],
+    };
+  }
+  const nested =
+    payload.ContentTypeItemExits && typeof payload.ContentTypeItemExits === "object"
+      ? payload.ContentTypeItemExits
+      : payload.contentTypeItemExits && typeof payload.contentTypeItemExits === "object"
+        ? payload.contentTypeItemExits
+        : payload;
+  const asList = (raw, itemKey) => {
+    if (raw == null) {
+      return [];
+    }
+    if (Array.isArray(raw)) {
+      return raw;
+    }
+    if (typeof raw !== "object") {
+      return [];
+    }
+    if (Array.isArray(raw[itemKey])) {
+      return raw[itemKey];
+    }
+    if (raw[itemKey] && typeof raw[itemKey] === "object") {
+      return [raw[itemKey]];
+    }
+    if (typeof raw.empty === "boolean" && Object.keys(raw).every((k) => k === "empty")) {
+      return [];
+    }
+    if (raw.extension || raw.name || "value" in raw) {
+      return [raw];
+    }
+    return [];
+  };
+  const normalizeParams = (raw) =>
+    asList(raw, "ContentTypeItemExitParam").map((p) => {
+      const out = {};
+      if (p && typeof p.name === "string") {
+        out.name = p.name;
+      }
+      out.value = p && p.value != null ? String(p.value) : "";
+      return out;
+    });
+  const normalizeExits = (raw) =>
+    asList(raw, "ContentTypeItemExit").map((item) => ({
+      extension: exitExtension(item),
+      parameters: normalizeParams(item && item.parameters),
+    }));
+  return {
+    inputTranslations: normalizeExits(nested.inputTranslations),
+    outputTranslations: normalizeExits(nested.outputTranslations),
+    validations: normalizeExits(nested.validations),
+    maxErrorsToStopValidation: nested.maxErrorsToStopValidation,
+  };
+}
+
+function exitExtension(item) {
+  if (!item || typeof item !== "object") {
+    return "";
+  }
+  return String(item.extension || item.name || "").trim();
+}
+
+function firstParamValue(item) {
+  if (!item || !Array.isArray(item.parameters) || item.parameters.length === 0) {
+    return "";
+  }
+  const v = item.parameters[0] && item.parameters[0].value;
+  return v != null ? String(v) : "";
+}
+
+function exitKey(item) {
+  return `${exitExtension(item).toLowerCase()}|${firstParamValue(item)}`;
+}
+
+const SAMPLE_KEY = `${SAMPLE_FQN.toLowerCase()}|${SAMPLE_PARAM}`;
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(unexpectedConsole, `console error: ${unexpectedConsole.join(" | ")}`).toEqual([]);
+}
+
+function itemExitsUrl(typeName) {
+  return `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(typeName)}/itemExits`;
+}
+
+function lockUrl(typeName) {
+  return `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(typeName)}/lock`;
+}
+
+function unlockUrl(typeName) {
+  return `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(typeName)}/unlock`;
+}
+
+async function getJson(page, url) {
+  const res = await page.request.get(url, {
+    headers: { Accept: "application/json" },
+  });
+  const text = await res.text();
+  let json = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(`Non-JSON GET ${res.status()} ${url}: ${String(text).slice(0, 400)}`);
+  }
+  return { status: res.status(), json, text };
+}
+
+async function postJson(page, url) {
+  const res = await page.request.post(url, {
+    headers: { Accept: "application/json" },
+  });
+  const text = await res.text();
+  return { status: res.status(), text };
+}
+
+async function putItemExits(page, typeName, envelope) {
+  const wrapRes = await page.request.put(itemExitsUrl(typeName), {
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    data: { ContentTypeItemExits: envelope },
+  });
+  return { status: wrapRes.status(), text: await wrapRes.text() };
+}
+
+function persistEnvelope(current, extraInput) {
+  const inputs = [...(current.inputTranslations || [])];
+  if (extraInput) {
+    inputs.push(extraInput);
+  }
+  const envelope = {
+    inputTranslations: inputs,
+    outputTranslations: current.outputTranslations || [],
+    validations: current.validations || [],
+  };
+  if (current.maxErrorsToStopValidation != null) {
+    envelope.maxErrorsToStopValidation = current.maxErrorsToStopValidation;
+  }
+  return envelope;
+}
+
+async function resolveSampleType(page) {
+  const failures = [];
+  for (const name of SAMPLE_TYPES) {
+    const got = await getJson(page, itemExitsUrl(name));
+    if (got.status === 200) {
+      return { typeName: name, current: unwrapItemExits(got.json) };
+    }
+    failures.push(`${name}:${got.status}:${String(got.text).slice(0, 180)}`);
+  }
+  throw new Error(
+    `GET itemExits failed — fail closed: ${failures.join(" | ")}`,
+  );
+}
+
+test.describe("Developer content type item-level exits (CD-09 / #3905)", () => {
+  test("unlocked itemExits PUT is 409; lock is not stolen", async ({ page }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    const { typeName } = await resolveSampleType(page);
+    const put = await putItemExits(page, typeName, persistEnvelope({
+      inputTranslations: [],
+      outputTranslations: [],
+      validations: [],
+    }));
+    expect(put.status, `unlocked PUT ${put.status} ${put.text}`).toBe(409);
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+
+  test("Admin lock, PUT reconstructed item-level exits, GET reflects values", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    const { typeName, current } = await resolveSampleType(page);
+    const originalFqns = current.inputTranslations.map(exitExtension).filter(Boolean);
+    const originalKeys = current.inputTranslations.map(exitKey);
+    const alreadyHasSample = originalKeys.includes(SAMPLE_KEY);
+
+    const lock = await postJson(page, lockUrl(typeName));
+    expect(lock.status, `POST lock ${lock.status} ${lock.text}`).toBe(200);
+
+    const sample = {
+      extension: SAMPLE_FQN,
+      parameters: [{ value: SAMPLE_PARAM }],
+    };
+
+    try {
+      const roundTrip = await putItemExits(page, typeName, persistEnvelope(current));
+      expect(
+        roundTrip.status,
+        `Round-trip GET→PUT failed PUT ${roundTrip.status} ${roundTrip.text}`,
+      ).toBe(200);
+
+      if (alreadyHasSample) {
+        const without = persistEnvelope({
+          ...current,
+          inputTranslations: current.inputTranslations.filter(
+            (item) => exitKey(item) !== SAMPLE_KEY,
+          ),
+        });
+        const removed = await putItemExits(page, typeName, without);
+        expect(
+          removed.status,
+          `Remove item-exit save failed PUT ${removed.status} ${removed.text}`,
+        ).toBe(200);
+        const afterRemove = unwrapItemExits(JSON.parse(removed.text || "{}"));
+        expect(afterRemove.inputTranslations.map(exitKey)).not.toContain(SAMPLE_KEY);
+
+        const added = await putItemExits(page, typeName, persistEnvelope(afterRemove, sample));
+        expect(
+          added.status,
+          `Add item-exit save failed PUT ${added.status} ${added.text}`,
+        ).toBe(200);
+      } else {
+        const added = await putItemExits(page, typeName, persistEnvelope(current, sample));
+        expect(
+          added.status,
+          `Add item-exit save failed PUT ${added.status} ${added.text}`,
+        ).toBe(200);
+        const afterAdd = unwrapItemExits(JSON.parse(added.text || "{}"));
+        expect(afterAdd.inputTranslations.map(exitKey)).toContain(SAMPLE_KEY);
+      }
+
+      const restore = await putItemExits(page, typeName, persistEnvelope(current));
+      expect(
+        restore.status,
+        `Restore item-exit save failed PUT ${restore.status} ${restore.text}`,
+      ).toBe(200);
+      const restoredGet = await getJson(page, itemExitsUrl(typeName));
+      expect(restoredGet.status, `GET after restore ${restoredGet.text}`).toBe(200);
+      const restoredFqns = unwrapItemExits(restoredGet.json)
+        .inputTranslations.map(exitExtension)
+        .filter(Boolean);
+      expect([...restoredFqns].sort()).toEqual([...originalFqns].sort());
+    } finally {
+      const unlock = await postJson(page, unlockUrl(typeName));
+      expect(
+        unlock.status === 200 || unlock.status === 204,
+        `POST unlock ${unlock.status} ${unlock.text}`,
+      ).toBe(true);
+    }
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -19,8 +19,13 @@ visibility / transform **expressions** stay summary-only on the detail table.
 Integrators write them with REST
 `GET`/`PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions`
 (held design lock for PUT). Item-level pre/post exits and validations (CD-09)
-use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
-**not** add Properties-tab or expression-editor chrome.
+use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits` after a held design
+lock. Item-level input translations must be request pre-processors (for
+example `sys_cleanReservedHtmlClasses` or `sys_itemHTMLEncodeTransformer`),
+not field UDFs such as `sys_ToUpperCase` (those stay on field rule
+expressions). Omitting `preExits`/`postExits` leaves pipe extensions
+unchanged. This page does **not** add Properties-tab or expression-editor
+chrome.
 
 ## Product path — lock, save, unlock
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -320,17 +320,27 @@ translations**, **output translations**, **validations**, and dataset-pipe
 required. Empty arrays mean none are configured.
 
 Each exit is an object with `extension` (fully-qualified ref such as
-`Java/global/percussion/generic/sys_ToUpperCase`), optional `name`,
+`Java/global/percussion/content/sys_cleanReservedHtmlClasses`), optional `name`,
 `parameters[]` (`name`/`value`), a read-only `condition` summary, optional
 `maxErrorsToStop`, and a human-readable `summary`. `maxErrorsToStopValidation`
 is the item-validation stop count.
 
+Item-level **input** translations and **pre-exits** must implement
+`IPSRequestPreProcessor` / `IPSItemInputTransformer`. Item-level **output**
+translations and **post-exits** must implement `IPSResultDocumentProcessor`.
+Field-level UDFs such as `Java/global/percussion/generic/sys_ToUpperCase`
+belong on `PUT .../fields/{field}/ruleExpressions`, not on this item-level
+path — using them here fails design-save validation (**400**).
+
 `PUT` on the same path replaces `inputTranslations`, `outputTranslations`, and
 `validations` (empty list clears). Hold the design-session lock first
 (`POST .../lock`). `preExits` / `postExits` omitted leave pipe extensions
-unchanged; a non-null list is a full replace. Each exit needs a resolvable
-extension FQN; parameter values are stored as literals. **Apply-when
-conditions are not written** (see `designGaps` code `CT_ITEM_EXIT_CONDITIONS`).
+unchanged; a non-null list is a full replace (content-editor pipes use the
+CE-specific input-data setter; `setInputDataExtensions` is not supported on
+percPage). Each exit needs a resolvable extension FQN; parameter values are
+stored as literals. Unchanged GET rows keep their original apply-when and
+parameter types. **Apply-when conditions are not written** for new rows (see
+`designGaps` code `CT_ITEM_EXIT_CONDITIONS`).
 
 Typical flow: `POST .../lock` → `PUT .../itemExits` → `POST .../unlock`.
 
@@ -341,7 +351,7 @@ Jackson root wrap:
   "ContentTypeItemExits": {
     "inputTranslations": [
       {
-        "extension": "Java/global/percussion/generic/sys_ToUpperCase",
+        "extension": "Java/global/percussion/content/sys_itemHTMLEncodeTransformer",
         "parameters": [{ "value": "sys_title" }]
       }
     ],
@@ -355,7 +365,7 @@ Jackson root wrap:
 | Status | Typical meaning |
 |--------|-----------------|
 | `200` | GET or PUT success (PUT keeps the lock held) |
-| `400` | Missing required lists, invalid extension FQN, or `maxErrorsToStopValidation` ≤ 0 |
+| `400` | Missing required lists, invalid extension FQN, `maxErrorsToStopValidation` ≤ 0, or design-save validation (wrong item-level extension interface) |
 | `403` | Caller is not Admin (PUT) |
 | `404` | Content type not found |
 | `409` | No design lock, or locked by another user |

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -817,14 +817,23 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         if (hasLockError(e.getErrors())) {
           throw lockConflict(e, "Could not update content type item-level exits");
         }
-        log.error("Failed to save content type item-level exits {}: {}", idOrName, e.getMessage(), e);
-        throw new IllegalStateException("Failed to save content type item-level exits", e);
+        String detail = formatSaveErrors(e);
+        log.error(
+            "Failed to save content type item-level exits {}: {}", idOrName, detail, e);
+        for (Object err : e.getErrors().values()) {
+          if (err instanceof PSErrorException pe && StringUtils.isNotBlank(pe.getStack())) {
+            log.error("saveContentTypes error map stack: {}", pe.getStack());
+          }
+        }
+        String message = "Failed to save content type item-level exits: " + detail;
+        if (isValidationSaveFailure(e)) {
+          throw new IllegalArgumentException(message, e);
+        }
+        throw new IllegalStateException(message, e);
       }
       PSItemDefinition reloaded = reloadItemDef(trimmed);
       return reloaded != null ? toItemExits(reloaded) : toItemExits(def);
-    } catch (ContentTypeDesignLockException
-        | IllegalArgumentException
-        | WebApplicationException e) {
+    } catch (IllegalStateException | IllegalArgumentException | WebApplicationException e) {
       throw e;
     } catch (Exception e) {
       log.error("Failed to replace item-level exits for {}: {}", idOrName, e.getMessage(), e);
@@ -1667,12 +1676,19 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       throw new IllegalStateException(
           "Could not update content type item-level exits; content editor missing");
     }
+    List<PSConditionalExit> existingInput =
+        copyConditionalExits(editor.getInputTranslations());
+    List<PSConditionalExit> existingOutput =
+        copyConditionalExits(editor.getOutputTranslations());
+    List<PSConditionalExit> existingValidations =
+        copyConditionalExits(editor.getValidationRules());
     editor.setInputTranslation(
-        toInputTranslations(body.getInputTranslations(), "inputTranslations"));
+        toInputTranslations(body.getInputTranslations(), existingInput, "inputTranslations"));
     editor.setOutputTranslation(
-        toOutputTranslations(body.getOutputTranslations(), "outputTranslations"));
+        toOutputTranslations(
+            body.getOutputTranslations(), existingOutput, "outputTranslations"));
     PSValidationRules validations =
-        toValidationRules(body.getValidations(), "validations");
+        toValidationRules(body.getValidations(), existingValidations, "validations");
     if (body.getMaxErrorsToStopValidation() != null) {
       int max = body.getMaxErrorsToStopValidation();
       if (max <= 0) {
@@ -1692,7 +1708,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         }
       } else {
         if (body.getPreExits() != null) {
-          pipe.setInputDataExtensions(toCallSet(body.getPreExits(), "preExits"));
+          setPipeInputDataExtensions(pipe, toCallSet(body.getPreExits(), "preExits"));
         }
         if (body.getPostExits() != null) {
           pipe.setResultDataExtensions(toCallSet(body.getPostExits(), "postExits"));
@@ -1701,13 +1717,26 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     }
   }
 
+  /**
+   * Content-editor pipes throw {@link UnsupportedOperationException} from {@link
+   * PSPipe#setInputDataExtensions}; use the CE-specific setter so percPage PUT can omit-or-replace
+   * pre-exits without SAVE_FAILED / UOE.
+   */
+  static void setPipeInputDataExtensions(PSPipe pipe, PSExtensionCallSet calls) {
+    if (pipe instanceof PSContentEditorPipe cePipe) {
+      cePipe.setContentEditorInputDataExtensions(calls);
+    } else {
+      pipe.setInputDataExtensions(calls);
+    }
+  }
+
   @SuppressWarnings("unchecked")
   private static PSInputTranslations toInputTranslations(
-      List<ContentTypeItemExit> items, String field) {
+      List<ContentTypeItemExit> items, List<PSConditionalExit> existing, String field) {
     PSInputTranslations col = new PSInputTranslations();
     int i = 0;
     for (ContentTypeItemExit item : items) {
-      col.add(toConditionalExit(item, field + "[" + i + "]"));
+      col.add(reuseOrCreateConditionalExit(item, existing, field + "[" + i + "]"));
       i++;
     }
     return col;
@@ -1715,11 +1744,11 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
 
   @SuppressWarnings("unchecked")
   private static PSOutputTranslations toOutputTranslations(
-      List<ContentTypeItemExit> items, String field) {
+      List<ContentTypeItemExit> items, List<PSConditionalExit> existing, String field) {
     PSOutputTranslations col = new PSOutputTranslations();
     int i = 0;
     for (ContentTypeItemExit item : items) {
-      col.add(toConditionalExit(item, field + "[" + i + "]"));
+      col.add(reuseOrCreateConditionalExit(item, existing, field + "[" + i + "]"));
       i++;
     }
     return col;
@@ -1727,14 +1756,89 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
 
   @SuppressWarnings("unchecked")
   private static PSValidationRules toValidationRules(
-      List<ContentTypeItemExit> items, String field) {
+      List<ContentTypeItemExit> items, List<PSConditionalExit> existing, String field) {
     PSValidationRules col = new PSValidationRules();
     int i = 0;
     for (ContentTypeItemExit item : items) {
-      col.add(toConditionalExit(item, field + "[" + i + "]"));
+      col.add(reuseOrCreateConditionalExit(item, existing, field + "[" + i + "]"));
       i++;
     }
     return col;
+  }
+
+  /**
+   * Keep the original {@link PSConditionalExit} (apply-when, ids, param value types) when GET→PUT
+   * reconstructs an unchanged row. New FQN/param rows are created from the DTO.
+   */
+  static PSConditionalExit reuseOrCreateConditionalExit(
+      ContentTypeItemExit item, List<PSConditionalExit> existing, String field) {
+    PSConditionalExit created = toConditionalExit(item, field);
+    if (existing == null || existing.isEmpty()) {
+      return created;
+    }
+    String key = exitCallKey(firstCall(created));
+    if (key.isEmpty()) {
+      return created;
+    }
+    for (int i = 0; i < existing.size(); i++) {
+      PSConditionalExit orig = existing.get(i);
+      if (orig == null || orig.getRules() == null || orig.getRules().size() != 1) {
+        continue;
+      }
+      if (key.equals(exitCallKey(firstCall(orig)))) {
+        existing.remove(i);
+        PSConditionalExit clone = (PSConditionalExit) orig.clone();
+        if (item != null && item.getMaxErrorsToStop() != null) {
+          int max = item.getMaxErrorsToStop();
+          if (max <= 0) {
+            throw new IllegalArgumentException(field + ".maxErrorsToStop must be greater than 0");
+          }
+          clone.setMaxErrorsToStop(max);
+        }
+        return clone;
+      }
+    }
+    return created;
+  }
+
+  static List<PSConditionalExit> copyConditionalExits(Iterator<?> exits) {
+    List<PSConditionalExit> out = new ArrayList<>();
+    if (exits == null) {
+      return out;
+    }
+    while (exits.hasNext()) {
+      Object o = exits.next();
+      if (o instanceof PSConditionalExit conditional) {
+        out.add(conditional);
+      }
+    }
+    return out;
+  }
+
+  static PSExtensionCall firstCall(PSConditionalExit exit) {
+    if (exit == null || exit.getRules() == null || exit.getRules().isEmpty()) {
+      return null;
+    }
+    Object o = exit.getRules().get(0);
+    return o instanceof PSExtensionCall call ? call : null;
+  }
+
+  static String exitCallKey(PSExtensionCall call) {
+    if (call == null || call.getExtensionRef() == null) {
+      return "";
+    }
+    StringBuilder key = new StringBuilder(call.getExtensionRef().getFQN());
+    PSExtensionParamValue[] values = call.getParamValues();
+    if (values != null) {
+      for (PSExtensionParamValue value : values) {
+        key.append('\0');
+        if (value != null && value.getValue() != null) {
+          String text = value.getValue().getValueDisplayText();
+          key.append(text != null ? text : "");
+        }
+      }
+    }
+    return key.toString();
   }
 
   @SuppressWarnings("unchecked")
@@ -2737,6 +2841,60 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       }
     }
     return false;
+  }
+
+  /**
+   * Concatenate {@link PSErrorsException} error-map messages so REST 400/500 can surface the
+   * design-save failure (PSSystemValidationException, extension interface, etc.) instead of a
+   * bare SAVE_FAILED 500.
+   */
+  static String formatSaveErrors(PSErrorsException e) {
+    if (e == null) {
+      return "unknown error";
+    }
+    if (e.getErrors() == null || e.getErrors().isEmpty()) {
+      return StringUtils.isNotBlank(e.getMessage()) ? e.getMessage() : "unknown error";
+    }
+    List<String> parts = new ArrayList<>();
+    for (Object err : e.getErrors().values()) {
+      if (err instanceof PSErrorException pe) {
+        String msg = pe.getErrorMessage();
+        if (StringUtils.isBlank(msg)) {
+          msg = pe.getMessage();
+        }
+        if (StringUtils.isNotBlank(msg)) {
+          parts.add(msg.trim());
+        }
+      } else if (err != null) {
+        String msg = String.valueOf(err).trim();
+        if (!msg.isEmpty()) {
+          parts.add(msg);
+        }
+      }
+    }
+    if (parts.isEmpty()) {
+      return StringUtils.isNotBlank(e.getMessage()) ? e.getMessage() : "unknown error";
+    }
+    return String.join("; ", parts);
+  }
+
+  /**
+   * True when a batched {@code saveContentTypes} SAVE_FAILED looks like a design validation /
+   * extension-interface problem (HTTP 400) rather than an unexpected server failure (HTTP 500).
+   */
+  static boolean isValidationSaveFailure(PSErrorsException e) {
+    String text = formatSaveErrors(e);
+    if (StringUtils.isBlank(text)) {
+      return false;
+    }
+    String lower = text.toLowerCase();
+    return lower.contains("validation")
+        || lower.contains("does not implement")
+        || lower.contains("invalid extension")
+        || lower.contains("pssystemvalidation")
+        || lower.contains("psextensionexception")
+        || lower.contains("extension type")
+        || lower.contains("invalid_ext");
   }
 
   /** Map-keyed overload for {@code PSErrorsException} batched save errors. */

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -137,6 +137,9 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
                  GUID last-segment tokens; JAXB / UNWRAP_ROOT_VALUE expects
                  AllowedContentTypeMenusRequest. Bind both envelopes. -->
             <ref bean="allowedContentTypeMenusRequestJsonReader" />
+            <!-- #3905 / #3895 CD-09: PUT /contenttypes/{id}/itemExits wrap can arrive empty
+                 under CXF UNWRAP_ROOT_VALUE; bind wrap and flat before jacksonProvider. -->
+            <ref bean="contentTypeItemExitsJsonReader" />
             <ref bean="jacksonProvider" />
             <ref bean="jacksonContextResolver" />
             <ref bean="authorizationFilter" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorItemExitsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorItemExitsTest.java
@@ -18,6 +18,7 @@
 package com.percussion.apibridge;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,6 +28,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -36,9 +38,11 @@ import static org.mockito.Mockito.when;
 import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSApplyWhen;
 import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSConditionalExit;
 import com.percussion.design.objectstore.PSContentEditor;
+import com.percussion.design.objectstore.PSContentEditorPipe;
 import com.percussion.design.objectstore.PSExtensionCall;
 import com.percussion.design.objectstore.PSExtensionCallSet;
 import com.percussion.design.objectstore.PSExtensionParamValue;
@@ -61,6 +65,9 @@ import com.percussion.services.locking.data.PSObjectLockSummary;
 import com.percussion.util.PSCollection;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.IPSWebserviceErrors;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorsException;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import com.percussion.webservices.system.IPSSystemDesignWs;
 import java.util.Collections;
@@ -243,6 +250,187 @@ class ContentTypeAdaptorItemExitsTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> adaptor.replaceItemExits(null, "percPage", new ContentTypeItemExits()));
+  }
+
+  @Test
+  void replaceItemExits_contentEditorPipe_usesSetContentEditorInputDataExtensions()
+      throws Exception {
+    stubHeldLock();
+    when(editor.getInputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getOutputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getValidationRules()).thenReturn(Collections.emptyIterator());
+    PSContentEditorPipe pipe = mock(PSContentEditorPipe.class);
+    doThrow(new UnsupportedOperationException("percPage setInputDataExtensions"))
+        .when(pipe)
+        .setInputDataExtensions(any());
+    when(editor.getPipe()).thenReturn(pipe);
+    when(designSvc.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("test-user")))
+        .thenReturn(List.of(percPage));
+
+    ContentTypeItemExits body = emptyBody();
+    ContentTypeItemExit pre = new ContentTypeItemExit();
+    pre.setExtension("Java/global/percussion/content/sys_cleanReservedHtmlClasses");
+    pre.setParameters(List.of(new ContentTypeItemExitParam(null, "html")));
+    body.setPreExits(List.of(pre));
+
+    assertNotNull(adaptor.replaceItemExits(null, "percPage", body));
+    verify(pipe).setContentEditorInputDataExtensions(any(PSExtensionCallSet.class));
+    verify(pipe, never()).setInputDataExtensions(any());
+  }
+
+  @Test
+  void replaceItemExits_omittedPipeExits_doNotTouchPipe() throws Exception {
+    stubHeldLock();
+    when(editor.getInputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getOutputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getValidationRules()).thenReturn(Collections.emptyIterator());
+    PSContentEditorPipe pipe = mock(PSContentEditorPipe.class);
+    when(editor.getPipe()).thenReturn(pipe);
+    when(designSvc.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("test-user")))
+        .thenReturn(List.of(percPage));
+
+    assertNotNull(adaptor.replaceItemExits(null, "percPage", emptyBody()));
+    verify(pipe, never()).setInputDataExtensions(any());
+    verify(pipe, never()).setContentEditorInputDataExtensions(any());
+    verify(pipe, never()).setResultDataExtensions(any());
+  }
+
+  @Test
+  void replaceItemExits_saveFailedValidation_throws400WithErrorMap() throws Exception {
+    stubHeldLock();
+    when(editor.getInputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getOutputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getValidationRules()).thenReturn(Collections.emptyIterator());
+    when(editor.getPipe()).thenReturn(null);
+    when(designSvc.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("test-user")))
+        .thenReturn(List.of(percPage));
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(
+        new PSGuid(PSTypeEnum.NODEDEF, 311L),
+        new PSErrorException(
+            IPSWebserviceErrors.SAVE_FAILED,
+            "Failed to save PSItemDefinition 0-2-311: PSSystemValidationException:"
+                + " Java/global/percussion/generic/sys_ToUpperCase does not implement"
+                + " com.percussion.extension.IPSRequestPreProcessor",
+            "stack"));
+    doThrow(errors)
+        .when(designSvc)
+        .saveContentTypes(anyList(), eq(false), eq("test-session"), eq("test-user"));
+
+    ContentTypeItemExits body = emptyBody();
+    ContentTypeItemExit call = new ContentTypeItemExit();
+    call.setExtension("Java/global/percussion/generic/sys_ToUpperCase");
+    call.setParameters(List.of(new ContentTypeItemExitParam(null, "sys_title")));
+    body.setInputTranslations(List.of(call));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.replaceItemExits(null, "percPage", body));
+    assertTrue(ex.getMessage().contains("Failed to save content type item-level exits"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("does not implement"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("IPSRequestPreProcessor"), ex.getMessage());
+  }
+
+  @Test
+  void replaceItemExits_saveFailedUnexpected_throws500WithErrorMap() throws Exception {
+    stubHeldLock();
+    when(editor.getInputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getOutputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getValidationRules()).thenReturn(Collections.emptyIterator());
+    when(editor.getPipe()).thenReturn(null);
+    when(designSvc.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("test-user")))
+        .thenReturn(List.of(percPage));
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(
+        new PSGuid(PSTypeEnum.NODEDEF, 311L),
+        new PSErrorException(
+            IPSWebserviceErrors.SAVE_FAILED,
+            "Failed to save PSItemDefinition 0-2-311: java.io.IOException: disk full",
+            "stack"));
+    doThrow(errors)
+        .when(designSvc)
+        .saveContentTypes(anyList(), eq(false), eq("test-session"), eq("test-user"));
+
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> adaptor.replaceItemExits(null, "percPage", emptyBody()));
+    assertTrue(ex.getMessage().contains("disk full"), ex.getMessage());
+  }
+
+  @Test
+  void replaceItemExits_reusesExistingConditionalExit_preservesApplyWhen() throws Exception {
+    stubHeldLock();
+    PSExtensionCallSet calls = new PSExtensionCallSet();
+    calls.add(
+        new PSExtensionCall(
+            new PSExtensionRef("Java/global/percussion/content/sys_cleanReservedHtmlClasses"),
+            new PSExtensionParamValue[] {new PSExtensionParamValue(new PSTextLiteral("html"))}));
+    PSConditionalExit existing = new PSConditionalExit(calls);
+    PSCollection conditionals = new PSCollection(PSConditional.class);
+    conditionals.add(
+        new PSConditional(
+            new PSTextLiteral("sys_communityid"),
+            PSConditional.OPTYPE_EQUALS,
+            new PSTextLiteral("1001")));
+    PSApplyWhen when = new PSApplyWhen();
+    when.add(new PSRule(conditionals));
+    existing.setCondition(when);
+    PSInputTranslations existingCol = new PSInputTranslations();
+    existingCol.add(existing);
+    when(editor.getInputTranslations()).thenAnswer(inv -> existingCol.iterator());
+    when(editor.getOutputTranslations()).thenReturn(Collections.emptyIterator());
+    when(editor.getValidationRules()).thenReturn(Collections.emptyIterator());
+    when(editor.getPipe()).thenReturn(null);
+    when(designSvc.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("test-user")))
+        .thenReturn(List.of(percPage));
+
+    ContentTypeItemExits body = emptyBody();
+    ContentTypeItemExit keep = new ContentTypeItemExit();
+    keep.setExtension("Java/global/percussion/content/sys_cleanReservedHtmlClasses");
+    keep.setParameters(List.of(new ContentTypeItemExitParam(null, "html")));
+    ContentTypeItemExit added = new ContentTypeItemExit();
+    added.setExtension("Java/global/percussion/content/sys_itemHTMLEncodeTransformer");
+    added.setParameters(List.of(new ContentTypeItemExitParam(null, "sys_title")));
+    body.setInputTranslations(List.of(keep, added));
+
+    assertNotNull(adaptor.replaceItemExits(null, "percPage", body));
+    ArgumentCaptor<PSInputTranslations> applied = ArgumentCaptor.forClass(PSInputTranslations.class);
+    verify(editor).setInputTranslation(applied.capture());
+    assertEquals(2, applied.getValue().size());
+    PSConditionalExit first = (PSConditionalExit) applied.getValue().get(0);
+    assertNotNull(first.getCondition());
+    assertEquals(1, first.getCondition().size());
+    PSConditionalExit second = (PSConditionalExit) applied.getValue().get(1);
+    assertEquals(
+        "sys_itemHTMLEncodeTransformer",
+        second.getRules().get(0) instanceof PSExtensionCall call
+            ? call.getExtensionRef().getExtensionName()
+            : null);
+  }
+
+  @Test
+  void formatSaveErrors_andValidationDetection() {
+    assertEquals("unknown error", ContentTypeAdaptor.formatSaveErrors(null));
+    PSErrorsException empty = new PSErrorsException();
+    assertEquals("unknown error", ContentTypeAdaptor.formatSaveErrors(empty));
+    assertFalse(ContentTypeAdaptor.isValidationSaveFailure(empty));
+
+    PSErrorsException validation = new PSErrorsException();
+    validation.addError(
+        new PSGuid(PSTypeEnum.NODEDEF, 311L),
+        new PSErrorException(
+            IPSWebserviceErrors.SAVE_FAILED,
+            "PSSystemValidationException: exit does not implement IPSRequestPreProcessor",
+            "stack"));
+    assertTrue(ContentTypeAdaptor.formatSaveErrors(validation).contains("does not implement"));
+    assertTrue(ContentTypeAdaptor.isValidationSaveFailure(validation));
+
+    PSErrorsException io = new PSErrorsException();
+    io.addError(
+        new PSGuid(PSTypeEnum.NODEDEF, 311L),
+        new PSErrorException(IPSWebserviceErrors.SAVE_FAILED, "java.io.IOException: disk", "stack"));
+    assertFalse(ContentTypeAdaptor.isValidationSaveFailure(io));
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeItemExitsJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeItemExitsJsonReader.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for PUT {@code /contenttypes/{id}/itemExits} (CD-09 / #3895).
+ *
+ * <p>Live H2 CXF {@code UNWRAP_ROOT_VALUE} can deliver an empty {@link ContentTypeItemExits}
+ * (null required lists → 400) for the documented wrap {@code {"ContentTypeItemExits":{…}}}. This
+ * reader binds either envelope with a mapper that does <em>not</em> unwrap:
+ *
+ * <ul>
+ *   <li>{@code {"ContentTypeItemExits":{"inputTranslations":[],…}}} (SPA wrap)
+ *   <li>{@code {"inputTranslations":[],"outputTranslations":[],"validations":[]}} (flat)
+ * </ul>
+ *
+ * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code jacksonProvider}.
+ */
+@Provider
+@Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("contentTypeItemExitsJsonReader")
+public class ContentTypeItemExitsJsonReader implements MessageBodyReader<ContentTypeItemExits> {
+
+  /** Mapper without UNWRAP_ROOT_VALUE so a flat or nested object is readable. */
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  /** No-arg ctor for Spring / JAX-RS. */
+  public ContentTypeItemExitsJsonReader() {}
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    if (type == null || !ContentTypeItemExits.class.isAssignableFrom(type)) {
+      return false;
+    }
+    return mediaType == null || isJsonCompatible(mediaType);
+  }
+
+  @Override
+  public ContentTypeItemExits readFrom(
+      Class<ContentTypeItemExits> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new ContentTypeItemExits();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new ContentTypeItemExits();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Bind item-exits JSON. Empty / whitespace is an empty envelope (resource still 400s missing
+   * required lists).
+   */
+  public static ContentTypeItemExits parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new ContentTypeItemExits();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid item-exits body", 400);
+    }
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new ContentTypeItemExits();
+    }
+    if (!root.isObject()) {
+      throw new WebApplicationException("Invalid item-exits body", 400);
+    }
+    JsonNode nested = firstObject(root, "ContentTypeItemExits", "contentTypeItemExits");
+    JsonNode fields = nested != null ? nested : root;
+    try {
+      return MAPPER.treeToValue(fields, ContentTypeItemExits.class);
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid item-exits body", 400);
+    }
+  }
+
+  private static JsonNode firstObject(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && n.isObject()) {
+        return n;
+      }
+    }
+    return null;
+  }
+
+  static boolean isJsonCompatible(MediaType mediaType) {
+    if (mediaType == null || mediaType.isWildcardType() || mediaType.isWildcardSubtype()) {
+      return true;
+    }
+    String subtype = mediaType.getSubtype();
+    if (subtype == null) {
+      return false;
+    }
+    String lower = subtype.toLowerCase();
+    return "json".equals(lower) || lower.endsWith("+json");
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -1227,7 +1227,9 @@ public class ContentTypesResource {
             content = @Content(schema = @Schema(implementation = ContentTypeItemExits.class))),
         @ApiResponse(
             responseCode = "400",
-            description = "Missing required lists or invalid extension FQN"),
+            description =
+                "Missing required lists, invalid extension FQN, or design-save validation"
+                    + " (wrong item-level extension interface / SAVE_FAILED validation)"),
         @ApiResponse(responseCode = "403", description = "Admin role required"),
         @ApiResponse(responseCode = "404", description = "Content type not found"),
         @ApiResponse(
@@ -1235,8 +1237,23 @@ public class ContentTypesResource {
             description = "Design lock not held by the current user"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
+  public ContentTypeItemExits replaceItemExitsFromJson(
+      @PathParam("idOrName") String idOrName, java.io.InputStream jsonBody) {
+    try {
+      byte[] raw = jsonBody == null ? new byte[0] : jsonBody.readAllBytes();
+      String json = new String(raw, java.nio.charset.StandardCharsets.UTF_8);
+      return replaceItemExits(idOrName, ContentTypeItemExitsJsonReader.parse(json));
+    } catch (java.io.IOException e) {
+      throw new WebApplicationException("Invalid item-exits body", 400);
+    }
+  }
+
+  /**
+   * Replace item-level exits. Package tests call this with a bound DTO; HTTP PUT uses {@link
+   * #replaceItemExitsFromJson} so CXF UNWRAP_ROOT_VALUE cannot drop required lists (#3905).
+   */
   public ContentTypeItemExits replaceItemExits(
-      @PathParam("idOrName") String idOrName, ContentTypeItemExits body) {
+      String idOrName, ContentTypeItemExits body) {
     if (body == null
         || body.getInputTranslations() == null
         || body.getOutputTranslations() == null

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypeItemExitsJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypeItemExitsJsonReaderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class ContentTypeItemExitsJsonReaderTest {
+
+  @Test
+  public void parseWrappedEnvelopePopulatesRequiredLists() {
+    ContentTypeItemExits out =
+        ContentTypeItemExitsJsonReader.parse(
+            "{\"ContentTypeItemExits\":{"
+                + "\"inputTranslations\":[{\"extension\":\"Java/global/percussion/generic/sys_ToUpperCase\","
+                + "\"parameters\":[{\"value\":\"sys_title\"}]}],"
+                + "\"outputTranslations\":[],\"validations\":[],\"preExits\":[],\"postExits\":[],"
+                + "\"maxErrorsToStopValidation\":10}}");
+    assertNotNull(out.getInputTranslations());
+    assertEquals(1, out.getInputTranslations().size());
+    assertEquals(
+        "Java/global/percussion/generic/sys_ToUpperCase",
+        out.getInputTranslations().get(0).getExtension());
+    assertNotNull(out.getOutputTranslations());
+    assertTrue(out.getOutputTranslations().isEmpty());
+    assertNotNull(out.getValidations());
+    assertEquals(Integer.valueOf(10), out.getMaxErrorsToStopValidation());
+  }
+
+  @Test
+  public void parseFlatBodyPopulatesRequiredLists() {
+    ContentTypeItemExits out =
+        ContentTypeItemExitsJsonReader.parse(
+            "{\"inputTranslations\":[],\"outputTranslations\":[],\"validations\":[]}");
+    assertNotNull(out.getInputTranslations());
+    assertTrue(out.getInputTranslations().isEmpty());
+    assertNotNull(out.getValidations());
+  }
+
+  @Test
+  public void parseBlankReturnsEmptyEnvelope() {
+    ContentTypeItemExits empty = ContentTypeItemExitsJsonReader.parse("  ");
+    assertNotNull(empty);
+  }
+
+  @Test
+  public void parseArrayIs400() {
+    assertThrows(
+        WebApplicationException.class, () -> ContentTypeItemExitsJsonReader.parse("[1,2]"));
+  }
+}

--- a/system/src/test/java/com/percussion/webservices/content/impl/PSContentDesignWsContentTypeLockObjectIdTest.java
+++ b/system/src/test/java/com/percussion/webservices/content/impl/PSContentDesignWsContentTypeLockObjectIdTest.java
@@ -82,4 +82,22 @@ class PSContentDesignWsContentTypeLockObjectIdTest {
     assertEquals(stored, PSGuidUtils.toFullLong(loadId));
     assertEquals(PACKED_NODEDEF_PERC_PAGE, stored);
   }
+
+  @Test
+  void contentTypeSaveVersionPrefersLockThenExistingNodeNeverMinusOneWhenNodeExists() {
+    assertEquals(7, PSContentDesignWs.contentTypeSaveVersion(7, 3));
+    assertEquals(0, PSContentDesignWs.contentTypeSaveVersion(0, 9));
+    assertEquals(4, PSContentDesignWs.contentTypeSaveVersion(null, 4));
+    assertEquals(4, PSContentDesignWs.contentTypeSaveVersion(-1, 4));
+    assertEquals(-1, PSContentDesignWs.contentTypeSaveVersion(null, null));
+    assertEquals(-1, PSContentDesignWs.contentTypeSaveVersion(-1, null));
+  }
+
+  @Test
+  void rootCauseMessageSkipsUnfilledTemplate() {
+    RuntimeException root = new IllegalArgumentException("dataset type mismatch");
+    Exception wrapped = new RuntimeException("An unknown exception occurred while communicating with the server: {0}", root);
+    assertEquals("dataset type mismatch", PSContentDesignWs.rootCauseMessage(wrapped));
+    assertEquals("unknown error", PSContentDesignWs.rootCauseMessage(null));
+  }
 }

--- a/system/webservices/src/com/percussion/webservices/content/impl/PSContentDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/content/impl/PSContentDesignWs.java
@@ -1641,9 +1641,19 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                lock = lockService.findLockByObjectId(id, session, user);
                if (lock != null)
                {
-                  // get version from lock
-                  int version = lock.getLockedVersion() == null ? -1 : lock
-                     .getLockedVersion();
+                  // Existing types must not be saved as create (version -1):
+                  // a failed create deletes the node def (#3905).
+                  Integer lockedVersion = lock.getLockedVersion();
+                  Integer nodeVersion = null;
+                  if (lockedVersion == null || lockedVersion < 0) {
+                    PSNodeDefinition existing =
+                        PSContentTypeHelper.findNodeDef(
+                            new PSGuid(PSTypeEnum.NODEDEF, def.getTypeId()));
+                    if (existing != null) {
+                      nodeVersion = existing.getVersion();
+                    }
+                  }
+                  int version = contentTypeSaveVersion(lockedVersion, nodeVersion);
 
                   // save
                   PSSaveNodeDefListener listener = null;
@@ -1703,8 +1713,8 @@ public class PSContentDesignWs extends PSContentBaseWs implements
                PSDesignGuid guid = new PSDesignGuid(id);
                PSErrorException error = new PSErrorException(code,
                   PSWebserviceErrors.createErrorMessage(code,
-                     PSItemDefinition.class.getName(), guid.getValue(), e
-                        .getLocalizedMessage()), ExceptionUtils
+                     PSItemDefinition.class.getName(), guid.getValue(),
+                     rootCauseMessage(e)), ExceptionUtils
                      .getFullStackTrace(e));
                results.addError(id, error);
             }
@@ -1739,6 +1749,41 @@ public class PSContentDesignWs extends PSContentBaseWs implements
     */
    static IPSGuid contentTypeLockObjectId(long typeId) {
       return new PSDesignGuid(PSTypeEnum.NODEDEF, typeId);
+   }
+
+   /**
+    * Hibernate version for {@link PSContentTypeHelper#saveContentType}. {@code -1} means
+    * create; a null lock version on an <em>existing</em> type must use the node-def version
+    * so a failed save cannot delete the type (#3905).
+    */
+   static int contentTypeSaveVersion(Integer lockedVersion, Integer existingNodeVersion) {
+      if (lockedVersion != null && lockedVersion >= 0) {
+         return lockedVersion;
+      }
+      if (existingNodeVersion != null && existingNodeVersion >= 0) {
+         return existingNodeVersion;
+      }
+      return -1;
+   }
+
+   /** Prefer the deepest cause message so SAVE_FAILED is not a bare {@code {0}} template. */
+   static String rootCauseMessage(Throwable e) {
+      if (e == null) {
+         return "unknown error";
+      }
+      Throwable t = e;
+      while (t.getCause() != null && t.getCause() != t) {
+         t = t.getCause();
+      }
+      String root = t.getMessage();
+      if (root == null || root.isBlank()) {
+         root = t.getClass().getName();
+      }
+      String top = e.getMessage();
+      if (top != null && !top.isBlank() && !top.equals(root) && !top.contains("{0}")) {
+         return top + " [root: " + root + "]";
+      }
+      return root;
    }
 
    /**


### PR DESCRIPTION
## Summary

Cycle Verify residual of CD-09 item-level exits persist (`PUT /services/contenttypes/{id}/itemExits` after a held lock returned **500** `SAVE_FAILED`). This PR does **not** re-do SPA chrome (open PR #3901).

- **Pipe pre-exits:** `PSContentEditorPipe.setInputDataExtensions` is UOE on percPage. Adaptor now uses `setContentEditorInputDataExtensions`. Omitted `preExits`/`postExits` leave pipe unchanged.
- **Reconstructed GET rows:** matching FQN+params reuse cloned `PSConditionalExit` (apply-when / param types preserved).
- **SAVE_FAILED:** error-map text is included; validation / wrong extension interface is HTTP **400**.
- **Create vs update:** `saveContentTypes` no longer treats a null lock version as create (`-1`). That path deleted existing node defs when app save failed.
- **Wrap JSON:** `ContentTypeItemExitsJsonReader` + `replaceItemExitsFromJson(InputStream)` so CXF `UNWRAP_ROOT_VALUE` cannot drop required lists.
- **Playwright:** persist uses item-level `sys_cleanReservedHtmlClasses` + `sys_title`, not field UDF `sys_ToUpperCase`.

Fixes #3905. Also leftover #3902. Parent #1690 / slice #3895.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Unit: `ContentTypeAdaptorItemExitsTest` (18) — CE pipe setter, omit pipe, SAVE_FAILED 400/500, reuse apply-when.
2. Unit: `PSContentDesignWsContentTypeLockObjectIdTest` — `contentTypeSaveVersion` / `rootCauseMessage`.
3. REST: `ContentTypeItemExitsJsonReaderTest` wrap/flat bind.
4. H2 QA: `perc-devctl qa-up --skip-image-build` TEST_CMS_URL=http://127.0.0.1:9993; qa-health RESULT:OK HTTP:200 HEALTH:healthy.
5. docker cp rest + sitemanage + perc-system into `webapps/Rhythmyx/WEB-INF/lib/` + beans.xml; in-cell StopJetty/StartJetty; qa-health again.
6. `npm run test:surface -- --path tests/developer-content-type-item-exits.spec.js` — **2 passed** (unlocked 409; lock → PUT persist → GET). console-clean=yes. server.log-clean=yes for persist window.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-content-types.md` and `product-docs/8.2/developer/rest.md` (item-level vs field UDF; 400 validation; CE pipe setter)
- [x] **Unit / module tests** — adaptor + saveContentTypes helpers + JsonReader; standalone `mvnw clean install` on system, sitemanage, rest, perc-qa-automation
- [x] **WebUI + Playwright** — `developer-content-type-item-exits.spec.js` (REST persist; no SPA chrome in this PR)
- [x] **Build gates** — standalone clean install of changed modules (no skipTests)
- [x] **Cross-platform** — N/A (REST URL `/` only; no filesystem path joins)

### C3 evidence

- modules_built= system, rest, projects/sitemanage, modules/perc-qa-automation
- build_evidence= `cd system && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 2488, Failures: 0, Skipped: 245; `cd rest && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 642, Failures: 0; `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS Tests run: 1634, Failures: 0, Skipped: 125; `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` BUILD SUCCESS
- downstream_checked= rest JsonReader + resource; sitemanage beans.xml jaxrs:providers; no `final`/public signature blast radius (package-visible helpers only)

### C5 UI proof

- qa-up `--skip-image-build` TEST_CMS_URL=http://127.0.0.1:9993 QA_CONTAINER=perc-matrix-cms-h2
- qa-health RESULT:OK HTTP:200 HEALTH:healthy (after qa-up and after Jetty restart)
- Playwright: `npm run test:surface -- --path tests/developer-content-type-item-exits.spec.js` — 2 passed
- console-clean=yes
- server.log-clean=yes for persist window

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
