### PR TITLE
feat(WebUI): Developer CT field-rule expressions chrome (CD-05-07) (#3896)

### DIFF
--- a/WebUI/src/main/ts/api/developer/contentTypeFieldRules.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypeFieldRules.ts
@@ -1,0 +1,834 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { get, put } from "../client";
+import { PATHS } from "../paths";
+import { asJacksonArray } from "./slotLists";
+import { normalizeContentTypeDesignGaps } from "./contentTypeLists";
+import type { DesignGapWire } from "./designGaps";
+
+/** Jackson {@code WRAP_ROOT_VALUE} root for {@code ContentTypeFieldRuleExpressions}. */
+export const CONTENT_TYPE_FIELD_RULE_EXPRESSIONS_ROOT = "ContentTypeFieldRuleExpressions";
+
+export const FIELD_RULE_TYPE_CONDITIONAL = "conditional";
+export const FIELD_RULE_TYPE_EXTENSION = "extension";
+export const FIELD_RULE_TYPE_REFERENCE = "reference";
+
+export type FieldRuleType =
+  | typeof FIELD_RULE_TYPE_CONDITIONAL
+  | typeof FIELD_RULE_TYPE_EXTENSION
+  | typeof FIELD_RULE_TYPE_REFERENCE;
+
+export interface ContentTypeFieldConditional {
+  variable?: string;
+  operator?: string;
+  value?: string;
+  booleanOperator?: string;
+}
+
+export interface ContentTypeFieldRuleParam {
+  name?: string;
+  value?: string;
+}
+
+export interface ContentTypeFieldRule {
+  type?: FieldRuleType | string;
+  conditionals?: ContentTypeFieldConditional[];
+  extension?: string;
+  name?: string;
+  parameters?: ContentTypeFieldRuleParam[];
+  reference?: string;
+  summary?: string;
+}
+
+export interface ContentTypeFieldTranslation {
+  extension?: string;
+  name?: string;
+  parameters?: ContentTypeFieldRuleParam[];
+  condition?: string;
+  maxErrorsToStop?: number;
+  summary?: string;
+}
+
+export interface ContentTypeFieldRuleExpressions {
+  fieldName?: string;
+  validation?: ContentTypeFieldRule[];
+  visibility?: ContentTypeFieldRule[];
+  inputTranslation?: ContentTypeFieldTranslation[];
+  outputTranslation?: ContentTypeFieldTranslation[];
+  maxErrorsToStop?: number;
+  errorMessage?: string;
+  validationExpression?: string;
+  visibilityExpression?: string;
+  inputTranslationExpression?: string;
+  outputTranslationExpression?: string;
+  designGaps?: DesignGapWire[];
+}
+
+/** Operator-facing text for the four rule lists. */
+export interface FieldRuleExpressionTexts {
+  validation: string;
+  visibility: string;
+  inputTranslation: string;
+  outputTranslation: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function looksLikeParam(obj: Record<string, unknown>): boolean {
+  return "name" in obj || "value" in obj;
+}
+
+function looksLikeConditional(obj: Record<string, unknown>): boolean {
+  return "variable" in obj || "operator" in obj || "value" in obj;
+}
+
+function looksLikeRule(obj: Record<string, unknown>): boolean {
+  return (
+    "type" in obj ||
+    "conditionals" in obj ||
+    "extension" in obj ||
+    "reference" in obj ||
+    "summary" in obj
+  );
+}
+
+function looksLikeTranslation(obj: Record<string, unknown>): boolean {
+  return "extension" in obj || "name" in obj || "parameters" in obj || "summary" in obj;
+}
+
+function normalizeParams(raw: unknown): ContentTypeFieldRuleParam[] {
+  return asJacksonArray<ContentTypeFieldRuleParam>(
+    raw,
+    ["ContentTypeItemExitParam", "contentTypeItemExitParam", "parameters"],
+    looksLikeParam,
+  ).map((p) => {
+    const out: ContentTypeFieldRuleParam = {};
+    if (typeof p.name === "string") {
+      out.name = p.name;
+    }
+    if (typeof p.value === "string") {
+      out.value = p.value;
+    }
+    return out;
+  });
+}
+
+function normalizeConditionals(raw: unknown): ContentTypeFieldConditional[] {
+  return asJacksonArray<ContentTypeFieldConditional>(
+    raw,
+    ["ContentTypeFieldConditional", "contentTypeFieldConditional", "conditionals"],
+    looksLikeConditional,
+  ).map((c) => {
+    const out: ContentTypeFieldConditional = {};
+    if (typeof c.variable === "string") {
+      out.variable = c.variable;
+    }
+    if (typeof c.operator === "string") {
+      out.operator = c.operator;
+    }
+    if (typeof c.value === "string") {
+      out.value = c.value;
+    }
+    if (typeof c.booleanOperator === "string") {
+      out.booleanOperator = c.booleanOperator;
+    }
+    return out;
+  });
+}
+
+function normalizeRule(raw: ContentTypeFieldRule): ContentTypeFieldRule {
+  const out: ContentTypeFieldRule = {};
+  if (typeof raw.type === "string") {
+    out.type = raw.type;
+  }
+  out.conditionals = normalizeConditionals(raw.conditionals);
+  if (typeof raw.extension === "string") {
+    out.extension = raw.extension;
+  }
+  if (typeof raw.name === "string") {
+    out.name = raw.name;
+  }
+  out.parameters = normalizeParams(raw.parameters);
+  if (typeof raw.reference === "string") {
+    out.reference = raw.reference;
+  }
+  if (typeof raw.summary === "string") {
+    out.summary = raw.summary;
+  }
+  return out;
+}
+
+function normalizeTranslation(raw: ContentTypeFieldTranslation): ContentTypeFieldTranslation {
+  const out: ContentTypeFieldTranslation = {};
+  if (typeof raw.extension === "string") {
+    out.extension = raw.extension;
+  }
+  if (typeof raw.name === "string") {
+    out.name = raw.name;
+  }
+  out.parameters = normalizeParams(raw.parameters);
+  if (typeof raw.condition === "string") {
+    out.condition = raw.condition;
+  }
+  if (typeof raw.maxErrorsToStop === "number") {
+    out.maxErrorsToStop = raw.maxErrorsToStop;
+  }
+  if (typeof raw.summary === "string") {
+    out.summary = raw.summary;
+  }
+  return out;
+}
+
+export function normalizeFieldRules(raw: unknown): ContentTypeFieldRule[] {
+  return asJacksonArray<ContentTypeFieldRule>(
+    raw,
+    ["ContentTypeFieldRule", "contentTypeFieldRule"],
+    looksLikeRule,
+  ).map(normalizeRule);
+}
+
+export function normalizeFieldTranslations(raw: unknown): ContentTypeFieldTranslation[] {
+  return asJacksonArray<ContentTypeFieldTranslation>(
+    raw,
+    ["ContentTypeItemExit", "contentTypeItemExit"],
+    looksLikeTranslation,
+  ).map(normalizeTranslation);
+}
+
+export function emptyFieldRuleExpressions(fieldName = ""): ContentTypeFieldRuleExpressions {
+  return {
+    fieldName,
+    validation: [],
+    visibility: [],
+    inputTranslation: [],
+    outputTranslation: [],
+  };
+}
+
+function normalizeMaxErrors(raw: unknown): number | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return raw;
+  }
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const n = Number(raw);
+    if (Number.isFinite(n)) {
+      return n;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Flatten GET/PUT {@code .../ruleExpressions} JSON to {@link ContentTypeFieldRuleExpressions}.
+ *
+ * <p>Handles WRAP_ROOT {@code ContentTypeFieldRuleExpressions}, a flat body, JAXB
+ * list envelopes, singleton objects, and empty-collection beans.
+ */
+export function unwrapContentTypeFieldRuleExpressions(
+  payload: unknown,
+): ContentTypeFieldRuleExpressions {
+  const root = asRecord(payload);
+  if (!root) {
+    return emptyFieldRuleExpressions();
+  }
+  const nested = asRecord(
+    root[CONTENT_TYPE_FIELD_RULE_EXPRESSIONS_ROOT] ?? root.contentTypeFieldRuleExpressions,
+  );
+  const body = nested ?? root;
+  const out: ContentTypeFieldRuleExpressions = {
+    validation: normalizeFieldRules(body.validation),
+    visibility: normalizeFieldRules(body.visibility),
+    inputTranslation: normalizeFieldTranslations(body.inputTranslation),
+    outputTranslation: normalizeFieldTranslations(body.outputTranslation),
+    designGaps: normalizeContentTypeDesignGaps(body.designGaps),
+  };
+  if (typeof body.fieldName === "string") {
+    out.fieldName = body.fieldName;
+  }
+  const maxErrors = normalizeMaxErrors(body.maxErrorsToStop);
+  if (maxErrors != null) {
+    out.maxErrorsToStop = maxErrors;
+  }
+  if (typeof body.errorMessage === "string") {
+    out.errorMessage = body.errorMessage;
+  }
+  if (typeof body.validationExpression === "string") {
+    out.validationExpression = body.validationExpression;
+  }
+  if (typeof body.visibilityExpression === "string") {
+    out.visibilityExpression = body.visibilityExpression;
+  }
+  if (typeof body.inputTranslationExpression === "string") {
+    out.inputTranslationExpression = body.inputTranslationExpression;
+  }
+  if (typeof body.outputTranslationExpression === "string") {
+    out.outputTranslationExpression = body.outputTranslationExpression;
+  }
+  return out;
+}
+
+export function wrapContentTypeFieldRuleExpressionsForWire(
+  body: ContentTypeFieldRuleExpressions,
+): Record<string, ContentTypeFieldRuleExpressions> {
+  return { [CONTENT_TYPE_FIELD_RULE_EXPRESSIONS_ROOT]: body };
+}
+
+function cloneParams(params: ContentTypeFieldRuleParam[] | undefined): ContentTypeFieldRuleParam[] {
+  return (params ?? []).map((p) => ({ name: p.name, value: p.value }));
+}
+
+function cloneRule(rule: ContentTypeFieldRule): ContentTypeFieldRule {
+  return {
+    type: rule.type,
+    conditionals: (rule.conditionals ?? []).map((c) => ({
+      variable: c.variable,
+      operator: c.operator,
+      value: c.value,
+      booleanOperator: c.booleanOperator,
+    })),
+    extension: rule.extension,
+    name: rule.name,
+    parameters: cloneParams(rule.parameters),
+    reference: rule.reference,
+    summary: rule.summary,
+  };
+}
+
+function cloneTranslation(t: ContentTypeFieldTranslation): ContentTypeFieldTranslation {
+  return {
+    extension: t.extension,
+    name: t.name,
+    parameters: cloneParams(t.parameters),
+    condition: t.condition,
+    maxErrorsToStop: t.maxErrorsToStop,
+    summary: t.summary,
+  };
+}
+
+export function cloneFieldRuleExpressions(
+  env: ContentTypeFieldRuleExpressions,
+): ContentTypeFieldRuleExpressions {
+  return {
+    fieldName: env.fieldName,
+    validation: (env.validation ?? []).map(cloneRule),
+    visibility: (env.visibility ?? []).map(cloneRule),
+    inputTranslation: (env.inputTranslation ?? []).map(cloneTranslation),
+    outputTranslation: (env.outputTranslation ?? []).map(cloneTranslation),
+    maxErrorsToStop: env.maxErrorsToStop,
+    errorMessage: env.errorMessage,
+    validationExpression: env.validationExpression,
+    visibilityExpression: env.visibilityExpression,
+    inputTranslationExpression: env.inputTranslationExpression,
+    outputTranslationExpression: env.outputTranslationExpression,
+    designGaps: env.designGaps ? [...env.designGaps] : undefined,
+  };
+}
+
+function paramsEqual(
+  a: ContentTypeFieldRuleParam[] | undefined,
+  b: ContentTypeFieldRuleParam[] | undefined,
+): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let i = 0; i < left.length; i++) {
+    if ((left[i].name || "") !== (right[i].name || "")) {
+      return false;
+    }
+    if ((left[i].value || "") !== (right[i].value || "")) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function conditionalsEqual(
+  a: ContentTypeFieldConditional[] | undefined,
+  b: ContentTypeFieldConditional[] | undefined,
+): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let i = 0; i < left.length; i++) {
+    if ((left[i].variable || "") !== (right[i].variable || "")) {
+      return false;
+    }
+    if ((left[i].operator || "") !== (right[i].operator || "")) {
+      return false;
+    }
+    if ((left[i].value || "") !== (right[i].value || "")) {
+      return false;
+    }
+    if ((left[i].booleanOperator || "") !== (right[i].booleanOperator || "")) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function rulesEqual(
+  a: ContentTypeFieldRule[] | undefined,
+  b: ContentTypeFieldRule[] | undefined,
+): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let i = 0; i < left.length; i++) {
+    if ((left[i].type || "") !== (right[i].type || "")) {
+      return false;
+    }
+    if (!conditionalsEqual(left[i].conditionals, right[i].conditionals)) {
+      return false;
+    }
+    if ((left[i].extension || "") !== (right[i].extension || "")) {
+      return false;
+    }
+    if ((left[i].reference || "") !== (right[i].reference || "")) {
+      return false;
+    }
+    if (!paramsEqual(left[i].parameters, right[i].parameters)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function translationsEqual(
+  a: ContentTypeFieldTranslation[] | undefined,
+  b: ContentTypeFieldTranslation[] | undefined,
+): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let i = 0; i < left.length; i++) {
+    if ((left[i].extension || left[i].name || "") !== (right[i].extension || right[i].name || "")) {
+      return false;
+    }
+    if (!paramsEqual(left[i].parameters, right[i].parameters)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function fieldRuleExpressionsEqual(
+  a: ContentTypeFieldRuleExpressions,
+  b: ContentTypeFieldRuleExpressions,
+): boolean {
+  return (
+    rulesEqual(a.validation, b.validation) &&
+    rulesEqual(a.visibility, b.visibility) &&
+    translationsEqual(a.inputTranslation, b.inputTranslation) &&
+    translationsEqual(a.outputTranslation, b.outputTranslation)
+  );
+}
+
+export function emptyFieldRuleExpressionTexts(): FieldRuleExpressionTexts {
+  return {
+    validation: "",
+    visibility: "",
+    inputTranslation: "",
+    outputTranslation: "",
+  };
+}
+
+export function fieldRuleExpressionTextsEqual(
+  a: FieldRuleExpressionTexts,
+  b: FieldRuleExpressionTexts,
+): boolean {
+  return (
+    a.validation === b.validation &&
+    a.visibility === b.visibility &&
+    a.inputTranslation === b.inputTranslation &&
+    a.outputTranslation === b.outputTranslation
+  );
+}
+
+const CONDITIONAL_OPERATORS = [
+  "IS NOT NULL",
+  "IS NULL",
+  "NOT BETWEEN",
+  "BETWEEN",
+  "NOT LIKE",
+  "LIKE",
+  "NOT IN",
+  "IN",
+  "<=",
+  ">=",
+  "<>",
+  "!=",
+  "=",
+  "<",
+  ">",
+] as const;
+
+function unquote(raw: string): string {
+  const t = raw.trim();
+  if (t.length >= 2) {
+    const a = t.charAt(0);
+    const b = t.charAt(t.length - 1);
+    if ((a === '"' && b === '"') || (a === "'" && b === "'")) {
+      return t.slice(1, -1);
+    }
+  }
+  return t;
+}
+
+function quoteIfNeeded(raw: string): string {
+  if (raw === "") {
+    return '""';
+  }
+  if (/\s/.test(raw) || raw.includes("|")) {
+    return `"${raw.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  }
+  return raw;
+}
+
+function firstParamValue(params: ContentTypeFieldRuleParam[] | undefined): string {
+  const first = (params ?? []).find((p) => (p.value ?? "") !== "" || (p.name ?? "") !== "");
+  if (!first) {
+    return "";
+  }
+  return first.value ?? "";
+}
+
+function findConditionalOperator(line: string): { op: string; index: number } | null {
+  const upper = line.toUpperCase();
+  let found: { op: string; index: number } | null = null;
+  for (const op of CONDITIONAL_OPERATORS) {
+    const idx = op.match(/[A-Z]/) ? upper.indexOf(op) : line.indexOf(op);
+    if (idx < 0) {
+      continue;
+    }
+    if (found == null || idx < found.index || (idx === found.index && op.length > found.op.length)) {
+      found = { op, index: idx };
+    }
+  }
+  return found;
+}
+
+function parseExtensionLine(rest: string): { extension: string; param: string } {
+  const pipe = rest.indexOf("|");
+  if (pipe < 0) {
+    return { extension: rest.trim(), param: "" };
+  }
+  return {
+    extension: rest.slice(0, pipe).trim(),
+    param: unquote(rest.slice(pipe + 1)),
+  };
+}
+
+/**
+ * Parse one validation/visibility line into a rule.
+ *
+ * <p>{@code ext:FQN} or {@code ext:FQN | param} → extension. {@code ref:name} →
+ * reference. Otherwise {@code variable operator value} (operator {@code !=}
+ * becomes {@code <>}).
+ */
+export function parseFieldRuleLine(line: string, list: "validation" | "visibility"): ContentTypeFieldRule {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    throw new Error("Empty rule line");
+  }
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith("ext:")) {
+    const { extension, param } = parseExtensionLine(trimmed.slice(4));
+    if (!extension) {
+      throw new Error("Extension FQN is required");
+    }
+    const rule: ContentTypeFieldRule = { type: FIELD_RULE_TYPE_EXTENSION, extension };
+    if (param) {
+      rule.parameters = [{ value: param }];
+    }
+    return rule;
+  }
+  if (lower.startsWith("ref:")) {
+    if (list === "visibility") {
+      throw new Error("Visibility rules cannot use type=reference");
+    }
+    const reference = trimmed.slice(4).trim();
+    if (!reference) {
+      throw new Error("Rule reference name is required");
+    }
+    return { type: FIELD_RULE_TYPE_REFERENCE, reference };
+  }
+  const found = findConditionalOperator(trimmed);
+  if (!found) {
+    throw new Error(`No operator in: ${trimmed}`);
+  }
+  const variable = trimmed.slice(0, found.index).trim();
+  const valueRaw = trimmed.slice(found.index + found.op.length);
+  if (!variable) {
+    throw new Error("Conditional variable is required");
+  }
+  const operator = found.op === "!=" ? "<>" : found.op;
+  const value = unquote(valueRaw);
+  return {
+    type: FIELD_RULE_TYPE_CONDITIONAL,
+    conditionals: [{ variable, operator, value }],
+  };
+}
+
+export function parseTranslationLine(line: string): ContentTypeFieldTranslation {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    throw new Error("Empty translation line");
+  }
+  const rest = trimmed.toLowerCase().startsWith("ext:") ? trimmed.slice(4) : trimmed;
+  const { extension, param } = parseExtensionLine(rest);
+  if (!extension) {
+    throw new Error("Translation extension FQN is required");
+  }
+  const out: ContentTypeFieldTranslation = { extension };
+  if (param) {
+    out.parameters = [{ value: param }];
+  }
+  return out;
+}
+
+export function parseFieldRuleLines(
+  text: string,
+  list: "validation" | "visibility",
+): ContentTypeFieldRule[] {
+  const lines = text.split(/\r?\n/);
+  const out: ContentTypeFieldRule[] = [];
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    out.push(parseFieldRuleLine(line, list));
+  }
+  return out;
+}
+
+export function parseTranslationLines(text: string): ContentTypeFieldTranslation[] {
+  const lines = text.split(/\r?\n/);
+  const out: ContentTypeFieldTranslation[] = [];
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    out.push(parseTranslationLine(line));
+  }
+  return out;
+}
+
+export function formatFieldRuleLine(rule: ContentTypeFieldRule): string {
+  const type = (rule.type || "").toLowerCase();
+  if (type === FIELD_RULE_TYPE_EXTENSION || (!type && rule.extension)) {
+    const fqn = (rule.extension || rule.name || "").trim();
+    const param = firstParamValue(rule.parameters);
+    return param ? `ext:${fqn} | ${quoteIfNeeded(param)}` : `ext:${fqn}`;
+  }
+  if (type === FIELD_RULE_TYPE_REFERENCE || (!type && rule.reference)) {
+    return `ref:${(rule.reference || "").trim()}`;
+  }
+  const first = (rule.conditionals ?? [])[0];
+  if (first) {
+    const variable = (first.variable || "").trim();
+    const operator = (first.operator || "=").trim();
+    const value = first.value ?? "";
+    return `${variable} ${operator} ${quoteIfNeeded(value)}`;
+  }
+  return (rule.summary || "").trim();
+}
+
+export function formatTranslationLine(t: ContentTypeFieldTranslation): string {
+  const fqn = (t.extension || t.name || "").trim();
+  const param = firstParamValue(t.parameters);
+  if (!fqn) {
+    return (t.summary || "").trim();
+  }
+  return param ? `${fqn} | ${quoteIfNeeded(param)}` : fqn;
+}
+
+export function formatFieldRuleLines(rules: ContentTypeFieldRule[] | undefined): string {
+  return (rules ?? [])
+    .map(formatFieldRuleLine)
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+export function formatTranslationLines(
+  list: ContentTypeFieldTranslation[] | undefined,
+): string {
+  return (list ?? [])
+    .map(formatTranslationLine)
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+export function fieldRuleExpressionsToTexts(
+  env: ContentTypeFieldRuleExpressions,
+): FieldRuleExpressionTexts {
+  return {
+    validation: formatFieldRuleLines(env.validation),
+    visibility: formatFieldRuleLines(env.visibility),
+    inputTranslation: formatTranslationLines(env.inputTranslation),
+    outputTranslation: formatTranslationLines(env.outputTranslation),
+  };
+}
+
+/**
+ * Build the four required PUT lists from operator text. Throws with a
+ * field-prefixed message when a line cannot be parsed.
+ */
+export function textsToFieldRuleExpressions(
+  fieldName: string,
+  texts: FieldRuleExpressionTexts,
+): ContentTypeFieldRuleExpressions {
+  try {
+    const validation = parseFieldRuleLines(texts.validation, "validation");
+    const visibility = parseFieldRuleLines(texts.visibility, "visibility");
+    const inputTranslation = parseTranslationLines(texts.inputTranslation);
+    const outputTranslation = parseTranslationLines(texts.outputTranslation);
+    return {
+      fieldName,
+      validation,
+      visibility,
+      inputTranslation,
+      outputTranslation,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(msg);
+  }
+}
+
+function toParamPayload(p: ContentTypeFieldRuleParam): ContentTypeFieldRuleParam {
+  const out: ContentTypeFieldRuleParam = {};
+  if (p.name) {
+    out.name = p.name;
+  }
+  if (p.value != null && p.value !== "") {
+    out.value = p.value;
+  }
+  return out;
+}
+
+function toRulePutPayload(rule: ContentTypeFieldRule): ContentTypeFieldRule {
+  const type = (rule.type || FIELD_RULE_TYPE_CONDITIONAL).toLowerCase();
+  const out: ContentTypeFieldRule = { type };
+  if (type === FIELD_RULE_TYPE_EXTENSION) {
+    out.extension = (rule.extension || rule.name || "").trim();
+    const params = (rule.parameters ?? []).map(toParamPayload).filter((p) => p.value != null || p.name);
+    if (params.length > 0) {
+      out.parameters = params;
+    }
+    return out;
+  }
+  if (type === FIELD_RULE_TYPE_REFERENCE) {
+    out.reference = (rule.reference || "").trim();
+    return out;
+  }
+  out.conditionals = (rule.conditionals ?? []).map((c) => {
+    const row: ContentTypeFieldConditional = {
+      variable: (c.variable || "").trim(),
+      operator: (c.operator || "").trim(),
+    };
+    if (c.value != null) {
+      row.value = c.value;
+    }
+    if (c.booleanOperator) {
+      row.booleanOperator = c.booleanOperator;
+    }
+    return row;
+  });
+  return out;
+}
+
+function toTranslationPutPayload(t: ContentTypeFieldTranslation): ContentTypeFieldTranslation {
+  const out: ContentTypeFieldTranslation = {
+    extension: (t.extension || t.name || "").trim(),
+  };
+  const params = (t.parameters ?? []).map(toParamPayload).filter((p) => p.value != null || p.name);
+  if (params.length > 0) {
+    out.parameters = params;
+  }
+  return out;
+}
+
+/** PUT body: required lists only (empty clears). */
+export function toFieldRuleExpressionsPutBody(
+  env: ContentTypeFieldRuleExpressions,
+): ContentTypeFieldRuleExpressions {
+  return {
+    fieldName: env.fieldName,
+    validation: (env.validation ?? []).map(toRulePutPayload),
+    visibility: (env.visibility ?? []).map(toRulePutPayload),
+    inputTranslation: (env.inputTranslation ?? []).map(toTranslationPutPayload),
+    outputTranslation: (env.outputTranslation ?? []).map(toTranslationPutPayload),
+  };
+}
+
+function ruleExpressionsPath(idOrName: string, fieldName: string): string {
+  const typeKey = encodeURIComponent(idOrName);
+  const fieldKey = encodeURIComponent(fieldName);
+  return `${PATHS.CONTENT_TYPES}/${typeKey}/fields/${fieldKey}/ruleExpressions`;
+}
+
+/**
+ * GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions.
+ * No design lock required.
+ */
+export async function getContentTypeFieldRuleExpressions(
+  idOrName: string,
+  fieldName: string,
+): Promise<ContentTypeFieldRuleExpressions> {
+  const payload = await get<unknown>(ruleExpressionsPath(idOrName, fieldName));
+  const unwrapped = unwrapContentTypeFieldRuleExpressions(payload);
+  if (!unwrapped.fieldName) {
+    unwrapped.fieldName = fieldName;
+  }
+  return unwrapped;
+}
+
+/**
+ * PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions.
+ *
+ * <p>Requires a held design-session lock. Does not acquire or release the lock.
+ * HTTP 409 when unlocked or locked by another user. Full replace of the four lists.
+ */
+export async function replaceContentTypeFieldRuleExpressions(
+  idOrName: string,
+  fieldName: string,
+  body: ContentTypeFieldRuleExpressions,
+): Promise<ContentTypeFieldRuleExpressions> {
+  const payload = await put<unknown>(
+    ruleExpressionsPath(idOrName, fieldName),
+    wrapContentTypeFieldRuleExpressionsForWire(toFieldRuleExpressionsPutBody(body)),
+  );
+  const unwrapped = unwrapContentTypeFieldRuleExpressions(payload);
+  if (!unwrapped.fieldName) {
+    unwrapped.fieldName = fieldName;
+  }
+  return unwrapped;
+}

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -53,6 +53,10 @@ import {
   type DesignGapWire,
 } from "../api/developer/designGaps";
 import { ObjectAclSection } from "./ObjectAclSection";
+import {
+  ContentTypeFieldRulesSection,
+  type ContentTypeFieldRulesHandle,
+} from "./ContentTypeFieldRulesSection";
 import { isApiError } from "../api/client";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
@@ -156,6 +160,8 @@ export function ContentTypeDetailPanel({
   const [newTplName, setNewTplName] = useState("");
   const [heldLock, setHeldLock] = useState(false);
   const heldLockRef = useRef(false);
+  const fieldRulesRef = useRef<ContentTypeFieldRulesHandle | null>(null);
+  const [fieldRulesDirty, setFieldRulesDirty] = useState(false);
 
   useEffect(() => {
     heldLockRef.current = heldLock;
@@ -178,6 +184,7 @@ export function ContentTypeDetailPanel({
     setNotice(null);
     setHeldLock(false);
     heldLockRef.current = false;
+    setFieldRulesDirty(false);
     getContentTypeDetail(idOrName)
       .then((d) => {
         if (cancelled) return;
@@ -230,7 +237,8 @@ export function ContentTypeDetailPanel({
       enabled !== (detail.enabled !== false) ||
       fieldsDirty ||
       workflowsDirty ||
-      templatesDirty);
+      templatesDirty ||
+      fieldRulesDirty);
 
   const objectGuid = resolveContentTypeObjectGuid(detail, catalogGuid);
   const fieldRows = contentTypeFields(detail);
@@ -380,7 +388,7 @@ export function ContentTypeDetailPanel({
       label !== (detail.label || "") ||
       description !== (detail.description || "") ||
       fieldsDirty;
-    if (!enabledDirty && !workflowsDirty && !templatesDirty && !bulkNeeded) {
+    if (!enabledDirty && !workflowsDirty && !templatesDirty && !bulkNeeded && !fieldRulesDirty) {
       return;
     }
     setBusy(true);
@@ -476,7 +484,25 @@ export function ContentTypeDetailPanel({
           throw tplErr;
         }
       }
+      if (fieldRulesDirty) {
+        try {
+          await fieldRulesRef.current?.save();
+        } catch (frErr) {
+          if (saved != null) {
+            setDetail(saved);
+            setEnabled(saved.enabled !== false);
+            setWorkflows(
+              withDefaultWorkflowFlags(saved.allowedWorkflows, saved.defaultWorkflow),
+            );
+            setTemplates(cloneNamedObjectRefs(saved.allowedTemplates));
+          }
+          throw frErr;
+        }
+      }
       if (saved == null) {
+        if (fieldRulesDirty) {
+          setNotice(DEV_MSG.CT_SAVED);
+        }
         return;
       }
       const normalized = normalizeDetailLists(saved);
@@ -1057,6 +1083,18 @@ export function ContentTypeDetailPanel({
               </table>
             </div>
           </section>
+
+          <ContentTypeFieldRulesSection
+            ref={fieldRulesRef}
+            idOrName={idOrName}
+            fields={fieldRows}
+            canEdit={canEdit}
+            onDirtyChange={setFieldRulesDirty}
+            onLockLost={() => {
+              heldLockRef.current = false;
+              setHeldLock(false);
+            }}
+          />
 
           <ObjectAclSection
             objectGuid={objectGuid}

--- a/WebUI/src/main/ts/developer/ContentTypeFieldRulesSection.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeFieldRulesSection.tsx
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
+import {
+  emptyFieldRuleExpressionTexts,
+  fieldRuleExpressionTextsEqual,
+  fieldRuleExpressionsToTexts,
+  getContentTypeFieldRuleExpressions,
+  replaceContentTypeFieldRuleExpressions,
+  textsToFieldRuleExpressions,
+  type FieldRuleExpressionTexts,
+} from "../api/developer/contentTypeFieldRules";
+import type { ContentTypeFieldSummary } from "../api/developer/types";
+import { isApiError } from "../api/client";
+import { catalogColors } from "./catalogStyles";
+import { panelErrMsg } from "./errors";
+import { DEV_MSG } from "./messages";
+
+const inputStyle: React.CSSProperties = {
+  padding: "8px",
+  border: `1px solid ${catalogColors.softBorder}`,
+  borderRadius: "4px",
+  font: "inherit",
+  width: "100%",
+  boxSizing: "border-box",
+};
+
+const textareaStyle: React.CSSProperties = {
+  ...inputStyle,
+  fontFamily: "monospace",
+  minHeight: "4.5rem",
+  resize: "vertical",
+};
+
+export type ContentTypeFieldRulesHandle = {
+  isDirty: () => boolean;
+  save: () => Promise<void>;
+};
+
+function fieldNames(fields: ContentTypeFieldSummary[]): string[] {
+  const names: string[] = [];
+  for (const f of fields) {
+    const n = (f.name || "").trim();
+    if (n && !names.includes(n)) {
+      names.push(n);
+    }
+  }
+  return names;
+}
+
+function FieldRuleTextarea({
+  id,
+  testId,
+  label,
+  hint,
+  value,
+  canEdit,
+  onChange,
+}: {
+  id: string;
+  testId: string;
+  label: string;
+  hint: string;
+  value: string;
+  canEdit: boolean;
+  onChange: (next: string) => void;
+}): React.ReactElement {
+  return (
+    <div style={{ marginTop: "12px" }}>
+      <label htmlFor={id} style={{ display: "block", marginBottom: 4 }}>
+        {label}
+      </label>
+      <p style={{ color: catalogColors.muted, fontSize: "0.8rem", margin: "0 0 6px" }}>{hint}</p>
+      <textarea
+        id={id}
+        data-testid={testId}
+        style={textareaStyle}
+        value={value}
+        disabled={!canEdit}
+        readOnly={!canEdit}
+        aria-disabled={canEdit ? undefined : true}
+        onChange={(e) => {
+          if (!canEdit) {
+            return;
+          }
+          onChange(e.target.value);
+        }}
+      />
+    </div>
+  );
+}
+
+export const ContentTypeFieldRulesSection = React.forwardRef<
+  ContentTypeFieldRulesHandle,
+  {
+    idOrName: string;
+    fields: ContentTypeFieldSummary[];
+    canEdit: boolean;
+    onDirtyChange?: (dirty: boolean) => void;
+    onLockLost?: () => void;
+  }
+>(function ContentTypeFieldRulesSection(
+  { idOrName, fields, canEdit, onDirtyChange, onLockLost },
+  ref,
+): React.ReactElement {
+  const names = fieldNames(fields);
+  const catalogKey = names.join("|");
+  const [selected, setSelected] = useState(names[0] || "");
+  const [drafts, setDrafts] = useState<Record<string, FieldRuleExpressionTexts>>({});
+  const [loaded, setLoaded] = useState<Record<string, FieldRuleExpressionTexts>>({});
+  const [busyField, setBusyField] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const onDirtyChangeRef = useRef(onDirtyChange);
+  const onLockLostRef = useRef(onLockLost);
+
+  useEffect(() => {
+    onDirtyChangeRef.current = onDirtyChange;
+  }, [onDirtyChange]);
+
+  useEffect(() => {
+    onLockLostRef.current = onLockLost;
+  }, [onLockLost]);
+
+  useEffect(() => {
+    setDrafts({});
+    setLoaded({});
+    setError(null);
+    setBusyField(null);
+    setSelected(names[0] || "");
+  }, [idOrName, catalogKey]);
+
+  useEffect(() => {
+    if (!selected) {
+      return;
+    }
+    if (loaded[selected] != null) {
+      return;
+    }
+    const fieldName = selected;
+    let cancelled = false;
+    setBusyField(fieldName);
+    setError(null);
+    getContentTypeFieldRuleExpressions(idOrName, fieldName)
+      .then((env) => {
+        if (cancelled) return;
+        const texts = fieldRuleExpressionsToTexts(env);
+        setLoaded((prev) => ({ ...prev, [fieldName]: texts }));
+        setDrafts((prev) => (prev[fieldName] != null ? prev : { ...prev, [fieldName]: texts }));
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(panelErrMsg(err, DEV_MSG.CT_FR_LOAD_ERROR));
+        const empty = emptyFieldRuleExpressionTexts();
+        setLoaded((prev) => ({ ...prev, [fieldName]: empty }));
+        setDrafts((prev) => (prev[fieldName] != null ? prev : { ...prev, [fieldName]: empty }));
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setBusyField(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [idOrName, selected, loaded[selected]]);
+
+  const dirtyFields = names.filter((n) => {
+    const d = drafts[n];
+    const l = loaded[n];
+    if (d == null || l == null) {
+      return false;
+    }
+    return !fieldRuleExpressionTextsEqual(d, l);
+  });
+  const dirty = dirtyFields.length > 0;
+
+  useEffect(() => {
+    onDirtyChangeRef.current?.(dirty);
+  }, [dirty]);
+
+  const current = drafts[selected] ?? emptyFieldRuleExpressionTexts();
+
+  function patchDraft(patch: Partial<FieldRuleExpressionTexts>) {
+    if (!canEdit || !selected) {
+      return;
+    }
+    setError(null);
+    setDrafts((prev) => ({
+      ...prev,
+      [selected]: { ...(prev[selected] ?? emptyFieldRuleExpressionTexts()), ...patch },
+    }));
+  }
+
+  async function save(): Promise<void> {
+    if (!dirty) {
+      return;
+    }
+    for (const fieldName of dirtyFields) {
+      const texts = drafts[fieldName];
+      if (!texts) {
+        continue;
+      }
+      let body;
+      try {
+        body = textsToFieldRuleExpressions(fieldName, texts);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(`${DEV_MSG.CT_FR_PARSE_ERROR} ${msg}`);
+        throw err;
+      }
+      try {
+        const saved = await replaceContentTypeFieldRuleExpressions(idOrName, fieldName, body);
+        const nextTexts = fieldRuleExpressionsToTexts(saved);
+        setLoaded((prev) => ({ ...prev, [fieldName]: nextTexts }));
+        setDrafts((prev) => ({ ...prev, [fieldName]: nextTexts }));
+      } catch (err: unknown) {
+        if (isApiError(err) && err.status === 409) {
+          onLockLostRef.current?.();
+        }
+        setError(panelErrMsg(err, DEV_MSG.CT_FR_SAVE_ERROR));
+        throw err;
+      }
+    }
+  }
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      isDirty: () => dirty,
+      save,
+    }),
+    // save closes over dirtyFields/drafts; rebind when those change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dirty, dirtyFields.join("|"), drafts, idOrName],
+  );
+
+  return (
+    <section style={{ marginBottom: "16px" }} data-testid="developer-ct-field-rule-expressions">
+      <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.CT_FIELD_RULES}</h3>
+      <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>{DEV_MSG.CT_FIELD_RULES_HINT}</p>
+      {error ? (
+        <div role="alert" data-testid="developer-ct-fr-error" style={{ color: catalogColors.error }}>
+          {error}
+        </div>
+      ) : null}
+      {names.length === 0 ? (
+        <p style={{ color: catalogColors.empty }} data-testid="developer-ct-fr-empty">
+          {DEV_MSG.CT_NONE}
+        </p>
+      ) : (
+        <>
+          <div style={{ marginTop: "8px", maxWidth: "24rem" }}>
+            <label htmlFor="ct-fr-field" style={{ display: "block", marginBottom: 4 }}>
+              {DEV_MSG.CT_FR_FIELD}
+            </label>
+            <select
+              id="ct-fr-field"
+              data-testid="developer-ct-fr-field"
+              style={inputStyle}
+              value={selected}
+              disabled={names.length === 0}
+              onChange={(e) => {
+                setError(null);
+                setSelected(e.target.value);
+              }}
+            >
+              {names.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </div>
+          {busyField === selected ? (
+            <div data-testid="developer-ct-fr-loading" style={{ marginTop: "8px" }}>
+              {DEV_MSG.CT_FR_LOADING}
+            </div>
+          ) : null}
+          <FieldRuleTextarea
+            id="ct-fr-validation"
+            testId="developer-ct-fr-validation"
+            label={DEV_MSG.CT_FR_VALIDATION}
+            hint={DEV_MSG.CT_FR_VALIDATION_HINT}
+            value={current.validation}
+            canEdit={canEdit}
+            onChange={(validation) => patchDraft({ validation })}
+          />
+          <FieldRuleTextarea
+            id="ct-fr-visibility"
+            testId="developer-ct-fr-visibility"
+            label={DEV_MSG.CT_FR_VISIBILITY}
+            hint={DEV_MSG.CT_FR_VISIBILITY_HINT}
+            value={current.visibility}
+            canEdit={canEdit}
+            onChange={(visibility) => patchDraft({ visibility })}
+          />
+          <FieldRuleTextarea
+            id="ct-fr-input"
+            testId="developer-ct-fr-input"
+            label={DEV_MSG.CT_FR_INPUT}
+            hint={DEV_MSG.CT_FR_TRANSLATION_HINT}
+            value={current.inputTranslation}
+            canEdit={canEdit}
+            onChange={(inputTranslation) => patchDraft({ inputTranslation })}
+          />
+          <FieldRuleTextarea
+            id="ct-fr-output"
+            testId="developer-ct-fr-output"
+            label={DEV_MSG.CT_FR_OUTPUT}
+            hint={DEV_MSG.CT_FR_TRANSLATION_HINT}
+            value={current.outputTranslation}
+            canEdit={canEdit}
+            onChange={(outputTranslation) => patchDraft({ outputTranslation })}
+          />
+        </>
+      )}
+    </section>
+  );
+});

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -137,7 +137,7 @@ export const DEV_MSG_KEYS = {
   CT_COL_LABEL: "perc.ui.developer@Label",
   CT_COL_DESCRIPTION: "perc.ui.developer@Description",
   CT_COL_ID: "perc.ui.developer@Id",
-  CT_HINT: "perc.ui.developer@Select a content type to view fields and edit label, description, enabled, field flags, workflows, and templates.",
+  CT_HINT: "perc.ui.developer@Select a content type to view fields and edit label, description, enabled, field flags, workflows, templates, and field-rule expressions.",
   CT_BACK: "perc.ui.developer@Back to list",
   CT_DETAIL_LOADING: "perc.ui.developer@Loading content type...",
   CT_DETAIL_ERROR: "perc.ui.developer@Could not load content type detail.",
@@ -192,6 +192,24 @@ export const DEV_MSG_KEYS = {
   CT_TPL_NAME_PLACEHOLDER: "perc.ui.developer@Template name or GUID (0-10-347)",
   CT_SET_DEFAULT: "perc.ui.developer@Default",
   CT_NONE: "perc.ui.developer@None",
+  CT_FIELD_RULES: "perc.ui.developer@Field rule expressions",
+  CT_FIELD_RULES_HINT:
+    "perc.ui.developer@Lock to edit. One expression per line. Save writes GET/PUT .../fields/{field}/ruleExpressions while the lock is held and does not unlock. This is not the Workbench rule builder.",
+  CT_FR_FIELD: "perc.ui.developer@Field",
+  CT_FR_VALIDATION: "perc.ui.developer@Validation",
+  CT_FR_VISIBILITY: "perc.ui.developer@Visibility",
+  CT_FR_INPUT: "perc.ui.developer@Input translation",
+  CT_FR_OUTPUT: "perc.ui.developer@Output translation",
+  CT_FR_VALIDATION_HINT:
+    "perc.ui.developer@Conditional: variable operator value (e.g. sys_title <> \"\"). Extension: ext:FQN. Named rule: ref:name.",
+  CT_FR_VISIBILITY_HINT:
+    "perc.ui.developer@Conditional: variable operator value. Extension: ext:FQN. Visibility cannot use ref:.",
+  CT_FR_TRANSLATION_HINT:
+    "perc.ui.developer@One extension FQN per line. Optional literal parameter after | (e.g. Java/global/percussion/generic/sys_ToUpperCase | sys_title).",
+  CT_FR_LOADING: "perc.ui.developer@Loading field rule expressions...",
+  CT_FR_LOAD_ERROR: "perc.ui.developer@Could not load field rule expressions.",
+  CT_FR_SAVE_ERROR: "perc.ui.developer@Could not save field rule expressions.",
+  CT_FR_PARSE_ERROR: "perc.ui.developer@Could not parse field rule expressions.",
   YES: "perc.ui.developer@Yes",
   NO: "perc.ui.developer@No",
   KW_LOADING: "perc.ui.developer@Loading keywords...",

--- a/WebUI/src/test/ts/api/developer/contentTypeFieldRules.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypeFieldRules.test.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CONTENT_TYPE_FIELD_RULE_EXPRESSIONS_ROOT,
+  emptyFieldRuleExpressions,
+  fieldRuleExpressionTextsEqual,
+  fieldRuleExpressionsEqual,
+  fieldRuleExpressionsToTexts,
+  formatFieldRuleLine,
+  getContentTypeFieldRuleExpressions,
+  parseFieldRuleLine,
+  parseFieldRuleLines,
+  parseTranslationLine,
+  parseTranslationLines,
+  replaceContentTypeFieldRuleExpressions,
+  textsToFieldRuleExpressions,
+  toFieldRuleExpressionsPutBody,
+  unwrapContentTypeFieldRuleExpressions,
+  wrapContentTypeFieldRuleExpressionsForWire,
+} from "../../../../main/ts/api/developer/contentTypeFieldRules";
+import * as client from "../../../../main/ts/api/client";
+import { PATHS } from "../../../../main/ts/api/paths";
+
+describe("unwrapContentTypeFieldRuleExpressions", () => {
+  it("unwraps Jackson ContentTypeFieldRuleExpressions root", () => {
+    const unwrapped = unwrapContentTypeFieldRuleExpressions({
+      ContentTypeFieldRuleExpressions: {
+        fieldName: "sys_title",
+        validation: [{ type: "conditional", conditionals: [{ variable: "sys_title", operator: "<>", value: "" }] }],
+        visibility: [],
+        inputTranslation: [{ extension: "Java/global/percussion/generic/sys_ToUpperCase" }],
+        outputTranslation: { empty: true },
+      },
+    });
+    expect(unwrapped.fieldName).toBe("sys_title");
+    expect(unwrapped.validation).toHaveLength(1);
+    expect(unwrapped.validation?.[0].conditionals?.[0].variable).toBe("sys_title");
+    expect(unwrapped.visibility).toEqual([]);
+    expect(unwrapped.inputTranslation?.[0].extension).toContain("sys_ToUpperCase");
+    expect(unwrapped.outputTranslation).toEqual([]);
+  });
+
+  it("unwraps a lone validation rule object and empty-collection beans", () => {
+    const unwrapped = unwrapContentTypeFieldRuleExpressions({
+      fieldName: "page_title",
+      validation: { type: "extension", extension: "Java/global/percussion/generic/sys_ToUpperCase" },
+      visibility: { empty: false },
+      inputTranslation: [],
+      outputTranslation: [],
+    });
+    expect(unwrapped.validation).toHaveLength(1);
+    expect(unwrapped.validation?.[0].type).toBe("extension");
+    expect(unwrapped.visibility).toEqual([]);
+  });
+
+  it("returns empty lists for null payload", () => {
+    expect(unwrapContentTypeFieldRuleExpressions(null)).toEqual(emptyFieldRuleExpressions());
+  });
+});
+
+describe("field-rule expression text parse/format", () => {
+  it("parses a conditional with != as <> and quoted empty value", () => {
+    const rule = parseFieldRuleLine('sys_title != ""', "validation");
+    expect(rule.type).toBe("conditional");
+    expect(rule.conditionals?.[0]).toEqual({
+      variable: "sys_title",
+      operator: "<>",
+      value: "",
+    });
+  });
+
+  it("parses IS NOT NULL before IS NULL", () => {
+    const rule = parseFieldRuleLine("sys_title IS NOT NULL", "validation");
+    expect(rule.conditionals?.[0].operator).toBe("IS NOT NULL");
+    expect(rule.conditionals?.[0].value).toBe("");
+  });
+
+  it("parses ext: FQN with optional param", () => {
+    const rule = parseFieldRuleLine(
+      "ext:Java/global/percussion/generic/sys_ToUpperCase | sys_title",
+      "validation",
+    );
+    expect(rule.type).toBe("extension");
+    expect(rule.extension).toBe("Java/global/percussion/generic/sys_ToUpperCase");
+    expect(rule.parameters).toEqual([{ value: "sys_title" }]);
+  });
+
+  it("parses ref: on validation and rejects it on visibility", () => {
+    expect(parseFieldRuleLine("ref:sharedRequired", "validation")).toEqual({
+      type: "reference",
+      reference: "sharedRequired",
+    });
+    expect(() => parseFieldRuleLine("ref:sharedRequired", "visibility")).toThrow(/reference/i);
+  });
+
+  it("skips blank lines when parsing lists", () => {
+    const rules = parseFieldRuleLines("sys_title <> \"\"\n\npage_title = hello\n", "validation");
+    expect(rules).toHaveLength(2);
+    expect(rules[1].conditionals?.[0].value).toBe("hello");
+  });
+
+  it("parses translation FQN with optional param", () => {
+    const t = parseTranslationLine("Java/global/percussion/generic/sys_ToUpperCase | sys_title");
+    expect(t.extension).toBe("Java/global/percussion/generic/sys_ToUpperCase");
+    expect(t.parameters).toEqual([{ value: "sys_title" }]);
+    expect(parseTranslationLines("\n\n").length).toBe(0);
+  });
+
+  it("round-trips conditional and extension text", () => {
+    const env = textsToFieldRuleExpressions("sys_title", {
+      validation: 'sys_title <> ""',
+      visibility: "ext:Java/global/percussion/generic/sys_ToUpperCase",
+      inputTranslation: "Java/global/percussion/generic/sys_ToUpperCase | sys_title",
+      outputTranslation: "",
+    });
+    const texts = fieldRuleExpressionsToTexts(env);
+    expect(texts.validation).toBe('sys_title <> ""');
+    expect(texts.visibility).toBe("ext:Java/global/percussion/generic/sys_ToUpperCase");
+    expect(texts.inputTranslation).toBe(
+      "Java/global/percussion/generic/sys_ToUpperCase | sys_title",
+    );
+    expect(texts.outputTranslation).toBe("");
+    expect(formatFieldRuleLine(env.validation![0])).toContain("sys_title");
+  });
+
+  it("compares texts and envelopes", () => {
+    const a = emptyFieldRuleExpressions("sys_title");
+    const b = emptyFieldRuleExpressions("sys_title");
+    expect(fieldRuleExpressionsEqual(a, b)).toBe(true);
+    b.validation = [{ type: "conditional", conditionals: [{ variable: "x", operator: "=", value: "1" }] }];
+    expect(fieldRuleExpressionsEqual(a, b)).toBe(false);
+    expect(
+      fieldRuleExpressionTextsEqual(
+        { validation: "", visibility: "", inputTranslation: "", outputTranslation: "" },
+        { validation: "", visibility: "", inputTranslation: "", outputTranslation: "" },
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("toFieldRuleExpressionsPutBody / wrap", () => {
+  it("sends the four required lists and wraps Jackson root", () => {
+    const body = toFieldRuleExpressionsPutBody({
+      fieldName: "sys_title",
+      validation: [
+        { type: "conditional", conditionals: [{ variable: "sys_title", operator: "<>", value: "" }] },
+      ],
+      visibility: [],
+      inputTranslation: [{ extension: "Java/global/percussion/generic/sys_ToUpperCase" }],
+      outputTranslation: [],
+      designGaps: [{ code: "CT_FIELD_RULE_APPLY_WHEN" }],
+      validationExpression: "ignored",
+    });
+    expect(body.designGaps).toBeUndefined();
+    expect(body.validationExpression).toBeUndefined();
+    expect(body.validation?.[0].type).toBe("conditional");
+    expect(wrapContentTypeFieldRuleExpressionsForWire(body)).toEqual({
+      [CONTENT_TYPE_FIELD_RULE_EXPRESSIONS_ROOT]: body,
+    });
+  });
+});
+
+describe("get/replace field rule expressions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("GETs the field path and unwraps the envelope", async () => {
+    const getMock = vi.spyOn(client, "get").mockResolvedValue({
+      ContentTypeFieldRuleExpressions: {
+        fieldName: "sys_title",
+        validation: [],
+        visibility: [],
+        inputTranslation: [],
+        outputTranslation: [],
+      },
+    });
+    const out = await getContentTypeFieldRuleExpressions("percPage", "sys_title");
+    expect(getMock).toHaveBeenCalledWith(
+      `${PATHS.CONTENT_TYPES}/${encodeURIComponent("percPage")}/fields/${encodeURIComponent("sys_title")}/ruleExpressions`,
+    );
+    expect(out.fieldName).toBe("sys_title");
+    expect(out.validation).toEqual([]);
+  });
+
+  it("PUTs a wrapped full-replace body", async () => {
+    const putMock = vi.spyOn(client, "put").mockResolvedValue({
+      ContentTypeFieldRuleExpressions: {
+        fieldName: "sys_title",
+        validation: [
+          { type: "conditional", conditionals: [{ variable: "sys_title", operator: "<>", value: "#3896" }] },
+        ],
+        visibility: [],
+        inputTranslation: [],
+        outputTranslation: [],
+      },
+    });
+    const out = await replaceContentTypeFieldRuleExpressions("percPage", "sys_title", {
+      fieldName: "sys_title",
+      validation: [
+        { type: "conditional", conditionals: [{ variable: "sys_title", operator: "<>", value: "#3896" }] },
+      ],
+      visibility: [],
+      inputTranslation: [],
+      outputTranslation: [],
+    });
+    expect(putMock).toHaveBeenCalledWith(
+      `${PATHS.CONTENT_TYPES}/${encodeURIComponent("percPage")}/fields/${encodeURIComponent("sys_title")}/ruleExpressions`,
+      {
+        ContentTypeFieldRuleExpressions: {
+          fieldName: "sys_title",
+          validation: [
+            {
+              type: "conditional",
+              conditionals: [{ variable: "sys_title", operator: "<>", value: "#3896" }],
+            },
+          ],
+          visibility: [],
+          inputTranslation: [],
+          outputTranslation: [],
+        },
+      },
+    );
+    expect(out.validation?.[0].conditionals?.[0].value).toBe("#3896");
+  });
+});

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionRedirectError } from "../../../main/ts/api/client";
 import * as contentTypesApi from "../../../main/ts/api/developer/contentTypesApi";
+import * as fieldRulesApi from "../../../main/ts/api/developer/contentTypeFieldRules";
 import { catalogColors } from "../../../main/ts/developer/catalogStyles";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { ContentTypeDetailPanel } from "../../../main/ts/developer/ContentTypeDetailPanel";
@@ -21,6 +22,16 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
   getContentTypeAllowedTemplates: vi.fn(),
   replaceContentTypeAllowedTemplates: vi.fn(),
 }));
+
+vi.mock("../../../main/ts/api/developer/contentTypeFieldRules", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../main/ts/api/developer/contentTypeFieldRules")>();
+  return {
+    ...actual,
+    getContentTypeFieldRuleExpressions: vi.fn(),
+    replaceContentTypeFieldRuleExpressions: vi.fn(),
+  };
+});
 
 // ObjectAclSection loads ACL via separate API; stub so detail success path stays isolated.
 vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
@@ -51,6 +62,10 @@ const getContentTypeAllowedTemplates =
   contentTypesApi.getContentTypeAllowedTemplates as ReturnType<typeof vi.fn>;
 const replaceContentTypeAllowedTemplates =
   contentTypesApi.replaceContentTypeAllowedTemplates as ReturnType<typeof vi.fn>;
+const getContentTypeFieldRuleExpressions =
+  fieldRulesApi.getContentTypeFieldRuleExpressions as ReturnType<typeof vi.fn>;
+const replaceContentTypeFieldRuleExpressions =
+  fieldRulesApi.replaceContentTypeFieldRuleExpressions as ReturnType<typeof vi.fn>;
 
 const sampleDetail = {
   name: "percPage",
@@ -96,6 +111,22 @@ describe("ContentTypeDetailPanel", () => {
     }));
     replaceContentTypeAllowedTemplates.mockImplementation(async (_id, templates) => templates);
     getContentTypeAllowedTemplates.mockImplementation(async () => []);
+    getContentTypeFieldRuleExpressions.mockReset();
+    replaceContentTypeFieldRuleExpressions.mockReset();
+    getContentTypeFieldRuleExpressions.mockResolvedValue({
+      fieldName: "sys_title",
+      validation: [],
+      visibility: [],
+      inputTranslation: [],
+      outputTranslation: [],
+    });
+    replaceContentTypeFieldRuleExpressions.mockImplementation(async (_id, fieldName, body) => ({
+      fieldName,
+      validation: body.validation ?? [],
+      visibility: body.visibility ?? [],
+      inputTranslation: body.inputTranslation ?? [],
+      outputTranslation: body.outputTranslation ?? [],
+    }));
   });
 
   it("renders lock toolbar while detail is loading so workflow lock is findable (#3835)", async () => {
@@ -1019,5 +1050,97 @@ describe("ContentTypeDetailPanel", () => {
     });
     expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
     expect(lockContentType).toHaveBeenCalledTimes(1);
+  });
+
+  const sampleWithField = {
+    ...sampleDetail,
+    fields: [{ name: "sys_title", label: "Title", fieldType: "system" }],
+  };
+
+  it("keeps field-rule expression editors disabled until lock (#3896)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleWithField);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-field-rule-expressions")).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(getContentTypeFieldRuleExpressions).toHaveBeenCalledWith("percPage", "sys_title");
+    });
+    const validation = screen.getByTestId("developer-ct-fr-validation") as HTMLTextAreaElement;
+    expect(validation.disabled).toBe(true);
+    fireEvent.change(validation, { target: { value: 'sys_title <> "#nope"' } });
+    expect(validation.value).toBe("");
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(true);
+    expect(replaceContentTypeFieldRuleExpressions).not.toHaveBeenCalled();
+  });
+
+  it("saves field-rule expressions via dedicated PUT after lock (#3896)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleWithField);
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect(getContentTypeFieldRuleExpressions).toHaveBeenCalledWith("percPage", "sys_title");
+    });
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-fr-validation") as HTMLTextAreaElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-fr-validation"), {
+      target: { value: 'sys_title <> "#3896-field-rule"' },
+    });
+    expect((screen.getByTestId("developer-ct-save") as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(replaceContentTypeFieldRuleExpressions).toHaveBeenCalled();
+    });
+    const call = replaceContentTypeFieldRuleExpressions.mock.calls.at(-1);
+    expect(call?.[0]).toBe("percPage");
+    expect(call?.[1]).toBe("sys_title");
+    expect(call?.[2].validation?.[0].conditionals?.[0].value).toBe("#3896-field-rule");
+    expect(updateContentTypeDetail).not.toHaveBeenCalled();
+    expect(unlockContentType).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-notice").textContent).toMatch(/saved/i);
+    });
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
+  });
+
+  it("clears the held lock when field-rule PUT returns 409 (#3896)", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleWithField);
+    replaceContentTypeFieldRuleExpressions.mockRejectedValueOnce({
+      status: 409,
+      statusText: "Conflict",
+      body: { message: "Locked by another user" },
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-fr-validation") as HTMLTextAreaElement).disabled).toBe(
+        false,
+      );
+    });
+    fireEvent.change(screen.getByTestId("developer-ct-fr-validation"), {
+      target: { value: 'sys_title <> "#3896"' },
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-fr-error").textContent).toMatch(
+        /Could not save field rule expressions/i,
+      );
+    });
+    expect(screen.getByTestId("developer-ct-detail-error").textContent).toMatch(
+      /Could not save content type/i,
+    );
+    expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    expect((screen.getByTestId("developer-ct-fr-validation") as HTMLTextAreaElement).disabled).toBe(
+      true,
+    );
   });
 });

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -7,6 +7,25 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DeveloperShell } from "../../../main/ts/developer/DeveloperShell";
 
+vi.mock("../../../main/ts/api/developer/contentTypeFieldRules", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../main/ts/api/developer/contentTypeFieldRules")>();
+  return {
+    ...actual,
+    getContentTypeFieldRuleExpressions: vi.fn().mockResolvedValue({
+      fieldName: "sys_title",
+      validation: [],
+      visibility: [],
+      inputTranslation: [],
+      outputTranslation: [],
+    }),
+    replaceContentTypeFieldRuleExpressions: vi.fn().mockImplementation(async (_id, fieldName, body) => ({
+      fieldName,
+      ...body,
+    })),
+  };
+});
+
 vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../../../main/ts/api/developer/contentTypesApi")>();
@@ -722,8 +741,9 @@ describe("DeveloperShell", () => {
       expect(screen.getByTestId("developer-ct-detail")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-ct-fields-table")).toBeTruthy();
-    expect(screen.getByText("sys_title")).toBeTruthy();
+    expect(screen.getAllByText("sys_title").length).toBeGreaterThan(0);
     expect(screen.getAllByTestId("developer-ct-field-rules")[0].textContent).toMatch(/validation/);
+    expect(screen.getByTestId("developer-ct-field-rule-expressions")).toBeTruthy();
     // Occurrence cell value is lowercase "required" (distinct from "Required" header)
     expect(screen.getAllByTestId("developer-ct-field-occurrence")[0].textContent).toBe("required");
     expect(screen.getByTestId("developer-ct-workflows")).toBeTruthy();

--- a/docs/ai-generated/code-reviews/issue-3896-ct-field-rule-expressions-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3896-ct-field-rule-expressions-chrome-erlang.md
@@ -1,0 +1,57 @@
+# Erlang review — issue #3896 Developer CT field-rule expressions chrome (CD-05-07)
+
+**Branch:** `feat/issue-3896-ct-field-rule-expressions`  
+**Date:** 2026-08-27  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (WebUI chrome + Vitest + Playwright + product-docs); live CXF consume needs MessageBodyReader ahead of jacksonProvider (ViewExecuteRequest / item-exits peers); dedicated section file to reduce merge conflict with open PRs on ContentTypeDetailPanel.
+
+## Summary
+
+Developer Content Type detail chrome for field-rule **expression text** (validation / visibility / input / output translation). Consumes existing GET/PUT `.../fields/{fieldName}/ruleExpressions` (#3784). Lock-gated editors; main **Save content type** PUTs dirty fields; 409 does not steal the lock. Live CXF JAXB rejected a flat `fieldName` body; a JsonReader binds wrap + flat (same pattern as ViewExecuteRequestJsonReader).
+
+## Scope
+
+- Base: `origin/main`
+- Files: WebUI field-rule API/helpers + `ContentTypeFieldRulesSection` + minimal panel/messages wiring; rest JsonReader + test; sitemanage jaxrs provider ref; Playwright surface spec; product-docs 8.2 admin + REST
+- Peer: item-exits #3901 / control properties #3903 (do not steal); REST PUT #3784
+- Prior report: `issue-3784-erlang.md` (REST only; chrome was out of scope)
+- Memory patterns hit: CXF consume wrap/flat; Playwright C5 H2 QA; dedicated section vs mega-panel
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- Missing behavioral tests: no
+- Non-portable path/file I/O: no
+- May commit/push: yes
+
+## Issues
+
+None blocking.
+
+PUT persist uses held design lock and does not unlock. Unlocked textareas are disabled. 409 on field-rule PUT clears the held lock via `onLockLost`. Expression text is one line per rule (`variable operator value`, `ext:FQN`, `ref:name`); not a Workbench visual builder (documented).
+
+Change-class closure: WebUI API + section + panel hook + Vitest (unwrap/parse/PUT wrap + lock/save/409) + Playwright surface + product-docs. JsonReader + beans.xml so live CXF binds the existing PUT (not a re-implementation of save semantics).
+
+`ContentTypeDetailPanel` changes are small (ref + dirty + one save call + mount) so peer PRs #3901/#3903 can rebase.
+
+## Cross-platform path checklist
+
+Applied. No filesystem path construction. REST `/services/contenttypes/.../ruleExpressions` strings are URI paths (correct `/`). Playwright uses `path` from Node only in existing helpers.
+
+## Tests
+
+- WebUI Vitest: field-rule unwrap/parse/PUT wrap; panel unlocked/save/409; DeveloperShell catalog/detail
+- rest: JsonReader wrap + flat + camelCase root
+- Playwright: `npm run test:surface -- --path tests/developer-content-type-field-rules.spec.js` — 2 passed on H2 QA
+- Module suites: `rest` Tests run: 648, Failures: 0; `sitemanage` Tests run: 1628, Failures: 0, Skipped: 125; `WebUI` BUILD SUCCESS (Vitest 3154 passed)
+
+## Non-blocking notes
+
+- Full Workbench rule-builder parity remains out of scope (expression text only).
+- Control property values chrome remains a sibling (#3903).
+- C5: console-clean=yes; server.log-clean=yes (no ERROR/FATAL in test window).

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-field-rules.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-field-rules.spec.js
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Content Type field-rule expressions chrome (CD-05–07 / #3896).
+ *
+ * Admin locks a type, edits validation/visibility/input/output translation
+ * expression text, saves via PUT .../fields/{field}/ruleExpressions, then GET
+ * reflects the expressions. Unlocked editors stay disabled; 409 lock is not
+ * stolen.
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/developer-content-type-field-rules.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { catalogRowSelector } = require("./helpers/developer-catalog-selectors");
+
+const MARKER = "#3896-field-rule";
+
+function developerContentTypesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "content-types",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+function unwrapRuleExpressions(payload) {
+  if (payload == null || typeof payload !== "object") {
+    return {};
+  }
+  return (
+    payload.ContentTypeFieldRuleExpressions ||
+    payload.contentTypeFieldRuleExpressions ||
+    payload
+  );
+}
+
+function validationValues(env) {
+  const rules = Array.isArray(env.validation) ? env.validation : env.validation ? [env.validation] : [];
+  const values = [];
+  for (const rule of rules) {
+    const conds = Array.isArray(rule.conditionals)
+      ? rule.conditionals
+      : rule.conditionals
+        ? [rule.conditionals]
+        : [];
+    for (const c of conds) {
+      if (c && c.value != null) {
+        values.push(String(c.value));
+      }
+    }
+    if (rule.summary) {
+      values.push(String(rule.summary));
+    }
+  }
+  if (env.validationExpression) {
+    values.push(String(env.validationExpression));
+  }
+  return values;
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(unexpectedConsole, `console error: ${unexpectedConsole.join(" | ")}`).toEqual([]);
+}
+
+async function openContentTypeDetail(page, namePattern) {
+  await page.goto(developerContentTypesUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+
+  const panel = page.locator('[data-testid="developer-ct-panel"]');
+  const empty = page.locator('[data-testid="developer-ct-empty"]');
+  const listError = page.locator('[data-testid="developer-ct-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer content types catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  if (await empty.isVisible()) {
+    throw new Error(
+      "No content types in catalog — fail closed (H2 QA must include sample types)",
+    );
+  }
+
+  const table = page.locator('[data-testid="developer-ct-table"]');
+  await expect(table).toBeVisible({ timeout: 15_000 });
+  const named = table.locator('[data-testid^="developer-ct-row-"]').filter({
+    hasText: namePattern || /percPage/,
+  });
+  const targetRow =
+    (await named.count()) > 0
+      ? named.first()
+      : page.locator(catalogRowSelector("developer-ct-row", 0));
+  await expect(targetRow).toBeVisible();
+  const openBtn = targetRow.locator('button[aria-label^="Open "]');
+  if (await openBtn.count()) {
+    await openBtn.click();
+  } else {
+    await targetRow.click();
+  }
+
+  const detail = page.locator('[data-testid="developer-ct-detail"]');
+  const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
+  await expect(detail.or(detailError).first()).toBeVisible({ timeout: 30_000 });
+  if (await detailError.isVisible()) {
+    throw new Error(
+      `Content type detail error: ${(await detailError.innerText()).trim()}`,
+    );
+  }
+  await expect(page.locator('[data-testid="developer-ct-lock-toolbar"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.locator('[data-testid="developer-ct-field-rule-expressions"]')).toBeVisible({
+    timeout: 30_000,
+  });
+  return detail;
+}
+
+async function getRuleExpressions(page, typeName, fieldName) {
+  const res = await page.request.get(
+    `${BASE_URL}/Rhythmyx/services/contenttypes/${encodeURIComponent(typeName)}/fields/${encodeURIComponent(fieldName)}/ruleExpressions`,
+  );
+  expect(res.ok(), `GET ruleExpressions HTTP ${res.status()}`).toBe(true);
+  return unwrapRuleExpressions(await res.json());
+}
+
+async function releaseDesignLock(page) {
+  const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
+  if (await unlockBtn.isEnabled()) {
+    await unlockBtn.click();
+    await expect(page.locator('[data-testid="developer-ct-lock-status"]')).toHaveText(
+      /Not locked/i,
+      { timeout: 20_000 },
+    );
+  }
+}
+
+test.describe("Developer content type field-rule expressions (CD-05-07 / #3896)", () => {
+  test("unlocked expression editors stay disabled; 409 lock is not stolen", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    await openContentTypeDetail(page);
+
+    const validation = page.locator('[data-testid="developer-ct-fr-validation"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+
+    await expect(validation).toBeVisible({ timeout: 20_000 });
+    await expect(validation).toBeDisabled();
+    await expect(page.locator('[data-testid="developer-ct-fr-visibility"]')).toBeDisabled();
+    await expect(page.locator('[data-testid="developer-ct-fr-input"]')).toBeDisabled();
+    await expect(page.locator('[data-testid="developer-ct-fr-output"]')).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+
+    const putUrls = [];
+    page.on("request", (req) => {
+      if (req.method() === "PUT" && /\/ruleExpressions(?:\?|$)/.test(req.url())) {
+        putUrls.push(req.url());
+      }
+    });
+    await saveBtn.click({ force: true });
+    expect(putUrls, "unlocked save must not PUT ruleExpressions").toEqual([]);
+
+    await page.route("**/services/contenttypes/**/lock", async (route) => {
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Locked by another user" }),
+      });
+    });
+
+    await lockBtn.click();
+    await expect(page.locator('[data-testid="developer-ct-detail-error"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(status).toHaveText(/Not locked/i);
+    await expect(validation).toBeDisabled();
+    await expect(saveBtn).toBeDisabled();
+    expect(putUrls).toEqual([]);
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+
+  test("Admin lock, edit expressions, save, GET reflects", async ({ page }) => {
+    test.setTimeout(180_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    await openContentTypeDetail(
+      page,
+      /percSimpleTextAsset|percFileAsset|percRawHtmlAsset|percPage/,
+    );
+
+    const typeName = (
+      await page.locator('[data-testid="developer-ct-detail-name"]').innerText()
+    ).trim();
+    expect(typeName.length, "detail name for GET").toBeGreaterThan(0);
+
+    const fieldSelect = page.locator('[data-testid="developer-ct-fr-field"]');
+    await expect(fieldSelect).toBeVisible({ timeout: 20_000 });
+    const fieldName = (await fieldSelect.inputValue()) || "sys_title";
+    expect(fieldName.length, "field name for ruleExpressions").toBeGreaterThan(0);
+
+    const validation = page.locator('[data-testid="developer-ct-fr-validation"]');
+    await expect(validation).toBeVisible();
+    await expect(page.locator('[data-testid="developer-ct-fr-loading"]')).toHaveCount(0, {
+      timeout: 20_000,
+    });
+
+    const lockBtn = page.locator('[data-testid="developer-ct-lock"]');
+    const saveBtn = page.locator('[data-testid="developer-ct-save"]');
+    const unlockBtn = page.locator('[data-testid="developer-ct-unlock"]');
+    const status = page.locator('[data-testid="developer-ct-lock-status"]');
+    const notice = page.locator('[data-testid="developer-ct-detail-notice"]');
+    const saveError = page.locator('[data-testid="developer-ct-detail-error"]');
+    const frError = page.locator('[data-testid="developer-ct-fr-error"]');
+
+    await expect(lockBtn).toBeEnabled({ timeout: 30_000 });
+    const lockResponsePromise = page.waitForResponse(
+      (r) => r.request().method() === "POST" && /\/contenttypes\/[^/]+\/lock(?:\?|$)/.test(r.url()),
+      { timeout: 20_000 },
+    );
+    await lockBtn.click();
+    const lockRes = await lockResponsePromise;
+    if (!lockRes.ok()) {
+      const body = await lockRes.text();
+      throw new Error(`Lock HTTP ${lockRes.status()} ${body}`);
+    }
+    if (await saveError.isVisible()) {
+      throw new Error(`Lock failed: ${(await saveError.innerText()).trim()}`);
+    }
+    await expect(status).toHaveText(/Locked by you/i, { timeout: 20_000 });
+    await expect(validation).toBeEnabled();
+
+    const originalText = await validation.inputValue();
+    const markerLine = `${fieldName} <> "${MARKER}"`;
+    try {
+      await validation.fill(markerLine);
+      await expect(saveBtn).toBeEnabled();
+
+      const putRespPromise = page.waitForResponse(
+        (res) =>
+          res.request().method() === "PUT" && /\/ruleExpressions(?:\?|$)/.test(res.url()),
+        { timeout: 20_000 },
+      );
+      await saveBtn.click();
+      const putRes = await putRespPromise;
+      await expect(notice.or(saveError).or(frError).first()).toBeVisible({ timeout: 20_000 });
+      if (await saveError.isVisible()) {
+        throw new Error(
+          `Save failed: ${(await saveError.innerText()).trim()} PUT ${putRes.status()}`,
+        );
+      }
+      if (await frError.isVisible()) {
+        throw new Error(`Field-rule save failed: ${(await frError.innerText()).trim()}`);
+      }
+      expect(putRes.status(), `PUT ruleExpressions HTTP ${putRes.status()}`).toBe(200);
+      await expect(notice).toContainText(/saved/i);
+      await expect(status).toHaveText(/Locked by you/i);
+
+      const after = await getRuleExpressions(page, typeName, fieldName);
+      const afterValues = validationValues(after);
+      expect(
+        afterValues.some((v) => v.includes(MARKER)),
+        `GET validation should include marker ${MARKER}; got ${JSON.stringify(afterValues)}`,
+      ).toBe(true);
+
+      await validation.fill(originalText);
+      if (originalText !== markerLine) {
+        await expect(saveBtn).toBeEnabled();
+        await saveBtn.click();
+        await expect(notice.or(saveError).or(frError).first()).toBeVisible({ timeout: 20_000 });
+        if (await saveError.isVisible()) {
+          throw new Error(`Restore save failed: ${(await saveError.innerText()).trim()}`);
+        }
+        if (await frError.isVisible()) {
+          throw new Error(`Restore field-rule save failed: ${(await frError.innerText()).trim()}`);
+        }
+        await expect(notice).toContainText(/saved/i);
+      }
+
+      const restored = await getRuleExpressions(page, typeName, fieldName);
+      const restoredValues = validationValues(restored);
+      expect(
+        restoredValues.some((v) => v.includes(MARKER)),
+        `GET after restore must not keep marker; got ${JSON.stringify(restoredValues)}`,
+      ).toBe(false);
+
+      await unlockBtn.click();
+      await expect(status).toHaveText(/Not locked/i, { timeout: 20_000 });
+      await expect(validation).toBeDisabled();
+      await expect(saveBtn).toBeDisabled();
+    } finally {
+      await releaseDesignLock(page);
+    }
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, enable or disable, save allowed workflows and templates, and unlock a content type from Developer detail chrome
+description: Lock, enable or disable, save allowed workflows, templates, and field-rule expressions, and unlock a content type from Developer detail chrome
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -14,13 +14,16 @@ for fields, allowed workflows, allowed templates, and Object ACL. Design edits
 use an explicit **design-session lock** so two Admins cannot overwrite the same
 type at once.
 
-This is **not** the full Workbench field-rule editor. Field validation /
-visibility / transform **expressions** stay summary-only on the detail table.
-Integrators write them with REST
+This is **not** the full Workbench field-rule editor. The detail table still
+shows rule **flags** (validation / visibility / transforms present). After
+**Lock**, **Field rule expressions** lets you edit validation, visibility,
+input translation, and output translation **text** (one expression per line)
+and save with the same **Save content type** control. Integrators can also
+call REST
 `GET`/`PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions`
 (held design lock for PUT). Item-level pre/post exits and validations (CD-09)
-use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. This page does
-**not** add Properties-tab or expression-editor chrome.
+use `GET`/`PUT /services/contenttypes/{idOrName}/itemExits`. Control property
+values remain a dedicated REST surface (not this chrome).
 
 ## Product path — lock, save, unlock
 
@@ -87,6 +90,33 @@ the lock (including while the type is still loading). After **Lock**:
 
 This is not the full Workbench template picker.
 
+### Field rule expressions (after lock)
+
+The **Field rule expressions** section lists the type's fields. Choose a field
+to load its current validation, visibility, input translation, and output
+translation expressions. The text areas are **read-only** until you hold the
+lock.
+
+1. Click **Lock**. Status becomes **Locked by you**.
+2. Select a field. Each list is one expression per line:
+   * Validation / visibility **conditionals**: `variable operator value` (for
+     example `sys_title <> ""`). Operator `!=` is stored as `<>`.
+   * Extension call: `ext:Java/global/percussion/generic/sys_ToUpperCase`
+     (optional literal parameter after `|`).
+   * Named validation rule: `ref:ruleName` (validation only; visibility
+     rejects `ref:`).
+   * Input / output translation: one extension FQN per line, optional
+     `| parameter`.
+3. Click **Save content type**. The product replaces that field's four lists
+   (`PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions`).
+   Empty text clears that list. Save does **not** unlock. A following GET of
+   the same path reflects the new expressions.
+4. Without a lock, the text areas and Save stay **disabled**. The product does
+   **not** steal another user's lock (lock failure is **409**).
+
+This is expression **text**, not the Workbench visual rule builder. Apply-when
+conditions on field validation are not written.
+
 Locks expire after **30 minutes**. If Save fails because the lock expired,
 click **Lock** again and retry.
 
@@ -117,15 +147,16 @@ The chrome calls:
 | Save allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (requires a held lock; does not unlock) |
 | Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` (held lock; full replace) |
 | Confirm allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` |
+| Load field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` |
+| Save field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` (held lock; full replace of validation, visibility, inputTranslation, outputTranslation) |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` |
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on
 the same detail panel: [Object ACL & default template](id:admin-object-acl).
 
-Field **control property values**, **choice catalogs**, and **rule expressions** are not
-edited in this chrome. Integrators use:
+Field **control property values** and **choice catalogs** are not edited in this
+chrome. Integrators use:
 
 * `GET` / `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties`
-* `GET` / `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions`
 
-Hold the design-session lock before either PUT. See [REST API — Content types](id:developer-rest).
+Hold the design-session lock before PUT. See [REST API — Content types](id:developer-rest).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -434,8 +434,13 @@ validation is not written (see `designGaps` code `CT_FIELD_RULE_APPLY_WHEN`).
 | `409` | No design lock, or locked by another user |
 | `500` | Unexpected error |
 
-This slice does **not** add a field-rule expression editor in Developer Content Types
-chrome. Control property **values** and choice catalogs use the dedicated CD-07 path
+**Developer → Content types** detail chrome edits these four lists as expression
+**text** after **Lock** (one line per rule or extension call). **Save content type**
+calls this PUT, then GET reflects the new expressions. Save stays disabled until
+the lock is held; the product does not steal another user's lock. This is not
+the Workbench visual rule builder. See [Developer Content Types](id:admin-developer-content-types).
+
+Control property **values** and choice catalogs use the dedicated CD-07 path
 below.
 
 ### Control property values (CD-07)

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -137,6 +137,9 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
                  GUID last-segment tokens; JAXB / UNWRAP_ROOT_VALUE expects
                  AllowedContentTypeMenusRequest. Bind both envelopes. -->
             <ref bean="allowedContentTypeMenusRequestJsonReader" />
+            <!-- #3896: Developer field-rule PUT; JAXB rejects flat fieldName and
+                 UNWRAP_ROOT_VALUE can leave the four lists null. Bind wrap + flat. -->
+            <ref bean="contentTypeFieldRuleExpressionsJsonReader" />
             <ref bean="jacksonProvider" />
             <ref bean="jacksonContextResolver" />
             <ref bean="authorizationFilter" />

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldRuleExpressionsJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldRuleExpressionsJsonReader.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for {@link ContentTypeFieldRuleExpressions} that accepts the Jackson root envelope
+ * and a flat object.
+ *
+ * <p>Live CXF JAXB/Jettison rejects a flat {@code fieldName} body ({@code unexpected element
+ * fieldName}) and UNWRAP_ROOT_VALUE can leave the four lists null so PUT returns 400 required.
+ * Developer Content Type chrome (#3896) sends either:
+ *
+ * <ul>
+ *   <li>{@code {"ContentTypeFieldRuleExpressions":{…}}} (preferred)
+ *   <li>{@code {"fieldName":"sys_title","validation":[],…}} (flat)
+ * </ul>
+ *
+ * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code jacksonProvider}.
+ */
+@Provider
+@Consumes(MediaType.APPLICATION_JSON)
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("contentTypeFieldRuleExpressionsJsonReader")
+public class ContentTypeFieldRuleExpressionsJsonReader
+    implements MessageBodyReader<ContentTypeFieldRuleExpressions> {
+
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return type != null && ContentTypeFieldRuleExpressions.class.isAssignableFrom(type);
+  }
+
+  @Override
+  public ContentTypeFieldRuleExpressions readFrom(
+      Class<ContentTypeFieldRuleExpressions> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new ContentTypeFieldRuleExpressions();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new ContentTypeFieldRuleExpressions();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Bind PUT JSON. Empty / whitespace is an empty envelope (resource still requires the four
+   * lists).
+   *
+   * @param json request body; may be null
+   * @return non-null envelope
+   */
+  public static ContentTypeFieldRuleExpressions parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new ContentTypeFieldRuleExpressions();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid field rule expressions", 400);
+    }
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new ContentTypeFieldRuleExpressions();
+    }
+    if (!root.isObject()) {
+      throw new WebApplicationException("Invalid field rule expressions", 400);
+    }
+    JsonNode nested =
+        firstObject(root, "ContentTypeFieldRuleExpressions", "contentTypeFieldRuleExpressions");
+    JsonNode fields = nested != null ? nested : root;
+    try {
+      ContentTypeFieldRuleExpressions out =
+          MAPPER.treeToValue(fields, ContentTypeFieldRuleExpressions.class);
+      return out != null ? out : new ContentTypeFieldRuleExpressions();
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid field rule expressions", 400);
+    }
+  }
+
+  private static JsonNode firstObject(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && n.isObject()) {
+        return n;
+      }
+    }
+    return null;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypeFieldRuleExpressionsJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypeFieldRuleExpressionsJsonReaderTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class ContentTypeFieldRuleExpressionsJsonReaderTest {
+
+  private static final String FLAT =
+      "{"
+          + "\"fieldName\":\"sys_title\","
+          + "\"validation\":[{\"type\":\"conditional\",\"conditionals\":"
+          + "[{\"variable\":\"sys_title\",\"operator\":\"<>\",\"value\":\"#3896\"}]}],"
+          + "\"visibility\":[],"
+          + "\"inputTranslation\":[],"
+          + "\"outputTranslation\":[]"
+          + "}";
+
+  private final ContentTypeFieldRuleExpressionsJsonReader reader =
+      new ContentTypeFieldRuleExpressionsJsonReader();
+
+  @Test
+  public void parseAcceptsWrappedEnvelope() {
+    ContentTypeFieldRuleExpressions out =
+        ContentTypeFieldRuleExpressionsJsonReader.parse(
+            "{\"ContentTypeFieldRuleExpressions\":" + FLAT + "}");
+    assertEquals("sys_title", out.getFieldName());
+    assertNotNull(out.getValidation());
+    assertEquals(1, out.getValidation().size());
+    assertEquals("conditional", out.getValidation().get(0).getType());
+    assertEquals("#3896", out.getValidation().get(0).getConditionals().get(0).getValue());
+    assertNotNull(out.getVisibility());
+    assertTrue(out.getVisibility().isEmpty());
+    assertNotNull(out.getInputTranslation());
+    assertNotNull(out.getOutputTranslation());
+  }
+
+  @Test
+  public void parseAcceptsFlatBody() {
+    ContentTypeFieldRuleExpressions out = ContentTypeFieldRuleExpressionsJsonReader.parse(FLAT);
+    assertEquals("sys_title", out.getFieldName());
+    assertEquals(1, out.getValidation().size());
+    assertTrue(out.getVisibility().isEmpty());
+  }
+
+  @Test
+  public void parseAcceptsCamelCaseRootAlias() {
+    ContentTypeFieldRuleExpressions out =
+        ContentTypeFieldRuleExpressionsJsonReader.parse(
+            "{\"contentTypeFieldRuleExpressions\":" + FLAT + "}");
+    assertEquals("sys_title", out.getFieldName());
+  }
+
+  @Test
+  public void parseEmptyIsEmptyEnvelope() {
+    ContentTypeFieldRuleExpressions empty = ContentTypeFieldRuleExpressionsJsonReader.parse("  ");
+    assertTrue(empty.getValidation() == null || empty.getValidation().isEmpty());
+  }
+
+  @Test
+  public void parseRejectsNonObject() {
+    assertThrows(
+        WebApplicationException.class, () -> ContentTypeFieldRuleExpressionsJsonReader.parse("[1]"));
+  }
+
+  @Test
+  public void readFromReadsUtf8Body() throws Exception {
+    byte[] raw = FLAT.getBytes(StandardCharsets.UTF_8);
+    ContentTypeFieldRuleExpressions out =
+        reader.readFrom(
+            ContentTypeFieldRuleExpressions.class,
+            ContentTypeFieldRuleExpressions.class,
+            new java.lang.annotation.Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(raw));
+    assertEquals("sys_title", out.getFieldName());
+    assertTrue(reader.isReadable(ContentTypeFieldRuleExpressions.class, null, null, null));
+  }
+}


### PR DESCRIPTION
## Summary

Developer Content Type **field-rule expressions** chrome (CD-05–07, parent #1690, slice of closed REST #3784).

After **Lock**, operators edit validation / visibility / input translation / output translation **expression text** (one line per rule) and **Save content type**. Save calls existing `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` while the lock is held. GET reflects the new expressions. Unlocked editors stay disabled; a **409** lock is not stolen.

A JAX-RS `ContentTypeFieldRuleExpressionsJsonReader` binds wrap-root and flat JSON so live CXF JAXB does not reject the PUT (`unexpected element fieldName` / null lists). This does **not** re-implement REST save semantics.

Dedicated `ContentTypeFieldRulesSection` (minimal hook into `ContentTypeDetailPanel`) so open PRs #3901/#3903 can rebase without stealing those slices.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3896
Parent: #1690

## Test plan

1. H2 QA: `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (use printed `TEST_CMS_URL`; do not hardcode :9993).
2. Hot-copy WebUI `cm/modern/assets`, `rest-*-SNAPSHOT.jar`, `sitemanage-*-SNAPSHOT.jar`, and `sitemanage-beans.xml`; in-cell StopJetty/StartJetty; `qa-health` again.
3. `cd modules/perc-qa-automation/frontend` with `TEST_CMS_URL`, `ADMIN_USERNAME=Admin`, `ADMIN_PASSWORD` from qa-up, `TEST_DB_TYPE=h2`, `TEST_PRODUCT=cms`.
4. `npm run test:surface -- --path tests/developer-content-type-field-rules.spec.js`
5. Confirm: unlocked editors disabled; 409 lock not stolen; Admin lock → edit validation line → save → GET includes marker → restore → unlock.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-content-types.md` and `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — Vitest unwrap/parse/PUT + panel lock/save/409; rest JsonReader wrap+flat
- [x] **WebUI + Playwright** — `tests/developer-content-type-field-rules.spec.js` (2 passed)
- [x] **Build gates** — standalone `mvnw clean install` on changed modules (no skipTests)
- [x] **Cross-platform** — URI paths only (`/`); no filesystem path joins

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 648, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1628, Failures: 0, Skipped: 125
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS, Java Tests run: 63, Failures: 0; Vitest Test Files 394 passed, Tests 3154 passed
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (npm ci; no Java tests)
- **downstream_checked:** JsonReader is a new consume helper (not a `final` type / signature break). Grep not required for `extends`/`new Type() {`. sitemanage beans.xml registers the provider; sitemanage clean install green.

### C5 UI proof

- `perc-devctl.py qa-up --skip-image-build` — `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER=perc-matrix-cms-h2`
- `qa-health --url http://127.0.0.1:9993/Rhythmyx/rest/mimetypes` — RESULT:OK HTTP:200 HEALTH:healthy
- Deploy: docker cp rest + sitemanage jars + `sitemanage-beans.xml` + WebUI `cm/modern/assets`; in-cell `StopJetty.sh` / `StartJetty.sh`; qa-health again RESULT:OK HTTP:200 HEALTH:healthy
- Playwright: `npm run test:surface -- --path tests/developer-content-type-field-rules.spec.js` — **2 passed** (6.2s)
- console-clean=yes (spec pageerror/console guards)
- server.log-clean=yes (no ERROR/FATAL in the Playwright window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
