### PR TITLE
feat(webui): Developer Sites rss-atom source kind chrome (#3889)

### DIFF
--- a/WebUI/src/main/ts/api/developer/types.ts
+++ b/WebUI/src/main/ts/api/developer/types.ts
@@ -790,10 +790,12 @@ export interface SiteDef {
  * <p>Blank / missing {@code sourceKind} (or value {@code repository}) means a
  * traditional repository Site. Allow-listed virtual adapters:
  * {@code git-filesystem}, {@code csv-filesystem}, {@code sql-database},
- * {@code http-json}, {@code object-storage}. Developer Sites save chrome
- * includes http-json and object-storage (local {@code rootPath} only; no
- * cloud URLs or credentials). Build, Preview, and Publish chrome are shown
- * after save for git/csv/sql/http-json/object-storage.
+ * {@code http-json}, {@code object-storage}, {@code rss-atom}. Developer Sites
+ * save chrome includes http-json, object-storage, and rss-atom (local
+ * {@code rootPath} only; no cloud URLs, live feed credentials, or
+ * {@code virtual.remoteUrl} on those kinds). Build, Preview, and Publish
+ * chrome are shown after save for git/csv/sql/http-json/object-storage.
+ * rss-atom Build/Preview/Publish chrome stays a later phase.
  */
 export interface VirtualSiteProperties {
   sourceKind?: string | null;

--- a/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
+++ b/WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx
@@ -51,6 +51,7 @@ import {
   SOURCE_KIND_HTTP_JSON,
   SOURCE_KIND_OBJECT_STORAGE,
   SOURCE_KIND_REPOSITORY,
+  SOURCE_KIND_RSS_ATOM,
   SOURCE_KIND_SELECT_VALUES,
   SOURCE_KIND_SQL_DATABASE,
   emptyVirtualSiteForm,
@@ -59,6 +60,7 @@ import {
   isGitFilesystemSourceKind,
   isHttpJsonSourceKind,
   isObjectStorageSourceKind,
+  isRssAtomSourceKind,
   isSqlDatabaseSourceKind,
   isVirtualSourceKind,
   validateVirtualSiteForm,
@@ -76,6 +78,7 @@ const SOURCE_KIND_OPTION_LABEL: Record<
   [SOURCE_KIND_SQL_DATABASE]: DEV_MSG.SITE_VIRT_KIND_SQL_DATABASE,
   [SOURCE_KIND_HTTP_JSON]: DEV_MSG.SITE_VIRT_KIND_HTTP_JSON,
   [SOURCE_KIND_OBJECT_STORAGE]: DEV_MSG.SITE_VIRT_KIND_OBJECT_STORAGE,
+  [SOURCE_KIND_RSS_ATOM]: DEV_MSG.SITE_VIRT_KIND_RSS_ATOM,
 };
 
 const formRow: React.CSSProperties = {
@@ -166,6 +169,8 @@ function validationMessage(
  * sql-database, http-json, and object-storage. Preview last-build HTML for
  * those kinds. Publish ({@code POST …/virtual/publish}) for the same kinds
  * after a successful Build. Repository / blank / unknown kinds stay hidden.
+ * rss-atom save chrome is in this panel (local {@code rootPath} only);
+ * Build/Preview/Publish for rss-atom stay a later phase.
  */
 export function VirtualSiteSourcePanel({
   siteName,
@@ -355,11 +360,12 @@ export function VirtualSiteSourcePanel({
   const sqlMode = isSqlDatabaseSourceKind(form.sourceKind);
   const httpJsonMode = isHttpJsonSourceKind(form.sourceKind);
   const objectStorageMode = isObjectStorageSourceKind(form.sourceKind);
-  /** Build chrome: git/csv/sql/http-json/object-storage (never repository). */
+  const rssAtomMode = isRssAtomSourceKind(form.sourceKind);
+  /** Build chrome: git/csv/sql/http-json/object-storage (never repository or rss-atom). */
   const showBuildChrome = shouldShowVirtualBuildChrome(form.sourceKind);
-  /** Preview chrome: git/csv/sql/http-json/object-storage (never repository). */
+  /** Preview chrome: git/csv/sql/http-json/object-storage (never repository or rss-atom). */
   const showPreviewChrome = shouldShowVirtualPreviewChrome(form.sourceKind);
-  /** Publish chrome: git/csv/sql/http-json/object-storage (never repository). */
+  /** Publish chrome: git/csv/sql/http-json/object-storage (never repository or rss-atom). */
   const showPublishChrome = shouldShowVirtualPublishChrome(form.sourceKind);
   const busy = saving || building || publishing;
   const buildSummary = buildResult ? formatVirtualSiteBuildSummary(buildResult) : null;
@@ -485,6 +491,14 @@ export function VirtualSiteSourcePanel({
                   data-testid="developer-site-virtual-object-storage-hint"
                 >
                   {DEV_MSG.SITE_VIRT_OBJECT_STORAGE_HINT}
+                </p>
+              ) : null}
+              {rssAtomMode ? (
+                <p
+                  style={{ ...mutedHintText, margin: "0 0 10px" }}
+                  data-testid="developer-site-virtual-rss-atom-hint"
+                >
+                  {DEV_MSG.SITE_VIRT_RSS_ATOM_HINT}
                 </p>
               ) : null}
               {gitMode ? (

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -808,7 +808,7 @@ export const DEV_MSG_KEYS = {
     "perc.ui.developer@Workflow association is browsed under the Workflows catalog",
   SITE_VIRT_TITLE: "perc.ui.developer@Virtual Site source",
   SITE_VIRT_HINT:
-    "perc.ui.developer@Configure whether this Site reads content from the repository or from a Virtual Site adapter (Git filesystem, CSV filesystem, SQL database, HTTP JSON, or object storage). Blank/repository keeps traditional repository content.",
+    "perc.ui.developer@Configure whether this Site reads content from the repository or from a Virtual Site adapter (Git filesystem, CSV filesystem, SQL database, HTTP JSON, object storage, or RSS / Atom). Blank/repository keeps traditional repository content.",
   SITE_VIRT_LOADING: "perc.ui.developer@Loading Virtual Site source...",
   SITE_VIRT_ERROR: "perc.ui.developer@Could not load Virtual Site source.",
   SITE_VIRT_SAVE_ERROR: "perc.ui.developer@Could not save Virtual Site source.",
@@ -838,6 +838,9 @@ export const DEV_MSG_KEYS = {
   SITE_VIRT_KIND_OBJECT_STORAGE: "perc.ui.developer@Object storage",
   SITE_VIRT_OBJECT_STORAGE_HINT:
     "perc.ui.developer@Object storage uses the root path only (no Git remote). Treat the directory as a local object-key bucket (Markdown, HTML, or JSON). Save sourceKind=object-storage, then Build Virtual Site, then Preview assembled site. Publish Virtual Site copies assembled files to the Site filesystem target. Cloud URLs and access keys are never sent on the REST envelope.",
+  SITE_VIRT_KIND_RSS_ATOM: "perc.ui.developer@RSS / Atom",
+  SITE_VIRT_RSS_ATOM_HINT:
+    "perc.ui.developer@RSS / Atom uses the root path only (no Git remote). Point at a local RSS or Atom fixture directory. Save sourceKind=rss-atom. Live feed URLs and credentials are never sent on the REST envelope. Build, Preview, and Publish Virtual Site for this kind stay a later phase.",
   SITE_VIRT_STATUS_REPO: "perc.ui.developer@Mode: traditional repository Site",
   SITE_VIRT_STATUS_VIRTUAL: "perc.ui.developer@Mode: Virtual Site",
   SITE_VIRT_ERR_ROOT_REQUIRED:

--- a/WebUI/src/main/ts/developer/virtualSiteBuild.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteBuild.ts
@@ -29,7 +29,8 @@ function normalizedSourceKind(sourceKind: string | null | undefined): string {
  * Git-filesystem, csv-filesystem, sql-database, http-json, and object-storage
  * Virtual Sites all run POST /virtual/build (SQL JDBC, HTTP JSON catalog, and
  * object-storage keys stay in _config.yaml / the local root).
- * Repository / blank / unknown kinds must not display this chrome.
+ * Repository / blank / unknown kinds and rss-atom must not display this chrome
+ * (rss-atom Build stays a later phase).
  */
 export function shouldShowVirtualBuildChrome(
   sourceKind: string | null | undefined,
@@ -47,7 +48,8 @@ export function shouldShowVirtualBuildChrome(
 /**
  * True when Preview assembled site should be shown.
  * Last-output preview for git-filesystem, csv-filesystem, sql-database,
- * http-json, and object-storage. Repository / blank / unknown kinds stay hidden.
+ * http-json, and object-storage. Repository / blank / unknown kinds and
+ * rss-atom stay hidden (rss-atom Preview stays a later phase).
  */
 export function shouldShowVirtualPreviewChrome(
   sourceKind: string | null | undefined,
@@ -66,7 +68,8 @@ export function shouldShowVirtualPreviewChrome(
  * True when the Publish Virtual Site control should be shown.
  * Git-filesystem, csv-filesystem, sql-database, http-json, and object-storage
  * all run POST /virtual/publish (build then copy to IPSSite.root).
- * Repository / blank / unknown kinds stay hidden.
+ * Repository / blank / unknown kinds and rss-atom stay hidden
+ * (rss-atom Publish stays a later phase).
  */
 export function shouldShowVirtualPublishChrome(
   sourceKind: string | null | undefined,

--- a/WebUI/src/main/ts/developer/virtualSiteForm.ts
+++ b/WebUI/src/main/ts/developer/virtualSiteForm.ts
@@ -35,6 +35,9 @@ export const SOURCE_KIND_HTTP_JSON = "http-json";
 /** Virtual Site adapter wire name for a local object-key directory (no cloud secrets). */
 export const SOURCE_KIND_OBJECT_STORAGE = "object-storage";
 
+/** Virtual Site adapter wire name for a local RSS/Atom fixture (no live feed credentials). */
+export const SOURCE_KIND_RSS_ATOM = "rss-atom";
+
 /** Form select values for source kind. */
 export type VirtualSourceKindOption =
   | typeof SOURCE_KIND_REPOSITORY
@@ -42,7 +45,8 @@ export type VirtualSourceKindOption =
   | typeof SOURCE_KIND_CSV_FILESYSTEM
   | typeof SOURCE_KIND_SQL_DATABASE
   | typeof SOURCE_KIND_HTTP_JSON
-  | typeof SOURCE_KIND_OBJECT_STORAGE;
+  | typeof SOURCE_KIND_OBJECT_STORAGE
+  | typeof SOURCE_KIND_RSS_ATOM;
 
 /**
  * Product order for the Developer Sites source-kind {@code <select>}.
@@ -56,6 +60,7 @@ export const SOURCE_KIND_SELECT_VALUES: readonly VirtualSourceKindOption[] = [
   SOURCE_KIND_SQL_DATABASE,
   SOURCE_KIND_HTTP_JSON,
   SOURCE_KIND_OBJECT_STORAGE,
+  SOURCE_KIND_RSS_ATOM,
 ];
 
 /** Editable form model for the Virtual Site source panel. */
@@ -71,8 +76,8 @@ export interface VirtualSiteFormModel {
 /**
  * Normalize a wire/sourceKind string into a form select option.
  * Blank, missing, or {@code repository} → repository; git-filesystem,
- * csv-filesystem, sql-database, http-json, and object-storage map to themselves;
- * unknown kinds → repository (safe default).
+ * csv-filesystem, sql-database, http-json, object-storage, and rss-atom map
+ * to themselves; unknown kinds → repository (safe default).
  */
 export function normalizeSourceKindOption(
   raw: string | null | undefined,
@@ -95,6 +100,9 @@ export function normalizeSourceKindOption(
   }
   if (v === SOURCE_KIND_OBJECT_STORAGE) {
     return SOURCE_KIND_OBJECT_STORAGE;
+  }
+  if (v === SOURCE_KIND_RSS_ATOM) {
+    return SOURCE_KIND_RSS_ATOM;
   }
   // Unknown kinds: surface as repository so operators do not accidentally
   // re-save an unsupported adapter without changing the select.
@@ -130,6 +138,11 @@ export function isHttpJsonSourceKind(kind: string | null | undefined): boolean {
 /** True when source kind is the local object-storage adapter (root path only; no cloud secrets). */
 export function isObjectStorageSourceKind(kind: string | null | undefined): boolean {
   return (kind ?? "").trim().toLowerCase() === SOURCE_KIND_OBJECT_STORAGE;
+}
+
+/** True when source kind is the local RSS/Atom adapter (root path only; no live feed credentials). */
+export function isRssAtomSourceKind(kind: string | null | undefined): boolean {
+  return (kind ?? "").trim().toLowerCase() === SOURCE_KIND_RSS_ATOM;
 }
 
 /**
@@ -199,6 +212,16 @@ export function formToVirtualProps(form: VirtualSiteFormModel): VirtualSitePrope
     // object-key directory only — never send cloud URLs, IAM, or access keys.
     return {
       sourceKind: SOURCE_KIND_OBJECT_STORAGE,
+      rootPath: form.rootPath.trim() || null,
+      remoteUrl: "",
+      branch: "",
+    };
+  }
+  if (kind === SOURCE_KIND_RSS_ATOM) {
+    // RSS/Atom rejects a non-blank virtual.remoteUrl (REST 400). Local fixture
+    // directory only — never send live feed URLs or credentials.
+    return {
+      sourceKind: SOURCE_KIND_RSS_ATOM,
       rootPath: form.rootPath.trim() || null,
       remoteUrl: "",
       branch: "",

--- a/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
+++ b/WebUI/src/test/ts/api/developer/sitesApi.virtual.test.ts
@@ -197,6 +197,19 @@ describe("sitesApi virtual properties", () => {
         siteKey: null,
       },
     });
+    expect(
+      toVirtualSitePropertiesEnvelope({
+        sourceKind: "rss-atom",
+        rootPath: "C:/rss-atom-docs",
+      }),
+    ).toEqual({
+      VirtualSiteProperties: {
+        sourceKind: "rss-atom",
+        rootPath: "C:/rss-atom-docs",
+        configFile: null,
+        siteKey: null,
+      },
+    });
   });
 
   it("updateVirtualSiteProperties PUTs VirtualSiteProperties envelope", async () => {

--- a/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
+++ b/WebUI/src/test/ts/developer/VirtualSiteSourcePanel.test.tsx
@@ -67,6 +67,7 @@ describe("VirtualSiteSourcePanel", () => {
       "sql-database",
       "http-json",
       "object-storage",
+      "rss-atom",
     ]);
     expect(kindSelect.value).toBe("repository");
     // Root path / remote hidden until virtual selected
@@ -750,6 +751,125 @@ describe("VirtualSiteSourcePanel", () => {
       expect(screen.queryByTestId("developer-site-virtual-root-path")).toBeNull();
     });
     expect(screen.queryByTestId("developer-site-virtual-object-storage-hint")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-preview")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
+  });
+
+  it("loads rss-atom values with root path and no Build/Preview/Publish chrome", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "rss-atom",
+      rootPath: "C:/rss-atom-docs",
+      virtual: true,
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-root-path")).toBeTruthy();
+    });
+    expect(
+      (screen.getByTestId("developer-site-virtual-source-kind") as HTMLSelectElement).value,
+    ).toBe("rss-atom");
+    expect(
+      (screen.getByTestId("developer-site-virtual-root-path") as HTMLInputElement).value,
+    ).toBe("C:/rss-atom-docs");
+    expect(screen.getByTestId("developer-site-virtual-rss-atom-hint")).toBeTruthy();
+    expect(screen.getByTestId("developer-site-virtual-rss-atom-hint").textContent).toBe(
+      DEV_MSG.SITE_VIRT_RSS_ATOM_HINT,
+    );
+    expect(screen.getByTestId("developer-site-virtual-rss-atom-hint").textContent).toContain(
+      "later phase",
+    );
+    expect(screen.queryByTestId("developer-site-virtual-remote-url")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-branch")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-config-file")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-preview")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
+    expect(screen.getByTestId("developer-site-virtual-status").textContent).toContain(
+      DEV_MSG.SITE_VIRT_STATUS_VIRTUAL,
+    );
+  });
+
+  it("saves rss-atom configuration without Git remote fields or live feed credentials", async () => {
+    getVirtual
+      .mockResolvedValueOnce({ sourceKind: null, virtual: false })
+      .mockResolvedValueOnce({
+        sourceKind: "rss-atom",
+        rootPath: "C:/rss-atom-docs",
+        virtual: true,
+      });
+    updateVirtual.mockResolvedValue({
+      sourceKind: "rss-atom",
+      rootPath: "C:/rss-atom-docs",
+      virtual: true,
+    });
+    render(<VirtualSiteSourcePanel siteName="Corporate" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-form")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-site-virtual-source-kind"), {
+      target: { value: "rss-atom" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-root-path")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-error").textContent).toContain(
+        DEV_MSG.SITE_VIRT_ERR_ROOT_REQUIRED,
+      );
+    });
+    expect(updateVirtual).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByTestId("developer-site-virtual-root-path"), {
+      target: { value: "C:/rss-atom-docs" },
+    });
+    fireEvent.click(screen.getByTestId("developer-site-virtual-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-saved")).toBeTruthy();
+    });
+    expect(updateVirtual).toHaveBeenCalledWith("Corporate", {
+      sourceKind: "rss-atom",
+      rootPath: "C:/rss-atom-docs",
+      remoteUrl: "",
+      branch: "",
+    });
+    const savedBody = updateVirtual.mock.calls[0][1] as Record<string, unknown>;
+    expect(savedBody).not.toHaveProperty("password");
+    expect(JSON.stringify(savedBody)).not.toMatch(
+      /authorization|api[_-]?key|feed[_-]?url|credential|token/i,
+    );
+    expect(getVirtual).toHaveBeenCalledTimes(2);
+    expect(
+      (screen.getByTestId("developer-site-virtual-root-path") as HTMLInputElement).value,
+    ).toBe("C:/rss-atom-docs");
+    expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-preview")).toBeNull();
+    expect(screen.queryByTestId("developer-site-virtual-publish")).toBeNull();
+    expect(screen.getByTestId("developer-site-virtual-status").textContent).toContain(
+      DEV_MSG.SITE_VIRT_STATUS_VIRTUAL,
+    );
+  });
+
+  it("switching rss-atom back to repository hides virtual fields", async () => {
+    getVirtual.mockResolvedValue({
+      sourceKind: "rss-atom",
+      rootPath: "C:/rss-atom-docs",
+      virtual: true,
+    });
+    render(<VirtualSiteSourcePanel siteName="Help" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-site-virtual-root-path")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-site-virtual-source-kind"), {
+      target: { value: "repository" },
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("developer-site-virtual-root-path")).toBeNull();
+    });
+    expect(screen.queryByTestId("developer-site-virtual-rss-atom-hint")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-build-section")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-build")).toBeNull();
     expect(screen.queryByTestId("developer-site-virtual-preview")).toBeNull();

--- a/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteBuild.test.ts
@@ -32,6 +32,8 @@ describe("virtualSiteBuild helpers", () => {
     expect(shouldShowVirtualBuildChrome("object-storage")).toBe(true);
     expect(shouldShowVirtualBuildChrome("Object-Storage")).toBe(true);
     expect(shouldShowVirtualBuildChrome("  object-storage  ")).toBe(true);
+    expect(shouldShowVirtualBuildChrome("rss-atom")).toBe(false);
+    expect(shouldShowVirtualBuildChrome("RSS-Atom")).toBe(false);
   });
 
   it("shouldShowVirtualPreviewChrome for git, csv, sql-database, http-json, and object-storage (not repository)", () => {
@@ -50,6 +52,8 @@ describe("virtualSiteBuild helpers", () => {
     expect(shouldShowVirtualPreviewChrome("object-storage")).toBe(true);
     expect(shouldShowVirtualPreviewChrome("Object-Storage")).toBe(true);
     expect(shouldShowVirtualPreviewChrome("  object-storage  ")).toBe(true);
+    expect(shouldShowVirtualPreviewChrome("rss-atom")).toBe(false);
+    expect(shouldShowVirtualPreviewChrome("RSS-Atom")).toBe(false);
   });
 
   it("shouldShowVirtualPublishChrome for git-filesystem, csv-filesystem, sql-database, http-json, and object-storage", () => {
@@ -70,6 +74,8 @@ describe("virtualSiteBuild helpers", () => {
     expect(shouldShowVirtualPublishChrome("object-storage")).toBe(true);
     expect(shouldShowVirtualPublishChrome("Object-Storage")).toBe(true);
     expect(shouldShowVirtualPublishChrome("  object-storage  ")).toBe(true);
+    expect(shouldShowVirtualPublishChrome("rss-atom")).toBe(false);
+    expect(shouldShowVirtualPublishChrome("RSS-Atom")).toBe(false);
   });
 
   it("formatVirtualSitePublishSummary reports files copied and dest path", () => {

--- a/WebUI/src/test/ts/developer/virtualSiteForm.test.ts
+++ b/WebUI/src/test/ts/developer/virtualSiteForm.test.ts
@@ -9,6 +9,7 @@ import {
   SOURCE_KIND_HTTP_JSON,
   SOURCE_KIND_OBJECT_STORAGE,
   SOURCE_KIND_REPOSITORY,
+  SOURCE_KIND_RSS_ATOM,
   SOURCE_KIND_SELECT_VALUES,
   SOURCE_KIND_SQL_DATABASE,
   emptyVirtualSiteForm,
@@ -17,6 +18,7 @@ import {
   isGitFilesystemSourceKind,
   isHttpJsonSourceKind,
   isObjectStorageSourceKind,
+  isRssAtomSourceKind,
   isSqlDatabaseSourceKind,
   isVirtualSourceKind,
   normalizeSourceKindOption,
@@ -25,7 +27,7 @@ import {
 } from "../../../main/ts/developer/virtualSiteForm";
 
 describe("virtualSiteForm helpers", () => {
-  it("SOURCE_KIND_SELECT_VALUES lists object-storage with the other product kinds (#3893)", () => {
+  it("SOURCE_KIND_SELECT_VALUES lists object-storage and rss-atom with the other product kinds", () => {
     expect(SOURCE_KIND_SELECT_VALUES).toEqual([
       SOURCE_KIND_REPOSITORY,
       SOURCE_KIND_GIT_FILESYSTEM,
@@ -33,10 +35,11 @@ describe("virtualSiteForm helpers", () => {
       SOURCE_KIND_SQL_DATABASE,
       SOURCE_KIND_HTTP_JSON,
       SOURCE_KIND_OBJECT_STORAGE,
+      SOURCE_KIND_RSS_ATOM,
     ]);
   });
 
-  it("normalizeSourceKindOption maps blank/repository, git-filesystem, csv-filesystem, sql-database, http-json, and object-storage", () => {
+  it("normalizeSourceKindOption maps blank/repository, git-filesystem, csv-filesystem, sql-database, http-json, object-storage, and rss-atom", () => {
     expect(normalizeSourceKindOption(undefined)).toBe(SOURCE_KIND_REPOSITORY);
     expect(normalizeSourceKindOption("")).toBe(SOURCE_KIND_REPOSITORY);
     expect(normalizeSourceKindOption("  ")).toBe(SOURCE_KIND_REPOSITORY);
@@ -52,6 +55,8 @@ describe("virtualSiteForm helpers", () => {
     expect(normalizeSourceKindOption("HTTP-JSON")).toBe(SOURCE_KIND_HTTP_JSON);
     expect(normalizeSourceKindOption("object-storage")).toBe(SOURCE_KIND_OBJECT_STORAGE);
     expect(normalizeSourceKindOption("Object-Storage")).toBe(SOURCE_KIND_OBJECT_STORAGE);
+    expect(normalizeSourceKindOption("rss-atom")).toBe(SOURCE_KIND_RSS_ATOM);
+    expect(normalizeSourceKindOption("RSS-Atom")).toBe(SOURCE_KIND_RSS_ATOM);
     expect(normalizeSourceKindOption("future-adapter")).toBe(SOURCE_KIND_REPOSITORY);
     expect(normalizeSourceKindOption("sql-api")).toBe(SOURCE_KIND_REPOSITORY);
   });
@@ -65,33 +70,44 @@ describe("virtualSiteForm helpers", () => {
     expect(isVirtualSourceKind("sql-database")).toBe(true);
     expect(isVirtualSourceKind("http-json")).toBe(true);
     expect(isVirtualSourceKind("object-storage")).toBe(true);
+    expect(isVirtualSourceKind("rss-atom")).toBe(true);
     expect(isGitFilesystemSourceKind("git-filesystem")).toBe(true);
     expect(isGitFilesystemSourceKind("csv-filesystem")).toBe(false);
     expect(isGitFilesystemSourceKind("sql-database")).toBe(false);
     expect(isGitFilesystemSourceKind("http-json")).toBe(false);
     expect(isGitFilesystemSourceKind("object-storage")).toBe(false);
+    expect(isGitFilesystemSourceKind("rss-atom")).toBe(false);
     expect(isCsvFilesystemSourceKind("csv-filesystem")).toBe(true);
     expect(isCsvFilesystemSourceKind("git-filesystem")).toBe(false);
     expect(isCsvFilesystemSourceKind("sql-database")).toBe(false);
     expect(isCsvFilesystemSourceKind("http-json")).toBe(false);
     expect(isCsvFilesystemSourceKind("object-storage")).toBe(false);
+    expect(isCsvFilesystemSourceKind("rss-atom")).toBe(false);
     expect(isSqlDatabaseSourceKind("sql-database")).toBe(true);
     expect(isSqlDatabaseSourceKind("SQL-Database")).toBe(true);
     expect(isSqlDatabaseSourceKind("csv-filesystem")).toBe(false);
     expect(isSqlDatabaseSourceKind("git-filesystem")).toBe(false);
     expect(isSqlDatabaseSourceKind("http-json")).toBe(false);
     expect(isSqlDatabaseSourceKind("object-storage")).toBe(false);
+    expect(isSqlDatabaseSourceKind("rss-atom")).toBe(false);
     expect(isHttpJsonSourceKind("http-json")).toBe(true);
     expect(isHttpJsonSourceKind("HTTP-JSON")).toBe(true);
     expect(isHttpJsonSourceKind("sql-database")).toBe(false);
     expect(isHttpJsonSourceKind("csv-filesystem")).toBe(false);
     expect(isHttpJsonSourceKind("git-filesystem")).toBe(false);
     expect(isHttpJsonSourceKind("object-storage")).toBe(false);
+    expect(isHttpJsonSourceKind("rss-atom")).toBe(false);
     expect(isObjectStorageSourceKind("object-storage")).toBe(true);
     expect(isObjectStorageSourceKind("Object-Storage")).toBe(true);
     expect(isObjectStorageSourceKind("http-json")).toBe(false);
     expect(isObjectStorageSourceKind("sql-database")).toBe(false);
     expect(isObjectStorageSourceKind("git-filesystem")).toBe(false);
+    expect(isObjectStorageSourceKind("rss-atom")).toBe(false);
+    expect(isRssAtomSourceKind("rss-atom")).toBe(true);
+    expect(isRssAtomSourceKind("RSS-Atom")).toBe(true);
+    expect(isRssAtomSourceKind("object-storage")).toBe(false);
+    expect(isRssAtomSourceKind("http-json")).toBe(false);
+    expect(isRssAtomSourceKind("git-filesystem")).toBe(false);
   });
 
   it("virtualPropsToForm and formToVirtualProps round-trip repository clear", () => {
@@ -296,6 +312,43 @@ describe("virtualSiteForm helpers", () => {
     );
   });
 
+  it("virtualPropsToForm maps rss-atom and PUT omits Git remotes", () => {
+    const form = virtualPropsToForm({
+      sourceKind: "rss-atom",
+      rootPath: "C:/rss-atom-docs",
+      virtual: true,
+    });
+    expect(form.sourceKind).toBe(SOURCE_KIND_RSS_ATOM);
+    expect(form.rootPath).toBe("C:/rss-atom-docs");
+    expect(formToVirtualProps(form)).toEqual({
+      sourceKind: SOURCE_KIND_RSS_ATOM,
+      rootPath: "C:/rss-atom-docs",
+      remoteUrl: "",
+      branch: "",
+    });
+  });
+
+  it("formToVirtualProps for rss-atom clears leftover Git remote fields", () => {
+    const body = formToVirtualProps({
+      sourceKind: SOURCE_KIND_RSS_ATOM,
+      rootPath: "  C:/rss-atom-docs  ",
+      remoteUrl: "https://feeds.example.com/blog.xml",
+      branch: "main",
+      configFile: "_config.yaml",
+      siteKey: "docs",
+    });
+    expect(body).toEqual({
+      sourceKind: SOURCE_KIND_RSS_ATOM,
+      rootPath: "C:/rss-atom-docs",
+      remoteUrl: "",
+      branch: "",
+    });
+    expect(body).not.toHaveProperty("password");
+    expect(JSON.stringify(body)).not.toMatch(
+      /authorization|api[_-]?key|feed[_-]?url|credential|token/i,
+    );
+  });
+
   it("formToVirtualProps trims and nulls empty optional fields", () => {
     const body = formToVirtualProps({
       sourceKind: SOURCE_KIND_GIT_FILESYSTEM,
@@ -496,6 +549,39 @@ describe("virtualSiteForm helpers", () => {
       validateVirtualSiteForm({
         sourceKind: SOURCE_KIND_OBJECT_STORAGE,
         rootPath: "C:/object-docs",
+        remoteUrl: "",
+        branch: "",
+        configFile: "",
+        siteKey: "",
+      }),
+    ).toBeNull();
+
+    expect(
+      validateVirtualSiteForm({
+        sourceKind: SOURCE_KIND_RSS_ATOM,
+        rootPath: "",
+        remoteUrl: "",
+        branch: "",
+        configFile: "",
+        siteKey: "",
+      }),
+    ).toBe("root-required");
+
+    expect(
+      validateVirtualSiteForm({
+        sourceKind: SOURCE_KIND_RSS_ATOM,
+        rootPath: "../escape",
+        remoteUrl: "",
+        branch: "",
+        configFile: "",
+        siteKey: "",
+      }),
+    ).toBe("root-unsafe");
+
+    expect(
+      validateVirtualSiteForm({
+        sourceKind: SOURCE_KIND_RSS_ATOM,
+        rootPath: "C:/rss-atom-docs",
         remoteUrl: "",
         branch: "",
         configFile: "",

--- a/docs/ai-generated/code-reviews/3889-rss-atom-source-chrome-erlang.md
+++ b/docs/ai-generated/code-reviews/3889-rss-atom-source-chrome-erlang.md
@@ -1,0 +1,60 @@
+# Erlang review — #3889 Developer Sites rss-atom source chrome
+
+**Branch:** `feat/issue-3889-rss-atom-source-chrome`  
+**Date:** 2026-08-27  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class companions (WebUI panel + Vitest + Playwright + product-docs); Playwright HARD GATE for screen work; omit-vs-empty remoteUrl keep/clear (#3568); consume REST/SPI siblings without re-implementing them; no secrets on REST envelope.
+
+## Summary
+
+Parent #2678 slice (rss-atom source chrome). Developer Sites Virtual Site source panel offers **RSS / Atom** (`rss-atom`) as a source-kind option, peer of object-storage (#3856) and http-json (#3796). Operators can select it, set the existing **Root path** field, save, reload, and switch back to **Repository (traditional)**. Git remotes / config / site key stay Git-only. PUT never sends live feed URLs or credentials (`remoteUrl: ""` / `branch: ""` so a prior Git remote is cleared). **Build / Preview / Publish chrome is intentionally hidden** for rss-atom (later phase unless REST Build is on `main`; it is not). REST persist is sibling #3888 / PR #3898 — this slice consumes the contract and does not re-implement REST/SPI.
+
+## Scope
+
+- `WebUI/src/main/ts/developer/virtualSiteForm.ts` — `SOURCE_KIND_RSS_ATOM`, normalize, `formToVirtualProps`
+- `WebUI/src/main/ts/developer/virtualSiteBuild.ts` — comments only; Build/Preview/Publish remain git/csv/sql/http-json (+ object-storage Build/Preview)
+- `WebUI/src/main/ts/developer/VirtualSiteSourcePanel.tsx` — select option + rss-atom hint + reuse root path
+- `WebUI/src/main/ts/developer/messages.ts` — i18n keys (`perc.ui.developer@RSS / Atom`)
+- `WebUI/src/main/ts/api/developer/types.ts` — allow-list javadoc
+- Vitest: `virtualSiteForm.test.ts`, `virtualSiteBuild.test.ts`, `VirtualSiteSourcePanel.test.tsx`, `sitesApi.virtual.test.ts`
+- Playwright: `modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js`
+- Product-docs: `product-docs/8.2/admin/sites.md`, `developer/virtual-sites.md`
+- Consumed (not re-implemented): REST persist #3888 / PR #3898
+- No QA assignment in this slice (human QA candidacy only after C5)
+
+## Issues
+
+None.
+
+## Cross-platform path review
+
+- [x] No new `".../" +` or `"...\\" +` filesystem joins
+- [x] UI/tests use operator-style examples (`C:/rss-atom-docs`) as field values, not OS file joins
+- [x] Playwright fill uses the same portable example style as HTTP JSON/SQL/CSV/object-storage peers
+- [x] Line-ending assertions not added
+- [x] Client validation still rejects `..` in root path (server NIO remains source of truth)
+
+## Tests
+
+- `virtualSiteForm` — normalize rss-atom; unknown (`sql-api`) still repository; PUT clears leftover Git remotes and live feed URL; no password/Authorization/token; root-required / root-unsafe for rss-atom
+- `virtualSiteBuild` — rss-atom does **not** show Build/Preview/Publish chrome; git/csv/sql/http-json/object-storage unchanged; repository / unknown stay hidden
+- `VirtualSiteSourcePanel` — option list includes rss-atom; load root-only; save envelope; switch back to repository hides fields; no Build chrome after save
+- Playwright — option present; unknown `sql-api` absent; rss-atom vs Git field visibility; intercepted PUT/GET envelope; live save+reload then restore repository
+- REST/SPI internals — N/A for this slice (consume #3888 allow-list; Build chrome out of scope)
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| Source-kind select + form helpers | yes |
+| Vitest panel/form/build | yes |
+| Playwright `developer-site-virtual-source.spec.js` | yes |
+| Product-docs 8.2 admin Sites | yes |
+| REST/SPI internals | consume REST persist #3888 / PR #3898 (not re-implemented); Build chrome out of scope |
+| Human QA assignment | not created |
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -20,8 +20,10 @@
  *
  * Opens Sites catalog detail and asserts the Virtual Site source section mounts
  * with source-kind control (repository default, git-filesystem, csv-filesystem,
- * sql-database, http-json, object-storage), save chrome, Build + Preview + Publish chrome for git-filesystem,
- * csv-filesystem, sql-database, http-json, and object-storage (never repository). Also intercepts build REST
+ * sql-database, http-json, object-storage, rss-atom), save chrome, Build + Preview + Publish chrome for git-filesystem,
+ * csv-filesystem, sql-database, http-json, and object-storage (never repository). rss-atom save/GET-roundtrip
+ * uses a local fixture rootPath only (no live feed credentials, no virtual.remoteUrl);
+ * Build / Preview / Publish chrome for rss-atom stays hidden. Also intercepts build REST
  * to prove link-problem detail lines render on HTTP 200 and publish REST to prove
  * dest path + files copied on HTTP 200 (including csv-filesystem, http-json, and object-storage). Live H2 QA
  * deploys a CSV tree into the cell and asserts POST /virtual/build, GET
@@ -152,10 +154,11 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
         formatMissingVirtualSourceKindMessage(missingKinds, liveKindValues),
       ).toEqual([]);
       await expect(kind.locator('option[value="object-storage"]')).toHaveCount(1);
+      await expect(kind.locator('option[value="rss-atom"]')).toHaveCount(1);
       await expect(kind.locator('option[value="sql-api"]')).toHaveCount(0);
       // Default traditional sites use repository option
       await expect(kind).toHaveValue(
-        /repository|git-filesystem|csv-filesystem|sql-database|http-json|object-storage/,
+        /repository|git-filesystem|csv-filesystem|sql-database|http-json|object-storage|rss-atom/,
       );
       await expect(page.locator('[data-testid="developer-site-virtual-save"]')).toBeVisible();
 
@@ -239,6 +242,20 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
       await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toBeVisible();
       await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toBeVisible();
+
+      // Switch to rss-atom reveals root path only (no Git remotes; Build/Preview/Publish later)
+      await kind.selectOption("rss-atom");
+      await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-rss-atom-hint"]')).toBeVisible();
+      await expect(page.locator('[data-testid="developer-site-virtual-rss-atom-hint"]')).toContainText(
+        "later phase",
+      );
+      await expect(page.locator('[data-testid="developer-site-virtual-remote-url"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="developer-site-virtual-branch"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
 
       // Switch to git-filesystem reveals root path, optional remote, + Build / Publish
       await kind.selectOption("git-filesystem");
@@ -643,6 +660,266 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
     await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
     await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+    expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
+  });
+
+  test("rss-atom save PUTs envelope and GET-roundtrip persists without Build chrome (#3889)", async ({
+    page,
+  }) => {
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    let virtualState = {
+      sourceKind: "repository",
+      rootPath: null,
+      remoteUrl: null,
+      branch: null,
+      configFile: null,
+      siteKey: null,
+      virtual: false,
+    };
+    /** @type {unknown} */
+    let lastPutBody = null;
+
+    await page.route(
+      (url) => /\/services\/sites\/?(\?|$)/.test(url.toString()),
+      async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            SiteList: [{ name: "Help", label: "Help" }],
+          }),
+        });
+      },
+    );
+
+    await page.route("**/services/sites/**/virtual", async (route) => {
+      const url = route.request().url();
+      if (/\/virtual\//.test(url)) {
+        await route.fallback();
+        return;
+      }
+      const method = route.request().method();
+      if (method === "PUT") {
+        lastPutBody = route.request().postDataJSON();
+        const envelope =
+          lastPutBody &&
+          typeof lastPutBody === "object" &&
+          lastPutBody.VirtualSiteProperties
+            ? lastPutBody.VirtualSiteProperties
+            : lastPutBody;
+        virtualState = {
+          sourceKind: envelope.sourceKind || "repository",
+          rootPath: envelope.rootPath || null,
+          remoteUrl:
+            envelope.remoteUrl === undefined || envelope.remoteUrl === null
+              ? virtualState.remoteUrl
+              : envelope.remoteUrl || null,
+          branch:
+            envelope.branch === undefined || envelope.branch === null
+              ? virtualState.branch
+              : envelope.branch || null,
+          configFile: envelope.configFile || null,
+          siteKey: envelope.siteKey || null,
+          virtual:
+            envelope.sourceKind === "git-filesystem" ||
+            envelope.sourceKind === "csv-filesystem" ||
+            envelope.sourceKind === "sql-database" ||
+            envelope.sourceKind === "http-json" ||
+            envelope.sourceKind === "object-storage" ||
+            envelope.sourceKind === "rss-atom",
+        };
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ VirtualSiteProperties: virtualState }),
+        });
+        return;
+      }
+      if (method !== "GET") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ VirtualSiteProperties: virtualState }),
+      });
+    });
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+    if (await page.locator('[data-testid="developer-site-empty"]').isVisible().catch(() => false)) {
+      test.info().annotations.push({
+        type: "note",
+        description: "No sites in catalog — rss-atom Virtual Site save test requires a site row",
+      });
+      return;
+    }
+    if (await page.locator('[data-testid="developer-site-error"]').isVisible().catch(() => false)) {
+      throw new Error(
+        `Sites catalog error: ${await page.locator('[data-testid="developer-site-error"]').textContent()}`,
+      );
+    }
+
+    const rows = page.locator(catalogRowsSelector("developer-site-row"));
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+    await rows.first().locator('[data-testid="developer-site-open"]').click();
+
+    await expect(page.locator('[data-testid="developer-site-virtual-form"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const kind = page.locator('[data-testid="developer-site-virtual-source-kind"]');
+    await kind.selectOption("rss-atom");
+    await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-rss-atom-hint"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-remote-url"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+
+    await page.locator('[data-testid="developer-site-virtual-root-path"]').fill("C:/rss-atom-docs");
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    expect(lastPutBody).toBeTruthy();
+    expect(lastPutBody).toHaveProperty("VirtualSiteProperties");
+    expect(lastPutBody.VirtualSiteProperties.sourceKind).toBe("rss-atom");
+    expect(lastPutBody.VirtualSiteProperties.rootPath).toBe("C:/rss-atom-docs");
+    expect(lastPutBody.VirtualSiteProperties.remoteUrl ?? "").toBe("");
+    expect(lastPutBody).not.toHaveProperty("sourceKind");
+    expect(lastPutBody.VirtualSiteProperties).not.toHaveProperty("password");
+    expect(JSON.stringify(lastPutBody)).not.toMatch(
+      /password|authorization|api[_-]?key|feed[_-]?url|credential|token/i,
+    );
+
+    await expect(kind).toHaveValue("rss-atom");
+    await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toHaveValue(
+      "C:/rss-atom-docs",
+    );
+    await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+
+    await kind.selectOption("repository");
+    lastPutBody = null;
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    expect(lastPutBody.VirtualSiteProperties.sourceKind).toBe("repository");
+    await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+    expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
+  });
+
+  test("rss-atom live save+reload persists then restore repository (#3889)", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+    if (await page.locator('[data-testid="developer-site-empty"]').isVisible().catch(() => false)) {
+      test.info().annotations.push({
+        type: "note",
+        description: "No sites in catalog — live rss-atom persist requires a site row",
+      });
+      return;
+    }
+    if (await page.locator('[data-testid="developer-site-error"]').isVisible().catch(() => false)) {
+      throw new Error(
+        `Sites catalog error: ${await page.locator('[data-testid="developer-site-error"]').textContent()}`,
+      );
+    }
+
+    async function openFirstSite() {
+      const rows = page.locator(catalogRowsSelector("developer-site-row"));
+      await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+      await rows.first().locator('[data-testid="developer-site-open"]').click();
+      await expect(page.locator('[data-testid="developer-site-virtual-form"]')).toBeVisible({
+        timeout: 20_000,
+      });
+    }
+
+    await openFirstSite();
+    const kind = page.locator('[data-testid="developer-site-virtual-source-kind"]');
+    await kind.selectOption("rss-atom");
+    await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-rss-atom-hint"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-remote-url"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toHaveCount(0);
+    await page.locator('[data-testid="developer-site-virtual-root-path"]').fill("C:/rss-atom-docs");
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(kind).toHaveValue("rss-atom");
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+
+    await page.locator('[data-testid="developer-site-back"]').click();
+    await expect(page.locator(catalogRowsSelector("developer-site-row")).first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await openFirstSite();
+    await expect(kind).toHaveValue("rss-atom");
+    await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toHaveValue(
+      "C:/rss-atom-docs",
+    );
+    await expect(page.locator('[data-testid="developer-site-virtual-rss-atom-hint"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-build-section"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+
+    await kind.selectOption("repository");
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
     expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
   });
 

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -71,7 +71,7 @@ and Markdown tooling, not the classic page editor.
 
 | Property | Required | Example | Notes |
 |----------|----------|---------|-------|
-| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem`, `csv-filesystem`, `sql-database`, `http-json`, `object-storage`, or `rss-atom` | Allow-list: **`git-filesystem`**, **`csv-filesystem`**, **`sql-database`**, **`http-json`**, **`object-storage`**, **`rss-atom`**. **`rss-atom`** is a local/loopback syndication SPI (`feed.xml` / `atom.xml` or `_config.yaml` `rss.file`; loopback `rss.url` only — no live feed credentials). REST persist and Developer Sites chrome for this kind stay later slices. `virtual.remoteUrl` and credential properties are rejected. REST **GET/PUT** `/sites/{nameOrId}/virtual` round-trips **`object-storage`** with a portable-safe local `rootPath` (cloud URLs and credential properties are **400**; `virtual.remoteUrl` is **400**). REST **Build** (`POST …/virtual/build`) also runs **object-storage** against that local bucket. REST **Preview** (`GET …/virtual/preview`) streams last-build HTML after a successful Build (`available=true`; missing build is `available=false` HTTP 200). REST **Publish** (`POST …/virtual/publish`) copies assembled HTML to the Site filesystem root for **object-storage** (local object-key `rootPath`; leftover `virtual.remoteUrl` is **400**; no AWS/IAM/secrets). Developer Sites can save **Object storage** the same way as HTTP JSON (GET round-trips `object-storage`), then **Build Virtual Site**, **Preview assembled site**, and **Publish Virtual Site**. Blank or `repository` = traditional Site. Developer Sites can save Git, CSV, SQL, **HTTP JSON**, or **Object storage**. **Build Virtual Site** (REST and Developer Sites) runs Git, CSV, SQL, **HTTP JSON**, and **Object storage** after save (local JSON fixture, loopback catalog, or local object-key bucket). **Preview assembled site** (REST and Developer Sites) streams last-build HTML for Git, CSV, SQL, **HTTP JSON**, and **object-storage**. **Publish Virtual Site** (REST and Developer Sites) runs Git, CSV, SQL, **HTTP JSON**, and **Object storage** after Build (copies assembled HTML to the Site filesystem root). REST **GET/PUT** `/sites/{nameOrId}/virtual` also round-trips **`http-json`** (safe `rootPath` JSON fixture; `virtual.remoteUrl` is **400** — catalog URL/file stay in `_config.yaml`, no secrets on the REST envelope). `http-json` assemble is SPI/CLI plus REST Build and REST Publish (see [Virtual Sites](id:developer-virtual-sites)). `sql-database` is in-memory H2 (`jdbc:h2:mem:`; JDBC URL/user/query in `_config.yaml` — never passwords on the REST envelope). CSV trees may omit `_config.yaml`. Unknown kinds are rejected. |
+| `virtual.sourceKind` | Yes (for Virtual) | `git-filesystem`, `csv-filesystem`, `sql-database`, `http-json`, `object-storage`, or `rss-atom` | Allow-list: **`git-filesystem`**, **`csv-filesystem`**, **`sql-database`**, **`http-json`**, **`object-storage`**, **`rss-atom`**. **`rss-atom`** is a local/loopback syndication SPI (`feed.xml` / `atom.xml` or `_config.yaml` `rss.file`; loopback `rss.url` only — no live feed credentials). REST **GET/PUT** `/sites/{nameOrId}/virtual` round-trips **`rss-atom`** with a portable-safe local `rootPath`. Developer Sites can save **RSS / Atom** (`sourceKind=rss-atom`); leftover `virtual.remoteUrl` and live feed credentials are **400**; Build / Preview / Publish chrome for rss-atom stays a later phase. REST **GET/PUT** also round-trips **`object-storage`** with a portable-safe local `rootPath` (cloud URLs and credential properties are **400**; `virtual.remoteUrl` is **400**). REST **Build** (`POST …/virtual/build`) also runs **object-storage** against that local bucket. REST **Preview** (`GET …/virtual/preview`) streams last-build HTML after a successful Build (`available=true`; missing build is `available=false` HTTP 200). REST **Publish** (`POST …/virtual/publish`) copies assembled HTML to the Site filesystem root for **object-storage** (local object-key `rootPath`; leftover `virtual.remoteUrl` is **400**; no AWS/IAM/secrets). Developer Sites can save **Object storage** the same way as HTTP JSON (GET round-trips `object-storage`), then **Build Virtual Site**, **Preview assembled site**, and **Publish Virtual Site**. Blank or `repository` = traditional Site. Developer Sites can save Git, CSV, SQL, **HTTP JSON**, **Object storage**, or **RSS / Atom**. **Build Virtual Site** (REST and Developer Sites) runs Git, CSV, SQL, **HTTP JSON**, and **Object storage** after save (local JSON fixture, loopback catalog, or local object-key bucket). **Preview assembled site** (REST and Developer Sites) streams last-build HTML for Git, CSV, SQL, **HTTP JSON**, and **object-storage**. **Publish Virtual Site** (REST and Developer Sites) runs Git, CSV, SQL, **HTTP JSON**, and **Object storage** after Build (copies assembled HTML to the Site filesystem root). REST **GET/PUT** `/sites/{nameOrId}/virtual` also round-trips **`http-json`** (safe `rootPath` JSON fixture; `virtual.remoteUrl` is **400** — catalog URL/file stay in `_config.yaml`, no secrets on the REST envelope). `http-json` assemble is SPI/CLI plus REST Build and REST Publish (see [Virtual Sites](id:developer-virtual-sites)). `sql-database` is in-memory H2 (`jdbc:h2:mem:`; JDBC URL/user/query in `_config.yaml` — never passwords on the REST envelope). CSV trees may omit `_config.yaml`. Unknown kinds are rejected. |
 | `virtual.rootPath` | Yes when remote is blank | absolute path to `product-docs` | Local tree when `virtual.remoteUrl` is blank. Prefer absolute portable paths (Windows/Linux/macOS). Paths with `..` after normalize are rejected. When a remote is set, use a **relative** folder inside the checkout (for example `product-docs`). |
 | `virtual.remoteUrl` | No | `https://git.example.com/org/product-docs.git` | Optional Git remote. Build clones or fetches into a contained server work directory, then discovers Markdown as usual. Blank = local-path mode. Allowed: `https://`, `ssh://`, `file://`, `git@host:path`. |
 | `virtual.branch` | No | `main` | Branch to checkout when a remote is set. Default `main`. |
@@ -133,16 +133,18 @@ blank). Load failures show **Could not load sites** rather than the empty state.
      (blank/`repository` on the server). Choose **Git filesystem** for Git/Markdown
      Virtual Sites, **CSV filesystem** for a CSV tree on disk, **SQL database**
      for an in-memory H2 JDBC source, **HTTP JSON** for a local JSON fixture or
-     loopback HTTP catalog, or **Object storage** for a local object-key directory.
+     loopback HTTP catalog, **Object storage** for a local object-key directory,
+     or **RSS / Atom** for a local RSS or Atom fixture directory.
      Repository stays the default.
    - **Root path** — absolute or install-relative path to the documentation, CSV,
-     SQL `_config.yaml`, HTTP JSON catalog, or object-storage tree (required when source kind is
+     SQL `_config.yaml`, HTTP JSON catalog, object-storage tree, or RSS/Atom
+     fixture (required when source kind is
      Virtual and no Git remote is set). Do not use `..` path segments. Shared by
-     Git, CSV, SQL, HTTP JSON, and Object storage. When a **Remote URL** is set (Git only), this
+     Git, CSV, SQL, HTTP JSON, Object storage, and RSS / Atom. When a **Remote URL** is set (Git only), this
      may be a relative folder inside the checkout.
    - **Remote URL** (optional, **Git filesystem** only) — Git remote (`https://`,
      `ssh://`, `file://`, or `git@host:path`). Hidden for **CSV filesystem**,
-     **SQL database**, **HTTP JSON**, and **Object storage** (the server rejects `virtual.remoteUrl`
+     **SQL database**, **HTTP JSON**, **Object storage**, and **RSS / Atom** (the server rejects `virtual.remoteUrl`
      on those kinds).
      Leave blank to keep the local **Root path**. When set, **Build Virtual Site**
      clones or fetches on the CMS host (`git` must be on the server `PATH`). The
@@ -166,17 +168,21 @@ blank). Load failures show **Could not load sites** rather than the empty state.
    local fixture (`http.file` / default `pages.json`) stay in `_config.yaml`.
    For Object storage it sends `{ "VirtualSiteProperties": {
    "sourceKind": "object-storage", "rootPath": "…" } }` (no `remoteUrl`, no
-   cloud URLs, IAM, or access keys). After a successful save the panel reloads properties from GET so the kind
+   cloud URLs, IAM, or access keys). For RSS / Atom it sends
+   `{ "VirtualSiteProperties": { "sourceKind": "rss-atom", "rootPath": "…" } }`
+   (no `remoteUrl`, no live feed URLs or credentials). After a successful save the panel reloads properties from GET so the kind
    and root persist without a full page reload. **Build Virtual Site**,
    **Preview assembled site**, and **Publish Virtual Site** appear for
    **Git filesystem**, **CSV filesystem**, **SQL database**, **HTTP JSON**, and
-   **Object storage**. Traditional **Repository** hides that chrome. After you save
-   **Object storage**, **Build Virtual Site** runs against the local object-key
+   **Object storage**. Traditional **Repository** and **RSS / Atom** hide that chrome.
+   After you save **Object storage**, **Build Virtual Site** runs against the local object-key
    directory (`virtual.rootPath`); **Preview assembled site** opens last-build home HTML
    the same way as Git/CSV/SQL/HTTP JSON. **Publish Virtual Site** (and REST
    `POST …/virtual/publish`) copies assembled files to the Site filesystem root
    (`IPSSite.root`) for Git, CSV, SQL, HTTP JSON, and object-storage (local object-key
    `rootPath`; leftover `virtual.remoteUrl` is **400**; no AWS/IAM/secrets).
+   After you save **RSS / Atom**, GET round-trips `sourceKind=rss-atom` with the
+   local fixture `rootPath`; Build / Preview / Publish chrome for this kind stays a later phase.
 6. To return a Virtual Site to traditional repository mode, set source kind back to
    **Repository (traditional)** and save (clears `virtual.*` properties). Switching
    the select back to Repository hides virtual fields immediately; Save is still
@@ -189,10 +195,11 @@ and **Branch** on this panel (or `virtual.remoteUrl` / `virtual.branch` via
 a local Git checkout path.
 
 Validation matches the server helper (`PSVirtualSiteHelper`): allow-listed source kinds
-(`git-filesystem`, `csv-filesystem`, `sql-database`, `http-json`, `object-storage`), required local root path when virtual and no remote,
-safe remote URLs/branches for Git only (`csv-filesystem`, `sql-database`, `http-json`, and `object-storage` reject `virtual.remoteUrl`), and
+(`git-filesystem`, `csv-filesystem`, `sql-database`, `http-json`, `object-storage`, `rss-atom`), required local root path when virtual and no remote,
+safe remote URLs/branches for Git only (`csv-filesystem`, `sql-database`, `http-json`, `object-storage`, and `rss-atom` reject `virtual.remoteUrl`), and
 safe path/config names (no remaining `..` after NIO normalize). `object-storage` also
-rejects cloud URLs and credential properties. After root, remote, or
+rejects cloud URLs and credential properties. `rss-atom` also rejects live feed
+URLs and credential properties (local fixture `rootPath` only). After root, remote, or
 config changes, re-run the offline docs build, the in-product **Build Virtual Site**
 action (below), or the CMS publish path to verify links.
 
@@ -216,7 +223,11 @@ the same way (GET round-trips `object-storage`) and then **Build Virtual Site**,
 local object-key `rootPath` (`virtual.remoteUrl` is **400**). After a successful Build,
 **Preview assembled site** opens last-build home HTML, and **Publish Virtual Site**
 copies assembled HTML onto the Site filesystem root for Git, CSV, SQL, HTTP JSON, and
-object-storage.
+object-storage. Integrators persist RSS / Atom with `"sourceKind": "rss-atom"`
+and a safe local `rootPath` (GET round-trips the kind; no live feed URLs or credentials;
+`virtual.remoteUrl` is **400**). Developer Sites can save **RSS / Atom** the same way
+(GET round-trips `rss-atom`). **Build Virtual Site**, **Preview assembled site**, and
+**Publish Virtual Site** stay hidden for this kind until a later phase.
 
 ### Build a Virtual Site from the product UI
 

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -78,6 +78,15 @@ syndication SPI — **no live cloud feeds, no Authorization / API keys, no useri
 persist, REST Build/Preview/Publish, and Developer **Sites** chrome for this kind stay
 later slices.
 
+An **RSS / Atom** adapter (`rss-atom`) reads a **local** RSS or Atom fixture directory
+under `virtual.rootPath` (portable path; no remaining `..`). REST **GET/PUT**
+`/sites/{nameOrId}/virtual` round-trips `sourceKind=rss-atom` with that local
+`rootPath`. Leftover `virtual.remoteUrl`, live feed URLs, and credential properties
+are **400** (no secrets on the REST envelope). Developer **Sites** can select
+**RSS / Atom**, save, and GET-roundtrip the kind. **Build Virtual Site**,
+**Preview assembled site**, and **Publish Virtual Site** chrome for this kind stay
+a later phase.
+
 Operators can create a **Virtual** type from **Content Explorer → Create Site** or
 **Navigation → New Site**. That flow does not prompt for managed navigation or a page template.
 After the site folder is created, an optional Git root is saved with


### PR DESCRIPTION
## Summary

Parent **#2678** slice: Developer **Sites** can select **RSS / Atom**, save `sourceKind=rss-atom` with a portable-safe local `rootPath`, and GET-roundtrip the kind.

- Source-kind option `rss-atom` in `VirtualSiteSourcePanel` (i18n + Vitest)
- PUT sends `{ VirtualSiteProperties: { sourceKind: "rss-atom", rootPath, remoteUrl: "", branch: "" } }` — no live feed credentials, no leftover Git remote
- Build / Preview / Publish chrome stays hidden (REST Build is not on `main`; later phase)
- Playwright save/GET-roundtrip on H2 QA (consumes REST persist **#3888** / PR **#3898** via hot-deploy; this PR does not re-implement REST)
- product-docs 8.2 admin Sites + developer Virtual Sites

Fixes #3889  
Partial #2678

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Vitest: `virtualSiteForm` / `VirtualSiteSourcePanel` / `virtualSiteBuild` — option, normalize, PUT envelope clears remotes/secrets, no Build chrome
2. Playwright (H2 QA): option present; intercepted PUT envelope; live save+reload then restore repository
3. Confirm git/csv/sql/http-json/object-storage chrome unchanged
4. Do **not** require rss-atom REST Build/Preview/Publish in this PR

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`admin/sites.md`, `developer/virtual-sites.md`)
- [x] **Unit / module tests** — behavioral tests for form/panel/build helpers; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `developer-site-virtual-source.spec.js` rss-atom option + intercept PUT + live GET-roundtrip
- [x] **Build gates** — standalone clean install (no skipTests)
- [x] **Cross-platform** — UI/tests use operator-style path strings (`C:/rss-atom-docs`), not OS file joins; client still rejects `..`

### C3 evidence

- **modules_built:** `WebUI,modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest Tests 3142 passed (393 files)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS; Surefire: No tests to run (Playwright is the live gate)
- **downstream_checked:** none (no `final`/sealed type or public Java API signature change; WebUI TS + Playwright + product-docs only)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` — `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER:perc-matrix-cms-h2`
- Hot-deploy: WebUI `cm/modern/assets` (this branch) + persist jars from PR #3898 (`perc-system`, `rest`, `sitemanage`) into `Rhythmyx/WEB-INF/lib`; in-cell `StopJetty.sh` / `StartJetty.sh` (not `docker restart`)
- `python docker/scripts/perc-devctl.py qa-health --timeout-seconds 60` — `RESULT:OK STEP:qa-health HTTP:200 HEALTH:healthy`
- Playwright: `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js --grep "rss-atom|Virtual Site source panel with repository default"` — **3 passed** (0 skipped)
- console-clean=yes (pageerror listeners)
- server.log-clean=yes (no ERROR/FATAL for rss-atom / virtual persist in the test window; AUTH-1001 login success only)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
