### PR TITLE
feat(rest): DELETE content types with held design lock (#3913)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3913-rest-cd01-delete-content-types-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3913-rest-cd01-delete-content-types-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review — #3913 REST CD-01 DELETE content types
+
+**Branch:** `feat/issue-3913-rest-cd01-delete-content-types`  
+**Scope:** uncommitted vs `origin/main` (rest, sitemanage, product-docs)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** rest+sitemanage change-class companions (resource + IXxxAdaptor + Spring test stub + apibridge impl + adaptor unit tests); Workbench replacement via IPS*DesignWs; product-docs REST note for public surface; do not steal design locks (409).
+
+## Summary
+
+Adds Admin-only `DELETE /services/contenttypes/{idOrName}` that requires a **held** design-session lock (peer PUT save / enabled):
+
+- Adaptor: `IPSContentDesignWs.deleteContentTypes(..., ignoreDependencies=false)`
+- 409 unlocked / other locker (`ContentTypeDesignLockException`); 404 missing; 403 non-Admin
+- 400 when design WS rejects in-use types (dependents); no item cascade
+- Does not steal locks; does not implement POST create/rename or SPA chrome
+
+## Issues
+
+None that block. Inner design-WS `IllegalStateException` is rethrown (not rewrapped) so 500 bodies keep the error map. `CT_CREATE_DELETE` gap **code** is kept stable; message now documents DELETE + remaining create/rename gap.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path I/O.
+
+## Tests / companions
+
+- Mockito: `ContentTypesResourceDetailTest` DELETE 204/400/403/404/409
+- Spring stub: `TestContentTypeAdaptor` (+ `ContentTypesTestAdaptor`)
+- Adaptor: `ContentTypeAdaptorDeleteTest` (held lock, other-user 409, missing 404, dependents 400, Admin 403)
+- product-docs/8.2/developer/rest.md + admin/developer-content-types.md
+- Standalone `rest` then `projects/sitemanage` `mvnw clean install` green

--- a/docs/ai-generated/code-reviews/issue-3913-rest-cd01-delete-content-types-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3913-rest-cd01-delete-content-types-erlang.md
@@ -25,8 +25,30 @@ N/A — no filesystem path I/O.
 
 ## Tests / companions
 
-- Mockito: `ContentTypesResourceDetailTest` DELETE 204/400/403/404/409
+- Mockito: `ContentTypesResourceDetailTest` DELETE 204/400/403/404/409/500
 - Spring stub: `TestContentTypeAdaptor` (+ `ContentTypesTestAdaptor`)
-- Adaptor: `ContentTypeAdaptorDeleteTest` (held lock, other-user 409, missing 404, dependents 400, Admin 403)
+- Adaptor: `ContentTypeAdaptorDeleteTest` (held lock, other-user 409, missing 404, dependents 400, Admin 403, blank-before-session 404)
 - product-docs/8.2/developer/rest.md + admin/developer-content-types.md
 - Standalone `rest` then `projects/sitemanage` `mvnw clean install` green
+
+## Re-review (PR #3919 kilo-code-bot threads)
+
+**Scope:** uncommitted follow-up vs HEAD (`deleteContentType` order, `CT_CREATE_DELETE` path wording, resource 500 test).  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for validation-order and shared error mapping; REST-GAPS-01 message consistency.
+
+### Changes
+
+- Blank `idOrName` now returns null (HTTP 404) **before** `requireSessionUserForLock()` (matches lock/unlock). No-session + blank is no longer 403.
+- `CT_CREATE_DELETE` message uses `/contenttypes` (no `/services` prefix) for both Create and DELETE, matching `CT_ITEM_EXITS`.
+- Resource `deleteContentTypeGenericFailureIs500` covers `mapMutationFailure` `IllegalStateException` → 500 (name `percBlockquote` must not become 409).
+
+### Issues
+
+None that block. `setContentTypeEnabled` still checks session before blank; that method is out of this PR's review threads and already returns 400 after session. No public method/ctor signature change. Cross-platform path checklist N/A.
+
+### Evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 676, Failures: 0 (`ContentTypesResourceDetailTest` 69/0)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1676, Failures: 0, Skipped: 125 (`ContentTypeAdaptorDeleteTest` 11/0)

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -190,6 +190,18 @@ type is available for runtime use.
    product does **not** steal the lock, Save stays disabled, and **Enabled**
    remains read-only.
 
+## Delete a content type (REST)
+
+The Developer Content types chrome does **not** expose delete in this release.
+Integrators delete a type over REST after holding the design-session lock:
+
+1. `POST /services/contenttypes/{idOrName}/lock` as **Admin**.
+2. `DELETE /services/contenttypes/{idOrName}`. Success is **204**. The lock is
+   not stolen if another user holds it (**409**). Missing types are **404**.
+3. A following `GET /services/contenttypes/{idOrName}` is **404**.
+4. Types that still have dependents fail with **400**. The product does **not**
+   cascade-delete items. Rename remains out of scope.
+
 ## REST
 
 The chrome calls:
@@ -209,6 +221,7 @@ The chrome calls:
 | Load field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` |
 | Save field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` (held lock; full replace of validation, visibility, inputTranslation, outputTranslation) |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` |
+| Delete | `DELETE /services/contenttypes/{idOrName}` (Admin; held lock; 204; 409 if unlocked or another user holds the lock; 400 if dependents; no SPA chrome) |
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on
 the same detail panel: [Object ACL & default template](id:admin-object-acl).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -190,6 +190,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Operation | Path | Notes |
 |-----------|------|--------|
 | List | `GET /services/contenttypes` | Name, label, description, guid |
+| Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. Duplicate name is **409** (catalog check and persist-time unique-name failure). Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Rename remains unsupported. |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `enabled`, `designGaps` |
 | Allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` | Read-only list of associated templates (CD-12). No lock required. Empty list means none. Same set as `ContentTypeDetail.allowedTemplates`. |
 | Item-level exits | `GET /services/contenttypes/{idOrName}/itemExits` | Item-level input/output translations, validations, and pipe pre/post exits (CD-09). No lock required. Empty lists mean none. Apply-when conditions are a read-only summary. Jackson root wrap is `ContentTypeItemExits`. |
@@ -204,19 +205,20 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | Field-level validation, visibility, and input/output translation expressions (CD-05–07). No lock required. Empty lists mean none. Unknown field is **404**. Jackson root wrap is `ContentTypeFieldRuleExpressions`. |
 | Replace field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | **Admin** (CD-05–07). Requires a **held** design-session lock. Full replace of `validation`, `visibility`, `inputTranslation`, and `outputTranslation` (empty lists clear). Unknown field names are **400**. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
+| Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. Rename remains out of scope. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. SPA create-wizard chrome is not part of this API. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
 
-Lock / save / unlock status codes:
+Lock / save / unlock / create / delete status codes:
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Lock acquired (body is `ObjectLockSummary`) or PUT save / enable / disable succeeded (lock still held) |
-| `204` | Unlock success |
-| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag) |
-| `403` | Caller is not Admin |
+| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable succeeded (lock still held), or POST create succeeded (`ContentTypeDetail`) |
+| `204` | Unlock success, or content type deleted |
+| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag), invalid create name (blank, spaces, wildcard), or DELETE rejected because the type has dependents |
+| `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found |
-| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen) |
+| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time) |
 | `500` | Design service or server failure |
 
 ### Enable or disable (CD-13)

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -439,7 +439,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add(
         DesignGap.of(
             "CT_CREATE_DELETE",
-            "Create via POST /services/contenttypes. DELETE /contenttypes/{idOrName} requires a held"
+            "Create via POST /contenttypes. DELETE /contenttypes/{idOrName} requires a held"
                 + " design lock. Rename not supported; PUT save requires a held design lock for"
                 + " label/description/enabled, field searchable/occurrence, workflows (+ default),"
                 + " and templates"));
@@ -606,10 +606,10 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   @Override
   public Boolean deleteContentType(URI baseUri, String idOrName) {
     requireAdmin();
-    requireSessionUserForLock();
     if (StringUtils.isBlank(idOrName)) {
       return null;
     }
+    requireSessionUserForLock();
     String trimmed = idOrName.trim();
     if (trimmed.contains("*")) {
       throw new IllegalArgumentException("idOrName must not contain wildcards");

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -316,7 +316,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    *
    * @param includeDisabledFromStore when {@code true}, a cache miss falls back to the
    *     object store so disabled types (unregistered from the editor cache) still load.
-   *     Only GET detail and enable/disable (CD-13) pass {@code true}; other callers keep
+   *     GET detail, enable/disable (CD-13), and DELETE pass {@code true}; other callers keep
    *     the pre-CD-13 cache-only 404 for disabled types.
    */
   private PSItemDefinition resolveItemDef(String idOrName, boolean includeDisabledFromStore)
@@ -439,7 +439,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add(
         DesignGap.of(
             "CT_CREATE_DELETE",
-            "Create via POST /services/contenttypes. Delete / rename not supported; PUT save requires a held design lock for"
+            "Create via POST /services/contenttypes. DELETE /contenttypes/{idOrName} requires a held"
+                + " design lock. Rename not supported; PUT save requires a held design lock for"
                 + " label/description/enabled, field searchable/occurrence, workflows (+ default),"
                 + " and templates"));
     gaps.add(
@@ -600,6 +601,51 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     }
     systemDesign.releaseLocks(Collections.singletonList(ctGuid), session, user);
     return Boolean.TRUE;
+  }
+
+  @Override
+  public Boolean deleteContentType(URI baseUri, String idOrName) {
+    requireAdmin();
+    requireSessionUserForLock();
+    if (StringUtils.isBlank(idOrName)) {
+      return null;
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      PSItemDefinition current = resolveItemDef(trimmed, true);
+      if (current == null) {
+        return null;
+      }
+      IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
+      requireHeldLock(ctGuid, "Could not delete content type");
+      try {
+        designSvc.deleteContentTypes(Collections.singletonList(ctGuid), false, session, user);
+      } catch (PSErrorsException e) {
+        if (isNotLockedError(e) || hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not delete content type");
+        }
+        String details = formatSaveErrors(e);
+        if (isDeleteDependencyFailure(e)) {
+          throw new IllegalArgumentException("Could not delete content type: " + details, e);
+        }
+        log.error("Failed to delete content type {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to delete content type: " + details, e);
+      }
+      return Boolean.TRUE;
+    } catch (IllegalArgumentException | IllegalStateException | WebApplicationException e) {
+      throw e;
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for delete: {}", idOrName);
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to delete content type {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to delete content type", e);
+    }
   }
 
   @Override
@@ -2682,41 +2728,39 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    * @throws ContentTypeDesignLockException when unlocked or locked by another user (HTTP 409)
    */
   private void requireHeldLock(IPSGuid ctGuid) {
+    requireHeldLock(ctGuid, "Could not save content type");
+  }
+
+  private void requireHeldLock(IPSGuid ctGuid, String prefix) {
     if (systemDesign == null) {
-      throw new IllegalStateException(
-          "Could not save content type; design service unavailable");
+      throw new IllegalStateException(prefix + "; design service unavailable");
     }
     List<PSObjectSummary> locked;
     try {
       locked = systemDesign.isLocked(Collections.singletonList(ctGuid), currentUser());
     } catch (PSErrorResultsException e) {
       if (isNotFoundError(e)) {
-        throw new ContentTypeDesignLockException(
-            "Could not save content type; design lock required", e);
+        throw new ContentTypeDesignLockException(prefix + "; design lock required", e);
       }
       if (hasLockError(e)) {
         String locker = firstLockLocker(e);
         throw new ContentTypeDesignLockException(
-            locker != null
-                ? "Could not save content type; locked by " + locker
-                : "Could not save content type; design lock required",
+            locker != null ? prefix + "; locked by " + locker : prefix + "; design lock required",
             e);
       }
-      throw new IllegalStateException("Could not save content type; design service error", e);
+      throw new IllegalStateException(prefix + "; design service error", e);
     }
     PSObjectSummary summary =
         locked == null || locked.isEmpty() ? null : locked.get(0);
     if (summary == null || !summary.isLocked()) {
-      throw new ContentTypeDesignLockException("Could not save content type; design lock required");
+      throw new ContentTypeDesignLockException(prefix + "; design lock required");
     }
     String user = currentUser();
     PSObjectLockSummary info = summary.getLocked();
     if (!summary.isLockedBy(user)) {
       String locker = info != null ? info.getLocker() : null;
       throw new ContentTypeDesignLockException(
-          locker != null
-              ? "Could not save content type; locked by " + locker
-              : "Could not save content type; design lock required");
+          locker != null ? prefix + "; locked by " + locker : prefix + "; design lock required");
     }
   }
 
@@ -2741,12 +2785,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (RuntimeException e) {
       log.debug("Admin check failed: {}", e.getMessage());
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, or save content types",
+          "Admin role required to create, lock, unlock, save, or delete content types",
           Response.Status.FORBIDDEN);
     }
     if (!allowed) {
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, or save content types",
+          "Admin role required to create, lock, unlock, save, or delete content types",
           Response.Status.FORBIDDEN);
     }
   }
@@ -3029,6 +3073,19 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         || lower.contains("psextensionexception")
         || lower.contains("extension type")
         || lower.contains("invalid_ext");
+  }
+
+  /**
+   * True when a batched {@code deleteContentTypes} error is a dependents / in-use rejection rather
+   * than an unexpected server failure.
+   */
+  static boolean isDeleteDependencyFailure(PSErrorsException e) {
+    String text = formatSaveErrors(e);
+    if (StringUtils.isBlank(text)) {
+      return false;
+    }
+    String lower = text.toLowerCase();
+    return lower.contains("depend") || lower.contains("in use") || lower.contains("in-use");
   }
 
   /** Map-keyed overload for {@code PSErrorsException} batched save errors. */

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorDeleteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorDeleteTest.java
@@ -200,6 +200,16 @@ class ContentTypeAdaptorDeleteTest {
   }
 
   @Test
+  void delete_blankIdOrName_returnsNullBeforeSessionCheck() throws Exception {
+    PSRequestInfoBase.resetRequestInfo();
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    assertNull(adaptor.deleteContentType(null, "  "));
+    assertNull(adaptor.deleteContentType(null, null));
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+    verify(systemDesign, never()).isLocked(anyList(), any());
+  }
+
+  @Test
   void isDeleteDependencyFailure_detectsDependentsMessage() {
     PSErrorsException errors = new PSErrorsException();
     errors.addError(guid, new PSErrorException(1, "object has dependents", "stack"));

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorDeleteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorDeleteTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSInvalidContentTypeException;
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CD-01 DELETE requires a held design-session lock and calls {@code
+ * IPSContentDesignWs.deleteContentTypes} without ignoring dependents.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorDeleteTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void delete_whenLockHeld_callsDesignWsWithoutIgnoringDependents() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+
+    assertEquals(Boolean.TRUE, adaptor.deleteContentType(null, "311"));
+
+    verify(designWs)
+        .deleteContentTypes(eq(List.of(guid)), eq(false), eq("test-session"), eq("Admin"));
+    verify(systemDesign).isLocked(anyList(), eq("Admin"));
+  }
+
+  @Test
+  void delete_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(Collections.singletonList(null));
+    stubDefinition();
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_conflictWhenLockedByOtherUser() throws Exception {
+    PSObjectSummary other = new PSObjectSummary(guid, "percPage");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+    stubDefinition();
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_lockErrorFromDesignWs_is409() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(
+        guid, new PSLockErrorException(1, "is not locked", "stack", "Admin", 12));
+    doThrow(errors)
+        .when(designWs)
+        .deleteContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+  }
+
+  @Test
+  void delete_dependents_throws400() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(
+        guid,
+        new PSErrorException(
+            1, "Content Type 311 has dependents: percPage items", "stack"));
+    doThrow(errors)
+        .when(designWs)
+        .deleteContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().contains("dependents"), ex.getMessage());
+  }
+
+  @Test
+  void delete_unexpectedDesignError_is500() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(
+        guid, new PSErrorException(1, "Failed to delete PSItemDefinition 0-2-311: disk full", "stack"));
+    doThrow(errors)
+        .when(designWs)
+        .deleteContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().contains("Failed to delete content type"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("disk full"), ex.getMessage());
+  }
+
+  @Test
+  void delete_unknownName_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.deleteContentType(null, "missing"));
+    verify(systemDesign, never()).isLocked(anyList(), any());
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.deleteContentType(null, "311"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void delete_wildcardName_isBadRequest() throws Exception {
+    assertThrows(
+        IllegalArgumentException.class, () -> adaptor.deleteContentType(null, "perc*"));
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void isDeleteDependencyFailure_detectsDependentsMessage() {
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(guid, new PSErrorException(1, "object has dependents", "stack"));
+    assertTrue(ContentTypeAdaptor.isDeleteDependencyFailure(errors));
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private void stubDefinition() throws Exception {
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn("percPage");
+    when(def.getTypeId()).thenReturn(311);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -47,6 +47,8 @@ class DesignGapsStructuredTest {
                 g ->
                     "CT_CREATE_DELETE".equals(g.getCode())
                         && g.getMessage().contains("POST /services/contenttypes")
+                        && g.getMessage().contains("DELETE")
+                        && g.getMessage().toLowerCase().contains("held")
                         && !g.getMessage().startsWith("Create / delete not supported")),
         () -> gaps.toString());
     assertFalse(codes.contains("CT_CONTROL_RESOLUTION"));

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -46,7 +46,7 @@ class DesignGapsStructuredTest {
             .anyMatch(
                 g ->
                     "CT_CREATE_DELETE".equals(g.getCode())
-                        && g.getMessage().contains("POST /services/contenttypes")
+                        && g.getMessage().contains("POST /contenttypes")
                         && g.getMessage().contains("DELETE")
                         && g.getMessage().toLowerCase().contains("held")
                         && !g.getMessage().startsWith("Create / delete not supported")),

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -927,7 +927,8 @@ public class ContentTypesResource {
               + " structure are not changed. Field rule expressions use PUT"
               + " .../fields/{fieldName}/ruleExpressions. Control property values use PUT"
               + " .../fields/{fieldName}/controlProperties. Create uses POST /contenttypes."
-              + " Delete/rename remain unsupported (see designGaps).",
+              + " Delete uses DELETE .../{idOrName} with a held lock. Rename remains"
+              + " unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -1016,6 +1017,42 @@ public class ContentTypesResource {
     try {
       Boolean released = requireAdaptor().unlockContentType(uriInfo.getBaseUri(), idOrName);
       if (released == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapMutationFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete content type",
+      description =
+          "Admin. Deletes a content type via IPSContentDesignWs.deleteContentTypes. Requires a"
+              + " design-session lock already held by the current user/session (POST .../lock)."
+              + " Does not steal locks. Does not cascade items (ignoreDependencies=false); in-use"
+              + " types with dependents fail clearly. Following GET .../{idOrName} is 404 after a"
+              + " successful delete.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid id/name, or design WS rejected in-use type (dependents)"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock required, or locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteContentType(@PathParam("idOrName") String idOrName) {
+    try {
+      Boolean deleted = requireAdaptor().deleteContentType(uriInfo.getBaseUri(), idOrName);
+      if (deleted == null) {
         throw new WebApplicationException("Content type not found: " + idOrName, 404);
       }
       return Response.noContent().build();

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -111,6 +111,21 @@ public interface IContentTypesAdaptor {
   Boolean unlockContentType(URI baseUri, String idOrName);
 
   /**
+   * Delete a content type via {@code IPSContentDesignWs.deleteContentTypes}. Admin only. Requires a
+   * design-session lock already held by the current user ({@link #lockContentType}). Does not
+   * acquire, steal, or ignore locks. Does not cascade item delete ({@code ignoreDependencies=false}).
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or internal name
+   * @return {@code Boolean.TRUE} when deleted; {@code null} when not found
+   * @throws ContentTypeDesignLockException when no lock is held or the lock is owned by another
+   *     user
+   * @throws IllegalArgumentException when the design web service rejects the delete (in-use /
+   *     dependents)
+   */
+  Boolean deleteContentType(URI baseUri, String idOrName);
+
+  /**
    * Enable or disable a content type for runtime use (CD-13). Requires a design-session lock
    * already held by the current user (peer lock REST). Does not acquire or release the lock.
    *

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 import com.percussion.rest.DesignGap;
 import com.percussion.rest.Guid;
@@ -592,6 +593,72 @@ public class ContentTypesResourceDetailTest {
     when(adaptor.unlockContentType(any(), eq("percPage"))).thenReturn(Boolean.TRUE);
     Response response = resource.unlockContentType("percPage");
     assertEquals(204, response.getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeNoContent() {
+    when(adaptor.deleteContentType(any(), eq("percPage"))).thenReturn(Boolean.TRUE);
+    Response response = resource.deleteContentType("percPage");
+    assertEquals(204, response.getStatus());
+    verify(adaptor).deleteContentType(any(), eq("percPage"));
+  }
+
+  @Test
+  public void deleteContentTypeNotFound() {
+    when(adaptor.deleteContentType(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeLockConflictWhenLockNotHeld() {
+    when(adaptor.deleteContentType(any(), eq("percPage")))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not delete content type; design lock required"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("percPage"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeLockConflictWhenLockedByOtherUser() {
+    when(adaptor.deleteContentType(any(), eq("percPage")))
+        .thenThrow(
+            new ContentTypeDesignLockException("Could not delete content type; locked by editor2"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("percPage"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeForbiddenWhenNotAdmin() {
+    when(adaptor.deleteContentType(any(), eq("percPage")))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("percPage"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeInUseIs400() {
+    when(adaptor.deleteContentType(any(), eq("percPage")))
+        .thenThrow(
+            new IllegalArgumentException(
+                "Could not delete content type: Content Type 311 has dependents"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("percPage"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeWildcardIs400() {
+    when(adaptor.deleteContentType(any(), eq("perc*")))
+        .thenThrow(new IllegalArgumentException("idOrName must not contain wildcards"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("perc*"));
+    assertEquals(400, ex.getResponse().getStatus());
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -662,6 +662,17 @@ public class ContentTypesResourceDetailTest {
   }
 
   @Test
+  public void deleteContentTypeGenericFailureIs500() {
+    when(adaptor.deleteContentType(any(), eq("percBlockquote")))
+        .thenThrow(
+            new IllegalStateException("Failed to delete content type: percBlockquote"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteContentType("percBlockquote"));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void unlockContentTypeNotFound() {
     when(adaptor.unlockContentType(any(), eq("missing"))).thenReturn(null);
     WebApplicationException ex =

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -96,6 +96,11 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public Boolean deleteContentType(URI baseUri, String idOrName) {
+    return Boolean.TRUE;
+  }
+
+  @Override
   public ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled) {
     return null;
   }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -115,6 +115,11 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public Boolean deleteContentType(URI baseUri, String idOrName) {
+    return Boolean.TRUE;
+  }
+
+  @Override
   public ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled) {
     return null;
   }


### PR DESCRIPTION
## Summary

Implements REST **CD-01 DELETE** for content types (parent #1690, slice #3913).

`DELETE /services/contenttypes/{idOrName}` is Admin-only and requires a **held** design-session lock (`POST .../lock`), same as PUT save / enabled. It calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. Locks are not stolen.

| Status | Meaning |
|--------|---------|
| 204 | Deleted; following GET is 404 |
| 400 | Wildcard id/name, or design WS rejected in-use type (dependents) |
| 403 | Not Admin |
| 404 | Missing |
| 409 | Unlocked, or locked by another user |

Create/rename and SPA chrome are out of scope (sibling POST create).

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3913
Parent: #1690

## Test plan

1. Unit: Mockito resource DELETE 204/400/403/404/409; sitemanage adaptor held-lock, other-user 409, missing 404, dependents 400, Admin 403.
2. Standalone `cd rest && ../mvnw.cmd clean install` then `cd projects/sitemanage && ../../mvnw.cmd clean install`.
3. Integrator: Admin `POST .../lock` → `DELETE .../{idOrName}` → `GET` 404; unlocked DELETE 409; other-user lock 409.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` and `product-docs/8.2/admin/developer-content-types.md`
- [x] **Unit / module tests** — behavioral tests; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST-only)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 662, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1574, Failures: 0, Skipped: 125 (`ContentTypeAdaptorDeleteTest` 10 tests)
- **downstream_checked:** grepped `implements IContentTypesAdaptor` / `new IContentTypesAdaptor` (only `ContentTypeAdaptor` + rest Spring/test stubs); standalone sitemanage clean install after rest install. Added interface method (not `final`/signature break of existing methods).

### C5 UI proof

N/A — no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
