### PR TITLE
feat(rest): CD-01 rename content type via PUT .../name (#3914)

### DIFF
--- a/docs/ai-generated/code-reviews/3914-rest-cd01-rename-content-type-erlang.md
+++ b/docs/ai-generated/code-reviews/3914-rest-cd01-rename-content-type-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — issue #3914 REST CD-01 rename content type
+
+**Branch:** `fix/issue-3914-rest-cd01-rename-content-type`  
+**Date:** 2026-08-27  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class completeness (rest resource + adaptor interface + sitemanage impl + Mockito resource tests + Spring `TestContentTypeAdaptor` stub + sitemanage adaptor tests + product-docs); lock-typed 409 vs message sniffing; bulk PUT must not silently overload name.
+
+## Summary
+
+Dedicated `PUT /services/contenttypes/{idOrName}/name` under a held design-session lock. Bulk PUT still ignores name. Unique (case-insensitive) new name; spaces/wildcards/invalid chars 400; unlocked/other locker 409. GET by old name 404; GET by id returns new name.
+
+## Issues
+
+None (hard-gate).
+
+### Notes (non-blocking)
+
+- Uniqueness scans `findContentTypes("*")` (same catalog used by list). Acceptable for this design surface.
+- Application/editor URL rewrite is delegated to existing `PSContentTypeHelper.saveContentType` after `PSItemDefinition.setName`.
+- No filesystem path I/O in this change. Cross-platform path checklist: N/A (clean).
+
+## Tests
+
+- rest `ContentTypesResourceDetailTest` rename 200/400/404/409/403
+- rest Spring stub `TestContentTypeAdaptor.renameContentType`
+- sitemanage `ContentTypeAdaptorRenameTest` persist, GET old/new, lock, spaces, collision, same-name, admin, wildcards
+
+## Builds
+
+- `rest`: `mvnw.cmd clean install` BUILD SUCCESS — Tests run: 663, Failures: 0
+- `projects/sitemanage`: `mvnw.cmd clean install` BUILD SUCCESS — Tests run: 1649, Failures: 0, Skipped: 125; `ContentTypeAdaptorRenameTest` 13 passed
+
+## C2 downstream
+
+Interface method added on `IContentTypesAdaptor`. Grep `implements IContentTypesAdaptor`: rest test stubs + sitemanage `ContentTypeAdaptor` (all updated). sitemanage standalone install green.
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -54,7 +54,8 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
 | Shared field file editing                            | CD-15        | Separate object                                   |
 | System def                                           | CD-16        | Separate object                                   |
-| Create / rename / delete                             | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Rename / delete still SOAP design only; lock + PUT save via REST |
+| Create / delete                                      | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Delete still SOAP design only; lock + PUT save via REST |
+| Rename                                               | CD-01, §5.2  | **REST `PUT /contenttypes/{id}/name`** (#3914, held design lock; unique, no spaces; bulk PUT does not rename) |
 | Import/export CT                                     | CD-14        | Workbench wizards                                 |
 | ACL                                                  | CD-19, §5.4  | Existing ACL REST may help later                  |
 | ~~Keyword write~~                                    | CD-17        | **Done** — REST + SPA + design WS (#1612/#1701)   |

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, enable or disable, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
+description: Lock, enable or disable, rename via REST, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -190,6 +190,22 @@ type is available for runtime use.
    product does **not** steal the lock, Save stays disabled, and **Enabled**
    remains read-only.
 
+## Rename a content type (REST)
+
+Developer Content Type chrome does **not** rename the type. Integrators rename
+with REST after a held design-session lock:
+
+1. `POST /services/contenttypes/{idOrName}/lock`
+2. `PUT /services/contenttypes/{idOrName}/name` with Jackson root
+   `ContentTypeName` (`name` required). The new name must be unique
+   (case-insensitive) and must not contain spaces.
+3. `GET /services/contenttypes/{id}` returns the new name. `GET` by the
+   previous name is **404**.
+4. `POST .../unlock` when done.
+
+Bulk `PUT /services/contenttypes/{idOrName}` still does **not** change name.
+Unlocked or another user's lock is **409**. Collision or spaces is **400**.
+
 ## REST
 
 The chrome calls:
@@ -199,6 +215,7 @@ The chrome calls:
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
 | Save (label, description, fields) | `PUT /services/contenttypes/{idOrName}` (requires a held lock; does not send `enabled`, `allowedWorkflows`, or `allowedTemplates`) |
 | Enable / disable | `PUT /services/contenttypes/{idOrName}/enabled` (CD-13; requires a held lock; does not acquire or release it) |
+| Rename | `PUT /services/contenttypes/{idOrName}/name` (CD-01; Admin; held lock; unique name, no spaces; bulk PUT does not rename) |
 | Save allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (requires a held lock; does not unlock) |
 | Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` (held lock; full replace) |
 | Confirm allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` |

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -190,34 +190,68 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Operation | Path | Notes |
 |-----------|------|--------|
 | List | `GET /services/contenttypes` | Name, label, description, guid |
+| Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. Duplicate name is **409** (catalog check and persist-time unique-name failure). Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Delete remains unsupported. |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `enabled`, `designGaps` |
 | Allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` | Read-only list of associated templates (CD-12). No lock required. Empty list means none. Same set as `ContentTypeDetail.allowedTemplates`. |
 | Item-level exits | `GET /services/contenttypes/{idOrName}/itemExits` | Item-level input/output translations, validations, and pipe pre/post exits (CD-09). No lock required. Empty lists mean none. Apply-when conditions are a read-only summary. Jackson root wrap is `ContentTypeItemExits`. |
 | Replace item-level exits | `PUT /services/contenttypes/{idOrName}/itemExits` | Full replace of item-level translations/validations via `IPSContentDesignWs.saveContentTypes` (CD-09). Requires a **held** design-session lock. Empty lists clear. **409** if unlocked or locked by another user. **400** if required lists are missing or an extension FQN is invalid. `preExits`/`postExits` omitted leave pipe extensions unchanged. Apply-when is not written. Does not acquire or release the lock. |
 | Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` | Full replace of associated templates (CD-12). Requires a **held** design-session lock. Empty list clears associations. **409** if unlocked or locked by another user. **400** if a template name/guid cannot be resolved. Does not acquire or release the lock. |
 | Lock | `POST /services/contenttypes/{idOrName}/lock` | **Admin.** Self-only design-session lock (`IPSContentDesignWs.loadContentTypes` with `lock=true`, `overrideLock=false`). Does **not** save. `200` + `ObjectLockSummary` (`session`, `locker`, `remainingTime` minutes from the lock service). Locks expire after **30 minutes** (`PSObjectLock.LOCK_INTERVAL`). Re-lock by the same session user extends the lock. |
-| Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions use the dedicated path below (not this PUT). |
+| Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** change name (use `PUT .../name`). Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions use the dedicated path below (not this PUT). |
 | Allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` | **Admin** (CD-08 design action). Requires a held design-session lock (`POST .../lock` first). Does **not** acquire or release the lock. Full replace of `allowedWorkflows` (empty list clears). Optional `defaultWorkflow`. Workflow name/guid must exist. `200` + `ContentTypeDetail` with the new `allowedWorkflows` / `defaultWorkflow` (lock still held). |
 | Enable/disable | `PUT /services/contenttypes/{idOrName}/enabled` | **Admin** (CD-13 design action). Requires a held design-session lock — `POST .../lock` first, then `PUT .../enabled`, then `POST .../unlock` when done. Does **not** acquire or release the lock. `200` + `ContentTypeDetail` with the new `enabled` value (lock still held). |
+| Rename | `PUT /services/contenttypes/{idOrName}/name` | **Admin** (CD-01). Requires a **held** design-session lock. Sets the internal name. Unique (case-insensitive); **no spaces** or wildcards. Bulk `PUT .../{idOrName}` does **not** change name. After success, `GET` by the previous name is **404**; `GET` by id returns the new name. Does not acquire or release the lock. |
 | Field control properties | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | Control parameter **name/value** pairs and the choice catalog for one field (CD-07). No lock required. Empty `properties` means none. `choices` omitted when none. |
 | Replace field control properties | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | **Admin** (CD-07). Requires a **held** design-session lock. Full replace of `properties` (empty clears). `choices` omitted leaves the catalog unchanged; `type: none` clears. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | Field-level validation, visibility, and input/output translation expressions (CD-05–07). No lock required. Empty lists mean none. Unknown field is **404**. Jackson root wrap is `ContentTypeFieldRuleExpressions`. |
 | Replace field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | **Admin** (CD-05–07). Requires a **held** design-session lock. Full replace of `validation`, `visibility`, `inputTranslation`, and `outputTranslation` (empty lists clear). Unknown field names are **400**. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**.
 
-Lock / save / unlock status codes:
+Lock / save / unlock / create / rename status codes:
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Lock acquired (body is `ObjectLockSummary`) or PUT save / enable / disable succeeded (lock still held) |
+| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / rename succeeded (lock still held), or POST create succeeded (`ContentTypeDetail`) |
 | `204` | Unlock success |
-| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag) |
-| `403` | Caller is not Admin |
+| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid or colliding rename), or invalid create name (blank, spaces, wildcard) |
+| `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found |
-| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen) |
+| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time) |
 | `500` | Design service or server failure |
+
+### Rename (CD-01)
+
+`PUT /services/contenttypes/{idOrName}/name` changes the content type **internal
+name**. This is a dedicated design action. Bulk `PUT /services/contenttypes/{idOrName}`
+does **not** rename. Hold the design-session lock first; the rename keeps the lock
+so you can continue editing, then unlock.
+
+Typical flow: `POST .../lock` → `PUT .../name` → (optional further design writes)
+→ `POST .../unlock`.
+
+The new name must be unique (case-insensitive) and must not contain spaces or
+wildcards (`*` / `%`). Allowed characters are letters, digits, underscore, and
+dot. A colliding or invalid name is **400**. An unlocked type (or a lock held by
+another user) is **409** — the lock is not stolen.
+
+After a successful rename:
+
+* `GET /services/contenttypes/{id}` returns `200` with the new `name`.
+* `GET /services/contenttypes/{oldName}` returns **404**.
+
+Jackson root wrap:
+
+```json
+{
+  "ContentTypeName": {
+    "name": "percRenamedPage"
+  }
+}
+```
+
+Create and delete of content types remain unsupported on this REST surface.
 
 ### Enable or disable (CD-13)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -98,6 +98,7 @@ import com.percussion.user.service.IPSUserService;
 import com.percussion.util.PSCollection;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.utils.string.PSStringUtils;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
@@ -439,7 +440,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add(
         DesignGap.of(
             "CT_CREATE_DELETE",
-            "Create via POST /services/contenttypes. Delete / rename not supported; PUT save requires a held design lock for"
+            "Create via POST /services/contenttypes. Rename via PUT /contenttypes/{idOrName}/name"
+                + " (held lock). Delete not supported; PUT save requires a held design lock for"
                 + " label/description/enabled, field searchable/occurrence, workflows (+ default),"
                 + " and templates"));
     gaps.add(
@@ -660,6 +662,71 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (Exception e) {
       log.error("Failed to enable/disable content type {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to enable/disable content type", e);
+    }
+  }
+
+  @Override
+  public ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName) {
+    requireAdmin();
+    requireSessionUserForLock();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String validatedName = validateNewContentTypeName(newName);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      PSItemDefinition current = resolveItemDef(trimmed, true);
+      if (current == null) {
+        return null;
+      }
+      IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
+      requireUniqueContentTypeName(validatedName, current.getTypeId());
+      requireHeldLock(ctGuid);
+      if (validatedName.equals(current.getName())) {
+        return toDetail(current);
+      }
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not rename content type");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      def.setName(validatedName);
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not rename content type");
+        }
+        log.error("Failed to save content type name {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save content type name", e);
+      }
+      PSItemDefinition reloaded = reloadItemDef(String.valueOf(def.getTypeId()));
+      if (reloaded != null) {
+        return toDetail(reloaded);
+      }
+      return toDetail(def);
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for rename: {}", idOrName);
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to rename content type {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to rename content type", e);
     }
   }
 
@@ -1226,6 +1293,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   private void applyMetaUpdates(PSItemDefinition def, ContentTypeDetail body) {
+    // Name is not applied here; CD-01 rename uses renameContentType / PUT .../name.
     if (body.getLabel() != null) {
       def.setLabel(body.getLabel());
     }
@@ -2681,6 +2749,52 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    *
    * @throws ContentTypeDesignLockException when unlocked or locked by another user (HTTP 409)
    */
+  /**
+   * Validates a CD-01 rename target. Names must be non-blank, have no spaces or wildcards, and
+   * use only characters allowed for content type names.
+   */
+  static String validateNewContentTypeName(String newName) {
+    if (StringUtils.isBlank(newName)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String trimmed = newName.trim();
+    if (trimmed.indexOf('*') >= 0 || trimmed.indexOf('%') >= 0) {
+      throw new IllegalArgumentException("Content type name must not contain wildcards");
+    }
+    for (int i = 0; i < trimmed.length(); i++) {
+      if (Character.isWhitespace(trimmed.charAt(i))) {
+        throw new IllegalArgumentException("Content type name must not contain spaces");
+      }
+    }
+    Character invalid = PSStringUtils.validateContentTypeName(trimmed);
+    if (invalid != null) {
+      throw new IllegalArgumentException(
+          "Content type name contains invalid character: " + invalid);
+    }
+    return trimmed;
+  }
+
+  /**
+   * Case-insensitive uniqueness against the design catalog. The current type id is excluded so a
+   * no-op or case-only rename of the same type is allowed.
+   */
+  private void requireUniqueContentTypeName(String newName, int currentTypeId) {
+    List<IPSCatalogSummary> found = designSvc.findContentTypes("*");
+    if (found == null) {
+      return;
+    }
+    for (IPSCatalogSummary sum : found) {
+      if (sum == null || !newName.equalsIgnoreCase(sum.getName())) {
+        continue;
+      }
+      IPSGuid guid = sum.getGUID();
+      int uuid = guid != null ? guid.getUUID() : -1;
+      if (uuid != currentTypeId) {
+        throw new IllegalArgumentException("Content type name already exists: " + newName);
+      }
+    }
+  }
+
   private void requireHeldLock(IPSGuid ctGuid) {
     if (systemDesign == null) {
       throw new IllegalStateException(
@@ -2741,12 +2855,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (RuntimeException e) {
       log.debug("Admin check failed: {}", e.getMessage());
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, or save content types",
+          "Admin role required to create, lock, unlock, save, or rename content types",
           Response.Status.FORBIDDEN);
     }
     if (!allowed) {
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, or save content types",
+          "Admin role required to create, lock, unlock, save, or rename content types",
           Response.Status.FORBIDDEN);
     }
   }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorRenameTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorRenameTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSInvalidContentTypeException;
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeDetail;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * CD-01 rename requires a held design-session lock and persists a unique new name without
+ * releasing the lock. GET by old name is not found; GET by id returns the new name.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorRenameTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void rename_persistsNameWhenLockHeld() throws Exception {
+    stubHeldLock();
+    stubCatalog("percPage", 311);
+    PSItemDefinition def = stubDefinition("percPage");
+
+    ContentTypeDetail out = adaptor.renameContentType(null, "311", "percRenamedPage");
+
+    assertEquals("percRenamedPage", out.getName());
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSItemDefinition>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveContentTypes(saved.capture(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    verify(def).setName("percRenamedPage");
+    verify(systemDesign).isLocked(anyList(), eq("Admin"));
+  }
+
+  @Test
+  void get_oldName404_idReturnsNewName() throws Exception {
+    stubHeldLock();
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+
+    ContentTypeDetail renamed = adaptor.renameContentType(null, "311", "percRenamedPage");
+    assertEquals("percRenamedPage", renamed.getName());
+
+    when(itemDefManager.getItemDef("percPage", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("percPage"));
+
+    assertNull(adaptor.getContentType(null, "percPage"));
+    ContentTypeDetail byId = adaptor.getContentType(null, "311");
+    assertEquals("percRenamedPage", byId.getName());
+  }
+
+  @Test
+  void rename_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(Collections.singletonList(null));
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.renameContentType(null, "311", "percRenamedPage"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(true), anyBoolean(), any(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_conflictWhenLockedByOtherUser() throws Exception {
+    PSObjectSummary other = new PSObjectSummary(guid, "percPage");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.renameContentType(null, "311", "percRenamedPage"));
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_conflictWhenLockedInAnotherSession() throws Exception {
+    stubHeldLock();
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+    PSErrorResultsException errors = new PSErrorResultsException();
+    errors.addError(
+        guid, new PSLockErrorException(1, "LOCK_EXTENSION_INVALID_SESSION", "stack", "Admin", 12));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenThrow(errors);
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.renameContentType(null, "311", "percRenamedPage"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_spaces_isBadRequest() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.renameContentType(null, "311", "perc Renamed"));
+    assertTrue(ex.getMessage().toLowerCase().contains("space"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_collision_isBadRequest() throws Exception {
+    stubCatalog("percPage", 311, "percEventAsset", 329);
+    stubDefinition("percPage");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.renameContentType(null, "311", "percEventAsset"));
+    assertTrue(ex.getMessage().toLowerCase().contains("exists"), ex.getMessage());
+    verify(systemDesign, never()).isLocked(anyList(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_caseInsensitiveCollision_isBadRequest() throws Exception {
+    stubCatalog("percPage", 311, "percEventAsset", 329);
+    stubDefinition("percPage");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.renameContentType(null, "311", "PERCEVENTASSET"));
+    assertTrue(ex.getMessage().toLowerCase().contains("exists"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_sameName_isIdempotentWhenLockHeld() throws Exception {
+    stubHeldLock();
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+
+    ContentTypeDetail out = adaptor.renameContentType(null, "311", "percPage");
+
+    assertEquals("percPage", out.getName());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_unknownName_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.renameContentType(null, "missing", "percRenamed"));
+    verify(systemDesign, never()).isLocked(anyList(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> denied.renameContentType(null, "311", "percRenamed"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void rename_wildcardName_isBadRequest() {
+    assertThrows(
+        IllegalArgumentException.class, () -> adaptor.renameContentType(null, "perc*", "percNew"));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void validateNewContentTypeName_rejectsBlankAndInvalid() {
+    assertThrows(
+        IllegalArgumentException.class, () -> ContentTypeAdaptor.validateNewContentTypeName(""));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ContentTypeAdaptor.validateNewContentTypeName("perc New"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ContentTypeAdaptor.validateNewContentTypeName("perc*"));
+    assertEquals("percRenamed", ContentTypeAdaptor.validateNewContentTypeName("percRenamed"));
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private void stubCatalog(String name, int typeId) {
+    stubCatalog(name, typeId, null, -1);
+  }
+
+  private void stubCatalog(String name, int typeId, String otherName, int otherTypeId) {
+    PSObjectSummary self = new PSObjectSummary(new PSGuid(PSTypeEnum.NODEDEF, typeId), name);
+    if (otherName != null) {
+      PSObjectSummary other =
+          new PSObjectSummary(new PSGuid(PSTypeEnum.NODEDEF, otherTypeId), otherName);
+      when(designWs.findContentTypes("*")).thenReturn(List.of(self, other));
+    } else {
+      when(designWs.findContentTypes("*")).thenReturn(List.of(self));
+    }
+  }
+
+  private PSItemDefinition stubDefinition(String currentName) throws Exception {
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn(currentName);
+    when(def.getLabel()).thenReturn("Page");
+    when(def.getDescription()).thenReturn("desc");
+    when(def.isEnabled()).thenReturn(true);
+    when(def.isHidden()).thenReturn(false);
+    when(def.getAppName()).thenReturn("rx_cePage");
+    when(def.getEditorUrl()).thenReturn("/Rhythmyx/rx_cePage/percPage.html");
+    when(def.getTypeId()).thenReturn(311);
+    when(def.getFieldSet()).thenReturn(null);
+    when(def.getContentEditor()).thenReturn(null);
+    doAnswer(
+            inv -> {
+              when(def.getName()).thenReturn(inv.getArgument(0));
+              return null;
+            })
+        .when(def)
+        .setName(any());
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    return def;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -47,6 +47,7 @@ class DesignGapsStructuredTest {
                 g ->
                     "CT_CREATE_DELETE".equals(g.getCode())
                         && g.getMessage().contains("POST /services/contenttypes")
+                        && g.getMessage().contains("PUT /contenttypes/{idOrName}/name")
                         && !g.getMessage().startsWith("Create / delete not supported")),
         () -> gaps.toString());
     assertFalse(codes.contains("CT_CONTROL_RESOLUTION"));

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
@@ -34,7 +34,8 @@ import java.util.List;
  * design lock for write). Control properties use {@code GET/PUT
  * .../fields/{fieldName}/controlProperties}. Partial update supports label, description, enabled,
  * field searchable / occurrence, allowed workflows (+ default), and allowed templates. PUT
- * requires a design-session lock already held by the current user ({@code POST
+ * does not change name (use {@code PUT .../name}). PUT
+ * requires a design-session lock already held by the current user ({@code POST}
  * /services/contenttypes/{idOrName}/lock}) and does not release it. Field rule expressions on this
  * detail payload remain summary strings (not written by PUT detail).
  *

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeName.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeName.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * New internal name for a Content Type rename (CD-01).
+ *
+ * <p>Jackson root wrap is {@code ContentTypeName} ({@code WRAP_ROOT_VALUE} /
+ * {@code UNWRAP_ROOT_VALUE}).
+ */
+@XmlRootElement(name = "ContentTypeName")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Content type rename payload")
+public class ContentTypeName {
+
+  @Schema(
+      required = true,
+      description =
+          "New internal name. Must be unique (case-insensitive), with no spaces or wildcards.")
+  private String name;
+
+  public ContentTypeName() {}
+
+  public ContentTypeName(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -924,10 +924,11 @@ public class ContentTypesResource {
               + " empty). Template associations are written after content-type save in a separate"
               + " design call — if that fails, meta/field/workflow changes may already be"
               + " committed (error message indicates partial success). Name/id and system field"
-              + " structure are not changed. Field rule expressions use PUT"
+              + " structure are not changed — rename uses PUT .../name. Field rule expressions"
+              + " use PUT"
               + " .../fields/{fieldName}/ruleExpressions. Control property values use PUT"
               + " .../fields/{fieldName}/controlProperties. Create uses POST /contenttypes."
-              + " Delete/rename remain unsupported (see designGaps).",
+              + " Rename uses PUT .../name. Delete remains unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -1059,6 +1060,53 @@ public class ContentTypesResource {
       ContentTypeDetail detail =
           requireAdaptor()
               .setContentTypeEnabled(uriInfo.getBaseUri(), idOrName, body.getEnabled());
+      if (detail == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return detail;
+    } catch (RuntimeException e) {
+      throw mapEnabledFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}/name")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Rename a content type",
+      description =
+          "CD-01 design action: sets the content type internal name. Admin only. Requires a"
+              + " design-session lock already held by the current user (POST .../lock). Does not"
+              + " acquire or release the lock. The new name must be unique (case-insensitive) and"
+              + " must not contain spaces or wildcards. Bulk PUT .../{idOrName} does not change"
+              + " name. After success, GET .../{oldName} is 404; GET by id returns the new name."
+              + " Jackson root wrap is ContentTypeName.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Renamed (lock is still held)",
+            content = @Content(schema = @Schema(implementation = ContentTypeDetail.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "name is required, invalid, contains spaces, or collides"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock required, or locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeDetail renameContentType(
+      @PathParam("idOrName") String idOrName, ContentTypeName body) {
+    if (body == null || body.getName() == null || body.getName().trim().isEmpty()) {
+      throw new WebApplicationException("name is required", 400);
+    }
+    try {
+      ContentTypeDetail detail =
+          requireAdaptor().renameContentType(uriInfo.getBaseUri(), idOrName, body.getName());
       if (detail == null) {
         throw new WebApplicationException("Content type not found: " + idOrName, 404);
       }

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -82,7 +82,8 @@ public interface IContentTypesAdaptor {
    * <p>Supports label, description, enabled, per-field {@code searchable} (and optional
    * occurrence), allowed workflows (+ default workflow id), and allowed templates. Association
    * lists use full-replace semantics when non-null; omit them to leave associations unchanged.
-   * Field rule expressions use {@link #replaceFieldRuleExpressions}. Control property values use
+   * Does not change name — use {@link #renameContentType}. Field rule expressions use {@link
+   * #replaceFieldRuleExpressions}. Control property values use
    * {@link #replaceFieldControlProperties}.
    *
    * @return updated detail, or {@code null} when not found
@@ -122,6 +123,22 @@ public interface IContentTypesAdaptor {
    *     user
    */
   ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled);
+
+  /**
+   * Rename a content type (CD-01). Requires a design-session lock already held by the current
+   * user. Does not acquire or release the lock. Bulk {@link #updateContentType} does not change
+   * name. After a successful rename, GET by the previous name is not found; GET by id returns the
+   * new name.
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or current internal name
+   * @param newName unique internal name (no spaces; case-insensitive unique)
+   * @return updated detail, or {@code null} when not found
+   * @throws ContentTypeDesignLockException when no lock is held or the lock is owned by another
+   *     user
+   * @throws IllegalArgumentException when the new name is invalid or collides
+   */
+  ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName);
 
   /**
    * List allowed template associations for a content type (read-only; no lock required).

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -851,4 +851,92 @@ public class ContentTypesResourceDetailTest {
         assertThrows(WebApplicationException.class, () -> resource.unlockContentType("percPage"));
     assertEquals(409, ex.getResponse().getStatus());
   }
+
+  @Test
+  public void renameContentTypeSuccess() {
+    ContentTypeDetail updated = new ContentTypeDetail();
+    updated.setName("percRenamedPage");
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percRenamedPage")))
+        .thenReturn(updated);
+    ContentTypeDetail out =
+        resource.renameContentType("percPage", new ContentTypeName("percRenamedPage"));
+    assertEquals("percRenamedPage", out.getName());
+  }
+
+  @Test
+  public void renameContentTypeRequiresName() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeSpaces400() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("perc Renamed")))
+        .thenThrow(new IllegalArgumentException("Content type name must not contain spaces"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("perc Renamed")));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeCollision400() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percEventAsset")))
+        .thenThrow(new IllegalArgumentException("Content type name already exists: percEventAsset"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("percEventAsset")));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeNotFound() {
+    when(adaptor.renameContentType(any(), eq("missing"), eq("percRenamed"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("missing", new ContentTypeName("percRenamed")));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeRequiresLock() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percRenamed")))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not save content type; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("percRenamed")));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeLockedByOtherUser() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percRenamed")))
+        .thenThrow(
+            new ContentTypeDesignLockException("Could not save content type; locked by editor2"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("percRenamed")));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeForbiddenWhenNotAdmin() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percRenamed")))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("percRenamed")));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -101,6 +101,11 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName) {
+    return null;
+  }
+
+  @Override
   public List<NamedObjectRef> getAllowedTemplates(URI baseUri, String idOrName) {
     return List.of();
   }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -120,6 +120,11 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName) {
+    return null;
+  }
+
+  @Override
   public List<NamedObjectRef> getAllowedTemplates(URI baseUri, String idOrName) {
     return List.of();
   }


### PR DESCRIPTION
## Summary

Public REST **rename** for a content type (parent [#1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690) CD-01). Dedicated `PUT /services/contenttypes/{idOrName}/name` under a held design-session lock. Bulk `PUT /services/contenttypes/{idOrName}` still does **not** change name.

Admin only. Unique new internal name (case-insensitive; no spaces or wildcards). **400** invalid/collision; **409** unlocked or locked by another user. After success, `GET` by the previous name is **404**; `GET` by id returns the new name.

Does not change system field structure, create, or delete. SPA rename chrome is out of scope.

Fixes #3914  
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. As Admin, `POST /services/contenttypes/{id}/lock`.
2. `PUT /services/contenttypes/{id}/name` with Jackson root `ContentTypeName` (`{"ContentTypeName":{"name":"percRenamedPage"}}`).
3. Expect `200` + `ContentTypeDetail` with the new name; lock still held.
4. `GET /services/contenttypes/{id}` returns the new name; `GET` by the old name is `404`.
5. Repeat without lock → `409`. Name with spaces or a colliding name → `400`.
6. Unit: rest `ContentTypesResourceDetailTest` rename cases; sitemanage `ContentTypeAdaptorRenameTest`.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/rest.md`, `admin/developer-content-types.md`)
- [x] **Unit / module tests** — behavioral tests for rename 400/409 and GET-by-new-name; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST-only)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest; ..\mvnw.cmd clean install` → **BUILD SUCCESS** — Tests run: 663, Failures: 0 (`ContentTypesResourceDetailTest` 63 passed)
  - `cd projects/sitemanage; ..\..\mvnw.cmd clean install` → **BUILD SUCCESS** — Tests run: 1649, Failures: 0, Skipped: 125 (`ContentTypeAdaptorRenameTest` 13 passed)
- **downstream_checked:** `IContentTypesAdaptor` gained `renameContentType`. Grep `implements IContentTypesAdaptor` → rest Spring stub `TestContentTypeAdaptor`, `ContentTypesTestAdaptor`, sitemanage `ContentTypeAdaptor` (all updated). sitemanage standalone clean install green. No `final`/`sealed` type change.

## C5 UI proof

N/A — REST/backend only; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
