### PR TITLE
feat(rest): restore CD-01 POST create docs and Folder 409 tests (#3926)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3926-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3926-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review — issue #3926 REST CD-01 create content type (docs + reserved)
+
+**Date:** 2026-08-27  
+**Branch:** `feat/issue-3926-rest-cd01-create-content-type`  
+**Scope:** uncommitted vs `HEAD` (based on `origin/main`)  
+**Memory patterns hit:** Change-class closure (product-docs companion after cluster absorb); typed 409 vs message-substring; exact implementors of `IContentTypesAdaptor`
+
+## Summary
+
+CD-01 `POST /services/contenttypes` already shipped on main via #3912 / PR #3918 (`IPSContentDesignWs.createContentTypes` then `saveContentTypes`). Cluster absorb #3923 dropped the Create row and create status codes from `product-docs/8.2/developer/rest.md`. This change restores that integrator documentation, notes reserved system types such as Folder as **409** collisions (SOAP `createContentType("Folder")` peer), and adds resource + adaptor tests for Folder plus create-then-GET. Does **not** remap collision to 400 (would regress the shipped 409 contract). No SPA chrome, rename, or DELETE.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs, missing behavioral tests, or non-portable path/file I/O.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| rest resource + OpenAPI | yes (description/409 text only; POST already on main) |
+| `IContentTypesAdaptor.createContentType` | javadoc only (no signature change) |
+| Mockito `ContentTypesResourceDetailTest` | reserved Folder 409 |
+| Spring stubs `TestContentTypeAdaptor` + `ContentTypesTestAdaptor` | already implement `createContentType` |
+| sitemanage `ContentTypeAdaptor` | already on main; tests added |
+| sitemanage adaptor tests | `ContentTypeAdaptorCreateTest` Folder 409 + create-then-GET |
+| product-docs 8.2 | `developer/rest.md` Create row restored; admin Content Types 400/403/409 |
+| rest → sitemanage Maven edge | none |
+| C2 implementors | grep `implements IContentTypesAdaptor` — 3 types; no signature change; no anonymous subclasses |
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction, temp files, or path assertions.
+
+## Issues
+
+None (blocking).
+
+## Nits (non-blocking)
+
+- Issue #3926 triage asked for collision **400**. Shipped #3918 uses **409** (REST Conflict vs invalid name 400). This PR keeps 409 and documents Folder as catalog collision.
+
+## Builds
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 669, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1667, Failures: 0, Skipped: 125
+- `scripts\ci-smoke-product-docs.bat` — OK

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -15,9 +15,13 @@ for fields, allowed workflows, allowed templates, **item-level exits**, **contro
 Admins cannot overwrite the same type at once.
 
 Integrators can **create** a content type with Admin `POST /services/contenttypes`
-(JSON `name` required; unique, no spaces). That call persists the type
-(Workbench Finish). This chrome does **not** include a create wizard; delete
-and rename are not supported here. See [REST API](id:developer-rest).
+(JSON `name` required; unique, no spaces; optional `label` / `description`).
+That call persists the type (Workbench Finish). A successful create is then
+`GET /services/contenttypes/{name}` **200**. Duplicate or reserved system names
+(for example **Folder**) are **409**. Invalid names (blank, spaces, wildcard)
+are **400**. Non-Admin callers are **403**. This chrome does **not** include a
+create wizard; delete and rename are not supported here. See
+[REST API](id:developer-rest).
 
 This is **not** the full Workbench field-rule editor. The detail table still
 shows rule **flags** (validation / visibility / transforms present). After

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -190,6 +190,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Operation | Path | Notes |
 |-----------|------|--------|
 | List | `GET /services/contenttypes` | Name, label, description, guid |
+| Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. The new type is then `GET /services/contenttypes/{name}` **200**. Duplicate name is **409** (catalog check and persist-time unique-name failure), including reserved system types such as **Folder**. Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Non-Admin is **403**. Delete and rename remain unsupported (open covering PRs). |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `enabled`, `designGaps` |
 | Allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` | Read-only list of associated templates (CD-12). No lock required. Empty list means none. Same set as `ContentTypeDetail.allowedTemplates`. |
 | Item-level exits | `GET /services/contenttypes/{idOrName}/itemExits` | Item-level input/output translations, validations, and pipe pre/post exits (CD-09). No lock required. Empty lists mean none. Apply-when conditions are a read-only summary. Jackson root wrap is `ContentTypeItemExits`. |
@@ -205,18 +206,18 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Replace field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | **Admin** (CD-05–07). Requires a **held** design-session lock. Full replace of `validation`, `visibility`, `inputTranslation`, and `outputTranslation` (empty lists clear). Unknown field names are **400**. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. SPA create-wizard chrome is not part of this API.
 
-Lock / save / unlock status codes:
+Lock / save / unlock / create status codes:
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Lock acquired (body is `ObjectLockSummary`) or PUT save / enable / disable succeeded (lock still held) |
+| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable succeeded (lock still held), or POST create succeeded (`ContentTypeDetail`) |
 | `204` | Unlock success |
-| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag) |
-| `403` | Caller is not Admin |
+| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag) or invalid create name (blank, spaces, wildcard) |
+| `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found |
-| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen) |
+| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time), including reserved system types such as Folder |
 | `500` | Design service or server failure |
 
 ### Enable or disable (CD-13)

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorCreateTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorCreateTest.java
@@ -192,6 +192,39 @@ class ContentTypeAdaptorCreateTest {
   }
 
   @Test
+  void create_reservedFolderName_is409BeforeCreate() throws Exception {
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("Folder");
+    when(designWs.findContentTypes("*")).thenReturn(List.of(existing));
+
+    ContentTypeDetail body = new ContentTypeDetail();
+    body.setName("Folder");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createContentType(null, body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createContentTypes(anyList(), any(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_thenGetByName_returnsDetail() throws Exception {
+    PSItemDefinition def = stubCreatedDefinition("percNewType", 9001);
+    when(designWs.createContentTypes(eq(List.of("percNewType")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    ContentTypeDetail body = new ContentTypeDetail();
+    body.setName("percNewType");
+    body.setLabel("New Type");
+
+    adaptor.createContentType(null, body);
+    ContentTypeDetail got = adaptor.getContentType(null, "percNewType");
+
+    assertEquals("percNewType", got.getName());
+    assertEquals("New Type", got.getLabel());
+  }
+
+  @Test
   void create_blankName_throwsBeforeDesignWs() throws Exception {
     assertThrows(IllegalArgumentException.class, () -> adaptor.createContentType(null, null));
     ContentTypeDetail blank = new ContentTypeDetail();

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -847,8 +847,9 @@ public class ContentTypesResource {
               + " then saveContentTypes (Workbench Finish, not an unsaved stub). Name is required,"
               + " must be unique (case-insensitive), and must not contain spaces. Optional label,"
               + " description, and enabled are applied before save. Omitted enabled defaults to"
-              + " true. Returns the new ContentTypeDetail. Duplicate name is 409 at catalog check"
-              + " and at persist. Delete/rename remain unsupported (see designGaps).",
+              + " true. Returns the new ContentTypeDetail (GET by name is then 200). Duplicate"
+              + " name is 409 at catalog check and at persist, including reserved system types"
+              + " such as Folder. Delete/rename remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -860,7 +861,11 @@ public class ContentTypesResource {
         @ApiResponse(
             responseCode = "403",
             description = "Admin role required, or request has no session/user"),
-        @ApiResponse(responseCode = "409", description = "A content type with that name exists"),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "A content type with that name exists (including reserved system types such as"
+                    + " Folder)"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public ContentTypeDetail createContentType(ContentTypeDetail body) {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -53,7 +53,7 @@ public interface IContentTypesAdaptor {
   /**
    * Create and persist a content type (Workbench Finish: {@code createContentTypes} then {@code
    * saveContentTypes}). Admin only. Name must be unique (case-insensitive) and must not contain
-   * spaces.
+   * spaces. Reserved system names such as {@code Folder} collide with existing catalog types.
    *
    * @param baseUri requesting URI
    * @param body request body; {@code name} is required. Optional label, description, and enabled
@@ -62,7 +62,7 @@ public interface IContentTypesAdaptor {
    * @throws IllegalArgumentException when the name is blank, contains whitespace, or contains
    *     wildcards
    * @throws jakarta.ws.rs.WebApplicationException {@code 409} when a content type with that name
-   *     already exists; {@code 403} when the caller is not Admin
+   *     already exists (including reserved system types); {@code 403} when the caller is not Admin
    */
   ContentTypeDetail createContentType(URI baseUri, ContentTypeDetail body);
 

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -564,6 +564,17 @@ public class ContentTypesResourceDetailTest {
   }
 
   @Test
+  public void createContentTypeReservedFolderIs409() {
+    ContentTypeDetail body = new ContentTypeDetail();
+    body.setName("Folder");
+    when(adaptor.createContentType(any(), any()))
+        .thenThrow(new WebApplicationException("Content type already exists: Folder", 409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createContentType(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void createContentTypeForbiddenWhenNotAdmin() {
     ContentTypeDetail body = new ContentTypeDetail();
     body.setName("percNewType");


### PR DESCRIPTION
## Summary

Parent: #1690. Slice: #3926 (CD-01 create content type).

`POST /services/contenttypes` already shipped on `main` via #3912 / PR #3918 (`IPSContentDesignWs.createContentTypes` then `saveContentTypes`, Admin only, unique name, no spaces). Cluster absorb #3923 dropped the **Create** row and create status codes from `product-docs/8.2/developer/rest.md`.

This PR:

- Restores integrator REST documentation for Admin `POST /services/contenttypes` (optional label/description, GET-by-name 200).
- Documents reserved system types such as **Folder** as **409** catalog collisions (SOAP `createContentType("Folder")` peer). Invalid names stay **400**; non-Admin stays **403**. Collision remains **409** (does not regress the shipped #3918 contract to 400).
- Adds Mockito resource + sitemanage adaptor tests for Folder 409 and create-then-GET.
- Updates Developer Content Types admin notes. No SPA chrome, rename (#3914 / #3920), or DELETE (#3913 / #3919). Siblings #3924 (CD-07 write) and #3929 (CD-15 read) are backlog — not in this PR.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3926
Partial #1690

## Test plan

1. Review OpenAPI on `ContentTypesResource.createContentType` (409 includes reserved Folder).
2. `cd rest && ../mvnw.cmd clean install` — Tests run: 669, Failures: 0.
3. `cd projects/sitemanage && ../../mvnw.cmd clean install` — Tests run: 1667, Failures: 0, Skipped: 125.
4. `scripts\ci-smoke-product-docs.bat` — OK (`tmp/product-docs-site/8.2/index.html`).
5. As Admin: `POST /services/contenttypes` with unique `name` → 200 `ContentTypeDetail`; `GET /services/contenttypes/{name}` → 200.
6. Collision / reserved `Folder` → 409; spaces/blank → 400; Editor → 403.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/rest.md`, `admin/developer-content-types.md`)
- [x] **Unit / module tests** — `ContentTypesResourceDetailTest` Folder 409; `ContentTypeAdaptorCreateTest` Folder 409 + create-then-GET; standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module standalone `clean install` (no skipTests); C2 no signature/`final` change
- [x] **Cross-platform** — N/A (no path/file I/O)

### Product-docs pointers

- Gate: root `AGENTS.md` → **Product documentation (HARD GATE)**
- Tree: `product-docs/README.md` (layout, frontmatter `id` stability, build smoke)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 669, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1667, Failures: 0, Skipped: 125
  - `scripts\ci-smoke-product-docs.bat` — OK
- **downstream_checked:** grep `implements IContentTypesAdaptor` — 3 types (`ContentTypeAdaptor`, `TestContentTypeAdaptor`, `ContentTypesTestAdaptor`); javadoc-only interface change; no anonymous subclasses; sitemanage standalone install green. C2 API-shape gate did not apply (no `final`/`sealed`, no method/ctor signature change).

## C5 UI proof

N/A — no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
