### PR TITLE
fix(webui): Content Types first-row Open mounts Object ACL (#3810)

### DIFF
--- a/WebUI/src/main/ts/api/developer/contentTypesApi.ts
+++ b/WebUI/src/main/ts/api/developer/contentTypesApi.ts
@@ -15,7 +15,10 @@
  * limitations under the License.
  */
 
-import { normalizeDesignObjectGuid } from "../displayFormatGuid";
+import {
+  normalizeDesignObjectGuid,
+  resolveContentTypeObjectGuid,
+} from "../displayFormatGuid";
 import { get, post, put } from "../client";
 import { PATHS } from "../paths";
 import {
@@ -74,8 +77,62 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return null;
 }
 
+const MAX_CONTENT_TYPE_TEXT_DEPTH = 4;
+
+/**
+ * Coerce catalog/detail string fields so JAXB wraps cannot hide Open keys
+ * or throw "Objects are not valid as a React child" (#3810 / #3706).
+ */
+export function asContentTypeText(value: unknown, depth = 0): string {
+  if (value == null || depth > MAX_CONTENT_TYPE_TEXT_DEPTH) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return "";
+  }
+  const o = value as Record<string, unknown>;
+  return asContentTypeText(
+    o.value ?? o.stringValue ?? o.$ ?? o._text ?? o.content,
+    depth + 1,
+  );
+}
+
+function optionalContentTypeText(value: unknown): string | undefined {
+  const text = asContentTypeText(value);
+  return text ? text : undefined;
+}
+
+function coerceContentTypeStringFields<T extends ContentTypeSummary>(item: T): T {
+  return {
+    ...item,
+    name: optionalContentTypeText(item.name),
+    label: optionalContentTypeText(item.label),
+    description: optionalContentTypeText(item.description),
+  };
+}
+
 function normalizeContentTypeSummary(item: ContentTypeSummary): ContentTypeSummary {
-  return normalizeDesignObjectGuid(item);
+  return normalizeDesignObjectGuid(coerceContentTypeStringFields(item));
+}
+
+/**
+ * Open-key for Content Types catalog → GET /services/contenttypes/{idOrName}.
+ * Prefers internal name, then object GUID. Null when the row cannot be opened
+ * (empty/wrapped name and no guid — no Open button, #3810).
+ */
+export function contentTypeSelectionKey(ct: ContentTypeSummary): string | null {
+  const name = asContentTypeText(ct.name);
+  if (name && name !== "—") {
+    return name;
+  }
+  const guid = resolveContentTypeObjectGuid(ct);
+  return guid || null;
 }
 
 /** Jackson WRAP_ROOT / JAXB / ArrayList envelopes for GET /services/contenttypes. */
@@ -162,7 +219,7 @@ function flattenContentTypeList(payload: unknown, depth = 0): unknown[] {
 
 function normalizeContentTypeDetail(detail: ContentTypeDetail): ContentTypeDetail {
   return {
-    ...detail,
+    ...coerceContentTypeStringFields(detail),
     fields: normalizeContentTypeFields(detail.fields),
     childFieldSets: normalizeContentTypeStringList(detail.childFieldSets),
     allowedWorkflows: normalizeNamedObjectRefs(detail.allowedWorkflows),
@@ -194,20 +251,33 @@ export function unwrapContentTypeDetail(payload: unknown): ContentTypeDetail {
   if (!root) {
     return {};
   }
-  const nested = asRecord(root[CONTENT_TYPE_DETAIL_ROOT] ?? root.contentTypeDetail);
+  const preferred = asRecord(root[CONTENT_TYPE_DETAIL_ROOT] ?? root.contentTypeDetail);
   let body: ContentTypeDetail;
-  if (nested) {
-    body = nested as ContentTypeDetail;
-  } else if (
-    "name" in root ||
-    "guid" in root ||
-    "guidString" in root ||
-    "fields" in root ||
-    "label" in root
-  ) {
-    body = root as ContentTypeDetail;
+  if (preferred) {
+    body = preferred as ContentTypeDetail;
   } else {
-    return {};
+    const alt = asRecord(root.ContentType ?? root.contentType);
+    if (
+      alt &&
+      (alt.name != null ||
+        alt.fields != null ||
+        alt.guid != null ||
+        alt.label != null ||
+        alt.allowedTemplates != null)
+    ) {
+      body = alt as ContentTypeDetail;
+    } else if (
+      "name" in root ||
+      "guid" in root ||
+      "guidString" in root ||
+      "fields" in root ||
+      "label" in root ||
+      "allowedTemplates" in root
+    ) {
+      body = root as ContentTypeDetail;
+    } else {
+      return {};
+    }
   }
   return normalizeDesignObjectGuid(normalizeContentTypeDetail(body));
 }

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -18,6 +18,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
+  asContentTypeText,
   getContentTypeAllowedTemplates,
   getContentTypeDetail,
   getContentTypeItemExits,
@@ -253,8 +254,8 @@ export function ContentTypeDetailPanel({
         if (cancelled) return;
         const normalized = normalizeDetailLists(d);
         setDetail(normalized);
-        setLabel(normalized.label || "");
-        setDescription(normalized.description || "");
+        setLabel(asContentTypeText(normalized.label));
+        setDescription(asContentTypeText(normalized.description));
         setEnabled(normalized.enabled !== false);
         setFieldDrafts(toDrafts(normalized.fields));
         setWorkflows(
@@ -746,8 +747,8 @@ export function ContentTypeDetailPanel({
       }
       const normalized = normalizeDetailLists(saved);
       setDetail(normalized);
-      setLabel(normalized.label || "");
-      setDescription(normalized.description || "");
+      setLabel(asContentTypeText(normalized.label));
+      setDescription(asContentTypeText(normalized.description));
       setEnabled(normalized.enabled !== false);
       setFieldDrafts(toDrafts(normalized.fields));
       setWorkflows(
@@ -897,7 +898,9 @@ export function ContentTypeDetailPanel({
       </div>
 
       <div style={{ fontFamily: "monospace", color: catalogColors.muted, marginBottom: "12px" }}>
-        <span data-testid="developer-ct-detail-name">{detail?.name || idOrName}</span>
+        <span data-testid="developer-ct-detail-name">
+          {asContentTypeText(detail?.name) || idOrName}
+        </span>
         {detail ? (
           <>
             {" · "}
@@ -1244,7 +1247,7 @@ export function ContentTypeDetailPanel({
         <>
           <header style={{ marginBottom: "16px" }}>
             <h2 style={{ margin: "0 0 4px" }} data-testid="developer-ct-detail-title">
-              {label || detail.name || idOrName}
+              {label || asContentTypeText(detail.name) || idOrName}
             </h2>
             <div style={{ marginTop: "12px" }}>
               <label htmlFor="ct-label" style={{ display: "block", marginBottom: 4 }}>
@@ -1555,12 +1558,6 @@ export function ContentTypeDetailPanel({
             }}
           />
 
-          <ObjectAclSection
-            objectGuid={objectGuid}
-            objectKind="content-type"
-            testIdPrefix="developer-ct-acl"
-          />
-
           {gapRows.length > 0 ? (
             <section data-testid="developer-ct-gaps">
               <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.CT_GAPS}</h3>
@@ -1575,6 +1572,13 @@ export function ContentTypeDetailPanel({
           ) : null}
         </>
       ) : null}
+
+      {/* Mount Object ACL from catalogGuid before GET detail finishes (#3810). */}
+      <ObjectAclSection
+        objectGuid={objectGuid}
+        objectKind="content-type"
+        testIdPrefix="developer-ct-acl"
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/ContentTypesPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypesPanel.tsx
@@ -18,6 +18,8 @@
 import React, { useEffect, useState } from "react";
 import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
+  asContentTypeText,
+  contentTypeSelectionKey,
   listContentTypes,
   unwrapContentTypeList,
 } from "../api/developer/contentTypesApi";
@@ -29,15 +31,9 @@ import { DeveloperSectionErrorBoundary } from "./DeveloperSectionErrorBoundary";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
-/** Coerce catalog cell / sort keys so object JAXB wraps cannot throw. */
+/** Catalog cell / sort keys — JAXB wraps unwrap in {@link asContentTypeText}. */
 function asCatalogText(value: unknown): string {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return "";
+  return asContentTypeText(value);
 }
 
 /**
@@ -53,8 +49,8 @@ function displayId(ct: ContentTypeSummary): string {
   return resolveContentTypeObjectGuid(ct) || "—";
 }
 
-function selectionKey(ct: ContentTypeSummary): string {
-  return asCatalogText(ct.name) || resolveContentTypeObjectGuid(ct) || displayId(ct);
+function selectionKey(ct: ContentTypeSummary): string | null {
+  return contentTypeSelectionKey(ct);
 }
 
 function catalogSortKey(ct: ContentTypeSummary): string {
@@ -98,7 +94,7 @@ export function ContentTypesPanel(): React.ReactElement {
 
   function openContentType(ct: ContentTypeSummary) {
     const idOrName = selectionKey(ct);
-    if (!idOrName || idOrName === "—") return;
+    if (!idOrName) return;
     setSelected({
       idOrName,
       catalogGuid: resolveContentTypeObjectGuid(ct),
@@ -163,23 +159,22 @@ export function ContentTypesPanel(): React.ReactElement {
             name ||
             `${label || "ct"}-${displayId(ct)}`;
           const openKey = selectionKey(ct);
-          const interactive = openKey !== "—";
+          const interactive = !!openKey;
           return {
             key,
-            onClick: interactive ? () => openContentType(ct) : undefined,
+            dataAttrs: openKey ? { "data-ct-name": openKey } : undefined,
             cells: [
               interactive ? (
                 <button
                   key="open"
                   type="button"
                   style={openButtonStyle}
+                  data-testid="developer-ct-open"
+                  data-ct-name={openKey}
                   aria-label={`Open ${label || name || openKey}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    openContentType(ct);
-                  }}
+                  onClick={() => openContentType(ct)}
                 >
-                  {label || "—"}
+                  {label || name || "—"}
                 </button>
               ) : (
                 <span key="lbl" style={mutedCell}>

--- a/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/contentTypesApi.test.ts
@@ -4,6 +4,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  asContentTypeText,
+  contentTypeSelectionKey,
   getContentTypeAllowedTemplates,
   getFieldControlProperties,
   normalizeContentTypeControlProperties,
@@ -127,6 +129,48 @@ describe("unwrapContentTypeList", () => {
       },
     ]);
   });
+
+  it("coerces JAXB-wrapped name/label so catalog Open keys exist (#3810)", () => {
+    expect(
+      unwrapContentTypeList([
+        {
+          name: { value: "percPage" },
+          label: { $: "Page" },
+          description: { stringValue: "A page" },
+          guid: { hostId: 0, type: 2, uuid: 301 },
+        },
+      ]),
+    ).toEqual([
+      {
+        name: "percPage",
+        label: "Page",
+        description: "A page",
+        guid: { hostId: 0, type: 2, uuid: 301, stringValue: "0-2-301" },
+        guidString: "0-2-301",
+      },
+    ]);
+  });
+});
+
+describe("asContentTypeText / contentTypeSelectionKey (#3810)", () => {
+  it("unwraps JAXB string wrappers", () => {
+    expect(asContentTypeText("percPage")).toBe("percPage");
+    expect(asContentTypeText({ value: "percPage" })).toBe("percPage");
+    expect(asContentTypeText({ $: "Page" })).toBe("Page");
+    expect(asContentTypeText({ stringValue: "0-2-301" })).toBe("0-2-301");
+    expect(asContentTypeText({ foo: 1 })).toBe("");
+    expect(asContentTypeText(null)).toBe("");
+  });
+
+  it("prefers name then guid and never returns em-dash", () => {
+    expect(contentTypeSelectionKey({ name: "percPage" })).toBe("percPage");
+    expect(
+      contentTypeSelectionKey({ guid: { stringValue: "0-2-9" } }),
+    ).toBe("0-2-9");
+    expect(contentTypeSelectionKey({ name: { value: "percFile" } })).toBe("percFile");
+    expect(contentTypeSelectionKey({ label: "Broken" })).toBeNull();
+    expect(contentTypeSelectionKey({ name: "—" })).toBeNull();
+  });
 });
 
 describe("unwrapContentTypeDetail (#3319)", () => {
@@ -167,6 +211,31 @@ describe("unwrapContentTypeDetail (#3319)", () => {
   it("returns empty object for unrelated envelopes", () => {
     expect(unwrapContentTypeDetail({ Error: { message: "x" } })).toEqual({});
     expect(unwrapContentTypeDetail(null)).toEqual({});
+  });
+
+  it("unwraps ContentType root and JAXB name wraps (#3810)", () => {
+    const flat = unwrapContentTypeDetail({
+      ContentType: {
+        name: { value: "percPage" },
+        label: { $: "Page" },
+        guid: { stringValue: "0-2-301" },
+        fields: [],
+      },
+    });
+    expect(flat.name).toBe("percPage");
+    expect(flat.label).toBe("Page");
+    expect(flat.guid?.stringValue).toBe("0-2-301");
+  });
+
+  it("keeps ContentTypeDetail root when only allowedTemplates is present", () => {
+    const flat = unwrapContentTypeDetail({
+      ContentTypeDetail: {
+        allowedTemplates: [{ name: "t1", guid: { stringValue: "1-101-9" } }],
+      },
+    });
+    expect(flat.allowedTemplates).toEqual([
+      { name: "t1", guid: { stringValue: "1-101-9" } },
+    ]);
   });
 
   it("normalizes Jackson empty-collection beans to [] (#3712)", () => {

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -12,20 +12,25 @@ import { catalogColors } from "../../../main/ts/developer/catalogStyles";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { ContentTypeDetailPanel } from "../../../main/ts/developer/ContentTypeDetailPanel";
 
-vi.mock("../../../main/ts/api/developer/contentTypesApi", () => ({
-  getContentTypeDetail: vi.fn(),
-  updateContentTypeDetail: vi.fn(),
-  setContentTypeEnabled: vi.fn(),
-  setContentTypeAllowedWorkflows: vi.fn(),
-  lockContentType: vi.fn(),
-  unlockContentType: vi.fn(),
-  getContentTypeAllowedTemplates: vi.fn(),
-  replaceContentTypeAllowedTemplates: vi.fn(),
-  getFieldControlProperties: vi.fn(),
-  replaceFieldControlProperties: vi.fn(),
-  getContentTypeItemExits: vi.fn(),
-  replaceContentTypeItemExits: vi.fn(),
-}));
+vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../main/ts/api/developer/contentTypesApi")>();
+  return {
+    ...actual,
+    getContentTypeDetail: vi.fn(),
+    updateContentTypeDetail: vi.fn(),
+    setContentTypeEnabled: vi.fn(),
+    setContentTypeAllowedWorkflows: vi.fn(),
+    lockContentType: vi.fn(),
+    unlockContentType: vi.fn(),
+    getContentTypeAllowedTemplates: vi.fn(),
+    replaceContentTypeAllowedTemplates: vi.fn(),
+    getFieldControlProperties: vi.fn(),
+    replaceFieldControlProperties: vi.fn(),
+    getContentTypeItemExits: vi.fn(),
+    replaceContentTypeItemExits: vi.fn(),
+  };
+});
 
 vi.mock("../../../main/ts/api/developer/contentTypeFieldRules", async (importOriginal) => {
   const actual =
@@ -273,15 +278,35 @@ describe("ContentTypeDetailPanel", () => {
     );
   });
 
+  it("mounts ObjectAclSection immediately with catalogGuid before GET (#3810)", () => {
+    const hang = () => new Promise(() => undefined);
+    getContentTypeDetail.mockImplementation(hang);
+    getContentTypeItemExits.mockImplementation(hang);
+    getContentTypeAllowedTemplates.mockImplementation(hang);
+    getFieldControlProperties.mockImplementation(hang);
+    render(
+      <ContentTypeDetailPanel
+        idOrName="percPage"
+        catalogGuid="0-2-301"
+        onBack={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId("developer-ct-detail")).toBeTruthy();
+    const acl = screen.getByTestId("developer-ct-acl-stub");
+    expect(acl.getAttribute("data-object-kind")).toBe("content-type");
+    expect(acl.getAttribute("data-object-guid")).toBe("0-2-301");
+  });
+
   it("mounts ObjectAclSection with content-type kind and object guid (#3319)", async () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+      expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
+        "0-2-301",
+      );
     });
     const acl = screen.getByTestId("developer-ct-acl-stub");
     expect(acl.getAttribute("data-object-kind")).toBe("content-type");
-    expect(acl.getAttribute("data-object-guid")).toBe("0-2-301");
     expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("0-2-301");
   });
 
@@ -298,12 +323,11 @@ describe("ContentTypeDetailPanel", () => {
       />,
     );
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+      expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
+        "0-2-9",
+      );
     });
     expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("0-2-9");
-    expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
-      "0-2-9",
-    );
   });
 
   it("uses guidString when nested guid is absent (#3319)", async () => {
@@ -314,12 +338,11 @@ describe("ContentTypeDetailPanel", () => {
     });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+      expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
+        "0-2-88",
+      );
     });
     expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("0-2-88");
-    expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
-      "0-2-88",
-    );
   });
 
   it("synthesizes object guid from host/type/uuid parts on detail (#3319)", async () => {
@@ -329,12 +352,11 @@ describe("ContentTypeDetailPanel", () => {
     });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+      expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
+        "0-2-301",
+      );
     });
     expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("0-2-301");
-    expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
-      "0-2-301",
-    );
   });
 
   it("passes empty guid to ObjectAclSection when none can be resolved (#3319)", async () => {
@@ -345,9 +367,8 @@ describe("ContentTypeDetailPanel", () => {
     });
     render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
     await waitFor(() => {
-      expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+      expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("—");
     });
-    expect(screen.getByTestId("developer-ct-detail-guid").textContent).toBe("—");
     expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe("");
   });
 

--- a/WebUI/src/test/ts/developer/ContentTypesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypesPanel.test.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2026 Intersoft Data Labs, Inc.
  */
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionRedirectError } from "../../../main/ts/api/client";
@@ -16,8 +16,52 @@ vi.mock("../../../main/ts/api/developer/contentTypesApi", async (importOriginal)
   return {
     ...actual,
     listContentTypes: vi.fn(),
+    getContentTypeDetail: vi.fn().mockResolvedValue({
+      name: "percPage",
+      label: "Page",
+      guid: { stringValue: "0-2-301" },
+      fields: [],
+    }),
+    getContentTypeItemExits: vi.fn().mockResolvedValue({
+      inputTranslations: [],
+      outputTranslations: [],
+      validations: [],
+      preExits: [],
+      postExits: [],
+    }),
+    getContentTypeAllowedTemplates: vi.fn().mockResolvedValue([]),
+    getFieldControlProperties: vi.fn().mockResolvedValue({ properties: [] }),
   };
 });
+
+vi.mock("../../../main/ts/api/developer/contentTypeFieldRules", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../main/ts/api/developer/contentTypeFieldRules")>();
+  return {
+    ...actual,
+    getContentTypeFieldRuleExpressions: vi.fn().mockResolvedValue({
+      fieldName: "",
+      validation: [],
+      visibility: [],
+      inputTranslation: [],
+      outputTranslation: [],
+    }),
+  };
+});
+
+vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
+  ObjectAclSection: (props: {
+    objectGuid?: string | null;
+    objectKind?: string | null;
+    testIdPrefix?: string;
+  }) => (
+    <div
+      data-testid={`${props.testIdPrefix ?? "developer-acl"}-stub`}
+      data-object-guid={props.objectGuid ?? ""}
+      data-object-kind={props.objectKind ?? ""}
+    />
+  ),
+}));
 
 const listContentTypes = contentTypesApi.listContentTypes as ReturnType<typeof vi.fn>;
 
@@ -148,5 +192,76 @@ describe("ContentTypesPanel", () => {
       expect(screen.getByTestId("developer-ct-empty")).toBeTruthy();
     });
     expect(screen.queryByTestId("developer-section-error")).toBeNull();
+  });
+
+  it("exposes Open when name is a JAXB wrap and guid is present (#3810)", async () => {
+    listContentTypes.mockResolvedValue([
+      {
+        name: { value: "percPage" },
+        label: { $: "Page" },
+        guid: { hostId: 0, type: 2, uuid: 301 },
+      },
+    ]);
+    render(<ContentTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-open")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-open").getAttribute("data-ct-name")).toBe(
+      "percPage",
+    );
+    expect(screen.getByTestId("developer-ct-open").getAttribute("aria-label")).toMatch(
+      /Open Page/i,
+    );
+  });
+
+  it("exposes Open from guid when name is empty (#3810)", async () => {
+    listContentTypes.mockResolvedValue([
+      {
+        label: "Untitled",
+        guid: { stringValue: "0-2-9" },
+      },
+    ]);
+    render(<ContentTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-open")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-open").getAttribute("data-ct-name")).toBe(
+      "0-2-9",
+    );
+  });
+
+  it("hides Open when name and guid are both missing (#3810)", async () => {
+    listContentTypes.mockResolvedValue([{ label: "Broken" }]);
+    render(<ContentTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-ct-open")).toBeNull();
+    expect(screen.getByTestId("developer-ct-table").textContent).toContain("Broken");
+  });
+
+  it("Open mounts content-type detail and Object ACL (#3810)", async () => {
+    listContentTypes.mockResolvedValue([
+      {
+        name: "percPage",
+        label: "Page",
+        guid: { stringValue: "0-2-301" },
+      },
+    ]);
+    render(<ContentTypesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-open")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-acl-stub")).toBeTruthy();
+    expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-guid")).toBe(
+      "0-2-301",
+    );
+    expect(screen.getByTestId("developer-ct-acl-stub").getAttribute("data-object-kind")).toBe(
+      "content-type",
+    );
   });
 });

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -748,7 +748,7 @@ describe("DeveloperShell", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });
-    fireEvent.click(screen.getByTestId("developer-ct-row-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail")).toBeTruthy();
     });
@@ -790,7 +790,7 @@ describe("DeveloperShell", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });
-    fireEvent.click(screen.getByTestId("developer-ct-row-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-detail")).toBeTruthy();
     });
@@ -835,7 +835,7 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });
-    fireEvent.click(screen.getByTestId("developer-ct-row-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-field-search-page_title")).toBeTruthy();
     });
@@ -972,7 +972,7 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });
-    fireEvent.click(screen.getByTestId("developer-ct-row-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-wf-row-0")).toBeTruthy();
     });
@@ -1340,7 +1340,7 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });
-    fireEvent.click(screen.getByTestId("developer-ct-row-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-acl-table")).toBeTruthy();
     });
@@ -1389,7 +1389,7 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });
-    fireEvent.click(screen.getByTestId("developer-ct-row-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-acl-table")).toBeTruthy();
     });
@@ -1421,7 +1421,7 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });
-    fireEvent.click(screen.getByTestId("developer-ct-row-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-acl-table")).toBeTruthy();
     });
@@ -1473,7 +1473,7 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });
-    fireEvent.click(screen.getByTestId("developer-ct-row-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-acl-table")).toBeTruthy();
     });
@@ -1553,7 +1553,7 @@ it("loads views catalog section", async () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-table")).toBeTruthy();
     });
-    fireEvent.click(screen.getByTestId("developer-ct-row-0"));
+    fireEvent.click(screen.getByTestId("developer-ct-open"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-ct-acl-empty")).toBeTruthy();
     });

--- a/docs/ai-generated/code-reviews/3810-content-types-acl-detail-erlang.md
+++ b/docs/ai-generated/code-reviews/3810-content-types-acl-detail-erlang.md
@@ -1,0 +1,47 @@
+# Erlang review — #3810 Content Types first-row Object ACL detail
+
+**Branch:** `fix/issue-3810-content-types-acl-detail`  
+**Date:** 2026-08-27  
+**Reviewer:** Erlang (pre-commit, independent of implementer)
+
+## Summary
+
+Parent #3706 residual: catalog Jackson unwrap is on `main`, but first-row **Open**
+did not mount `[data-testid=developer-ct-detail]` / Object ACL. Causes addressed:
+
+1. **selectionKey** fell through to display `"—"` or missed JAXB-wrapped `name`,
+   so Open was missing or GET used a dummy key.
+2. Nested `<tr role="button">` + inner Open button (unlike Templates/Slots).
+3. `ObjectAclSection` only rendered after GET detail succeeded, so
+   `developer-ct-acl-section` was absent while loading / on GET failure.
+
+Fix: coerce name/label/description in unwrap; `contentTypeSelectionKey` (name then
+guid, never `"—"`); Open is button-only with `data-testid=developer-ct-open`;
+Object ACL mounts from `catalogGuid` immediately. Vitest covers helpers + Open
+navigation; Playwright clicks `developer-ct-open` and asserts detail + ACL.
+Product-docs step 3 documents Open + ACL on open.
+
+Memory patterns hit: Playwright companion for WebUI screen; product-docs for
+operator path; Jackson string wraps as React children / Open keys; nested
+interactive catalog rows.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Cross-platform path checklist
+
+Not applicable — no filesystem path/file I/O in the diff (JSON unwrap + React
+catalog/detail + Playwright selectors + Markdown).
+
+## Issues
+
+None blocking.
+
+- Vitest: `contentTypesApi` (58), `ContentTypesPanel` (13), `ContentTypeDetailPanel`
+  (53), `DeveloperShell` (38) — 162 passed focused run.
+- Change-class companions: WebUI SPA + Vitest + Playwright + product-docs.

--- a/modules/perc-qa-automation/frontend/tests/bugs/bug-3706-developer-content-types-catalog.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/bugs/bug-3706-developer-content-types-catalog.spec.js
@@ -108,16 +108,21 @@ test.describe("Developer Content Types catalog (#3706)", () => {
 
     const firstRow = page.locator(catalogRowSelector("developer-ct-row", 0));
     await expect(firstRow).toBeVisible({ timeout: 15_000 });
-    const openBtn = firstRow.locator("button");
+    const openBtn = firstRow.locator('[data-testid="developer-ct-open"]');
     await expect(
       openBtn,
       "first content-type row should expose Open when selectionKey is set",
     ).toBeVisible({ timeout: 5_000 });
     await openBtn.click();
 
-    await expect(page.locator('[data-testid="developer-ct-detail"]')).toBeVisible({
-      timeout: 20_000,
-    });
+    const detail = page.locator('[data-testid="developer-ct-detail"]');
+    const detailError = page.locator('[data-testid="developer-ct-detail-error"]');
+    await expect(detail.or(detailError).first()).toBeVisible({ timeout: 20_000 });
+    if (await detailError.isVisible()) {
+      const msg = (await detailError.innerText()).trim();
+      throw new Error(`Content type detail error after Open: ${msg}`);
+    }
+    await expect(detail).toBeVisible({ timeout: 5_000 });
     await expect(
       page.locator('[data-testid="developer-ct-acl-section"]'),
     ).toBeVisible({ timeout: 15_000 });

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -42,7 +42,9 @@ null-entry / default-selected writes are not in this chrome.
    rights for design lock/save).
 2. Open **Developer → Content types**, or deep-link
    `spa.jsp?entry=developer&section=content-types`.
-3. Open a catalog row.
+3. Click **Open** on a catalog row (the type label). The detail panel includes
+   **Object ACL** as soon as the type opens, including while the field catalog
+   is still loading.
 4. The **detail toolbar at the top of the panel** (sticky) shows **Lock**,
    **Save content type**, **Unlock**, and the **Enabled** checkbox. The type
    name and **Allowed templates** add/remove chrome are visible immediately


### PR DESCRIPTION
## Summary

Residual of **#3706** (Content Types catalog / Object ACL). Jackson `ContentTypeList` unwrap is already on `main` (PR #3776). Human QA still failed: first-row **Open** did not mount `[data-testid=developer-ct-detail]` (20s timeout).

This PR:

- Coerces JAXB-wrapped `name` / `label` / `description` so catalog **Open** has a real GET key (`contentTypeSelectionKey`: name then GUID, never `"—"`).
- Makes Open **button-only** (`data-testid=developer-ct-open`) — no nested `<tr role=button>` + inner button (Templates/Slots peer).
- Mounts **Object ACL** from `catalogGuid` as soon as the detail panel opens, without waiting for GET field catalog.
- Playwright `bug-3706-developer-content-types-catalog.spec.js` clicks `developer-ct-open` and asserts detail + ACL; Vitest covers unwrap, Open visibility, and ACL-before-GET.

Parent: #3706. Slice: #3810.

Fixes #3810  
Partial #3706

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 3213, Failures: 0.
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `qa-health` (port **9993** this run).
4. `python docker/scripts/perc-devctl.py qa-deploy-webui --skip-object-storage-check` (Vite 8 `mapDeps` entry does not match the deploy script’s `import"./developer-*.js"` regex; quoted `object-storage` **is** in `developer-*.js`).
5. `qa-health` again after copy.
6. `TEST_CMS_URL=http://127.0.0.1:9993` `npm run test:surface -- --path tests/bugs/bug-3706-developer-content-types-catalog.spec.js` — **1 passed**.
7. Also ran `tests/developer-object-acl-product-path.spec.js`: content-type ACL tests **passed**; unrelated view GUID (`#3380`) still reports `"—"` (pre-existing, not this slice).
8. `qa-down`.
9. Manual: Developer → Content types → **Open** on first row → detail + Object ACL (Design access / Runtime visibility) visible.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-content-types.md` (Open on catalog row; Object ACL visible as soon as the type opens)
- [x] **Unit / module tests** — Vitest for `asContentTypeText` / `contentTypeSelectionKey` / Open → detail + ACL-before-GET; WebUI standalone clean install 3213 tests
- [x] **WebUI + Playwright** — `tests/bugs/bug-3706-developer-content-types-catalog.spec.js` (H2 QA surface)
- [x] **Build gates** — standalone `mvnw clean install` on `WebUI` and `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — N/A (no filesystem path/file I/O; JSON unwrap + React + Playwright selectors)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI; ../mvnw.cmd clean install` → **BUILD SUCCESS**, Tests run: 3213, Failures: 0 (396 test files)
  - `cd modules/perc-qa-automation; ../../mvnw.cmd clean install` → **BUILD SUCCESS**, No tests to run (placeholder jar)
- **downstream_checked:** none (no Java `final`/public API shape change; SPA + tests + docs only)

### C5 UI live proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER:perc-matrix-cms-h2`
- `qa-health` → `RESULT:OK HTTP:200 HEALTH:healthy`
- Deploy: `qa-deploy-webui --skip-object-storage-check` (see test plan); `qa-health` again OK
- Playwright: `npm run test:surface -- --path tests/bugs/bug-3706-developer-content-types-catalog.spec.js` → **1 passed** (2.6s)
- **console-clean:** yes (spec asserts `pageerror` + related console errors empty)
- **server.log-clean:** yes (no ERROR/FATAL matching content type / contenttypes / ObjectAcl in the QA cell `server.log`)
- `qa-down` after the run

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
