### PR TITLE
fix(rest): Admin 403 and docs for CD-15 shared field catalog (#3929)

### DIFF
--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -2,7 +2,7 @@
 
 |  Field   |                                  Value                                   |
 |----------|--------------------------------------------------------------------------|
-| **Date** | 2026-07-28                                                               |
+| **Date** | 2026-08-28                                                               |
 | **FR**   | CD-01–CD-19 in `docs/developer-module/workbench-functional-inventory.md` |
 
 ## Surfaces available today
@@ -14,6 +14,8 @@
 | Public REST lock/unlock           | Self-only design-session lock       | `POST /services/contenttypes/{idOrName}/lock` / `.../unlock` |
 | Public REST PUT save              | Held-lock save (label/description/…) | `PUT /services/contenttypes/{idOrName}`        |
 | Public REST POST create           | Persist new type (Workbench Finish) | `POST /services/contenttypes`                  |
+| Public REST shared-field list     | CD-15 read catalog (Admin only)     | `GET /services/sharedfields`                   |
+| Public REST shared-field detail   | CD-15 read group fields (Admin only)| `GET /services/sharedfields/{idOrName}`        |
 | Design SOAP (Workbench)           | Full load/save/lock/create/delete   | `IPSContentDesignWs` / `ContentDesignSOAPImpl` |
 | Item def manager                  | Runtime CE definition cache         | `PSItemDefManager.getItemDef`                  |
 
@@ -52,7 +54,7 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 | Item-level pre/post exits & validations              | CD-09        | Properties tab                                    |
 | Edit workflow/template associations                  | CD-08, CD-12 | **CD-08 REST PUT .../allowedWorkflows** (#3763, held design lock); **CD-12 REST PUT .../allowedTemplates** (#3775, held design lock; full replace, empty list clears) |
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
-| Shared field file editing                            | CD-15        | Separate object                                   |
+| Shared field file **write**                          | CD-15        | **Read catalog shipped** (`GET /services/sharedfields` + `GET …/{idOrName}`, Admin 403, #3929 / PR #1650 list+detail). Create/rename/delete/save and SPA editor still open |
 | System def                                           | CD-16        | Separate object                                   |
 | Create / rename / delete                             | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Rename / delete still SOAP design only; lock + PUT save via REST |
 | Import/export CT                                     | CD-14        | Workbench wizards                                 |
@@ -66,7 +68,8 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 3. ~~Design-session lock + `PUT` save via thin REST over `IPSContentDesignWs`~~ **Lock** (#3742) + **PUT save requires held lock** (#3743)
 4. ~~Keyword create/update/delete~~ **Done CD-17** (REST write + design WS + SPA editor)
 5. ~~Control property value/choice catalogs~~ **Done CD-07 REST** (#3786). Field-rule write/save still open
-6. Templates/slots design editors
+6. ~~Shared field catalog read~~ **Done CD-15 read** (`GET /services/sharedfields`, Admin 403). Write still open
+7. Templates/slots design editors
 
 ## Client behavior
 

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -17,7 +17,10 @@ Admins cannot overwrite the same type at once.
 Integrators can **create** a content type with Admin `POST /services/contenttypes`
 (JSON `name` required; unique, no spaces). That call persists the type
 (Workbench Finish). This chrome does **not** include a create wizard; delete
-and rename are not supported here. See [REST API](id:developer-rest).
+and rename are not supported here. Shared field **files** are a separate design
+object: Admin-only `GET /services/sharedfields` and
+`GET /services/sharedfields/{idOrName}` (read catalog; write is not on REST).
+See [REST API](id:developer-rest).
 
 This is **not** the full Workbench field-rule editor. The detail table still
 shows rule **flags** (validation / visibility / transforms present). After

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -511,6 +511,52 @@ catalog. Choice filters, null-entry, and default-selected are not written.
 | `409` | No design lock, or locked by another user |
 | `500` | Unexpected error |
 
+## Shared fields (design catalog)
+
+Content-editor **shared field groups** (Workbench shared field files, CD-15) are a
+separate design object from content types. Public REST exposes a **read-only catalog**
+under `/services/sharedfields`. Load uses the same content **design** web service as
+Workbench (`IPSContentDesignWs.loadContentEditorSharedDef`).
+
+**Admin (Design) only.** There is no global JAX-RS Admin filter on this path — the
+sitemanage adaptor checks `IPSUserService.isAdminUser` for the current user and maps
+a non-Admin caller to **403**. Create, rename, delete, field-property write, and
+system-def (CD-16) remain unsupported.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/sharedfields` | List shared field groups (`name`, `filename`, `fieldCount`) |
+| `GET` | `/services/sharedfields/{idOrName}` | Load one group by **name** (case-insensitive). Shared groups have no numeric design id on this catalog. |
+
+`{idOrName}` is the shared field group name (for example a product set such as
+`shared`). Path separators and `..` are rejected as not found (**404**), not as a
+directory listing.
+
+### Response shape
+
+List entries use `SharedFieldGroupSummary`. Detail uses `SharedFieldGroupDetail`:
+
+- `name`, `filename`
+- `fields[]`: `name`, `dataType`, `searchable`, `required`, `readOnly`, `occurrence`
+  (`optional` / `required` / `oneOrMore` / `zeroOrMore` / `count` / `unknown`)
+- `designGaps[]` strings — write, control/choice edit, and system-def are later slices
+
+Prefer the generated OpenAPI schema as the integration source of truth.
+
+### Status codes and authorization
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | List (possibly empty) or group detail |
+| `403` | Caller is not Admin |
+| `404` | Group not found (unknown or unsafe name). Non-Admin callers receive **403**, not 404 |
+| `500` | Design service or server failure |
+
+Authenticated non-Admin sessions (Editor, Contributor, and similar) must not read this
+catalog. Callers should treat 403 as “no Design Admin rights,” not as a missing group.
+
+Write/save, lock, create, and delete of shared field files are **not** on this API.
+
 ## Templates (assembly catalog)
 
 Assembly templates used by Design and Developer are exposed under `/services/templates`.

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
@@ -25,31 +25,43 @@ import com.percussion.rest.sharedfields.ISharedFieldsAdaptor;
 import com.percussion.rest.sharedfields.SharedFieldGroupDetail;
 import com.percussion.rest.sharedfields.SharedFieldGroupSummary;
 import com.percussion.rest.sharedfields.SharedFieldSummary;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import com.percussion.webservices.content.PSContentWsLocator;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Read-only catalog of content-editor shared field groups ({@link PSContentEditorSharedDef}).
  *
  * <p>Workbench parity: loads via {@link IPSContentDesignWs#loadContentEditorSharedDef} (same design
  * web service SOAP uses), not {@code PSServer.getContentEditorSharedDef()} alone.
+ *
+ * <p>Admin (Design) only — same {@link IPSUserService#isAdminUser} gate as content-type design
+ * mutations. There is no global JAX-RS Admin filter on {@code /services/sharedfields}.
  */
 @PSSiteManageBean
 public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
 
   private static final Logger log = LogManager.getLogger(SharedFieldsAdaptor.class);
+
+  static final String ADMIN_REQUIRED = "Admin role required to read shared field groups";
 
   private static final List<String> DESIGN_GAPS =
       List.of(
@@ -58,6 +70,11 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
           "System def (global fields) is a separate catalog (later slice)");
 
   private final Supplier<PSContentEditorSharedDef> sharedDefLoader;
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   public SharedFieldsAdaptor() {
     this(
@@ -65,12 +82,26 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
             loadSharedDefFromDesignWs(
                 PSContentWsLocator.getContentDesignWebservice(),
                 (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID),
-                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER)));
+                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER)),
+        null);
   }
 
-  /** Package-visible for unit tests that inject a fake shared def source. */
+  /**
+   * Package-visible for unit tests that inject a fake shared def source. Admin is allowed so
+   * mapping tests can focus on catalog shape.
+   */
   SharedFieldsAdaptor(Supplier<PSContentEditorSharedDef> sharedDefLoader) {
+    this(sharedDefLoader, () -> true);
+  }
+
+  /**
+   * Package-visible for unit tests that inject a fake shared def source and Admin gate. {@code
+   * null} adminChecker uses {@link #isCurrentUserAdmin()}.
+   */
+  SharedFieldsAdaptor(
+      Supplier<PSContentEditorSharedDef> sharedDefLoader, BooleanSupplier adminChecker) {
     this.sharedDefLoader = sharedDefLoader;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   /**
@@ -90,6 +121,7 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
 
   @Override
   public List<SharedFieldGroupSummary> listGroups(URI baseUri) {
+    requireAdmin();
     // baseUri reserved for HATEOAS
     PSContentEditorSharedDef def = loadSharedDef();
     return mapSummaries(def);
@@ -97,6 +129,7 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
 
   @Override
   public SharedFieldGroupDetail getGroup(URI baseUri, String name) {
+    requireAdmin();
     if (!isSafeGroupName(name)) {
       return null;
     }
@@ -106,6 +139,41 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
       return null;
     }
     return toDetail(group);
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  /**
+   * Production Admin check via {@link IPSUserService}. Used when Spring wires the no-arg ctor and
+   * {@link #adminChecker} is the instance method reference.
+   */
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
   }
 
   private PSContentEditorSharedDef loadSharedDef() {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
@@ -39,7 +39,9 @@ import com.percussion.rest.sharedfields.SharedFieldGroupSummary;
 import com.percussion.util.PSCollection;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.content.IPSContentDesignWs;
+import jakarta.ws.rs.WebApplicationException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -172,5 +174,67 @@ class SharedFieldsAdaptorTest {
     SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(() -> def);
     assertNotNull(adaptor.listGroups(null));
     assertTrue(adaptor.listGroups(null).isEmpty());
+  }
+
+  @Test
+  void listGroups_forbiddenWhenNotAdmin() {
+    AtomicInteger loads = new AtomicInteger();
+    SharedFieldsAdaptor denied =
+        new SharedFieldsAdaptor(
+            () -> {
+              loads.incrementAndGet();
+              return mock(PSContentEditorSharedDef.class);
+            },
+            () -> false);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.listGroups(null));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertEquals(SharedFieldsAdaptor.ADMIN_REQUIRED, ex.getMessage());
+    assertEquals(0, loads.get());
+  }
+
+  @Test
+  void getGroup_forbiddenWhenNotAdmin() {
+    AtomicInteger loads = new AtomicInteger();
+    SharedFieldsAdaptor denied =
+        new SharedFieldsAdaptor(
+            () -> {
+              loads.incrementAndGet();
+              return mock(PSContentEditorSharedDef.class);
+            },
+            () -> false);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.getGroup(null, "shared"));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertEquals(SharedFieldsAdaptor.ADMIN_REQUIRED, ex.getMessage());
+    assertEquals(0, loads.get());
+  }
+
+  @Test
+  void requireAdmin_mapsCheckerFailureTo403() {
+    SharedFieldsAdaptor denied =
+        new SharedFieldsAdaptor(
+            () -> mock(PSContentEditorSharedDef.class),
+            () -> {
+              throw new IllegalStateException("user service down");
+            });
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.listGroups(null));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertEquals(SharedFieldsAdaptor.ADMIN_REQUIRED, ex.getMessage());
+  }
+
+  @Test
+  void listGroups_forbiddenWhenAdminCheckerFallsBackAndUserServiceMissing() {
+    SharedFieldsAdaptor denied =
+        new SharedFieldsAdaptor(() -> mock(PSContentEditorSharedDef.class), null);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.listGroups(null));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertFalse(denied.isCurrentUserAdmin());
   }
 }

--- a/rest/src/main/java/com/percussion/rest/sharedfields/ISharedFieldsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/ISharedFieldsAdaptor.java
@@ -27,6 +27,7 @@ public interface ISharedFieldsAdaptor {
    *
    * @param baseUri reserved for HATEOAS
    * @return group summaries, never {@code null}
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin
    */
   List<SharedFieldGroupSummary> listGroups(URI baseUri);
 
@@ -34,6 +35,7 @@ public interface ISharedFieldsAdaptor {
    * Load one shared field group by name (case-insensitive).
    *
    * @return detail, or {@code null} when not found / unsafe name
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin
    */
   SharedFieldGroupDetail getGroup(URI baseUri, String name);
 }

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldsResource.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldsResource.java
@@ -65,8 +65,8 @@ public class SharedFieldsResource {
   @Operation(
       summary = "List shared field groups",
       description =
-          "Lists shared field groups from the content-editor shared definition. Create/edit/delete"
-              + " are later slices.",
+          "Lists shared field groups from the content-editor shared definition. Admin (Design)"
+              + " only. Create/edit/delete are later slices.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -76,6 +76,7 @@ public class SharedFieldsResource {
                     array =
                         @ArraySchema(
                             schema = @Schema(implementation = SharedFieldGroupSummary.class)))),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public List<SharedFieldGroupSummary> listGroups() {
@@ -94,13 +95,14 @@ public class SharedFieldsResource {
   @Operation(
       summary = "Get shared field group detail",
       description =
-          "Loads one shared field group by name (read-only). Includes field catalog; write and"
-              + " system-def editor remain unsupported (see designGaps).",
+          "Loads one shared field group by name (read-only, Admin/Design only). Includes field"
+              + " catalog; write and system-def editor remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
             description = "OK",
             content = @Content(schema = @Schema(implementation = SharedFieldGroupDetail.class))),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
         @ApiResponse(responseCode = "404", description = "Group not found"),
         @ApiResponse(responseCode = "500", description = "Error")
       })

--- a/rest/src/test/java/com/percussion/rest/sharedfields/SharedFieldsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sharedfields/SharedFieldsResourceTest.java
@@ -115,4 +115,24 @@ public class SharedFieldsResourceTest {
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
   }
+
+  @Test
+  public void listGroupsForbiddenWhenNotAdmin() {
+    when(adaptor.listGroups(any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.listGroups());
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getGroupForbiddenWhenNotAdmin() {
+    when(adaptor.getGroup(any(), eq("shared")))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getGroup("shared"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSharedFieldsAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSharedFieldsAdaptor.java
@@ -28,6 +28,9 @@ import org.springframework.stereotype.Component;
 /**
  * Spring test stub for {@link ISharedFieldsAdaptor}. Required for ApplicationContext load after
  * constructor injection on {@code SharedFieldsResource}.
+ *
+ * <p>Admin 403 is <em>not</em> a global JAX-RS filter; production {@code SharedFieldsAdaptor}
+ * enforces it. This stub is only a Spring bean for {@code MainTest} and does not model AuthZ.
  */
 @Component
 @Lazy


### PR DESCRIPTION
## Summary

Closes leftover **CD-15 shared field catalog read** acceptance on parent [#1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690) / slice [#3929](https://github.com/intersoftdatalabs-in/percussioncms/issues/3929).

`GET /services/sharedfields` and `GET /services/sharedfields/{idOrName}` list+detail already shipped on `main` (PR #1650). This PR does **not** re-implement that catalog. It adds:

- **Admin (Design) 403** in `SharedFieldsAdaptor` via `IPSUserService.isAdminUser` (peer `ContentTypeAdaptor.requireAdmin`). There is **no** global JAX-RS Admin filter on this path — proven with adaptor + resource tests (non-Admin never loads the shared def).
- OpenAPI `@ApiResponse 403` on list and detail; resource rethrows `WebApplicationException` (not wrapped as 500).
- **product-docs 8.2** Developer REST section for the two GETs; brief cross-link from Developer Content Types.
- Gap map: CD-15 **read shipped**, write still open.

Write/create/delete, lock, system def (CD-16), and SPA chrome stay out of scope.

**Residual (parent #1690):** [#3944](https://github.com/intersoftdatalabs-in/percussioncms/issues/3944) REST CD-15 shared field write.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3929
Partial #1690

## Test plan

1. Review adaptor tests: `listGroups_forbiddenWhenNotAdmin`, `getGroup_forbiddenWhenNotAdmin`, checker failure → 403, missing `IPSUserService` → 403.
2. Review Mockito resource tests: list/detail 403 is not remapped to 500.
3. Spring `TestSharedFieldsAdaptor` stub still satisfies `MainTest` ApplicationContext (AuthZ is production adaptor, not a global filter).
4. Standalone `mvnw clean install` in `rest` then `projects/sitemanage`.
5. Product-docs smoke: `scripts\ci-smoke-product-docs.bat`.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/rest.md` Shared fields section; cross-link in `admin/developer-content-types.md`)
- [x] **Unit / module tests** — behavioral 403 tests; `rest` and `projects/sitemanage` green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); C2 reverse-deps N/A (no `final`/signature change)
- [x] **Cross-platform** — N/A (no path/file I/O)

### Product-docs pointers

- Gate: root `AGENTS.md` → **Product documentation (HARD GATE)**
- Tree: `product-docs/README.md` (layout, frontmatter `id` stability, build smoke)
- Smoke: `scripts\ci-smoke-product-docs.bat` → OK (`tmp/product-docs-site/8.2/index.html`)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 670, Failures: 0, Errors: 0, Skipped: 0 (`SharedFieldsResourceTest` Tests run: 8)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 1597, Failures: 0, Errors: 0, Skipped: 125 (`SharedFieldsAdaptorTest` Tests run: 13)
- **downstream_checked:** none (C2 did not apply: no `final`/`sealed` type, no public/protected method or ctor signature change; `ISharedFieldsAdaptor` methods unchanged)
- **C5 UI proof:** N/A — REST/docs only; no WebUI/Playwright surface

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
