### PR TITLE
cluster: CD-01 content type REST create/rename/delete (#3919 #3920 #3936)

### DIFF
--- a/docs/ai-generated/code-reviews/3914-rest-cd01-rename-content-type-erlang.md
+++ b/docs/ai-generated/code-reviews/3914-rest-cd01-rename-content-type-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — issue #3914 REST CD-01 rename content type
+
+**Branch:** `fix/issue-3914-rest-cd01-rename-content-type`  
+**Date:** 2026-08-27  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class completeness (rest resource + adaptor interface + sitemanage impl + Mockito resource tests + Spring `TestContentTypeAdaptor` stub + sitemanage adaptor tests + product-docs); lock-typed 409 vs message sniffing; bulk PUT must not silently overload name.
+
+## Summary
+
+Dedicated `PUT /services/contenttypes/{idOrName}/name` under a held design-session lock. Bulk PUT still ignores name. Unique (case-insensitive) new name; spaces/wildcards/invalid chars 400; unlocked/other locker 409. GET by old name 404; GET by id returns new name.
+
+## Issues
+
+None (hard-gate).
+
+### Notes (non-blocking)
+
+- Uniqueness scans `findContentTypes("*")` (same catalog used by list). Acceptable for this design surface.
+- Application/editor URL rewrite is delegated to existing `PSContentTypeHelper.saveContentType` after `PSItemDefinition.setName`.
+- No filesystem path I/O in this change. Cross-platform path checklist: N/A (clean).
+
+## Tests
+
+- rest `ContentTypesResourceDetailTest` rename 200/400/404/409/403
+- rest Spring stub `TestContentTypeAdaptor.renameContentType`
+- sitemanage `ContentTypeAdaptorRenameTest` persist, GET old/new, lock, spaces, collision, same-name, admin, wildcards
+
+## Builds
+
+- `rest`: `mvnw.cmd clean install` BUILD SUCCESS — Tests run: 663, Failures: 0
+- `projects/sitemanage`: `mvnw.cmd clean install` BUILD SUCCESS — Tests run: 1649, Failures: 0, Skipped: 125; `ContentTypeAdaptorRenameTest` 13 passed
+
+## C2 downstream
+
+Interface method added on `IContentTypesAdaptor`. Grep `implements IContentTypesAdaptor`: rest test stubs + sitemanage `ContentTypeAdaptor` (all updated). sitemanage standalone install green.
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/docs/ai-generated/code-reviews/issue-3913-rest-cd01-delete-content-types-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3913-rest-cd01-delete-content-types-erlang.md
@@ -1,0 +1,32 @@
+# Erlang review — #3913 REST CD-01 DELETE content types
+
+**Branch:** `feat/issue-3913-rest-cd01-delete-content-types`  
+**Scope:** uncommitted vs `origin/main` (rest, sitemanage, product-docs)  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** rest+sitemanage change-class companions (resource + IXxxAdaptor + Spring test stub + apibridge impl + adaptor unit tests); Workbench replacement via IPS*DesignWs; product-docs REST note for public surface; do not steal design locks (409).
+
+## Summary
+
+Adds Admin-only `DELETE /services/contenttypes/{idOrName}` that requires a **held** design-session lock (peer PUT save / enabled):
+
+- Adaptor: `IPSContentDesignWs.deleteContentTypes(..., ignoreDependencies=false)`
+- 409 unlocked / other locker (`ContentTypeDesignLockException`); 404 missing; 403 non-Admin
+- 400 when design WS rejects in-use types (dependents); no item cascade
+- Does not steal locks; does not implement POST create/rename or SPA chrome
+
+## Issues
+
+None that block. Inner design-WS `IllegalStateException` is rethrown (not rewrapped) so 500 bodies keep the error map. `CT_CREATE_DELETE` gap **code** is kept stable; message now documents DELETE + remaining create/rename gap.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path I/O.
+
+## Tests / companions
+
+- Mockito: `ContentTypesResourceDetailTest` DELETE 204/400/403/404/409
+- Spring stub: `TestContentTypeAdaptor` (+ `ContentTypesTestAdaptor`)
+- Adaptor: `ContentTypeAdaptorDeleteTest` (held lock, other-user 409, missing 404, dependents 400, Admin 403)
+- product-docs/8.2/developer/rest.md + admin/developer-content-types.md
+- Standalone `rest` then `projects/sitemanage` `mvnw clean install` green

--- a/docs/ai-generated/code-reviews/issue-3913-rest-cd01-delete-content-types-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3913-rest-cd01-delete-content-types-erlang.md
@@ -25,8 +25,30 @@ N/A — no filesystem path I/O.
 
 ## Tests / companions
 
-- Mockito: `ContentTypesResourceDetailTest` DELETE 204/400/403/404/409
+- Mockito: `ContentTypesResourceDetailTest` DELETE 204/400/403/404/409/500
 - Spring stub: `TestContentTypeAdaptor` (+ `ContentTypesTestAdaptor`)
-- Adaptor: `ContentTypeAdaptorDeleteTest` (held lock, other-user 409, missing 404, dependents 400, Admin 403)
+- Adaptor: `ContentTypeAdaptorDeleteTest` (held lock, other-user 409, missing 404, dependents 400, Admin 403, blank-before-session 404)
 - product-docs/8.2/developer/rest.md + admin/developer-content-types.md
 - Standalone `rest` then `projects/sitemanage` `mvnw clean install` green
+
+## Re-review (PR #3919 kilo-code-bot threads)
+
+**Scope:** uncommitted follow-up vs HEAD (`deleteContentType` order, `CT_CREATE_DELETE` path wording, resource 500 test).  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for validation-order and shared error mapping; REST-GAPS-01 message consistency.
+
+### Changes
+
+- Blank `idOrName` now returns null (HTTP 404) **before** `requireSessionUserForLock()` (matches lock/unlock). No-session + blank is no longer 403.
+- `CT_CREATE_DELETE` message uses `/contenttypes` (no `/services` prefix) for both Create and DELETE, matching `CT_ITEM_EXITS`.
+- Resource `deleteContentTypeGenericFailureIs500` covers `mapMutationFailure` `IllegalStateException` → 500 (name `percBlockquote` must not become 409).
+
+### Issues
+
+None that block. `setContentTypeEnabled` still checks session before blank; that method is out of this PR's review threads and already returns 400 after session. No public method/ctor signature change. Cross-platform path checklist N/A.
+
+### Evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 676, Failures: 0 (`ContentTypesResourceDetailTest` 69/0)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1676, Failures: 0, Skipped: 125 (`ContentTypeAdaptorDeleteTest` 11/0)

--- a/docs/ai-generated/code-reviews/issue-3926-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3926-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review — issue #3926 REST CD-01 create content type (docs + reserved)
+
+**Date:** 2026-08-27  
+**Branch:** `feat/issue-3926-rest-cd01-create-content-type`  
+**Scope:** uncommitted vs `HEAD` (based on `origin/main`)  
+**Memory patterns hit:** Change-class closure (product-docs companion after cluster absorb); typed 409 vs message-substring; exact implementors of `IContentTypesAdaptor`
+
+## Summary
+
+CD-01 `POST /services/contenttypes` already shipped on main via #3912 / PR #3918 (`IPSContentDesignWs.createContentTypes` then `saveContentTypes`). Cluster absorb #3923 dropped the Create row and create status codes from `product-docs/8.2/developer/rest.md`. This change restores that integrator documentation, notes reserved system types such as Folder as **409** collisions (SOAP `createContentType("Folder")` peer), and adds resource + adaptor tests for Folder plus create-then-GET. Does **not** remap collision to 400 (would regress the shipped 409 contract). No SPA chrome, rename, or DELETE.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs, missing behavioral tests, or non-portable path/file I/O.
+
+## Change-class closure
+
+| Companion | Status |
+|-----------|--------|
+| rest resource + OpenAPI | yes (description/409 text only; POST already on main) |
+| `IContentTypesAdaptor.createContentType` | javadoc only (no signature change) |
+| Mockito `ContentTypesResourceDetailTest` | reserved Folder 409 |
+| Spring stubs `TestContentTypeAdaptor` + `ContentTypesTestAdaptor` | already implement `createContentType` |
+| sitemanage `ContentTypeAdaptor` | already on main; tests added |
+| sitemanage adaptor tests | `ContentTypeAdaptorCreateTest` Folder 409 + create-then-GET |
+| product-docs 8.2 | `developer/rest.md` Create row restored; admin Content Types 400/403/409 |
+| rest → sitemanage Maven edge | none |
+| C2 implementors | grep `implements IContentTypesAdaptor` — 3 types; no signature change; no anonymous subclasses |
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction, temp files, or path assertions.
+
+## Issues
+
+None (blocking).
+
+## Nits (non-blocking)
+
+- Issue #3926 triage asked for collision **400**. Shipped #3918 uses **409** (REST Conflict vs invalid name 400). This PR keeps 409 and documents Folder as catalog collision.
+
+## Builds
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 669, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1667, Failures: 0, Skipped: 125
+- `scripts\ci-smoke-product-docs.bat` — OK

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -57,7 +57,8 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
 | Shared field file **write**                          | CD-15        | **Create/save/delete shipped** (`POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}`, Admin 403, lock 409, #3944). Field create/delete, control/choice write, and SPA editor still open |
 | System def                                           | CD-16        | Separate object                                   |
-| Create / rename / delete                             | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Rename / delete still SOAP design only; lock + PUT save via REST |
+| Create / delete                                      | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Delete still SOAP design only; lock + PUT save via REST |
+| Rename                                               | CD-01, §5.2  | **REST `PUT /contenttypes/{id}/name`** (#3914, held design lock; unique, no spaces; bulk PUT does not rename) |
 | Import/export CT                                     | CD-14        | Workbench wizards                                 |
 | ACL                                                  | CD-19, §5.4  | Existing ACL REST may help later                  |
 | ~~Keyword write~~                                    | CD-17        | **Done** — REST + SPA + design WS (#1612/#1701)   |

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -198,6 +198,18 @@ type is available for runtime use.
    product does **not** steal the lock, Save stays disabled, and **Enabled**
    remains read-only.
 
+## Delete a content type (REST)
+
+The Developer Content types chrome does **not** expose delete in this release.
+Integrators delete a type over REST after holding the design-session lock:
+
+1. `POST /services/contenttypes/{idOrName}/lock` as **Admin**.
+2. `DELETE /services/contenttypes/{idOrName}`. Success is **204**. The lock is
+   not stolen if another user holds it (**409**). Missing types are **404**.
+3. A following `GET /services/contenttypes/{idOrName}` is **404**.
+4. Types that still have dependents fail with **400**. The product does **not**
+   cascade-delete items. Rename remains out of scope.
+
 ## REST
 
 The chrome calls:
@@ -217,6 +229,7 @@ The chrome calls:
 | Load field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` |
 | Save field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` (held lock; full replace of validation, visibility, inputTranslation, outputTranslation) |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` |
+| Delete | `DELETE /services/contenttypes/{idOrName}` (Admin; held lock; 204; 409 if unlocked or another user holds the lock; 400 if dependents; no SPA chrome) |
 
 Integrator notes: [REST API — Content types](id:developer-rest). Object ACL on
 the same detail panel: [Object ACL & default template](id:admin-object-acl).

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -15,10 +15,13 @@ for fields, allowed workflows, allowed templates, **item-level exits**, **contro
 Admins cannot overwrite the same type at once.
 
 Integrators can **create** a content type with Admin `POST /services/contenttypes`
-(JSON `name` required; unique, no spaces). That call persists the type
-(Workbench Finish). This chrome does **not** include a create wizard; delete
-and rename are not supported here. Shared field **files** are a separate design
-object: Admin-only `GET /services/sharedfields` and
+(JSON `name` required; unique, no spaces; optional `label` / `description`).
+That call persists the type (Workbench Finish). A successful create is then
+`GET /services/contenttypes/{name}` **200**. Duplicate or reserved system names
+(for example **Folder**) are **409**. Invalid names (blank, spaces, wildcard)
+are **400**. Non-Admin callers are **403**. This chrome does **not** include a
+create wizard; rename and delete are REST-only (no SPA chrome). Shared field
+**files** are a separate design object: Admin-only `GET /services/sharedfields` and
 `GET /services/sharedfields/{idOrName}` (catalog), plus
 `POST /services/sharedfields`, `PUT /services/sharedfields/{idOrName}`, and
 `DELETE /services/sharedfields/{idOrName}` (create / save / delete; the shared

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, enable or disable, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
+description: Lock, enable or disable, rename via REST, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -198,6 +198,22 @@ type is available for runtime use.
    product does **not** steal the lock, Save stays disabled, and **Enabled**
    remains read-only.
 
+## Rename a content type (REST)
+
+Developer Content Type chrome does **not** rename the type. Integrators rename
+with REST after a held design-session lock:
+
+1. `POST /services/contenttypes/{idOrName}/lock`
+2. `PUT /services/contenttypes/{idOrName}/name` with Jackson root
+   `ContentTypeName` (`name` required). The new name must be unique
+   (case-insensitive) and must not contain spaces.
+3. `GET /services/contenttypes/{id}` returns the new name. `GET` by the
+   previous name is **404**.
+4. `POST .../unlock` when done.
+
+Bulk `PUT /services/contenttypes/{idOrName}` still does **not** change name.
+Unlocked or another user's lock is **409**. Collision or spaces is **400**.
+
 ## Delete a content type (REST)
 
 The Developer Content types chrome does **not** expose delete in this release.
@@ -208,7 +224,7 @@ Integrators delete a type over REST after holding the design-session lock:
    not stolen if another user holds it (**409**). Missing types are **404**.
 3. A following `GET /services/contenttypes/{idOrName}` is **404**.
 4. Types that still have dependents fail with **400**. The product does **not**
-   cascade-delete items. Rename remains out of scope.
+   cascade-delete items.
 
 ## REST
 
@@ -219,6 +235,7 @@ The chrome calls:
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
 | Save (label, description, fields) | `PUT /services/contenttypes/{idOrName}` (requires a held lock; does not send `enabled`, `allowedWorkflows`, or `allowedTemplates`) |
 | Enable / disable | `PUT /services/contenttypes/{idOrName}/enabled` (CD-13; requires a held lock; does not acquire or release it) |
+| Rename | `PUT /services/contenttypes/{idOrName}/name` (CD-01; Admin; held lock; unique name, no spaces; bulk PUT does not rename) |
 | Save allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (requires a held lock; does not unlock) |
 | Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` (held lock; full replace) |
 | Confirm allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` |

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -190,6 +190,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Operation | Path | Notes |
 |-----------|------|--------|
 | List | `GET /services/contenttypes` | Name, label, description, guid |
+| Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. Duplicate name is **409** (catalog check and persist-time unique-name failure). Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Rename remains unsupported. |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `enabled`, `designGaps` |
 | Allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` | Read-only list of associated templates (CD-12). No lock required. Empty list means none. Same set as `ContentTypeDetail.allowedTemplates`. |
 | Item-level exits | `GET /services/contenttypes/{idOrName}/itemExits` | Item-level input/output translations, validations, and pipe pre/post exits (CD-09). No lock required. Empty lists mean none. Apply-when conditions are a read-only summary. Jackson root wrap is `ContentTypeItemExits`. |
@@ -204,19 +205,20 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | Field-level validation, visibility, and input/output translation expressions (CD-05–07). No lock required. Empty lists mean none. Unknown field is **404**. Jackson root wrap is `ContentTypeFieldRuleExpressions`. |
 | Replace field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | **Admin** (CD-05–07). Requires a **held** design-session lock. Full replace of `validation`, `visibility`, `inputTranslation`, and `outputTranslation` (empty lists clear). Unknown field names are **400**. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
+| Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. Rename remains out of scope. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. SPA create-wizard chrome is not part of this API. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
 
-Lock / save / unlock status codes:
+Lock / save / unlock / create / delete status codes:
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Lock acquired (body is `ObjectLockSummary`) or PUT save / enable / disable succeeded (lock still held) |
-| `204` | Unlock success |
-| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag) |
-| `403` | Caller is not Admin |
+| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable succeeded (lock still held), or POST create succeeded (`ContentTypeDetail`) |
+| `204` | Unlock success, or content type deleted |
+| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag), invalid create name (blank, spaces, wildcard), or DELETE rejected because the type has dependents |
+| `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found |
-| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen) |
+| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time) |
 | `500` | Design service or server failure |
 
 ### Enable or disable (CD-13)

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -190,36 +190,69 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Operation | Path | Notes |
 |-----------|------|--------|
 | List | `GET /services/contenttypes` | Name, label, description, guid |
-| Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. Duplicate name is **409** (catalog check and persist-time unique-name failure). Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Rename remains unsupported. |
+| Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. Duplicate name is **409** (catalog check and persist-time unique-name failure). Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Rename uses `PUT .../name`. Delete uses `DELETE .../{idOrName}`. |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `enabled`, `designGaps` |
 | Allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` | Read-only list of associated templates (CD-12). No lock required. Empty list means none. Same set as `ContentTypeDetail.allowedTemplates`. |
 | Item-level exits | `GET /services/contenttypes/{idOrName}/itemExits` | Item-level input/output translations, validations, and pipe pre/post exits (CD-09). No lock required. Empty lists mean none. Apply-when conditions are a read-only summary. Jackson root wrap is `ContentTypeItemExits`. |
 | Replace item-level exits | `PUT /services/contenttypes/{idOrName}/itemExits` | Full replace of item-level translations/validations via `IPSContentDesignWs.saveContentTypes` (CD-09). Requires a **held** design-session lock. Empty lists clear. **409** if unlocked or locked by another user. **400** if required lists are missing or an extension FQN is invalid. `preExits`/`postExits` omitted leave pipe extensions unchanged. Apply-when is not written. Does not acquire or release the lock. |
 | Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` | Full replace of associated templates (CD-12). Requires a **held** design-session lock. Empty list clears associations. **409** if unlocked or locked by another user. **400** if a template name/guid cannot be resolved. Does not acquire or release the lock. |
 | Lock | `POST /services/contenttypes/{idOrName}/lock` | **Admin.** Self-only design-session lock (`IPSContentDesignWs.loadContentTypes` with `lock=true`, `overrideLock=false`). Does **not** save. `200` + `ObjectLockSummary` (`session`, `locker`, `remainingTime` minutes from the lock service). Locks expire after **30 minutes** (`PSObjectLock.LOCK_INTERVAL`). Re-lock by the same session user extends the lock. |
-| Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions use the dedicated path below (not this PUT). |
+| Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** change name (use `PUT .../name`). Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions use the dedicated path below (not this PUT). |
 | Allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` | **Admin** (CD-08 design action). Requires a held design-session lock (`POST .../lock` first). Does **not** acquire or release the lock. Full replace of `allowedWorkflows` (empty list clears). Optional `defaultWorkflow`. Workflow name/guid must exist. `200` + `ContentTypeDetail` with the new `allowedWorkflows` / `defaultWorkflow` (lock still held). |
 | Enable/disable | `PUT /services/contenttypes/{idOrName}/enabled` | **Admin** (CD-13 design action). Requires a held design-session lock — `POST .../lock` first, then `PUT .../enabled`, then `POST .../unlock` when done. Does **not** acquire or release the lock. `200` + `ContentTypeDetail` with the new `enabled` value (lock still held). |
+| Rename | `PUT /services/contenttypes/{idOrName}/name` | **Admin** (CD-01). Requires a **held** design-session lock. Sets the internal name. Unique (case-insensitive); **no spaces** or wildcards. Bulk `PUT .../{idOrName}` does **not** change name. After success, `GET` by the previous name is **404**; `GET` by id returns the new name. Does not acquire or release the lock. |
 | Field control properties | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | Control parameter **name/value** pairs and the choice catalog for one field (CD-07). No lock required. Empty `properties` means none. `choices` omitted when none. |
 | Replace field control properties | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | **Admin** (CD-07). Requires a **held** design-session lock. Full replace of `properties` (empty clears). `choices` omitted leaves the catalog unchanged; `type: none` clears. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | Field-level validation, visibility, and input/output translation expressions (CD-05–07). No lock required. Empty lists mean none. Unknown field is **404**. Jackson root wrap is `ContentTypeFieldRuleExpressions`. |
 | Replace field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | **Admin** (CD-05–07). Requires a **held** design-session lock. Full replace of `validation`, `visibility`, `inputTranslation`, and `outputTranslation` (empty lists clear). Unknown field names are **400**. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
-| Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. Rename remains out of scope. |
+| Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. SPA create-wizard chrome is not part of this API. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
 
-Lock / save / unlock / create / delete status codes:
+Lock / save / unlock / create / rename / delete status codes:
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable succeeded (lock still held), or POST create succeeded (`ContentTypeDetail`) |
+| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / rename succeeded (lock still held), or POST create succeeded (`ContentTypeDetail`) |
 | `204` | Unlock success, or content type deleted |
-| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag), invalid create name (blank, spaces, wildcard), or DELETE rejected because the type has dependents |
+| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid or colliding rename), invalid create name (blank, spaces, wildcard), or DELETE rejected because the type has dependents |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found |
 | `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time) |
 | `500` | Design service or server failure |
+
+### Rename (CD-01)
+
+`PUT /services/contenttypes/{idOrName}/name` changes the content type **internal
+name**. This is a dedicated design action. Bulk `PUT /services/contenttypes/{idOrName}`
+does **not** rename. Hold the design-session lock first; the rename keeps the lock
+so you can continue editing, then unlock.
+
+Typical flow: `POST .../lock` → `PUT .../name` → (optional further design writes)
+→ `POST .../unlock`.
+
+The new name must be unique (case-insensitive) and must not contain spaces or
+wildcards (`*` / `%`). Allowed characters are letters, digits, underscore, and
+dot. A colliding or invalid name is **400**. An unlocked type (or a lock held by
+another user) is **409** — the lock is not stolen.
+
+After a successful rename:
+
+* `GET /services/contenttypes/{id}` returns `200` with the new `name`.
+* `GET /services/contenttypes/{oldName}` returns **404**.
+
+Jackson root wrap:
+
+```json
+{
+  "ContentTypeName": {
+    "name": "percRenamedPage"
+  }
+}
+```
+
+Create and delete of content types remain unsupported on this REST surface.
 
 ### Enable or disable (CD-13)
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -190,7 +190,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Operation | Path | Notes |
 |-----------|------|--------|
 | List | `GET /services/contenttypes` | Name, label, description, guid |
-| Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. Duplicate name is **409** (catalog check and persist-time unique-name failure). Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Rename uses `PUT .../name`. Delete uses `DELETE .../{idOrName}`. |
+| Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. The new type is then `GET /services/contenttypes/{name}` **200**. Duplicate name is **409** (catalog check and persist-time unique-name failure), including reserved system types such as **Folder**. Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Non-Admin is **403**. Rename uses `PUT .../name`. Delete uses `DELETE .../{idOrName}`. |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `enabled`, `designGaps` |
 | Allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` | Read-only list of associated templates (CD-12). No lock required. Empty list means none. Same set as `ContentTypeDetail.allowedTemplates`. |
 | Item-level exits | `GET /services/contenttypes/{idOrName}/itemExits` | Item-level input/output translations, validations, and pipe pre/post exits (CD-09). No lock required. Empty lists mean none. Apply-when conditions are a read-only summary. Jackson root wrap is `ContentTypeItemExits`. |
@@ -219,7 +219,7 @@ Lock / save / unlock / create / rename / delete status codes:
 | `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid or colliding rename), invalid create name (blank, spaces, wildcard), or DELETE rejected because the type has dependents |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found |
-| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time) |
+| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time), including reserved system types such as Folder |
 | `500` | Design service or server failure |
 
 ### Rename (CD-01)

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -439,7 +439,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add(
         DesignGap.of(
             "CT_CREATE_DELETE",
-            "Create via POST /services/contenttypes. DELETE /contenttypes/{idOrName} requires a held"
+            "Create via POST /contenttypes. DELETE /contenttypes/{idOrName} requires a held"
                 + " design lock. Rename not supported; PUT save requires a held design lock for"
                 + " label/description/enabled, field searchable/occurrence, workflows (+ default),"
                 + " and templates"));
@@ -606,10 +606,10 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   @Override
   public Boolean deleteContentType(URI baseUri, String idOrName) {
     requireAdmin();
-    requireSessionUserForLock();
     if (StringUtils.isBlank(idOrName)) {
       return null;
     }
+    requireSessionUserForLock();
     String trimmed = idOrName.trim();
     if (trimmed.contains("*")) {
       throw new IllegalArgumentException("idOrName must not contain wildcards");

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -316,7 +316,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    *
    * @param includeDisabledFromStore when {@code true}, a cache miss falls back to the
    *     object store so disabled types (unregistered from the editor cache) still load.
-   *     Only GET detail and enable/disable (CD-13) pass {@code true}; other callers keep
+   *     GET detail, enable/disable (CD-13), and DELETE pass {@code true}; other callers keep
    *     the pre-CD-13 cache-only 404 for disabled types.
    */
   private PSItemDefinition resolveItemDef(String idOrName, boolean includeDisabledFromStore)
@@ -439,7 +439,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add(
         DesignGap.of(
             "CT_CREATE_DELETE",
-            "Create via POST /services/contenttypes. Delete / rename not supported; PUT save requires a held design lock for"
+            "Create via POST /services/contenttypes. DELETE /contenttypes/{idOrName} requires a held"
+                + " design lock. Rename not supported; PUT save requires a held design lock for"
                 + " label/description/enabled, field searchable/occurrence, workflows (+ default),"
                 + " and templates"));
     gaps.add(
@@ -600,6 +601,51 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     }
     systemDesign.releaseLocks(Collections.singletonList(ctGuid), session, user);
     return Boolean.TRUE;
+  }
+
+  @Override
+  public Boolean deleteContentType(URI baseUri, String idOrName) {
+    requireAdmin();
+    requireSessionUserForLock();
+    if (StringUtils.isBlank(idOrName)) {
+      return null;
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      PSItemDefinition current = resolveItemDef(trimmed, true);
+      if (current == null) {
+        return null;
+      }
+      IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
+      requireHeldLock(ctGuid, "Could not delete content type");
+      try {
+        designSvc.deleteContentTypes(Collections.singletonList(ctGuid), false, session, user);
+      } catch (PSErrorsException e) {
+        if (isNotLockedError(e) || hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not delete content type");
+        }
+        String details = formatSaveErrors(e);
+        if (isDeleteDependencyFailure(e)) {
+          throw new IllegalArgumentException("Could not delete content type: " + details, e);
+        }
+        log.error("Failed to delete content type {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to delete content type: " + details, e);
+      }
+      return Boolean.TRUE;
+    } catch (IllegalArgumentException | IllegalStateException | WebApplicationException e) {
+      throw e;
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for delete: {}", idOrName);
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to delete content type {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to delete content type", e);
+    }
   }
 
   @Override
@@ -2682,41 +2728,39 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    * @throws ContentTypeDesignLockException when unlocked or locked by another user (HTTP 409)
    */
   private void requireHeldLock(IPSGuid ctGuid) {
+    requireHeldLock(ctGuid, "Could not save content type");
+  }
+
+  private void requireHeldLock(IPSGuid ctGuid, String prefix) {
     if (systemDesign == null) {
-      throw new IllegalStateException(
-          "Could not save content type; design service unavailable");
+      throw new IllegalStateException(prefix + "; design service unavailable");
     }
     List<PSObjectSummary> locked;
     try {
       locked = systemDesign.isLocked(Collections.singletonList(ctGuid), currentUser());
     } catch (PSErrorResultsException e) {
       if (isNotFoundError(e)) {
-        throw new ContentTypeDesignLockException(
-            "Could not save content type; design lock required", e);
+        throw new ContentTypeDesignLockException(prefix + "; design lock required", e);
       }
       if (hasLockError(e)) {
         String locker = firstLockLocker(e);
         throw new ContentTypeDesignLockException(
-            locker != null
-                ? "Could not save content type; locked by " + locker
-                : "Could not save content type; design lock required",
+            locker != null ? prefix + "; locked by " + locker : prefix + "; design lock required",
             e);
       }
-      throw new IllegalStateException("Could not save content type; design service error", e);
+      throw new IllegalStateException(prefix + "; design service error", e);
     }
     PSObjectSummary summary =
         locked == null || locked.isEmpty() ? null : locked.get(0);
     if (summary == null || !summary.isLocked()) {
-      throw new ContentTypeDesignLockException("Could not save content type; design lock required");
+      throw new ContentTypeDesignLockException(prefix + "; design lock required");
     }
     String user = currentUser();
     PSObjectLockSummary info = summary.getLocked();
     if (!summary.isLockedBy(user)) {
       String locker = info != null ? info.getLocker() : null;
       throw new ContentTypeDesignLockException(
-          locker != null
-              ? "Could not save content type; locked by " + locker
-              : "Could not save content type; design lock required");
+          locker != null ? prefix + "; locked by " + locker : prefix + "; design lock required");
     }
   }
 
@@ -2741,12 +2785,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (RuntimeException e) {
       log.debug("Admin check failed: {}", e.getMessage());
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, or save content types",
+          "Admin role required to create, lock, unlock, save, or delete content types",
           Response.Status.FORBIDDEN);
     }
     if (!allowed) {
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, or save content types",
+          "Admin role required to create, lock, unlock, save, or delete content types",
           Response.Status.FORBIDDEN);
     }
   }
@@ -3029,6 +3073,19 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         || lower.contains("psextensionexception")
         || lower.contains("extension type")
         || lower.contains("invalid_ext");
+  }
+
+  /**
+   * True when a batched {@code deleteContentTypes} error is a dependents / in-use rejection rather
+   * than an unexpected server failure.
+   */
+  static boolean isDeleteDependencyFailure(PSErrorsException e) {
+    String text = formatSaveErrors(e);
+    if (StringUtils.isBlank(text)) {
+      return false;
+    }
+    String lower = text.toLowerCase();
+    return lower.contains("depend") || lower.contains("in use") || lower.contains("in-use");
   }
 
   /** Map-keyed overload for {@code PSErrorsException} batched save errors. */

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -98,6 +98,7 @@ import com.percussion.user.service.IPSUserService;
 import com.percussion.util.PSCollection;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.utils.string.PSStringUtils;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
@@ -439,8 +440,9 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     gaps.add(
         DesignGap.of(
             "CT_CREATE_DELETE",
-            "Create via POST /contenttypes. DELETE /contenttypes/{idOrName} requires a held"
-                + " design lock. Rename not supported; PUT save requires a held design lock for"
+            "Create via POST /contenttypes. Rename via PUT /contenttypes/{idOrName}/name"
+                + " (held lock). DELETE /contenttypes/{idOrName} requires a held"
+                + " design lock. PUT save requires a held design lock for"
                 + " label/description/enabled, field searchable/occurrence, workflows (+ default),"
                 + " and templates"));
     gaps.add(
@@ -706,6 +708,71 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (Exception e) {
       log.error("Failed to enable/disable content type {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to enable/disable content type", e);
+    }
+  }
+
+  @Override
+  public ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName) {
+    requireAdmin();
+    requireSessionUserForLock();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String validatedName = validateNewContentTypeName(newName);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      PSItemDefinition current = resolveItemDef(trimmed, true);
+      if (current == null) {
+        return null;
+      }
+      IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
+      requireUniqueContentTypeName(validatedName, current.getTypeId());
+      requireHeldLock(ctGuid);
+      if (validatedName.equals(current.getName())) {
+        return toDetail(current);
+      }
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not rename content type");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      def.setName(validatedName);
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not rename content type");
+        }
+        log.error("Failed to save content type name {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save content type name", e);
+      }
+      PSItemDefinition reloaded = reloadItemDef(String.valueOf(def.getTypeId()));
+      if (reloaded != null) {
+        return toDetail(reloaded);
+      }
+      return toDetail(def);
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for rename: {}", idOrName);
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to rename content type {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to rename content type", e);
     }
   }
 
@@ -1272,6 +1339,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   private void applyMetaUpdates(PSItemDefinition def, ContentTypeDetail body) {
+    // Name is not applied here; CD-01 rename uses renameContentType / PUT .../name.
     if (body.getLabel() != null) {
       def.setLabel(body.getLabel());
     }
@@ -2727,6 +2795,52 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    *
    * @throws ContentTypeDesignLockException when unlocked or locked by another user (HTTP 409)
    */
+  /**
+   * Validates a CD-01 rename target. Names must be non-blank, have no spaces or wildcards, and
+   * use only characters allowed for content type names.
+   */
+  static String validateNewContentTypeName(String newName) {
+    if (StringUtils.isBlank(newName)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String trimmed = newName.trim();
+    if (trimmed.indexOf('*') >= 0 || trimmed.indexOf('%') >= 0) {
+      throw new IllegalArgumentException("Content type name must not contain wildcards");
+    }
+    for (int i = 0; i < trimmed.length(); i++) {
+      if (Character.isWhitespace(trimmed.charAt(i))) {
+        throw new IllegalArgumentException("Content type name must not contain spaces");
+      }
+    }
+    Character invalid = PSStringUtils.validateContentTypeName(trimmed);
+    if (invalid != null) {
+      throw new IllegalArgumentException(
+          "Content type name contains invalid character: " + invalid);
+    }
+    return trimmed;
+  }
+
+  /**
+   * Case-insensitive uniqueness against the design catalog. The current type id is excluded so a
+   * no-op or case-only rename of the same type is allowed.
+   */
+  private void requireUniqueContentTypeName(String newName, int currentTypeId) {
+    List<IPSCatalogSummary> found = designSvc.findContentTypes("*");
+    if (found == null) {
+      return;
+    }
+    for (IPSCatalogSummary sum : found) {
+      if (sum == null || !newName.equalsIgnoreCase(sum.getName())) {
+        continue;
+      }
+      IPSGuid guid = sum.getGUID();
+      int uuid = guid != null ? guid.getUUID() : -1;
+      if (uuid != currentTypeId) {
+        throw new IllegalArgumentException("Content type name already exists: " + newName);
+      }
+    }
+  }
+
   private void requireHeldLock(IPSGuid ctGuid) {
     requireHeldLock(ctGuid, "Could not save content type");
   }
@@ -2785,12 +2899,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (RuntimeException e) {
       log.debug("Admin check failed: {}", e.getMessage());
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, save, or delete content types",
+          "Admin role required to create, lock, unlock, save, rename, or delete content types",
           Response.Status.FORBIDDEN);
     }
     if (!allowed) {
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, save, or delete content types",
+          "Admin role required to create, lock, unlock, save, rename, or delete content types",
           Response.Status.FORBIDDEN);
     }
   }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -714,10 +714,10 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   @Override
   public ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName) {
     requireAdmin();
-    requireSessionUserForLock();
     if (StringUtils.isBlank(idOrName)) {
       throw new IllegalArgumentException("idOrName is required");
     }
+    requireSessionUserForLock();
     String trimmed = idOrName.trim();
     if (trimmed.contains("*")) {
       throw new IllegalArgumentException("idOrName must not contain wildcards");

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorCreateTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorCreateTest.java
@@ -192,6 +192,39 @@ class ContentTypeAdaptorCreateTest {
   }
 
   @Test
+  void create_reservedFolderName_is409BeforeCreate() throws Exception {
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("Folder");
+    when(designWs.findContentTypes("*")).thenReturn(List.of(existing));
+
+    ContentTypeDetail body = new ContentTypeDetail();
+    body.setName("Folder");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createContentType(null, body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createContentTypes(anyList(), any(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_thenGetByName_returnsDetail() throws Exception {
+    PSItemDefinition def = stubCreatedDefinition("percNewType", 9001);
+    when(designWs.createContentTypes(eq(List.of("percNewType")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    ContentTypeDetail body = new ContentTypeDetail();
+    body.setName("percNewType");
+    body.setLabel("New Type");
+
+    adaptor.createContentType(null, body);
+    ContentTypeDetail got = adaptor.getContentType(null, "percNewType");
+
+    assertEquals("percNewType", got.getName());
+    assertEquals("New Type", got.getLabel());
+  }
+
+  @Test
   void create_blankName_throwsBeforeDesignWs() throws Exception {
     assertThrows(IllegalArgumentException.class, () -> adaptor.createContentType(null, null));
     ContentTypeDetail blank = new ContentTypeDetail();

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorDeleteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorDeleteTest.java
@@ -200,6 +200,16 @@ class ContentTypeAdaptorDeleteTest {
   }
 
   @Test
+  void delete_blankIdOrName_returnsNullBeforeSessionCheck() throws Exception {
+    PSRequestInfoBase.resetRequestInfo();
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    assertNull(adaptor.deleteContentType(null, "  "));
+    assertNull(adaptor.deleteContentType(null, null));
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+    verify(systemDesign, never()).isLocked(anyList(), any());
+  }
+
+  @Test
   void isDeleteDependencyFailure_detectsDependentsMessage() {
     PSErrorsException errors = new PSErrorsException();
     errors.addError(guid, new PSErrorException(1, "object has dependents", "stack"));

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorDeleteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorDeleteTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSInvalidContentTypeException;
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CD-01 DELETE requires a held design-session lock and calls {@code
+ * IPSContentDesignWs.deleteContentTypes} without ignoring dependents.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorDeleteTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void delete_whenLockHeld_callsDesignWsWithoutIgnoringDependents() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+
+    assertEquals(Boolean.TRUE, adaptor.deleteContentType(null, "311"));
+
+    verify(designWs)
+        .deleteContentTypes(eq(List.of(guid)), eq(false), eq("test-session"), eq("Admin"));
+    verify(systemDesign).isLocked(anyList(), eq("Admin"));
+  }
+
+  @Test
+  void delete_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(Collections.singletonList(null));
+    stubDefinition();
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_conflictWhenLockedByOtherUser() throws Exception {
+    PSObjectSummary other = new PSObjectSummary(guid, "percPage");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+    stubDefinition();
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_lockErrorFromDesignWs_is409() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(
+        guid, new PSLockErrorException(1, "is not locked", "stack", "Admin", 12));
+    doThrow(errors)
+        .when(designWs)
+        .deleteContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+  }
+
+  @Test
+  void delete_dependents_throws400() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(
+        guid,
+        new PSErrorException(
+            1, "Content Type 311 has dependents: percPage items", "stack"));
+    doThrow(errors)
+        .when(designWs)
+        .deleteContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().contains("dependents"), ex.getMessage());
+  }
+
+  @Test
+  void delete_unexpectedDesignError_is500() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(
+        guid, new PSErrorException(1, "Failed to delete PSItemDefinition 0-2-311: disk full", "stack"));
+    doThrow(errors)
+        .when(designWs)
+        .deleteContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.deleteContentType(null, "311"));
+    assertTrue(ex.getMessage().contains("Failed to delete content type"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("disk full"), ex.getMessage());
+  }
+
+  @Test
+  void delete_unknownName_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.deleteContentType(null, "missing"));
+    verify(systemDesign, never()).isLocked(anyList(), any());
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.deleteContentType(null, "311"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void delete_wildcardName_isBadRequest() throws Exception {
+    assertThrows(
+        IllegalArgumentException.class, () -> adaptor.deleteContentType(null, "perc*"));
+    verify(designWs, never()).deleteContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void isDeleteDependencyFailure_detectsDependentsMessage() {
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(guid, new PSErrorException(1, "object has dependents", "stack"));
+    assertTrue(ContentTypeAdaptor.isDeleteDependencyFailure(errors));
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private void stubDefinition() throws Exception {
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn("percPage");
+    when(def.getTypeId()).thenReturn(311);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorRenameTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorRenameTest.java
@@ -246,6 +246,24 @@ class ContentTypeAdaptorRenameTest {
   }
 
   @Test
+  void rename_blankIdOrName_isBadRequestBeforeSessionCheck() throws Exception {
+    PSRequestInfoBase.resetRequestInfo();
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    IllegalArgumentException blank =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.renameContentType(null, "  ", "percRenamed"));
+    assertTrue(blank.getMessage().contains("idOrName"), blank.getMessage());
+    IllegalArgumentException missing =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.renameContentType(null, null, "percRenamed"));
+    assertTrue(missing.getMessage().contains("idOrName"), missing.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+    verify(systemDesign, never()).isLocked(anyList(), any());
+  }
+
+  @Test
   void validateNewContentTypeName_rejectsBlankAndInvalid() {
     assertThrows(
         IllegalArgumentException.class, () -> ContentTypeAdaptor.validateNewContentTypeName(""));

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorRenameTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorRenameTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSInvalidContentTypeException;
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeDetail;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * CD-01 rename requires a held design-session lock and persists a unique new name without
+ * releasing the lock. GET by old name is not found; GET by id returns the new name.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorRenameTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void rename_persistsNameWhenLockHeld() throws Exception {
+    stubHeldLock();
+    stubCatalog("percPage", 311);
+    PSItemDefinition def = stubDefinition("percPage");
+
+    ContentTypeDetail out = adaptor.renameContentType(null, "311", "percRenamedPage");
+
+    assertEquals("percRenamedPage", out.getName());
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSItemDefinition>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveContentTypes(saved.capture(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    verify(def).setName("percRenamedPage");
+    verify(systemDesign).isLocked(anyList(), eq("Admin"));
+  }
+
+  @Test
+  void get_oldName404_idReturnsNewName() throws Exception {
+    stubHeldLock();
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+
+    ContentTypeDetail renamed = adaptor.renameContentType(null, "311", "percRenamedPage");
+    assertEquals("percRenamedPage", renamed.getName());
+
+    when(itemDefManager.getItemDef("percPage", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("percPage"));
+
+    assertNull(adaptor.getContentType(null, "percPage"));
+    ContentTypeDetail byId = adaptor.getContentType(null, "311");
+    assertEquals("percRenamedPage", byId.getName());
+  }
+
+  @Test
+  void rename_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(Collections.singletonList(null));
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.renameContentType(null, "311", "percRenamedPage"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(true), anyBoolean(), any(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_conflictWhenLockedByOtherUser() throws Exception {
+    PSObjectSummary other = new PSObjectSummary(guid, "percPage");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.renameContentType(null, "311", "percRenamedPage"));
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_conflictWhenLockedInAnotherSession() throws Exception {
+    stubHeldLock();
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+    PSErrorResultsException errors = new PSErrorResultsException();
+    errors.addError(
+        guid, new PSLockErrorException(1, "LOCK_EXTENSION_INVALID_SESSION", "stack", "Admin", 12));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenThrow(errors);
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.renameContentType(null, "311", "percRenamedPage"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_spaces_isBadRequest() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.renameContentType(null, "311", "perc Renamed"));
+    assertTrue(ex.getMessage().toLowerCase().contains("space"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_collision_isBadRequest() throws Exception {
+    stubCatalog("percPage", 311, "percEventAsset", 329);
+    stubDefinition("percPage");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.renameContentType(null, "311", "percEventAsset"));
+    assertTrue(ex.getMessage().toLowerCase().contains("exists"), ex.getMessage());
+    verify(systemDesign, never()).isLocked(anyList(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_caseInsensitiveCollision_isBadRequest() throws Exception {
+    stubCatalog("percPage", 311, "percEventAsset", 329);
+    stubDefinition("percPage");
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.renameContentType(null, "311", "PERCEVENTASSET"));
+    assertTrue(ex.getMessage().toLowerCase().contains("exists"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_sameName_isIdempotentWhenLockHeld() throws Exception {
+    stubHeldLock();
+    stubCatalog("percPage", 311);
+    stubDefinition("percPage");
+
+    ContentTypeDetail out = adaptor.renameContentType(null, "311", "percPage");
+
+    assertEquals("percPage", out.getName());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_unknownName_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.renameContentType(null, "missing", "percRenamed"));
+    verify(systemDesign, never()).isLocked(anyList(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void rename_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> denied.renameContentType(null, "311", "percRenamed"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void rename_wildcardName_isBadRequest() {
+    assertThrows(
+        IllegalArgumentException.class, () -> adaptor.renameContentType(null, "perc*", "percNew"));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void validateNewContentTypeName_rejectsBlankAndInvalid() {
+    assertThrows(
+        IllegalArgumentException.class, () -> ContentTypeAdaptor.validateNewContentTypeName(""));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ContentTypeAdaptor.validateNewContentTypeName("perc New"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ContentTypeAdaptor.validateNewContentTypeName("perc*"));
+    assertEquals("percRenamed", ContentTypeAdaptor.validateNewContentTypeName("percRenamed"));
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private void stubCatalog(String name, int typeId) {
+    stubCatalog(name, typeId, null, -1);
+  }
+
+  private void stubCatalog(String name, int typeId, String otherName, int otherTypeId) {
+    PSObjectSummary self = new PSObjectSummary(new PSGuid(PSTypeEnum.NODEDEF, typeId), name);
+    if (otherName != null) {
+      PSObjectSummary other =
+          new PSObjectSummary(new PSGuid(PSTypeEnum.NODEDEF, otherTypeId), otherName);
+      when(designWs.findContentTypes("*")).thenReturn(List.of(self, other));
+    } else {
+      when(designWs.findContentTypes("*")).thenReturn(List.of(self));
+    }
+  }
+
+  private PSItemDefinition stubDefinition(String currentName) throws Exception {
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn(currentName);
+    when(def.getLabel()).thenReturn("Page");
+    when(def.getDescription()).thenReturn("desc");
+    when(def.isEnabled()).thenReturn(true);
+    when(def.isHidden()).thenReturn(false);
+    when(def.getAppName()).thenReturn("rx_cePage");
+    when(def.getEditorUrl()).thenReturn("/Rhythmyx/rx_cePage/percPage.html");
+    when(def.getTypeId()).thenReturn(311);
+    when(def.getFieldSet()).thenReturn(null);
+    when(def.getContentEditor()).thenReturn(null);
+    doAnswer(
+            inv -> {
+              when(def.getName()).thenReturn(inv.getArgument(0));
+              return null;
+            })
+        .when(def)
+        .setName(any());
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    return def;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -47,6 +47,7 @@ class DesignGapsStructuredTest {
                 g ->
                     "CT_CREATE_DELETE".equals(g.getCode())
                         && g.getMessage().contains("POST /contenttypes")
+                        && g.getMessage().contains("PUT /contenttypes/{idOrName}/name")
                         && g.getMessage().contains("DELETE")
                         && g.getMessage().toLowerCase().contains("held")
                         && !g.getMessage().startsWith("Create / delete not supported")),

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -47,6 +47,8 @@ class DesignGapsStructuredTest {
                 g ->
                     "CT_CREATE_DELETE".equals(g.getCode())
                         && g.getMessage().contains("POST /services/contenttypes")
+                        && g.getMessage().contains("DELETE")
+                        && g.getMessage().toLowerCase().contains("held")
                         && !g.getMessage().startsWith("Create / delete not supported")),
         () -> gaps.toString());
     assertFalse(codes.contains("CT_CONTROL_RESOLUTION"));

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -46,7 +46,7 @@ class DesignGapsStructuredTest {
             .anyMatch(
                 g ->
                     "CT_CREATE_DELETE".equals(g.getCode())
-                        && g.getMessage().contains("POST /services/contenttypes")
+                        && g.getMessage().contains("POST /contenttypes")
                         && g.getMessage().contains("DELETE")
                         && g.getMessage().toLowerCase().contains("held")
                         && !g.getMessage().startsWith("Create / delete not supported")),

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
@@ -34,7 +34,8 @@ import java.util.List;
  * design lock for write). Control properties use {@code GET/PUT
  * .../fields/{fieldName}/controlProperties}. Partial update supports label, description, enabled,
  * field searchable / occurrence, allowed workflows (+ default), and allowed templates. PUT
- * requires a design-session lock already held by the current user ({@code POST
+ * does not change name (use {@code PUT .../name}). PUT
+ * requires a design-session lock already held by the current user ({@code POST}
  * /services/contenttypes/{idOrName}/lock}) and does not release it. Field rule expressions on this
  * detail payload remain summary strings (not written by PUT detail).
  *

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeName.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeName.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * New internal name for a Content Type rename (CD-01).
+ *
+ * <p>Jackson root wrap is {@code ContentTypeName} ({@code WRAP_ROOT_VALUE} /
+ * {@code UNWRAP_ROOT_VALUE}).
+ */
+@XmlRootElement(name = "ContentTypeName")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Content type rename payload")
+public class ContentTypeName {
+
+  @Schema(
+      required = true,
+      description =
+          "New internal name. Must be unique (case-insensitive), with no spaces or wildcards.")
+  private String name;
+
+  public ContentTypeName() {}
+
+  public ContentTypeName(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeName.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeName.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.contenttypes;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
@@ -28,6 +29,7 @@ import jakarta.xml.bind.annotation.XmlRootElement;
  * {@code UNWRAP_ROOT_VALUE}).
  */
 @XmlRootElement(name = "ContentTypeName")
+@JsonRootName("ContentTypeName")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Content type rename payload")
 public class ContentTypeName {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -849,7 +849,8 @@ public class ContentTypesResource {
               + " description, and enabled are applied before save. Omitted enabled defaults to"
               + " true. Returns the new ContentTypeDetail (GET by name is then 200). Duplicate"
               + " name is 409 at catalog check and at persist, including reserved system types"
-              + " such as Folder. Delete/rename remain unsupported (see designGaps).",
+              + " such as Folder. Rename uses PUT .../name. Delete uses DELETE .../{idOrName} with"
+              + " a held lock.",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -847,8 +847,9 @@ public class ContentTypesResource {
               + " then saveContentTypes (Workbench Finish, not an unsaved stub). Name is required,"
               + " must be unique (case-insensitive), and must not contain spaces. Optional label,"
               + " description, and enabled are applied before save. Omitted enabled defaults to"
-              + " true. Returns the new ContentTypeDetail. Duplicate name is 409 at catalog check"
-              + " and at persist. Delete/rename remain unsupported (see designGaps).",
+              + " true. Returns the new ContentTypeDetail (GET by name is then 200). Duplicate"
+              + " name is 409 at catalog check and at persist, including reserved system types"
+              + " such as Folder. Delete/rename remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -860,7 +861,11 @@ public class ContentTypesResource {
         @ApiResponse(
             responseCode = "403",
             description = "Admin role required, or request has no session/user"),
-        @ApiResponse(responseCode = "409", description = "A content type with that name exists"),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "A content type with that name exists (including reserved system types such as"
+                    + " Folder)"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public ContentTypeDetail createContentType(ContentTypeDetail body) {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -924,11 +924,11 @@ public class ContentTypesResource {
               + " empty). Template associations are written after content-type save in a separate"
               + " design call — if that fails, meta/field/workflow changes may already be"
               + " committed (error message indicates partial success). Name/id and system field"
-              + " structure are not changed. Field rule expressions use PUT"
+              + " structure are not changed — rename uses PUT .../name. Field rule expressions"
+              + " use PUT"
               + " .../fields/{fieldName}/ruleExpressions. Control property values use PUT"
               + " .../fields/{fieldName}/controlProperties. Create uses POST /contenttypes."
-              + " Delete uses DELETE .../{idOrName} with a held lock. Rename remains"
-              + " unsupported (see designGaps).",
+              + " Rename uses PUT .../name. Delete uses DELETE .../{idOrName} with a held lock.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -1096,6 +1096,53 @@ public class ContentTypesResource {
       ContentTypeDetail detail =
           requireAdaptor()
               .setContentTypeEnabled(uriInfo.getBaseUri(), idOrName, body.getEnabled());
+      if (detail == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return detail;
+    } catch (RuntimeException e) {
+      throw mapEnabledFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}/name")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Rename a content type",
+      description =
+          "CD-01 design action: sets the content type internal name. Admin only. Requires a"
+              + " design-session lock already held by the current user (POST .../lock). Does not"
+              + " acquire or release the lock. The new name must be unique (case-insensitive) and"
+              + " must not contain spaces or wildcards. Bulk PUT .../{idOrName} does not change"
+              + " name. After success, GET .../{oldName} is 404; GET by id returns the new name."
+              + " Jackson root wrap is ContentTypeName.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Renamed (lock is still held)",
+            content = @Content(schema = @Schema(implementation = ContentTypeDetail.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "name is required, invalid, contains spaces, or collides"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock required, or locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeDetail renameContentType(
+      @PathParam("idOrName") String idOrName, ContentTypeName body) {
+    if (body == null || body.getName() == null || body.getName().trim().isEmpty()) {
+      throw new WebApplicationException("name is required", 400);
+    }
+    try {
+      ContentTypeDetail detail =
+          requireAdaptor().renameContentType(uriInfo.getBaseUri(), idOrName, body.getName());
       if (detail == null) {
         throw new WebApplicationException("Content type not found: " + idOrName, 404);
       }

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -927,7 +927,8 @@ public class ContentTypesResource {
               + " structure are not changed. Field rule expressions use PUT"
               + " .../fields/{fieldName}/ruleExpressions. Control property values use PUT"
               + " .../fields/{fieldName}/controlProperties. Create uses POST /contenttypes."
-              + " Delete/rename remain unsupported (see designGaps).",
+              + " Delete uses DELETE .../{idOrName} with a held lock. Rename remains"
+              + " unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -1016,6 +1017,42 @@ public class ContentTypesResource {
     try {
       Boolean released = requireAdaptor().unlockContentType(uriInfo.getBaseUri(), idOrName);
       if (released == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapMutationFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete content type",
+      description =
+          "Admin. Deletes a content type via IPSContentDesignWs.deleteContentTypes. Requires a"
+              + " design-session lock already held by the current user/session (POST .../lock)."
+              + " Does not steal locks. Does not cascade items (ignoreDependencies=false); in-use"
+              + " types with dependents fail clearly. Following GET .../{idOrName} is 404 after a"
+              + " successful delete.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid id/name, or design WS rejected in-use type (dependents)"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock required, or locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteContentType(@PathParam("idOrName") String idOrName) {
+    try {
+      Boolean deleted = requireAdaptor().deleteContentType(uriInfo.getBaseUri(), idOrName);
+      if (deleted == null) {
         throw new WebApplicationException("Content type not found: " + idOrName, 404);
       }
       return Response.noContent().build();

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -111,6 +111,21 @@ public interface IContentTypesAdaptor {
   Boolean unlockContentType(URI baseUri, String idOrName);
 
   /**
+   * Delete a content type via {@code IPSContentDesignWs.deleteContentTypes}. Admin only. Requires a
+   * design-session lock already held by the current user ({@link #lockContentType}). Does not
+   * acquire, steal, or ignore locks. Does not cascade item delete ({@code ignoreDependencies=false}).
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or internal name
+   * @return {@code Boolean.TRUE} when deleted; {@code null} when not found
+   * @throws ContentTypeDesignLockException when no lock is held or the lock is owned by another
+   *     user
+   * @throws IllegalArgumentException when the design web service rejects the delete (in-use /
+   *     dependents)
+   */
+  Boolean deleteContentType(URI baseUri, String idOrName);
+
+  /**
    * Enable or disable a content type for runtime use (CD-13). Requires a design-session lock
    * already held by the current user (peer lock REST). Does not acquire or release the lock.
    *

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -53,7 +53,7 @@ public interface IContentTypesAdaptor {
   /**
    * Create and persist a content type (Workbench Finish: {@code createContentTypes} then {@code
    * saveContentTypes}). Admin only. Name must be unique (case-insensitive) and must not contain
-   * spaces.
+   * spaces. Reserved system names such as {@code Folder} collide with existing catalog types.
    *
    * @param baseUri requesting URI
    * @param body request body; {@code name} is required. Optional label, description, and enabled
@@ -62,7 +62,7 @@ public interface IContentTypesAdaptor {
    * @throws IllegalArgumentException when the name is blank, contains whitespace, or contains
    *     wildcards
    * @throws jakarta.ws.rs.WebApplicationException {@code 409} when a content type with that name
-   *     already exists; {@code 403} when the caller is not Admin
+   *     already exists (including reserved system types); {@code 403} when the caller is not Admin
    */
   ContentTypeDetail createContentType(URI baseUri, ContentTypeDetail body);
 

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -82,7 +82,8 @@ public interface IContentTypesAdaptor {
    * <p>Supports label, description, enabled, per-field {@code searchable} (and optional
    * occurrence), allowed workflows (+ default workflow id), and allowed templates. Association
    * lists use full-replace semantics when non-null; omit them to leave associations unchanged.
-   * Field rule expressions use {@link #replaceFieldRuleExpressions}. Control property values use
+   * Does not change name — use {@link #renameContentType}. Field rule expressions use {@link
+   * #replaceFieldRuleExpressions}. Control property values use
    * {@link #replaceFieldControlProperties}.
    *
    * @return updated detail, or {@code null} when not found
@@ -137,6 +138,22 @@ public interface IContentTypesAdaptor {
    *     user
    */
   ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled);
+
+  /**
+   * Rename a content type (CD-01). Requires a design-session lock already held by the current
+   * user. Does not acquire or release the lock. Bulk {@link #updateContentType} does not change
+   * name. After a successful rename, GET by the previous name is not found; GET by id returns the
+   * new name.
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or current internal name
+   * @param newName unique internal name (no spaces; case-insensitive unique)
+   * @return updated detail, or {@code null} when not found
+   * @throws ContentTypeDesignLockException when no lock is held or the lock is owned by another
+   *     user
+   * @throws IllegalArgumentException when the new name is invalid or collides
+   */
+  ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName);
 
   /**
    * List allowed template associations for a content type (read-only; no lock required).

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypeNameSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypeNameSerialDeserialTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.JacksonContextResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire contract for {@link ContentTypeName} under WRAP_ROOT_VALUE / UNWRAP_ROOT_VALUE.
+ *
+ * <p>Peer: {@link ContentTypeItemExitsJsonReaderTest#jacksonContextResolverWrapsFasterxmlJsonRootName()}.
+ */
+@Tag("UnitTest")
+public class ContentTypeNameSerialDeserialTest {
+
+  @Test
+  public void productionMapperSerializesContentTypeNameEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ContentTypeName.class);
+    String json = mapper.writeValueAsString(new ContentTypeName("percRenamedPage"));
+    assertTrue(json.contains("\"ContentTypeName\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("percRenamedPage"), json);
+
+    ContentTypeName roundTrip = mapper.readValue(json, ContentTypeName.class);
+    assertEquals("percRenamedPage", roundTrip.getName());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -587,6 +587,21 @@ public class ContentTypesResourceDetailTest {
   }
 
   @Test
+  public void createContentTypeOpenApiMentionsRenameAndDelete() throws Exception {
+    io.swagger.v3.oas.annotations.Operation op =
+        ContentTypesResource.class
+            .getMethod("createContentType", ContentTypeDetail.class)
+            .getAnnotation(io.swagger.v3.oas.annotations.Operation.class);
+    assertNotNull(op);
+    String description = op.description();
+    assertFalse(
+        description.contains("Delete/rename remain unsupported"),
+        "POST create OpenAPI must not claim delete/rename are unsupported: " + description);
+    assertTrue(description.contains("PUT .../name"), description);
+    assertTrue(description.contains("DELETE .../{idOrName}"), description);
+  }
+
+  @Test
   public void createContentTypeForbiddenWhenNoSession() {
     ContentTypeDetail body = new ContentTypeDetail();
     body.setName("percNewType");

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 import com.percussion.rest.DesignGap;
 import com.percussion.rest.Guid;
@@ -592,6 +593,72 @@ public class ContentTypesResourceDetailTest {
     when(adaptor.unlockContentType(any(), eq("percPage"))).thenReturn(Boolean.TRUE);
     Response response = resource.unlockContentType("percPage");
     assertEquals(204, response.getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeNoContent() {
+    when(adaptor.deleteContentType(any(), eq("percPage"))).thenReturn(Boolean.TRUE);
+    Response response = resource.deleteContentType("percPage");
+    assertEquals(204, response.getStatus());
+    verify(adaptor).deleteContentType(any(), eq("percPage"));
+  }
+
+  @Test
+  public void deleteContentTypeNotFound() {
+    when(adaptor.deleteContentType(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeLockConflictWhenLockNotHeld() {
+    when(adaptor.deleteContentType(any(), eq("percPage")))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not delete content type; design lock required"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("percPage"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeLockConflictWhenLockedByOtherUser() {
+    when(adaptor.deleteContentType(any(), eq("percPage")))
+        .thenThrow(
+            new ContentTypeDesignLockException("Could not delete content type; locked by editor2"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("percPage"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeForbiddenWhenNotAdmin() {
+    when(adaptor.deleteContentType(any(), eq("percPage")))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("percPage"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeInUseIs400() {
+    when(adaptor.deleteContentType(any(), eq("percPage")))
+        .thenThrow(
+            new IllegalArgumentException(
+                "Could not delete content type: Content Type 311 has dependents"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("percPage"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteContentTypeWildcardIs400() {
+    when(adaptor.deleteContentType(any(), eq("perc*")))
+        .thenThrow(new IllegalArgumentException("idOrName must not contain wildcards"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteContentType("perc*"));
+    assertEquals(400, ex.getResponse().getStatus());
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -565,6 +565,17 @@ public class ContentTypesResourceDetailTest {
   }
 
   @Test
+  public void createContentTypeReservedFolderIs409() {
+    ContentTypeDetail body = new ContentTypeDetail();
+    body.setName("Folder");
+    when(adaptor.createContentType(any(), any()))
+        .thenThrow(new WebApplicationException("Content type already exists: Folder", 409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createContentType(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void createContentTypeForbiddenWhenNotAdmin() {
     ContentTypeDetail body = new ContentTypeDetail();
     body.setName("percNewType");

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -662,6 +662,17 @@ public class ContentTypesResourceDetailTest {
   }
 
   @Test
+  public void deleteContentTypeGenericFailureIs500() {
+    when(adaptor.deleteContentType(any(), eq("percBlockquote")))
+        .thenThrow(
+            new IllegalStateException("Failed to delete content type: percBlockquote"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteContentType("percBlockquote"));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void unlockContentTypeNotFound() {
     when(adaptor.unlockContentType(any(), eq("missing"))).thenReturn(null);
     WebApplicationException ex =

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -929,4 +929,92 @@ public class ContentTypesResourceDetailTest {
         assertThrows(WebApplicationException.class, () -> resource.unlockContentType("percPage"));
     assertEquals(409, ex.getResponse().getStatus());
   }
+
+  @Test
+  public void renameContentTypeSuccess() {
+    ContentTypeDetail updated = new ContentTypeDetail();
+    updated.setName("percRenamedPage");
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percRenamedPage")))
+        .thenReturn(updated);
+    ContentTypeDetail out =
+        resource.renameContentType("percPage", new ContentTypeName("percRenamedPage"));
+    assertEquals("percRenamedPage", out.getName());
+  }
+
+  @Test
+  public void renameContentTypeRequiresName() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeSpaces400() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("perc Renamed")))
+        .thenThrow(new IllegalArgumentException("Content type name must not contain spaces"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("perc Renamed")));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeCollision400() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percEventAsset")))
+        .thenThrow(new IllegalArgumentException("Content type name already exists: percEventAsset"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("percEventAsset")));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeNotFound() {
+    when(adaptor.renameContentType(any(), eq("missing"), eq("percRenamed"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("missing", new ContentTypeName("percRenamed")));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeRequiresLock() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percRenamed")))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not save content type; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("percRenamed")));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeLockedByOtherUser() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percRenamed")))
+        .thenThrow(
+            new ContentTypeDesignLockException("Could not save content type; locked by editor2"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("percRenamed")));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void renameContentTypeForbiddenWhenNotAdmin() {
+    when(adaptor.renameContentType(any(), eq("percPage"), eq("percRenamed")))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.renameContentType("percPage", new ContentTypeName("percRenamed")));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -106,6 +106,11 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName) {
+    return null;
+  }
+
+  @Override
   public List<NamedObjectRef> getAllowedTemplates(URI baseUri, String idOrName) {
     return List.of();
   }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -96,6 +96,11 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public Boolean deleteContentType(URI baseUri, String idOrName) {
+    return Boolean.TRUE;
+  }
+
+  @Override
   public ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled) {
     return null;
   }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -115,6 +115,11 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public Boolean deleteContentType(URI baseUri, String idOrName) {
+    return Boolean.TRUE;
+  }
+
+  @Override
   public ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled) {
     return null;
   }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -125,6 +125,11 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName) {
+    return null;
+  }
+
+  @Override
   public List<NamedObjectRef> getAllowedTemplates(URI baseUri, String idOrName) {
     return List.of();
   }


### PR DESCRIPTION
## Summary

Overnight cluster absorb of **three CD-01 content-type REST PRs** that thrash the same adaptor, resource, tests, and product-docs pages. Merging them independently against `main` would re-conflict on every shared file.

**Thrash files**

- `rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java`
- `rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java`
- `rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java`
- `rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java`
- `rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java`
- `projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java`
- `projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java`
- `product-docs/8.2/developer/rest.md`
- `product-docs/8.2/admin/developer-content-types.md`

**Union (not product invention):** keep Admin `POST /services/contenttypes` (Folder reserved **409**, GET-by-name **200**), `PUT .../name` rename under a held lock, and `DELETE .../{idOrName}` under a held lock. Drop leftover “rename/delete remain unsupported” claims from the absorbed slices.

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | [#3919](https://github.com/intersoftdatalabs-in/percussioncms/pull/3919) | `feat/issue-3913-rest-cd01-delete-content-types` | yes | DELETE with held design lock (#3913) |
| yes | [#3920](https://github.com/intersoftdatalabs-in/percussioncms/pull/3920) | `fix/issue-3914-rest-cd01-rename-content-type` | yes | PUT `.../name` rename (#3914) |
| yes | [#3936](https://github.com/intersoftdatalabs-in/percussioncms/pull/3936) | `feat/issue-3926-rest-cd01-create-content-type` | yes | POST create docs + Folder 409 tests (#3926) |

Fixes #3913 #3914 #3926
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Review unioned OpenAPI on `ContentTypesResource` create / rename / DELETE — none claim the others are unsupported.
2. As Admin: `POST /services/contenttypes` unique name → 200; reserved **Folder** → 409; GET by name 200.
3. `POST .../lock` → `PUT .../name` → GET old name 404; GET by id returns new name.
4. `POST .../lock` → `DELETE .../{idOrName}` → 204; following GET 404.
5. Unlocked rename/delete → 409; non-Admin → 403.

## Checklist

- [x] **Product documentation** — unioned `product-docs/8.2/developer/rest.md` and `product-docs/8.2/admin/developer-content-types.md`
- [x] **Unit / module tests** — create/rename/delete resource + adaptor tests; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (REST-only; no SPA chrome)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest; ..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 685, Failures: 0 (`ContentTypesResourceDetailTest` 78 passed)
  - `cd projects/sitemanage; ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 1691, Failures: 0, Skipped: 125 (`ContentTypeAdaptorCreateTest` 15, `ContentTypeAdaptorRenameTest` 13, `ContentTypeAdaptorDeleteTest` 11, `DesignGapsStructuredTest` 4)
  - `scripts\ci-smoke-product-docs.bat` → OK (24 pages; `tmp/product-docs-site/8.2/index.html`)
- **downstream_checked:** grep `implements IContentTypesAdaptor` → `ContentTypeAdaptor`, `TestContentTypeAdaptor`, `ContentTypesTestAdaptor` (all updated). Additive `deleteContentType` / `renameContentType` on the interface; existing signatures unchanged. sitemanage standalone install after rest install.

### C5 UI proof

N/A — REST/backend only; no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs-cluster.
