### PR TITLE
fix(qa): H2 QA virtual-source object-storage/rss-atom after full WebUI deploy (#3948)

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -55,7 +55,7 @@ perc-devctl.py show-generated-passwords
 # QA mode — H2-in-Docker CMS for Playwright (no host install) — #1827 / #1927
 perc-devctl.py qa-up [--timeout-seconds N] [--skip-image-build]
 perc-devctl.py qa-preflight [--strict] [--no-content-hash]
-perc-devctl.py qa-rebuild-chain [--skip-tests] [--dist-only] [--then-qa-up] [--dry-run]
+perc-devctl.py qa-rebuild-chain [--skip-tests] [--dist-only] [--then-qa-up] [--then-qa-deploy-webui] [--skip-webui-deploy] [--dry-run]
 perc-devctl.py qa-health [--timeout-seconds N] [--interval-seconds N] [--url URL]
 perc-devctl.py qa-deploy-webui [--src DIR] [--container NAME]
 perc-devctl.py qa-down [--container NAME]
@@ -107,8 +107,15 @@ python3 docker/scripts/qa_rebuild_chain.py --skip-tests
 # Installer packaging only (WAR inputs already fresh)
 python3 docker/scripts/perc-devctl.py qa-rebuild-chain --dist-only
 
-# Optional: rebuild then qa-up in one invocation
+# Optional: rebuild then qa-up in one invocation (also copies
+# WebUI/target/generated-webui/cm/modern into the cell — #3948)
 python3 docker/scripts/perc-devctl.py qa-rebuild-chain --skip-tests --then-qa-up
+
+# Post-jar: after rest/sitemanage SNAPSHOT copies on a running skip-image-build
+# cell, copy the full modern SPA (not assets/ hashes only)
+python3 docker/scripts/perc-devctl.py qa-deploy-webui
+# or after a rebuild when the cell is already up:
+python3 docker/scripts/perc-devctl.py qa-rebuild-chain --skip-tests --then-qa-deploy-webui
 ```
 
 Cross-platform notes: each step `cwd`s into the module directory and invokes the **repo-root** `mvnw` / `mvnw.cmd` with `subprocess.run([...], shell=False)` (no shell quoting). Per-step and overall `RESULT:OK` / `RESULT:FAIL` lines are agent-parseable; Maven stdout/stderr goes under `docker/logs/`.
@@ -441,15 +448,19 @@ Default container: `percussion-cms-dts`. Default target: `both` (CMS + DTS lib d
 
 ### `docker/scripts/hot-deploy-webui-modern.py`
 
-Hot-copy the **full** built WebUI modern SPA into the H2 QA WAR (`#3893`). Cycle Verify failed when only hashed files under `cm/modern/assets/` were copied: `spa.jsp` still loaded a stale `perc-modern-ui.js` that imported an older `developer-<hash>.js` (csv/sql/http-json present, `option[value=object-storage]` count 0).
+Hot-copy the **full** built WebUI modern SPA into the H2 QA WAR (`#3893` / `#3948`). Cycle Verify failed when only hashed files under `cm/modern/assets/` were copied, and again when only `rest`/`sitemanage` SNAPSHOTs were jar-copied into a `--skip-image-build` cell: `spa.jsp` still loaded a stale `perc-modern-ui.js` that imported an older `developer-<hash>.js` (csv/sql/http-json present, `option[value=object-storage]` and `option[value=rss-atom]` count 0).
 
 ```
 python docker/scripts/perc-devctl.py qa-deploy-webui
 # equivalent:
 python docker/scripts/hot-deploy-webui-modern.py
+# after qa-rebuild-chain when a cell is already running:
+python docker/scripts/perc-devctl.py qa-rebuild-chain --skip-tests --then-qa-deploy-webui
+# qa-up on a skip-image-build cell that must pick up the current SPA:
+python docker/scripts/perc-devctl.py qa-up --skip-image-build --then-qa-deploy-webui
 ```
 
-Default source: `WebUI/target/generated-webui/cm/modern` (entry `assets/perc-modern-ui.js`, `assets/perc-modern-ui.css`, hashed chunks, optional `index.html`). Default container: `perc-matrix-cms-h2`. Dest: `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`. The script refuses a bundle unless `perc-modern-ui.js` or the `developer-*.js` chunk it imports contains the quoted wire value `"object-storage"` (not a bare substring; the TS identifier `SOURCE_KIND_OBJECT_STORAGE` is minified away). It does **not** `docker restart` the cell — restart Jetty inside the cell, then `qa-health`. Unit tests: `docker/scripts/test_hot_deploy_webui_modern.py`.
+Default source: `WebUI/target/generated-webui/cm/modern` (entry `assets/perc-modern-ui.js`, `assets/perc-modern-ui.css`, hashed chunks, optional `index.html`). Default container: `perc-matrix-cms-h2`. Dest: `/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern/`. The script refuses a bundle unless `perc-modern-ui.js` or the `developer-*.js` chunk it imports contains the quoted wire values `object-storage` **and** `rss-atom` (single/double quotes or template-literal backticks from Vite 8 minification — not a bare substring; TS identifiers are minified away). It does **not** `docker restart` the cell — restart Jetty inside the cell, then `qa-health`. Unit tests: `docker/scripts/test_hot_deploy_webui_modern.py`.
 
 ## Container entrypoint
 

--- a/docker/scripts/hot-deploy-webui-modern.py
+++ b/docker/scripts/hot-deploy-webui-modern.py
@@ -19,10 +19,11 @@
 Cross-platform (Windows / Linux / macOS). Stdlib only. ``subprocess.run``
 uses ``shell=False`` (root AGENTS.md).
 
-Cycle Verify #3893: copying only hashed files under ``cm/modern/assets/``
-without the stable entry ``perc-modern-ui.js`` (and optional ``index.html``)
-leaves the live SPA on a stale ``import("./developer-<oldhash>.js")``. That
-chunk has csv/sql/http-json but not ``option[value=object-storage]``.
+Cycle Verify #3893 / #3948: copying only hashed files under
+``cm/modern/assets/`` without the stable entry ``perc-modern-ui.js``
+(and optional ``index.html``) leaves the live SPA on a stale
+``import("./developer-<oldhash>.js")``. That chunk has csv/sql/http-json
+but not ``option[value=object-storage]`` or ``option[value=rss-atom]``.
 
 This script copies **every file** under
 ``WebUI/target/generated-webui/cm/modern/`` (entry JS/CSS, hashed chunks,
@@ -36,11 +37,14 @@ Callers restart Jetty *inside* the cell (StopJetty/StartJetty) then run
 
 By default the script refuses to deploy a bundle whose SPA entry
 (``assets/perc-modern-ui.js``) does not import a ``developer-*.js``
-chunk that contains the quoted wire value ``"object-storage"`` (or
-``'object-storage'``). A bare substring such as an API path is not
-enough. The TypeScript identifier ``SOURCE_KIND_OBJECT_STORAGE`` is
-not scanned: production bundles minify it away, while the option
-value string is what the live ``<select>`` renders.
+chunk that contains the quoted wire values ``object-storage`` and
+``rss-atom`` (single quotes, double quotes, or JS template-literal
+backticks — Vite 8 / rolldown minifies these SOURCE_KIND_* constants
+to backtick strings). A bare substring such as an API path is not
+enough. TypeScript identifiers (``SOURCE_KIND_OBJECT_STORAGE`` /
+``SOURCE_KIND_RSS_ATOM``) are not scanned: production bundles minify
+them away, while the option value strings are what the live
+``<select>`` renders.
 
 Exit codes:
 
@@ -48,7 +52,7 @@ Exit codes:
   1  invocation / argument error
   2  container not running
   3  source tree / entry file not found
-  4  object-storage marker missing in built JS
+  4  kind marker (object-storage and/or rss-atom) missing in built JS
   5  docker cp / docker exec failed
 """
 
@@ -75,12 +79,10 @@ DEFAULT_CONTAINER = "perc-matrix-cms-h2"
 DEFAULT_DEST = "/opt/Percussion/jetty/base/webapps/Rhythmyx/cm/modern"
 ENTRY_JS_REL = "assets/perc-modern-ui.js"
 ENTRY_CSS_REL = "assets/perc-modern-ui.css"
-# Wire value of SOURCE_KIND_OBJECT_STORAGE / option[value=object-storage].
+# Wire values of SOURCE_KIND_* / option[value=…] on developer-site-virtual-source-kind.
 OBJECT_STORAGE_MARKER = "object-storage"
-# Vite/esbuild keep the quoted string; the TS identifier is minified away.
-_QUOTED_MARKER_RE = re.compile(
-    r"""["']""" + re.escape(OBJECT_STORAGE_MARKER) + r"""["']"""
-)
+RSS_ATOM_MARKER = "rss-atom"
+REQUIRED_KIND_MARKERS: tuple[str, ...] = (OBJECT_STORAGE_MARKER, RSS_ATOM_MARKER)
 # Entry typically has import"./developer-<hash>.js" or import("./developer-<hash>.js").
 _DEVELOPER_IMPORT_RE = re.compile(
     r"""(?:import\s*\(?\s*["']|from\s+["'])(?:\./)?(developer-[^"']+\.js)["']""",
@@ -128,10 +130,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--skip-object-storage-check",
+        "--skip-kind-marker-check",
         action="store_true",
+        dest="skip_object_storage_check",
         help=(
-            "Do not refuse a bundle whose JS lacks the object-storage "
-            "marker (escape hatch only)."
+            "Do not refuse a bundle whose JS lacks quoted object-storage "
+            "and/or rss-atom markers (escape hatch only; #3948)."
         ),
     )
     p.add_argument(
@@ -203,10 +207,12 @@ def _read_js(path: Path) -> str:
 
 
 def _quoted_wire_value_in(text: str, marker: str) -> bool:
-    """True when ``text`` contains ``marker`` as a JS string literal."""
-    if marker == OBJECT_STORAGE_MARKER:
-        return _QUOTED_MARKER_RE.search(text) is not None
-    return re.search(r"""["']""" + re.escape(marker) + r"""["']""", text) is not None
+    """True when ``text`` contains ``marker`` as a JS string literal.
+
+    Accepts double quotes, single quotes, and JS template-literal
+    backticks (Vite 8 / rolldown emits backticks for SOURCE_KIND_* constants).
+    """
+    return re.search(r"""["'`]""" + re.escape(marker) + r"""["'`]""", text) is not None
 
 
 def developer_chunks_imported_by_entry(entry_text: str) -> list[str]:
@@ -223,9 +229,9 @@ def bundle_contains_marker(src: Path, marker: str = OBJECT_STORAGE_MARKER) -> bo
     """True when the live SPA entry's developer chunk has quoted ``marker``.
 
     Prefers ``assets/perc-modern-ui.js`` plus the ``developer-*.js`` files it
-    ``import()``s — the #3893 failure mode was a stale entry pointing at an
-    old developer chunk. Falls back to scanning ``assets/*.js`` only when
-    the entry does not import a developer chunk (inlined bundle).
+    ``import()``s — the #3893 / #3948 failure mode was a stale entry pointing
+    at an old developer chunk. Falls back to scanning ``assets/*.js`` only
+    when the entry does not import a developer chunk (inlined bundle).
     """
     assets = src / "assets"
     if not assets.is_dir():
@@ -250,8 +256,31 @@ def bundle_contains_marker(src: Path, marker: str = OBJECT_STORAGE_MARKER) -> bo
     return False
 
 
-def validate_src(src: Path, *, require_object_storage: bool) -> int:
-    """Return an exit code if ``src`` is not a deployable modern tree."""
+def bundle_missing_kind_markers(
+    src: Path,
+    markers: Iterable[str] = REQUIRED_KIND_MARKERS,
+) -> list[str]:
+    """Return required quoted kind markers absent from the live SPA bundle."""
+    missing: list[str] = []
+    for marker in markers:
+        if not bundle_contains_marker(src, marker):
+            missing.append(marker)
+    return missing
+
+
+def validate_src(
+    src: Path,
+    *,
+    require_kind_markers: bool = True,
+    require_object_storage: Optional[bool] = None,
+) -> int:
+    """Return an exit code if ``src`` is not a deployable modern tree.
+
+    ``require_object_storage`` is an alias for ``require_kind_markers``
+    (both object-storage and rss-atom; #3893 / #3948).
+    """
+    if require_object_storage is not None:
+        require_kind_markers = require_object_storage
     if not src.is_dir():
         LOG.error("modern source directory not found: %s", src)
         LOG.error(
@@ -270,20 +299,24 @@ def validate_src(src: Path, *, require_object_storage: bool) -> int:
     css = src / "assets" / "perc-modern-ui.css"
     if not css.is_file():
         LOG.warning("missing %s under %s (JSPs still link it)", ENTRY_CSS_REL, src)
-    if require_object_storage and not bundle_contains_marker(src):
-        LOG.error(
-            "built modern JS under %s does not contain quoted %r in "
-            "perc-modern-ui.js or the developer-*.js chunk it imports — "
-            "the live kind select would omit option[value=object-storage] (#3893)",
-            src,
-            OBJECT_STORAGE_MARKER,
-        )
-        LOG.error(
-            "hint: rebuild WebUI so the developer chunk includes the "
-            "SOURCE_KIND_OBJECT_STORAGE wire value as a string, then "
-            "deploy entry + hashed chunks"
-        )
-        return EXIT_MARKER_MISSING
+    if require_kind_markers:
+        missing = bundle_missing_kind_markers(src)
+        if missing:
+            LOG.error(
+                "built modern JS under %s does not contain quoted %s in "
+                "perc-modern-ui.js or the developer-*.js chunk it imports — "
+                "the live kind select would omit those option[value=…] "
+                "entries (#3893 / #3948)",
+                src,
+                ", ".join(repr(m) for m in missing),
+            )
+            LOG.error(
+                "hint: rebuild WebUI so the developer chunk includes the "
+                "SOURCE_KIND_OBJECT_STORAGE and SOURCE_KIND_RSS_ATOM wire "
+                "values as strings, then deploy entry + hashed chunks "
+                "(full generated-webui/cm/modern tree, not assets/ hashes only)"
+            )
+            return EXIT_MARKER_MISSING
     return EXIT_OK
 
 
@@ -292,12 +325,15 @@ def deploy(
     *,
     container_name: str = DEFAULT_CONTAINER,
     dest: str = DEFAULT_DEST,
-    require_object_storage: bool = True,
+    require_kind_markers: bool = True,
+    require_object_storage: Optional[bool] = None,
     dry_run: bool = False,
 ) -> int:
     """Copy every file under ``src`` into ``container_name:dest``."""
     src = src.resolve()
-    rc = validate_src(src, require_object_storage=require_object_storage)
+    if require_object_storage is not None:
+        require_kind_markers = require_object_storage
+    rc = validate_src(src, require_kind_markers=require_kind_markers)
     if rc != EXIT_OK:
         return rc
     if not dest.startswith("/"):
@@ -368,7 +404,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         src,
         container_name=args.container,
         dest=args.dest,
-        require_object_storage=not args.skip_object_storage_check,
+        require_kind_markers=not args.skip_object_storage_check,
         dry_run=args.dry_run,
     )
 

--- a/docker/scripts/perc-devctl.py
+++ b/docker/scripts/perc-devctl.py
@@ -29,12 +29,16 @@ QA mode (H2-in-Docker, no host install — issue #1827 / #1927) adds:
 * ``qa-rebuild-chain`` — drive the documented Maven order
   (sitemanage install → WebUI package → perc-distribution-tree package)
   via repo-root ``mvnw``/``mvnw.cmd``, portable paths, ``shell=False``
-  (#2533 residual of #2423 / #2486)
+  (#2533 residual of #2423 / #2486). ``--then-qa-up`` also copies
+  ``WebUI/target/generated-webui/cm/modern`` into the H2 QA cell after
+  the cell is up (post-jar SPA deploy; #3948) unless ``--skip-webui-deploy``.
 * ``qa-deploy-webui`` — copy the full generated ``cm/modern`` tree
   (stable ``perc-modern-ui.js`` entry + CSS + hashed chunks + any
   ``index.html``) into the H2 QA WAR. Copying only hashed ``assets/``
-  files leaves a stale developer chunk without
-  ``option[value=object-storage]`` (#3893)
+  files, or jar-only Cycle Verify hot-deploys of rest/sitemanage,
+  leaves a stale developer chunk without
+  ``option[value=object-storage]`` / ``option[value=rss-atom]``
+  (#3893 / #3948)
 
 Compose ``verify`` / ``verify-fix`` / ``deploy-jar --verify`` apply the same
 Rhythmyx context log scan against the cms-dts container (#2480 companion to
@@ -432,6 +436,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Pass --skip-image-build to matrix-install-smoke (reuse local image).",
     )
+    pqu.add_argument(
+        "--then-qa-deploy-webui",
+        action="store_true",
+        help=(
+            "After a successful qa-up, copy WebUI/target/generated-webui/"
+            "cm/modern into the H2 QA WAR (#3948). Required when "
+            "--skip-image-build leaves a stale SPA without "
+            "object-storage / rss-atom kind options."
+        ),
+    )
     pqu.add_argument("--dry-run", action="store_true")
 
     # --- Rebuild-chain preflight — #2486 / #2532 ---
@@ -483,7 +497,26 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "After a successful rebuild chain, run qa-up "
-            "(narrow optional handoff; fails if chain fails)."
+            "(narrow optional handoff; fails if chain fails). "
+            "Also copies generated-webui/cm/modern into the cell "
+            "unless --skip-webui-deploy (#3948)."
+        ),
+    )
+    pqrc.add_argument(
+        "--then-qa-deploy-webui",
+        action="store_true",
+        help=(
+            "After a successful rebuild chain (and after --then-qa-up "
+            "when both are set), copy WebUI/target/generated-webui/"
+            "cm/modern into the running H2 QA cell (#3948)."
+        ),
+    )
+    pqrc.add_argument(
+        "--skip-webui-deploy",
+        action="store_true",
+        help=(
+            "Do not copy the modern SPA after --then-qa-up "
+            "(opt out of the implied post-jar WebUI deploy)."
         ),
     )
     pqrc.add_argument(
@@ -541,7 +574,9 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help=(
             "Hot-copy the built WebUI modern SPA (entry perc-modern-ui.js + "
             "hashed chunks + CSS + any index.html) into the H2 QA WAR. "
-            "Does not docker-restart the cell (#3893)."
+            "Post-jar companion: run this after rest/sitemanage SNAPSHOT "
+            "copies so the live kind select keeps object-storage and "
+            "rss-atom (#3893 / #3948). Does not docker-restart the cell."
         ),
     )
     pqdw.add_argument(
@@ -559,8 +594,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     )
     pqdw.add_argument(
         "--skip-object-storage-check",
+        "--skip-kind-marker-check",
         action="store_true",
-        help="Allow a bundle whose JS lacks the object-storage marker.",
+        dest="skip_object_storage_check",
+        help=(
+            "Allow a bundle whose JS lacks quoted object-storage "
+            "and/or rss-atom markers (#3948)."
+        ),
     )
     pqdw.add_argument("--dry-run", action="store_true")
 
@@ -1084,6 +1124,22 @@ def cmd_it_verify(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> i
         dry_run=args.dry_run,
     )
     return rc
+
+
+def _qa_deploy_webui_ns(
+    *,
+    dry_run: bool,
+    src: Optional[str] = None,
+    container: str = QA_CMS_CONTAINER,
+    skip_object_storage_check: bool = False,
+) -> argparse.Namespace:
+    """Namespace for :func:`cmd_qa_deploy_webui` post-jar / post-up handoff."""
+    return argparse.Namespace(
+        dry_run=bool(dry_run),
+        src=src,
+        container=container,
+        skip_object_storage_check=bool(skip_object_storage_check),
+    )
 
 
 def _qa_deploy_webui_argv(
@@ -1661,10 +1717,20 @@ def cmd_qa_up(args: argparse.Namespace, paths: tuple[Path, Path, Path]) -> int:
 
     if dry_run:
         _qa_print_endpoint_banner(host_port)
+        if bool(getattr(args, "then_qa_deploy_webui", False)):
+            return cmd_qa_deploy_webui(
+                _qa_deploy_webui_ns(dry_run=True, container=QA_CMS_CONTAINER),
+                paths,
+            )
         return EXIT_OK
 
     admin_line = _qa_fetch_admin_password(QA_CMS_CONTAINER)
     _qa_print_endpoint_banner(host_port, admin_password_line=admin_line)
+    if bool(getattr(args, "then_qa_deploy_webui", False)):
+        return cmd_qa_deploy_webui(
+            _qa_deploy_webui_ns(dry_run=False, container=QA_CMS_CONTAINER),
+            paths,
+        )
     return EXIT_OK
 
 
@@ -1908,6 +1974,10 @@ def cmd_qa_rebuild_chain(
     Delegates to ``docker/scripts/qa_rebuild_chain.py`` (portable
     ``mvnw``/``mvnw.cmd``, ``shell=False``, RESULT lines). Optional
     ``--then-qa-up`` runs ``cmd_qa_up`` after a successful chain only.
+    After ``--then-qa-up`` the generated ``cm/modern`` tree is copied
+    into the H2 QA cell unless ``--skip-webui-deploy`` (#3948). Explicit
+    ``--then-qa-deploy-webui`` copies the tree even without qa-up (cell
+    already running after a jar-only hot-deploy).
     """
     import qa_rebuild_chain
 
@@ -1923,22 +1993,36 @@ def cmd_qa_rebuild_chain(
     )
     if rc != EXIT_OK:
         return rc
-    if not args.then_qa_up:
-        return rc
-    # Narrow handoff: reuse qa-up after a green rebuild chain.
-    # Rebuild-chain ``--timeout-seconds`` is optional (None = no Maven
-    # cap); qa-up requires a concrete probe timeout — fall back to the
-    # standard QA default when the operator did not pass one.
-    qa_up_args = argparse.Namespace(
-        dry_run=bool(args.dry_run),
-        timeout_seconds=(
-            args.timeout_seconds
-            if args.timeout_seconds is not None
-            else QA_PROBE_TIMEOUT_SECONDS_DEFAULT
-        ),
-        skip_image_build=bool(getattr(args, "skip_image_build", False)),
+    if args.then_qa_up:
+        # Narrow handoff: reuse qa-up after a green rebuild chain.
+        # Rebuild-chain ``--timeout-seconds`` is optional (None = no Maven
+        # cap); qa-up requires a concrete probe timeout — fall back to the
+        # standard QA default when the operator did not pass one.
+        qa_up_args = argparse.Namespace(
+            dry_run=bool(args.dry_run),
+            timeout_seconds=(
+                args.timeout_seconds
+                if args.timeout_seconds is not None
+                else QA_PROBE_TIMEOUT_SECONDS_DEFAULT
+            ),
+            skip_image_build=bool(getattr(args, "skip_image_build", False)),
+            then_qa_deploy_webui=False,
+        )
+        rc = cmd_qa_up(qa_up_args, paths)
+        if rc != EXIT_OK:
+            return rc
+    deploy_webui = bool(getattr(args, "then_qa_deploy_webui", False)) or (
+        bool(args.then_qa_up) and not bool(getattr(args, "skip_webui_deploy", False))
     )
-    return cmd_qa_up(qa_up_args, paths)
+    if deploy_webui:
+        return cmd_qa_deploy_webui(
+            _qa_deploy_webui_ns(
+                dry_run=bool(args.dry_run),
+                container=QA_CMS_CONTAINER,
+            ),
+            paths,
+        )
+    return rc
 
 
 # ---------------------------------------------------------------------------

--- a/docker/scripts/test_hot_deploy_webui_modern.py
+++ b/docker/scripts/test_hot_deploy_webui_modern.py
@@ -74,7 +74,13 @@ def _stub_subprocess(*, docker_ps_names=("perc-matrix-cms-h2",), returncodes=Non
     return calls, fake_run
 
 
-def _write_modern_tree(root: Path, *, include_object_storage: bool, include_index: bool = True) -> Path:
+def _write_modern_tree(
+    root: Path,
+    *,
+    include_object_storage: bool,
+    include_rss_atom: bool = True,
+    include_index: bool = True,
+) -> Path:
     modern = root / "cm" / "modern"
     assets = modern / "assets"
     assets.mkdir(parents=True)
@@ -86,6 +92,8 @@ def _write_modern_tree(root: Path, *, include_object_storage: bool, include_inde
     chunk = 'export const k="http-json";\n'
     if include_object_storage:
         chunk += 'export const os="object-storage";\n'
+    if include_rss_atom:
+        chunk += 'export const rss="rss-atom";\n'
     (assets / "developer-AbCd1234.js").write_text(chunk, encoding="utf-8")
     if include_index:
         (modern / "index.html").write_text(
@@ -122,9 +130,35 @@ class TestValidateSrc(unittest.TestCase):
 
     def test_marker_missing(self):
         with tempfile.TemporaryDirectory() as td:
-            src = _write_modern_tree(Path(td), include_object_storage=False)
+            src = _write_modern_tree(
+                Path(td), include_object_storage=False, include_rss_atom=False
+            )
             rc = hdw.validate_src(src, require_object_storage=True)
             self.assertEqual(rc, hdw.EXIT_MARKER_MISSING)
+            self.assertEqual(
+                hdw.bundle_missing_kind_markers(src),
+                ["object-storage", "rss-atom"],
+            )
+
+    def test_rss_atom_missing_fails_even_when_object_storage_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = _write_modern_tree(
+                Path(td), include_object_storage=True, include_rss_atom=False
+            )
+            rc = hdw.validate_src(src, require_kind_markers=True)
+            self.assertEqual(rc, hdw.EXIT_MARKER_MISSING)
+            self.assertEqual(hdw.bundle_missing_kind_markers(src), ["rss-atom"])
+            self.assertTrue(hdw.bundle_contains_marker(src, hdw.OBJECT_STORAGE_MARKER))
+            self.assertFalse(hdw.bundle_contains_marker(src, hdw.RSS_ATOM_MARKER))
+
+    def test_object_storage_missing_fails_even_when_rss_atom_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = _write_modern_tree(
+                Path(td), include_object_storage=False, include_rss_atom=True
+            )
+            rc = hdw.validate_src(src, require_kind_markers=True)
+            self.assertEqual(rc, hdw.EXIT_MARKER_MISSING)
+            self.assertEqual(hdw.bundle_missing_kind_markers(src), ["object-storage"])
 
     def test_marker_present(self):
         with tempfile.TemporaryDirectory() as td:
@@ -132,17 +166,52 @@ class TestValidateSrc(unittest.TestCase):
             rc = hdw.validate_src(src, require_object_storage=True)
             self.assertEqual(rc, hdw.EXIT_OK)
             self.assertTrue(hdw.bundle_contains_marker(src))
+            self.assertTrue(hdw.bundle_contains_marker(src, hdw.RSS_ATOM_MARKER))
+            self.assertEqual(hdw.bundle_missing_kind_markers(src), [])
 
     def test_unquoted_object_storage_substring_is_not_enough(self):
         with tempfile.TemporaryDirectory() as td:
-            src = _write_modern_tree(Path(td), include_object_storage=False)
+            src = _write_modern_tree(
+                Path(td), include_object_storage=False, include_rss_atom=False
+            )
             (src / "assets" / "developer-AbCd1234.js").write_text(
-                'const u="https://example.com/object-storage/keys";\n',
+                'const u="https://example.com/object-storage/keys";\n'
+                'const f="feed/rss-atom.xml";\n',
                 encoding="utf-8",
             )
             rc = hdw.validate_src(src, require_object_storage=True)
             self.assertEqual(rc, hdw.EXIT_MARKER_MISSING)
             self.assertFalse(hdw.bundle_contains_marker(src))
+            self.assertFalse(hdw.bundle_contains_marker(src, hdw.RSS_ATOM_MARKER))
+
+    def test_backtick_quoted_production_bundle_is_enough(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = _write_modern_tree(
+                Path(td), include_object_storage=False, include_rss_atom=False
+            )
+            (src / "assets" / "developer-AbCd1234.js").write_text(
+                "export const os=`object-storage`;\n"
+                "export const rss=`rss-atom`;\n",
+                encoding="utf-8",
+            )
+            rc = hdw.validate_src(src, require_kind_markers=True)
+            self.assertEqual(rc, hdw.EXIT_OK)
+            self.assertTrue(hdw.bundle_contains_marker(src, hdw.OBJECT_STORAGE_MARKER))
+            self.assertTrue(hdw.bundle_contains_marker(src, hdw.RSS_ATOM_MARKER))
+
+    def test_unquoted_rss_atom_substring_is_not_enough(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = _write_modern_tree(
+                Path(td), include_object_storage=True, include_rss_atom=False
+            )
+            chunk = (src / "assets" / "developer-AbCd1234.js").read_text(encoding="utf-8")
+            (src / "assets" / "developer-AbCd1234.js").write_text(
+                chunk + 'const p="/services/rss-atom/preview";\n',
+                encoding="utf-8",
+            )
+            rc = hdw.validate_src(src, require_kind_markers=True)
+            self.assertEqual(rc, hdw.EXIT_MARKER_MISSING)
+            self.assertFalse(hdw.bundle_contains_marker(src, hdw.RSS_ATOM_MARKER))
 
     def test_quoted_marker_only_in_unrelated_chunk_fails(self):
         with tempfile.TemporaryDirectory() as td:
@@ -161,12 +230,25 @@ class TestValidateSrc(unittest.TestCase):
             assets = src / "assets"
             assets.mkdir(parents=True)
             (assets / "perc-modern-ui.js").write_text(
-                'const k="object-storage";\n',
+                'const k="object-storage";\nconst r="rss-atom";\n',
                 encoding="utf-8",
             )
             (assets / "perc-modern-ui.css").write_text("/* css */\n", encoding="utf-8")
             rc = hdw.validate_src(src, require_object_storage=True)
             self.assertEqual(rc, hdw.EXIT_OK)
+
+    def test_inlined_object_storage_without_rss_atom_fails(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / "modern"
+            assets = src / "assets"
+            assets.mkdir(parents=True)
+            (assets / "perc-modern-ui.js").write_text(
+                'const k="object-storage";\n',
+                encoding="utf-8",
+            )
+            (assets / "perc-modern-ui.css").write_text("/* css */\n", encoding="utf-8")
+            rc = hdw.validate_src(src, require_kind_markers=True)
+            self.assertEqual(rc, hdw.EXIT_MARKER_MISSING)
 
 
 class TestContainerDestFile(unittest.TestCase):
@@ -240,8 +322,18 @@ class TestDeploy(unittest.TestCase):
 
     def test_skip_marker_allows_stale_bundle(self):
         with tempfile.TemporaryDirectory() as td:
-            src = _write_modern_tree(Path(td), include_object_storage=False)
+            src = _write_modern_tree(
+                Path(td), include_object_storage=False, include_rss_atom=False
+            )
             rc = hdw.deploy(src, require_object_storage=False, dry_run=True)
+            self.assertEqual(rc, hdw.EXIT_OK)
+
+    def test_skip_kind_marker_flag_is_alias(self):
+        with tempfile.TemporaryDirectory() as td:
+            src = _write_modern_tree(
+                Path(td), include_object_storage=False, include_rss_atom=False
+            )
+            rc = hdw.main(["--src", str(src), "--skip-kind-marker-check", "--dry-run"])
             self.assertEqual(rc, hdw.EXIT_OK)
 
 

--- a/docker/scripts/test_perc_devctl.py
+++ b/docker/scripts/test_perc_devctl.py
@@ -205,7 +205,32 @@ class TestQaRebuildChain(unittest.TestCase):
         self.assertEqual(rc, pdc.EXIT_OK)
         self.assertIn("RESULT:OK STEP:qa-rebuild-chain", out)
         self.assertIn("RESULT:OK STEP:qa-up", out)
+        self.assertIn("RESULT:OK STEP:qa-deploy-webui", out)
         self.assertIn("TEST_CMS_URL=", out)
+
+    def test_qa_rebuild_chain_then_qa_up_skip_webui_deploy(self):
+        _clear_port_env()
+        self.addCleanup(_clear_port_env)
+        rc, out = self.runner.run(
+            [
+                "qa-rebuild-chain",
+                "--skip-tests",
+                "--then-qa-up",
+                "--skip-webui-deploy",
+            ]
+        )
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-up", out)
+        self.assertNotIn("RESULT:OK STEP:qa-deploy-webui", out)
+
+    def test_qa_rebuild_chain_then_qa_deploy_webui_without_up(self):
+        rc, out = self.runner.run(
+            ["qa-rebuild-chain", "--skip-tests", "--then-qa-deploy-webui"]
+        )
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-rebuild-chain", out)
+        self.assertIn("RESULT:OK STEP:qa-deploy-webui", out)
+        self.assertNotIn("RESULT:OK STEP:qa-up", out)
 
 
 class TestDockerHealth(unittest.TestCase):
@@ -361,8 +386,18 @@ class TestSubcommandDryRun(unittest.TestCase):
         self.assertIn("--container", argv)
         self.assertIn(pdc.QA_CMS_CONTAINER, argv)
         self.assertNotIn("--skip-object-storage-check", argv)
+        self.assertNotIn("--skip-kind-marker-check", argv)
         self.assertNotIn("sh", argv)
         self.assertNotIn("-c", argv)
+
+    def test_qa_up_then_qa_deploy_webui_dry_run(self):
+        _clear_port_env()
+        self.addCleanup(_clear_port_env)
+        rc, out = self.runner.run(["qa-up", "--then-qa-deploy-webui"])
+        self.assertEqual(rc, pdc.EXIT_OK)
+        self.assertIn("RESULT:OK STEP:qa-up", out)
+        self.assertIn("RESULT:OK STEP:qa-deploy-webui", out)
+        self.assertIn("TEST_CMS_URL=", out)
 
     def test_verify_fix_dry_run(self):
         rc, out = self.runner.run([

--- a/docs/ai-generated/code-reviews/3948-qa-webui-virtual-source-kinds-erlang.md
+++ b/docs/ai-generated/code-reviews/3948-qa-webui-virtual-source-kinds-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — #3948 H2 QA virtual-source SPA kinds
+
+**Scope:** uncommitted vs `HEAD` on `fix/issue-3948-qa-webui-virtual-source-kinds` (vs `origin/main`).
+**Reviewer:** Erlang (independent of implementer).
+**Date:** 2026-08-28
+
+## Summary
+
+Cycle Verify #3948 failed Playwright `tests/developer-site-virtual-source.spec.js` because a skip-image-build H2 cell received only rest/sitemanage JARs. The live SPA `developer-site-virtual-source-kind` select was `[repository, git-filesystem, csv-filesystem, sql-database, http-json]` (no `object-storage` / `rss-atom`). origin/main SPA source already lists both kinds (`VirtualSiteSourcePanel` / `SOURCE_KIND_SELECT_VALUES`).
+
+This change hardens `hot-deploy-webui-modern.py` to require quoted `object-storage` **and** `rss-atom` in the live entry’s developer chunk, accepts Vite 8/rolldown template-literal backticks (production minification), and wires `qa-rebuild-chain --then-qa-up` plus `--then-qa-deploy-webui` so H2 QA gets `WebUI/target/generated-webui/cm/modern` after jar/rebuild paths.
+
+Memory patterns hit: missing behavioral tests; non-portable path joins (not present — host paths use `Path`, container dest is POSIX); incomplete change-class (deploy script + perc-devctl + tests + operator docs).
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] New path logic uses `Path` / `relative_to().as_posix()` / `container_dest_file`
+- [x] Container dest remains absolute POSIX (`/opt/Percussion/...`)
+- [x] Tests use `tempfile` + `Path`; no Unix-only absolute assertions
+- [x] `subprocess.run(..., shell=False)`
+
+## Issues
+
+None that block.
+
+Nit: `--skip-object-storage-check` remains the dest/flag name for skipping **all** kind markers (including rss-atom). Alias `--skip-kind-marker-check` is documented; keep the old flag so existing scripts do not break.
+
+## Tests
+
+- `python docker/scripts/test_hot_deploy_webui_modern.py` — 21 tests, OK
+- `python docker/scripts/test_perc_devctl.py` — 72 tests, OK
+- C5: `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` — 34 passed against `TEST_CMS_URL=http://127.0.0.1:9993` after full `qa-deploy-webui` + in-cell Jetty restart (and rest/sitemanage/perc-system SNAPSHOT copies for live save/build)
+
+## Product documentation
+
+N/A — operator H2 QA deploy toolchain (`perc-devctl` / docker scripts), not a CMS product-docs surface. Engineering notes: `docker/README.md`, `docs/developer-module/workbench-rest-and-qa-modes.md`, `modules/perc-qa-automation/README.md`.

--- a/docs/developer-module/workbench-rest-and-qa-modes.md
+++ b/docs/developer-module/workbench-rest-and-qa-modes.md
@@ -165,12 +165,14 @@ python docker/scripts/perc-devctl.py qa-health
 # Jetty can bind :9992 and answer 503 while ROOT failed (e.g. NoClassDefFoundError).
 # Copy product SNAPSHOTs to webapps/Rhythmyx/WEB-INF/lib/ (not jetty/base/lib).
 # If you copy sitemanage, also copy perc-system — --skip-image-build does not refresh it.
-# After WebUI SPA changes: copy the FULL generated cm/modern tree (stable
+# After WebUI SPA changes **or** after jar-only hot-deploys of rest/sitemanage
+# on a skip-image-build cell: copy the FULL generated cm/modern tree (stable
 # perc-modern-ui.js entry + CSS + hashed developer chunks + any index.html),
 # not only hashed files under assets/. Stale entry JS keeps the old
-# import("./developer-<hash>.js") — object-storage option missing while
-# csv/sql/http-json still render (#3893).
+# import("./developer-<hash>.js") — object-storage and rss-atom options missing
+# while csv/sql/http-json still render (#3893 / #3948).
 #   python docker/scripts/perc-devctl.py qa-deploy-webui
+# qa-rebuild-chain --then-qa-up implies this copy unless --skip-webui-deploy.
 # Restart Jetty inside the cell. Do not `docker restart perc-matrix-cms-h2` (reinstalls).
 # Docker Health.Status (in-image HEALTHCHECK, #2481) — orchestrators / docker ps:
 #   docker inspect -f "{{.State.Health.Status}}" perc-matrix-cms-h2

--- a/modules/perc-qa-automation/README.md
+++ b/modules/perc-qa-automation/README.md
@@ -117,7 +117,7 @@ python docker\scripts\perc-devctl.py qa-down
 | HTML report | `modules/perc-qa-automation/frontend/playwright-report/` |
 | Attach runbook | [playwright-failure-artifacts.md](../../docs/developer-module/playwright-failure-artifacts.md) |
 | Stack lifecycle | [workbench-rest-and-qa-modes.md](../../docs/developer-module/workbench-rest-and-qa-modes.md) §2 |
-| WebUI SPA hot-copy (#3893) | `perc-devctl.py qa-deploy-webui` — full `cm/modern` tree (entry `perc-modern-ui.js` + hashed chunks), not only `assets/` hashes |
+| WebUI SPA hot-copy (#3893 / #3948) | `perc-devctl.py qa-deploy-webui` — full `cm/modern` tree (entry `perc-modern-ui.js` + hashed chunks), not only `assets/` hashes; required after jar-only rest/sitemanage copies so `object-storage` and `rss-atom` stay on the kind select |
 
 #### Extended golden multi-path (`@folder-recycle` + `@profile`)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -349,7 +349,7 @@ Each entry below has been ported to cross-platform Python 3.9+ with pytest cover
 
 - `authenticate-sigstore.py` — Sigstore OIDC token retrieval + cache. Test: `test_authenticate_sigstore.py`.
 - `gh-preflight.py` — pre-flight checks for `gh` CLI usage. Test: `test_gh_preflight.py`.
-- `hot-deploy-local.py` — local hot-deploy helper for the CMS (jar modules + webui). Test: `test_hot_deploy_local.py`. H2 QA SPA copy (entry + hashed chunks, not host-install) is `docker/scripts/hot-deploy-webui-modern.py` / `perc-devctl.py qa-deploy-webui` (#3893).
+- `hot-deploy-local.py` — local hot-deploy helper for the CMS (jar modules + webui). Test: `test_hot_deploy_local.py`. H2 QA SPA copy (entry + hashed chunks, not host-install) is `docker/scripts/hot-deploy-webui-modern.py` / `perc-devctl.py qa-deploy-webui` (#3893 / #3948; refuses bundles missing quoted `object-storage` and `rss-atom`).
 - `resolve-conflicts.py` — git conflict resolution helper (ours / theirs / manual). Test: `test_resolve_conflicts.py`.
 - `verify-no-finder-jsp-references.py` — CI-gate artifact-grep for spec 992 / FR-019a (modern Track B shell, hard-cut in PR #1390). Test: `test_verify_no_finder_jsp_references.py`.
 - `verify-no-jqplot-vendor-refs.py` — CI-gate guard that the removed jqplot vendor library stays gone. Test: `test_verify_no_jqplot_vendor_refs.py`.


### PR DESCRIPTION
## Summary

Cycle Verify residual **#3948**: Playwright `tests/developer-site-virtual-source.spec.js` failed on H2 QA because the cell received **only** `rest` + `sitemanage` SNAPSHOT JARs. The live SPA `developer-site-virtual-source-kind` select was `[repository, git-filesystem, csv-filesystem, sql-database, http-json]` (no `object-storage` / `rss-atom`). origin/main SPA already lists both kinds (`SOURCE_KIND_SELECT_VALUES` / `VirtualSiteSourcePanel` tests).

This PR hardens the WebUI hot-deploy path:

- `hot-deploy-webui-modern.py` refuses a bundle unless the live `perc-modern-ui.js` developer chunk contains quoted **`object-storage` and `rss-atom`**.
- Production Vite 8 / rolldown minifies those constants to **template-literal backticks**; the checker now accepts `"…"`, `'…'`, and `` `…` `` (bare path substrings still fail).
- `perc-devctl qa-rebuild-chain --then-qa-up` copies `WebUI/target/generated-webui/cm/modern` into the H2 cell unless `--skip-webui-deploy`. Explicit `--then-qa-deploy-webui` is the **post-jar** companion after rest/sitemanage copies on a running skip-image-build cell.
- `qa-up --then-qa-deploy-webui` does the same after cell start.

Partial #3948 (Human QA candidate after Cycle verify; do not treat as a qa-task here).

Parent tracker: #3948. Peer: #3893 / PR #3897.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `python docker/scripts/test_hot_deploy_webui_modern.py` — 21 tests, OK
2. `python docker/scripts/test_perc_devctl.py` — 72 tests, OK
3. Package WebUI so `WebUI/target/generated-webui/cm/modern` contains both kind markers
4. `python docker/scripts/perc-devctl.py qa-up --skip-image-build` then `qa-health` (use printed `TEST_CMS_URL` / `QA_CMS_HOST_PORT`; freeport)
5. `python docker/scripts/perc-devctl.py qa-deploy-webui` (full `cm/modern` tree, not `assets/` hashes only)
6. In-cell StopJetty/StartJetty (do **not** `docker restart perc-matrix-cms-h2`)
7. `qa-health` again
8. `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/developer-site-virtual-source.spec.js`

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): H2 QA / perc-devctl deploy toolchain only; no CMS operator/admin/end-user product-docs change. Engineering notes updated in `docker/README.md` and `docs/developer-module/workbench-rest-and-qa-modes.md`.
- [x] **Unit / module tests** — behavioral Python tests for kind-marker validation (rss-atom missing, backticks, perc-devctl `--then-qa-deploy-webui` / `--skip-webui-deploy`)
- [x] **WebUI + Playwright** — existing `tests/developer-site-virtual-source.spec.js`; no SPA source change; C5 live proof below
- [x] **Build gates** — no Maven module sources changed; Python docker scripts + tests. WebUI `package -DskipTests` used only to produce generated-webui for C5 deploy.
- [x] **Cross-platform** — host paths via `pathlib.Path`; container dest POSIX; `subprocess.run(..., shell=False)`

### C3 evidence

- **modules_built:** none (Python `docker/scripts` + docs; no Java module source change)
- **build_evidence:**
  - `python docker/scripts/test_hot_deploy_webui_modern.py` → BUILD SUCCESS analog, Tests run: 21, Failures: 0
  - `python docker/scripts/test_perc_devctl.py` → Tests run: 72, Failures: 0
  - `cd WebUI && ../mvnw.cmd package -DskipTests` → BUILD SUCCESS (generated-webui for C5 only)
- **downstream_checked:** none (C2 did not apply: no Java `final`/API shape change)

### C5 UI proof

- `qa-up --skip-image-build` → cell `perc-matrix-cms-h2`, `TEST_CMS_URL=http://127.0.0.1:9993`
- `qa-health` RESULT:OK HTTP:200 HEALTH:healthy
- `qa-deploy-webui` RESULT:OK (full generated-webui/cm/modern)
- In-cell StopJetty/StartJetty; `qa-health` RESULT:OK again
- Also copied rest/sitemanage/perc-system SNAPSHOTs into WAR `WEB-INF/lib` (live save/build needed backend allow-list on skip-image-build image)
- Playwright: `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js` → **34 passed**, 0 failed (1.5m)
- console-clean=yes (no pageerror/uncaught JS on exercised paths)
- server.log-clean=yes (no feature-related ERROR/FATAL in the Playwright window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
