### PR TITLE
feat(rest): CD-15 shared field group create/save/delete (#3944)

### DIFF
--- a/docs/ai-generated/code-reviews/3944-shared-fields-rest-write-erlang.md
+++ b/docs/ai-generated/code-reviews/3944-shared-fields-rest-write-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — #3944 REST CD-15 shared field write
+
+**Branch:** `feat/issue-3944-shared-fields-rest-write`  
+**Date:** 2026-08-28  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (rest resource + adaptor + Spring stub + sitemanage impl + tests + product-docs); Admin 403 not a global JAX-RS filter; typed lock exception → 409; filename path-injection rejection.
+
+## Scope
+
+Uncommitted CD-15 write slice vs `origin/main`: `rest` sharedfields resource/adaptor/DTOs/tests/stub, `projects/sitemanage` `SharedFieldsAdaptor` + tests, `product-docs/8.2` Developer REST + admin content-types, gap map.
+
+## Summary
+
+Admin-only REST create / save / delete for shared field groups over existing `IPSContentDesignWs.loadContentEditorSharedDef` / `saveContentEditorSharedDef` (request-scoped lock + release). Peers: Keywords CRUD, CT PUT 400/403/404/409, GET catalog #3929. Field create/delete, control/choice write, SPA editor remain later slices (`designGaps`).
+
+## Issues
+
+None that block commit.
+
+## Cross-platform path checklist
+
+- No filesystem I/O. Group name / filename reject `/`, `\`, `..`, NUL (same as GET catalog).
+- Object-store `.xml` suffix is a filename constraint, not an OS path join.
+
+## Tests / companions
+
+- Mockito `SharedFieldsResourceTest` (23): POST/PUT/DELETE 200/204/400/403/404/409 + Spring stub methods on `TestSharedFieldsAdaptor`.
+- Adaptor `SharedFieldsAdaptorTest` (29): create/save/delete success, 403, 404, duplicate 409, lock 409, field patch, persistable empty group XML.
+- `MainTest` still loads after new adaptor methods (stub implements interface).
+- Standalone `rest` and `projects/sitemanage` `mvnw clean install` BUILD SUCCESS.
+
+## Product docs
+
+`product-docs/8.2/developer/rest.md` and `admin/developer-content-types.md` updated for POST/PUT/DELETE. Gap map CD-15 write marked shipped (group CRUD); field create/delete + SPA still open.

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -14,8 +14,9 @@
 | Public REST lock/unlock           | Self-only design-session lock       | `POST /services/contenttypes/{idOrName}/lock` / `.../unlock` |
 | Public REST PUT save              | Held-lock save (label/description/…) | `PUT /services/contenttypes/{idOrName}`        |
 | Public REST POST create           | Persist new type (Workbench Finish) | `POST /services/contenttypes`                  |
-| Public REST shared-field list     | CD-15 read catalog (Admin only)     | `GET /services/sharedfields`                   |
-| Public REST shared-field detail   | CD-15 read group fields (Admin only)| `GET /services/sharedfields/{idOrName}`        |
+| Public REST shared-field list     | CD-15 catalog (Admin only)          | `GET /services/sharedfields`                   |
+| Public REST shared-field detail   | CD-15 group fields (Admin only)     | `GET /services/sharedfields/{idOrName}`        |
+| Public REST shared-field write    | CD-15 create/save/delete (Admin)    | `POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}` |
 | Design SOAP (Workbench)           | Full load/save/lock/create/delete   | `IPSContentDesignWs` / `ContentDesignSOAPImpl` |
 | Item def manager                  | Runtime CE definition cache         | `PSItemDefManager.getItemDef`                  |
 
@@ -54,7 +55,7 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 | Item-level pre/post exits & validations              | CD-09        | Properties tab                                    |
 | Edit workflow/template associations                  | CD-08, CD-12 | **CD-08 REST PUT .../allowedWorkflows** (#3763, held design lock); **CD-12 REST PUT .../allowedTemplates** (#3775, held design lock; full replace, empty list clears) |
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
-| Shared field file **write**                          | CD-15        | **Read catalog shipped** (`GET /services/sharedfields` + `GET …/{idOrName}`, Admin 403, #3929 / PR #1650 list+detail). Create/rename/delete/save and SPA editor still open |
+| Shared field file **write**                          | CD-15        | **Create/save/delete shipped** (`POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}`, Admin 403, lock 409, #3944). Field create/delete, control/choice write, and SPA editor still open |
 | System def                                           | CD-16        | Separate object                                   |
 | Create / rename / delete                             | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Rename / delete still SOAP design only; lock + PUT save via REST |
 | Import/export CT                                     | CD-14        | Workbench wizards                                 |
@@ -68,7 +69,7 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 3. ~~Design-session lock + `PUT` save via thin REST over `IPSContentDesignWs`~~ **Lock** (#3742) + **PUT save requires held lock** (#3743)
 4. ~~Keyword create/update/delete~~ **Done CD-17** (REST write + design WS + SPA editor)
 5. ~~Control property value/choice catalogs~~ **Done CD-07 REST** (#3786). Field-rule write/save still open
-6. ~~Shared field catalog read~~ **Done CD-15 read** (`GET /services/sharedfields`, Admin 403). Write still open
+6. ~~Shared field catalog read~~ **Done CD-15 read** (`GET /services/sharedfields`, Admin 403). ~~Write~~ **Done CD-15 group create/save/delete** (`POST`/`PUT`/`DELETE`). Field create/delete + SPA editor still open
 7. Templates/slots design editors
 
 ## Client behavior

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -19,8 +19,11 @@ Integrators can **create** a content type with Admin `POST /services/contenttype
 (Workbench Finish). This chrome does **not** include a create wizard; delete
 and rename are not supported here. Shared field **files** are a separate design
 object: Admin-only `GET /services/sharedfields` and
-`GET /services/sharedfields/{idOrName}` (read catalog; write is not on REST).
-See [REST API](id:developer-rest).
+`GET /services/sharedfields/{idOrName}` (catalog), plus
+`POST /services/sharedfields`, `PUT /services/sharedfields/{idOrName}`, and
+`DELETE /services/sharedfields/{idOrName}` (create / save / delete; the shared
+definition is locked for the request). Field create/delete and the SPA editor
+are not in this chrome. See [REST API](id:developer-rest).
 
 This is **not** the full Workbench field-rule editor. The detail table still
 shows rule **flags** (validation / visibility / transforms present). After

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -514,23 +514,41 @@ catalog. Choice filters, null-entry, and default-selected are not written.
 ## Shared fields (design catalog)
 
 Content-editor **shared field groups** (Workbench shared field files, CD-15) are a
-separate design object from content types. Public REST exposes a **read-only catalog**
-under `/services/sharedfields`. Load uses the same content **design** web service as
-Workbench (`IPSContentDesignWs.loadContentEditorSharedDef`).
+separate design object from content types. Public REST exposes a catalog **and write**
+under `/services/sharedfields`. Load and save use the same content **design** web
+service as Workbench (`IPSContentDesignWs.loadContentEditorSharedDef` /
+`saveContentEditorSharedDef`). Writes acquire the shared-definition design lock for
+the request and **release** it on save (unlike content-type PUT, which requires a
+previously held lock).
 
 **Admin (Design) only.** There is no global JAX-RS Admin filter on this path — the
 sitemanage adaptor checks `IPSUserService.isAdminUser` for the current user and maps
-a non-Admin caller to **403**. Create, rename, delete, field-property write, and
+a non-Admin caller to **403**. Field **create/delete**, control/choice write, and
 system-def (CD-16) remain unsupported.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/sharedfields` | List shared field groups (`name`, `filename`, `fieldCount`) |
 | `GET` | `/services/sharedfields/{idOrName}` | Load one group by **name** (case-insensitive). Shared groups have no numeric design id on this catalog. |
+| `POST` | `/services/sharedfields` | Create an empty shared field group (`name` required, unique, no spaces). Optional `filename` defaults to `{name}.xml`. |
+| `PUT` | `/services/sharedfields/{idOrName}` | Save filename, optional rename (`body.name`), and patches to **existing** fields (`searchable`, occurrence / required). Null `fields` leaves the catalog unchanged. |
+| `DELETE` | `/services/sharedfields/{idOrName}` | Delete the group (**204**). |
 
 `{idOrName}` is the shared field group name (for example a product set such as
 `shared`). Path separators and `..` are rejected as not found (**404**), not as a
 directory listing.
+
+Create body is a `SharedFieldGroupDetail`:
+
+```json
+{
+  "name": "customShared",
+  "filename": "customShared.xml"
+}
+```
+
+PUT may include `fields[]` to patch existing fields by `name`. Unknown field names
+are **400**. New fields cannot be added on this slice.
 
 ### Response shape
 
@@ -539,7 +557,8 @@ List entries use `SharedFieldGroupSummary`. Detail uses `SharedFieldGroupDetail`
 - `name`, `filename`
 - `fields[]`: `name`, `dataType`, `searchable`, `required`, `readOnly`, `occurrence`
   (`optional` / `required` / `oneOrMore` / `zeroOrMore` / `count` / `unknown`)
-- `designGaps[]` strings — write, control/choice edit, and system-def are later slices
+- `designGaps[]` strings — field create/delete, control/choice edit, and system-def
+  remain later slices
 
 Prefer the generated OpenAPI schema as the integration source of truth.
 
@@ -547,15 +566,18 @@ Prefer the generated OpenAPI schema as the integration source of truth.
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | List (possibly empty) or group detail |
-| `403` | Caller is not Admin |
+| `200` | List (possibly empty), group detail, create, or save |
+| `204` | Deleted |
+| `400` | Invalid name/filename, or unknown field on PUT |
+| `403` | Caller is not Admin, or the request has no session/user (writes) |
 | `404` | Group not found (unknown or unsafe name). Non-Admin callers receive **403**, not 404 |
+| `409` | Duplicate group name, or the shared definition is locked by another user |
 | `500` | Design service or server failure |
 
-Authenticated non-Admin sessions (Editor, Contributor, and similar) must not read this
-catalog. Callers should treat 403 as “no Design Admin rights,” not as a missing group.
-
-Write/save, lock, create, and delete of shared field files are **not** on this API.
+Authenticated non-Admin sessions (Editor, Contributor, and similar) must not read or
+write this catalog. Callers should treat 403 as “no Design Admin rights,” not as a
+missing group. Treat 409 as “retry after the other designer releases the shared-def
+lock” (Workbench also locks the whole shared definition, not one group).
 
 ## Templates (assembly catalog)
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -536,7 +536,8 @@ system-def (CD-16) remain unsupported.
 
 `{idOrName}` is the shared field group name (for example a product set such as
 `shared`). Path separators and `..` are rejected as not found (**404**), not as a
-directory listing.
+directory listing. A blank path name on PUT or DELETE is **400** (same invalid-name
+rule as POST).
 
 Create body is a `SharedFieldGroupDetail`:
 
@@ -548,7 +549,11 @@ Create body is a `SharedFieldGroupDetail`:
 ```
 
 PUT may include `fields[]` to patch existing fields by `name`. Unknown field names
-are **400**. New fields cannot be added on this slice.
+are **400**. New fields cannot be added on this slice. `occurrence` and `required`
+map to the same dimension: when both are sent they must agree (`required=true`
+with `required` / `oneOrMore`; `required=false` with `optional` / `zeroOrMore` /
+`count`) or the request is **400**. `occurrence` is applied when present;
+`required` is used only when `occurrence` is omitted.
 
 ### Response shape
 
@@ -568,7 +573,7 @@ Prefer the generated OpenAPI schema as the integration source of truth.
 |--------|-----------------|
 | `200` | List (possibly empty), group detail, create, or save |
 | `204` | Deleted |
-| `400` | Invalid name/filename, or unknown field on PUT |
+| `400` | Invalid name/filename (including blank path name on PUT/DELETE), unknown field, or conflicting `occurrence`/`required` on PUT |
 | `403` | Caller is not Admin, or the request has no session/user (writes) |
 | `404` | Group not found (unknown or unsafe name). Non-Admin callers receive **403**, not 404 |
 | `409` | Duplicate group name, or the shared definition is locked by another user |

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
@@ -17,20 +17,32 @@
 
 package com.percussion.apibridge;
 
+import com.percussion.design.objectstore.PSBackEndCredential;
+import com.percussion.design.objectstore.PSContainerLocator;
 import com.percussion.design.objectstore.PSContentEditorSharedDef;
+import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSSharedFieldGroup;
+import com.percussion.design.objectstore.PSSystemValidationException;
+import com.percussion.design.objectstore.PSTableLocator;
+import com.percussion.design.objectstore.PSTableRef;
+import com.percussion.design.objectstore.PSTableSet;
+import com.percussion.design.objectstore.PSUIDefinition;
 import com.percussion.rest.sharedfields.ISharedFieldsAdaptor;
+import com.percussion.rest.sharedfields.SharedFieldDesignLockException;
 import com.percussion.rest.sharedfields.SharedFieldGroupDetail;
 import com.percussion.rest.sharedfields.SharedFieldGroupSummary;
+import com.percussion.rest.sharedfields.SharedFieldNotFoundException;
 import com.percussion.rest.sharedfields.SharedFieldSummary;
 import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.user.data.PSCurrentUser;
 import com.percussion.user.service.IPSUserService;
+import com.percussion.util.PSCollection;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import com.percussion.webservices.content.PSContentWsLocator;
 import jakarta.ws.rs.WebApplicationException;
@@ -48,27 +60,30 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only catalog of content-editor shared field groups ({@link PSContentEditorSharedDef}).
+ * Catalog and write of content-editor shared field groups ({@link PSContentEditorSharedDef}).
  *
- * <p>Workbench parity: loads via {@link IPSContentDesignWs#loadContentEditorSharedDef} (same design
- * web service SOAP uses), not {@code PSServer.getContentEditorSharedDef()} alone.
+ * <p>Workbench parity: loads and saves via {@link IPSContentDesignWs#loadContentEditorSharedDef} /
+ * {@link IPSContentDesignWs#saveContentEditorSharedDef} (same design web service SOAP uses), not
+ * {@code PSServer.getContentEditorSharedDef()} alone.
  *
  * <p>Admin (Design) only — same {@link IPSUserService#isAdminUser} gate as content-type design
- * mutations. There is no global JAX-RS Admin filter on {@code /services/sharedfields}.
+ * mutations. There is no global JAX-RS Admin filter on {@code /services/sharedfields}. Writes
+ * acquire the shared-def design lock for the request and release it on save.
  */
 @PSSiteManageBean
 public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
 
   private static final Logger log = LogManager.getLogger(SharedFieldsAdaptor.class);
 
-  static final String ADMIN_REQUIRED = "Admin role required to read shared field groups";
+  static final String ADMIN_REQUIRED = "Admin role required to read or write shared field groups";
 
   private static final List<String> DESIGN_GAPS =
       List.of(
-          "Shared field group create / rename / delete not supported via this API",
-          "Field property / control / choice write not supported via this API",
+          "Field create / delete not supported via this API",
+          "Field control / choice write not supported via this API",
           "System def (global fields) is a separate catalog (later slice)");
 
+  private final IPSContentDesignWs designWs;
   private final Supplier<PSContentEditorSharedDef> sharedDefLoader;
   private final BooleanSupplier adminChecker;
 
@@ -77,18 +92,25 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
   private IPSUserService userService;
 
   public SharedFieldsAdaptor() {
-    this(
+    this(PSContentWsLocator.getContentDesignWebservice(), null);
+  }
+
+  /**
+   * Package-visible for unit tests that inject a fake design web service. {@code null}
+   * adminChecker uses {@link #isCurrentUserAdmin()}.
+   */
+  SharedFieldsAdaptor(IPSContentDesignWs designWs, BooleanSupplier adminChecker) {
+    this.designWs = designWs;
+    this.sharedDefLoader =
         () ->
             loadSharedDefFromDesignWs(
-                PSContentWsLocator.getContentDesignWebservice(),
-                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID),
-                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER)),
-        null);
+                designWs, currentSession(), currentUser());
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   /**
    * Package-visible for unit tests that inject a fake shared def source. Admin is allowed so
-   * mapping tests can focus on catalog shape.
+   * mapping tests can focus on catalog shape. Writes require {@link IPSContentDesignWs}.
    */
   SharedFieldsAdaptor(Supplier<PSContentEditorSharedDef> sharedDefLoader) {
     this(sharedDefLoader, () -> true);
@@ -100,6 +122,7 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
    */
   SharedFieldsAdaptor(
       Supplier<PSContentEditorSharedDef> sharedDefLoader, BooleanSupplier adminChecker) {
+    this.designWs = null;
     this.sharedDefLoader = sharedDefLoader;
     this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
@@ -117,6 +140,205 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
       log.error("Failed to load content editor shared def via design WS", e);
       throw new IllegalStateException("Failed to load shared def", e);
     }
+  }
+
+  private void requireDesignWs() {
+    if (designWs == null) {
+      throw new IllegalStateException("Shared field design web service is not available");
+    }
+  }
+
+  private static void requireSessionUserForWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for shared field design write",
+          Response.Status.FORBIDDEN);
+    }
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+
+  private PSContentEditorSharedDef loadSharedDefLocked(String session, String user) {
+    try {
+      PSContentEditorSharedDef def =
+          designWs.loadContentEditorSharedDef(true, false, session, user);
+      return def != null ? def : new PSContentEditorSharedDef();
+    } catch (PSLockErrorException e) {
+      throw mapLockConflict(e);
+    } catch (PSErrorException e) {
+      log.error("Failed to load content editor shared def for write", e);
+      throw new IllegalStateException("Failed to load shared def for write", e);
+    }
+  }
+
+  private void saveSharedDef(PSContentEditorSharedDef def, String session, String user) {
+    try {
+      designWs.saveContentEditorSharedDef(def, true, session, user);
+    } catch (PSLockErrorException e) {
+      throw mapLockConflict(e);
+    } catch (PSErrorException e) {
+      log.error("Failed to save content editor shared def", e);
+      throw new IllegalStateException("Failed to save shared def", e);
+    }
+  }
+
+  static SharedFieldDesignLockException mapLockConflict(PSLockErrorException e) {
+    String locker = e != null ? e.getLocker() : null;
+    if (StringUtils.isNotBlank(locker)) {
+      return new SharedFieldDesignLockException(
+          "Could not save shared field group; locked by " + locker, e);
+    }
+    return new SharedFieldDesignLockException(
+        "Could not save shared field group; design lock required", e);
+  }
+
+  static String validateGroupName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    if (containsWhitespace(name)) {
+      throw new IllegalArgumentException("name cannot contain spaces");
+    }
+    if (name.contains("*")) {
+      throw new IllegalArgumentException("name must not contain wildcards");
+    }
+    if (!isSafeGroupName(name)) {
+      throw new IllegalArgumentException("name contains invalid path characters");
+    }
+    return name;
+  }
+
+  static String normalizeFilename(String filename, String groupName) {
+    String raw = StringUtils.isBlank(filename) ? groupName + ".xml" : filename.trim();
+    if (containsWhitespace(raw)) {
+      throw new IllegalArgumentException("filename cannot contain spaces");
+    }
+    if (!isSafeGroupName(stripXmlSuffix(raw))) {
+      throw new IllegalArgumentException("filename contains invalid path characters");
+    }
+    if (raw.toLowerCase().endsWith(".xml")) {
+      return stripXmlSuffix(raw) + ".xml";
+    }
+    if (raw.contains(".")) {
+      throw new IllegalArgumentException("filename must use a .xml extension");
+    }
+    return raw + ".xml";
+  }
+
+  private static String stripXmlSuffix(String filename) {
+    if (filename.toLowerCase().endsWith(".xml")) {
+      return filename.substring(0, filename.length() - 4);
+    }
+    return filename;
+  }
+
+  private static boolean containsWhitespace(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isWhitespace(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Persistable empty group: locator + empty field set + empty display mapper. Field create is a
+   * later slice.
+   */
+  static PSSharedFieldGroup newEmptyGroup(String name, String filename) {
+    PSBackEndCredential cred = new PSBackEndCredential("contentCredential");
+    cred.setDataSource("");
+    PSTableLocator tableLoc = new PSTableLocator(cred);
+    PSTableRef tableRef = new PSTableRef(tableNameForGroup(name));
+    PSTableSet ts = new PSTableSet(tableLoc, tableRef);
+    PSCollection<PSTableSet> tsCol = new PSCollection<>(PSTableSet.class);
+    tsCol.add(ts);
+    PSContainerLocator loc = new PSContainerLocator(tsCol);
+    PSFieldSet fs = new PSFieldSet(name);
+    PSDisplayMapper mapper = new PSDisplayMapper(name);
+    PSUIDefinition ui = new PSUIDefinition(mapper);
+    PSSharedFieldGroup group = new PSSharedFieldGroup(name, loc, fs, ui);
+    group.setFilename(filename);
+    return group;
+  }
+
+  static String tableNameForGroup(String name) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < name.length(); i++) {
+      char c = name.charAt(i);
+      if (Character.isLetterOrDigit(c)) {
+        sb.append(Character.toUpperCase(c));
+      } else if (c == '_' && sb.length() > 0) {
+        sb.append('_');
+      }
+    }
+    return sb.length() == 0 ? "SHARED_FIELDS" : sb.toString();
+  }
+
+  static void applyFieldPatches(PSSharedFieldGroup group, List<SharedFieldSummary> patches) {
+    if (patches == null || patches.isEmpty() || group == null) {
+      return;
+    }
+    PSFieldSet fieldSet = group.getFieldSet();
+    if (fieldSet == null) {
+      throw new IllegalArgumentException("Shared field group has no field set");
+    }
+    for (SharedFieldSummary patch : patches) {
+      if (patch == null || StringUtils.isBlank(patch.getName())) {
+        continue;
+      }
+      PSField field = fieldSet.findFieldByName(patch.getName(), false);
+      if (field == null) {
+        throw new IllegalArgumentException("Unknown field: " + patch.getName());
+      }
+      if (patch.getSearchable() != null) {
+        field.setUserSearchable(patch.getSearchable());
+      }
+      if (StringUtils.isNotBlank(patch.getOccurrence())) {
+        Integer dim = occurrenceFromApi(patch.getOccurrence());
+        if (dim == null) {
+          throw new IllegalArgumentException(
+              "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence());
+        }
+        try {
+          field.setOccurrenceDimension(dim, null);
+        } catch (PSSystemValidationException e) {
+          throw new IllegalArgumentException(
+              "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence(), e);
+        }
+      } else if (patch.getRequired() != null) {
+        int dim =
+            Boolean.TRUE.equals(patch.getRequired())
+                ? PSField.OCCURRENCE_DIMENSION_REQUIRED
+                : PSField.OCCURRENCE_DIMENSION_OPTIONAL;
+        try {
+          field.setOccurrenceDimension(dim, null);
+        } catch (PSSystemValidationException e) {
+          throw new IllegalArgumentException(
+              "Invalid required flag for field " + patch.getName(), e);
+        }
+      }
+    }
+  }
+
+  static Integer occurrenceFromApi(String occurrence) {
+    if (occurrence == null) {
+      return null;
+    }
+    return switch (occurrence) {
+      case "optional" -> PSField.OCCURRENCE_DIMENSION_OPTIONAL;
+      case "required" -> PSField.OCCURRENCE_DIMENSION_REQUIRED;
+      case "oneOrMore" -> PSField.OCCURRENCE_DIMENSION_ONE_OR_MORE;
+      case "zeroOrMore" -> PSField.OCCURRENCE_DIMENSION_ZERO_OR_MORE;
+      case "count" -> PSField.OCCURRENCE_DIMENSION_COUNT;
+      default -> null;
+    };
   }
 
   @Override
@@ -139,6 +361,85 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
       return null;
     }
     return toDetail(group);
+  }
+
+  @Override
+  public SharedFieldGroupDetail createGroup(URI baseUri, SharedFieldGroupDetail body) {
+    requireAdmin();
+    requireDesignWs();
+    requireSessionUserForWrite();
+    if (body == null || StringUtils.isBlank(body.getName())) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String name = validateGroupName(body.getName().trim());
+    String filename = normalizeFilename(body.getFilename(), name);
+    String session = currentSession();
+    String user = currentUser();
+    PSContentEditorSharedDef def = loadSharedDefLocked(session, user);
+    if (findGroup(def, name) != null) {
+      throw new WebApplicationException("Shared field group already exists: " + name, 409);
+    }
+    PSSharedFieldGroup created = newEmptyGroup(name, filename);
+    def.addFieldGroup(created);
+    saveSharedDef(def, session, user);
+    return toDetail(created);
+  }
+
+  @Override
+  public SharedFieldGroupDetail updateGroup(URI baseUri, String name, SharedFieldGroupDetail body) {
+    requireAdmin();
+    requireDesignWs();
+    requireSessionUserForWrite();
+    if (!isSafeGroupName(name)) {
+      return null;
+    }
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String session = currentSession();
+    String user = currentUser();
+    PSContentEditorSharedDef def = loadSharedDefLocked(session, user);
+    PSSharedFieldGroup group = findGroup(def, name.trim());
+    if (group == null) {
+      return null;
+    }
+    if (StringUtils.isNotBlank(body.getFilename())) {
+      group.setFilename(normalizeFilename(body.getFilename(), group.getName()));
+    }
+    if (StringUtils.isNotBlank(body.getName())) {
+      String newName = validateGroupName(body.getName().trim());
+      if (!newName.equalsIgnoreCase(group.getName())) {
+        if (findGroup(def, newName) != null) {
+          throw new WebApplicationException("Shared field group already exists: " + newName, 409);
+        }
+        group.setName(newName);
+      }
+    }
+    applyFieldPatches(group, body.getFields());
+    saveSharedDef(def, session, user);
+    return toDetail(group);
+  }
+
+  @Override
+  public void deleteGroup(URI baseUri, String name) {
+    requireAdmin();
+    requireDesignWs();
+    requireSessionUserForWrite();
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    if (!isSafeGroupName(name)) {
+      throw new SharedFieldNotFoundException("Shared field group not found");
+    }
+    String session = currentSession();
+    String user = currentUser();
+    PSContentEditorSharedDef def = loadSharedDefLocked(session, user);
+    PSSharedFieldGroup group = findGroup(def, name.trim());
+    if (group == null) {
+      throw new SharedFieldNotFoundException("Shared field group not found");
+    }
+    def.removeFieldGroup(group);
+    saveSharedDef(def, session, user);
   }
 
   private void requireAdmin() {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
@@ -281,6 +281,14 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
     return sb.length() == 0 ? "SHARED_FIELDS" : sb.toString();
   }
 
+  /**
+   * Apply {@code searchable} then occurrence. {@code occurrence} and {@code required} both map to
+   * the same object-store dimension. When both are present they must agree ({@code required=true}
+   * with {@code required}/{@code oneOrMore}; {@code required=false} with {@code
+   * optional}/{@code zeroOrMore}/{@code count}); otherwise this throws {@link
+   * IllegalArgumentException}. When they agree, {@code occurrence} is applied. {@code required} is
+   * used only when {@code occurrence} is omitted.
+   */
   static void applyFieldPatches(PSSharedFieldGroup group, List<SharedFieldSummary> patches) {
     if (patches == null || patches.isEmpty() || group == null) {
       return;
@@ -300,30 +308,51 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
       if (patch.getSearchable() != null) {
         field.setUserSearchable(patch.getSearchable());
       }
-      if (StringUtils.isNotBlank(patch.getOccurrence())) {
-        Integer dim = occurrenceFromApi(patch.getOccurrence());
-        if (dim == null) {
-          throw new IllegalArgumentException(
-              "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence());
-        }
-        try {
-          field.setOccurrenceDimension(dim, null);
-        } catch (PSSystemValidationException e) {
-          throw new IllegalArgumentException(
-              "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence(), e);
-        }
-      } else if (patch.getRequired() != null) {
-        int dim =
-            Boolean.TRUE.equals(patch.getRequired())
-                ? PSField.OCCURRENCE_DIMENSION_REQUIRED
-                : PSField.OCCURRENCE_DIMENSION_OPTIONAL;
-        try {
-          field.setOccurrenceDimension(dim, null);
-        } catch (PSSystemValidationException e) {
-          throw new IllegalArgumentException(
-              "Invalid required flag for field " + patch.getName(), e);
-        }
+      applyOccurrenceOrRequired(field, patch);
+    }
+  }
+
+  static void applyOccurrenceOrRequired(PSField field, SharedFieldSummary patch) {
+    boolean hasOccurrence = StringUtils.isNotBlank(patch.getOccurrence());
+    boolean hasRequired = patch.getRequired() != null;
+    if (hasOccurrence) {
+      Integer dim = occurrenceFromApi(patch.getOccurrence());
+      if (dim == null) {
+        throw new IllegalArgumentException(
+            "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence());
       }
+      if (hasRequired
+          && Boolean.TRUE.equals(patch.getRequired()) != occurrenceImpliesRequired(dim)) {
+        throw new IllegalArgumentException(
+            "occurrence and required conflict for field " + patch.getName());
+      }
+      setOccurrenceDimension(field, dim, patch.getName(), patch.getOccurrence());
+    } else if (hasRequired) {
+      int dim =
+          Boolean.TRUE.equals(patch.getRequired())
+              ? PSField.OCCURRENCE_DIMENSION_REQUIRED
+              : PSField.OCCURRENCE_DIMENSION_OPTIONAL;
+      try {
+        field.setOccurrenceDimension(dim, null);
+      } catch (PSSystemValidationException e) {
+        throw new IllegalArgumentException(
+            "Invalid required flag for field " + patch.getName(), e);
+      }
+    }
+  }
+
+  static boolean occurrenceImpliesRequired(int dimension) {
+    return dimension == PSField.OCCURRENCE_DIMENSION_REQUIRED
+        || dimension == PSField.OCCURRENCE_DIMENSION_ONE_OR_MORE;
+  }
+
+  private static void setOccurrenceDimension(
+      PSField field, int dim, String fieldName, String occurrenceLabel) {
+    try {
+      field.setOccurrenceDimension(dim, null);
+    } catch (PSSystemValidationException e) {
+      throw new IllegalArgumentException(
+          "Invalid occurrence for field " + fieldName + ": " + occurrenceLabel, e);
     }
   }
 
@@ -390,6 +419,9 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
     requireAdmin();
     requireDesignWs();
     requireSessionUserForWrite();
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name is required");
+    }
     if (!isSafeGroupName(name)) {
       return null;
     }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
@@ -389,6 +389,71 @@ class SharedFieldsAdaptorTest {
   }
 
   @Test
+  void updateGroup_blankNameIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.updateGroup(null, "  ", new SharedFieldGroupDetail()));
+    assertTrue(ex.getMessage().contains("name is required"));
+    verify(designWs, never()).loadContentEditorSharedDef(anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void applyFieldPatches_occurrenceWinsWhenRequiredAgrees() throws Exception {
+    PSField field = mock(PSField.class);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.findFieldByName("rx_title", false)).thenReturn(field);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    group.setFieldSet(set);
+
+    SharedFieldSummary patch = new SharedFieldSummary();
+    patch.setName("rx_title");
+    patch.setOccurrence("oneOrMore");
+    patch.setRequired(true);
+
+    SharedFieldsAdaptor.applyFieldPatches(group, List.of(patch));
+    verify(field).setOccurrenceDimension(eq(PSField.OCCURRENCE_DIMENSION_ONE_OR_MORE), isNull());
+  }
+
+  @Test
+  void applyFieldPatches_occurrenceAndRequiredConflictIs400() {
+    PSField field = mock(PSField.class);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.findFieldByName("rx_title", false)).thenReturn(field);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    group.setFieldSet(set);
+
+    SharedFieldSummary patch = new SharedFieldSummary();
+    patch.setName("rx_title");
+    patch.setOccurrence("optional");
+    patch.setRequired(true);
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> SharedFieldsAdaptor.applyFieldPatches(group, List.of(patch)));
+    assertTrue(ex.getMessage().contains("conflict"));
+  }
+
+  @Test
+  void applyFieldPatches_requiredOnlyWhenOccurrenceOmitted() throws Exception {
+    PSField field = mock(PSField.class);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.findFieldByName("rx_title", false)).thenReturn(field);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    group.setFieldSet(set);
+
+    SharedFieldSummary patch = new SharedFieldSummary();
+    patch.setName("rx_title");
+    patch.setRequired(true);
+
+    SharedFieldsAdaptor.applyFieldPatches(group, List.of(patch));
+    verify(field).setOccurrenceDimension(eq(PSField.OCCURRENCE_DIMENSION_REQUIRED), isNull());
+  }
+
+  @Test
   void updateGroup_missingReturnsNull() throws Exception {
     IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
     when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin"))
@@ -424,6 +489,16 @@ class SharedFieldsAdaptorTest {
         ArgumentCaptor.forClass(PSContentEditorSharedDef.class);
     verify(designWs).saveContentEditorSharedDef(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
     assertNull(SharedFieldsAdaptor.findGroup(saved.getValue(), "shared"));
+  }
+
+  @Test
+  void deleteGroup_blankNameIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.deleteGroup(null, " "));
+    assertTrue(ex.getMessage().contains("name is required"));
+    verify(designWs, never()).loadContentEditorSharedDef(anyBoolean(), anyBoolean(), any(), any());
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
@@ -24,9 +24,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,19 +38,40 @@ import com.percussion.design.objectstore.PSContentEditorSharedDef;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
 import com.percussion.design.objectstore.PSSharedFieldGroup;
+import com.percussion.rest.sharedfields.SharedFieldDesignLockException;
 import com.percussion.rest.sharedfields.SharedFieldGroupDetail;
 import com.percussion.rest.sharedfields.SharedFieldGroupSummary;
+import com.percussion.rest.sharedfields.SharedFieldNotFoundException;
+import com.percussion.rest.sharedfields.SharedFieldSummary;
 import com.percussion.util.PSCollection;
+import com.percussion.utils.request.PSRequestInfoBase;
 import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 @Tag("UnitTest")
 class SharedFieldsAdaptorTest {
+
+  @BeforeEach
+  void setRequestInfo() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+  }
+
+  @AfterEach
+  void clearRequestInfo() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
 
   @Test
   void mapSummaries_mapsNameFilenameAndFieldCount() {
@@ -236,5 +261,229 @@ class SharedFieldsAdaptorTest {
         assertThrows(WebApplicationException.class, () -> denied.listGroups(null));
     assertEquals(403, ex.getResponse().getStatus());
     assertFalse(denied.isCurrentUserAdmin());
+  }
+
+  @Test
+  void createGroup_addsEmptyGroupAndSavesWithLockRelease() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setName("custom");
+    SharedFieldGroupDetail out = adaptor.createGroup(null, body);
+
+    assertEquals("custom", out.getName());
+    assertEquals("custom.xml", out.getFilename());
+    assertEquals(0, out.getFields().size());
+    ArgumentCaptor<PSContentEditorSharedDef> saved =
+        ArgumentCaptor.forClass(PSContentEditorSharedDef.class);
+    verify(designWs).saveContentEditorSharedDef(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
+    assertNotNull(SharedFieldsAdaptor.findGroup(saved.getValue(), "custom"));
+  }
+
+  @Test
+  void createGroup_duplicateNameIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(SharedFieldsAdaptor.newEmptyGroup("custom", "custom.xml"));
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setName("custom");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createGroup(null, body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveContentEditorSharedDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void createGroup_forbiddenWhenNotAdmin() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor denied = new SharedFieldsAdaptor(designWs, () -> false);
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setName("custom");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.createGroup(null, body));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).loadContentEditorSharedDef(anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void createGroup_invalidNameIs400() {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createGroup(null, body));
+    assertTrue(ex.getMessage().contains("spaces"));
+  }
+
+  @Test
+  void createGroup_lockConflictIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSLockErrorException lockErr =
+        new PSLockErrorException(1, "locked", "stack", "other", 1000L);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin"))
+        .thenThrow(lockErr);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setName("custom");
+    SharedFieldDesignLockException ex =
+        assertThrows(SharedFieldDesignLockException.class, () -> adaptor.createGroup(null, body));
+    assertTrue(ex.getMessage().contains("locked by other"));
+  }
+
+  @Test
+  void updateGroup_patchesSearchableAndSaves() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSField field = mock(PSField.class);
+    when(field.getSubmitName()).thenReturn("rx_title");
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.getAllFields()).thenReturn(new PSField[] {field});
+    when(set.findFieldByName("rx_title", false)).thenReturn(field);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    group.setFieldSet(set);
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+
+    SharedFieldSummary patch = new SharedFieldSummary();
+    patch.setName("rx_title");
+    patch.setSearchable(true);
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setFields(List.of(patch));
+
+    SharedFieldGroupDetail out = adaptor.updateGroup(null, "shared", body);
+    assertEquals("shared", out.getName());
+    verify(field).setUserSearchable(true);
+    verify(designWs).saveContentEditorSharedDef(eq(def), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void updateGroup_unknownFieldIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.findFieldByName("missing", false)).thenReturn(null);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    group.setFieldSet(set);
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+
+    SharedFieldSummary patch = new SharedFieldSummary();
+    patch.setName("missing");
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setFields(List.of(patch));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.updateGroup(null, "shared", body));
+    assertTrue(ex.getMessage().contains("Unknown field"));
+    verify(designWs, never()).saveContentEditorSharedDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void updateGroup_missingReturnsNull() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin"))
+        .thenReturn(new PSContentEditorSharedDef());
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    assertNull(adaptor.updateGroup(null, "missing", new SharedFieldGroupDetail()));
+    verify(designWs, never()).saveContentEditorSharedDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void updateGroup_forbiddenWhenNotAdmin() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor denied = new SharedFieldsAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> denied.updateGroup(null, "shared", new SharedFieldGroupDetail()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void deleteGroup_removesAndSaves() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+
+    adaptor.deleteGroup(null, "shared");
+
+    ArgumentCaptor<PSContentEditorSharedDef> saved =
+        ArgumentCaptor.forClass(PSContentEditorSharedDef.class);
+    verify(designWs).saveContentEditorSharedDef(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
+    assertNull(SharedFieldsAdaptor.findGroup(saved.getValue(), "shared"));
+  }
+
+  @Test
+  void deleteGroup_missingThrowsNotFound() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin"))
+        .thenReturn(new PSContentEditorSharedDef());
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    assertThrows(SharedFieldNotFoundException.class, () -> adaptor.deleteGroup(null, "missing"));
+    verify(designWs, never()).saveContentEditorSharedDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteGroup_forbiddenWhenNotAdmin() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor denied = new SharedFieldsAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.deleteGroup(null, "shared"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void deleteGroup_saveLockConflictIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    doThrow(new PSLockErrorException(1, "not locked", "stack"))
+        .when(designWs)
+        .saveContentEditorSharedDef(any(), eq(true), eq("test-session"), eq("Admin"));
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldDesignLockException ex =
+        assertThrows(SharedFieldDesignLockException.class, () -> adaptor.deleteGroup(null, "shared"));
+    assertTrue(ex.getMessage().contains("design lock required"));
+  }
+
+  @Test
+  void newEmptyGroup_isPersistableXml() {
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("custom", "custom.xml");
+    assertEquals("custom", group.getName());
+    assertEquals("custom.xml", group.getFilename());
+    org.w3c.dom.Document doc =
+        com.percussion.xml.PSXmlDocumentBuilder.createXmlDocument();
+    org.w3c.dom.Element xml = group.toXml(doc);
+    assertEquals("custom", xml.getAttribute("name"));
+    assertEquals("custom.xml", xml.getAttribute("filename"));
+  }
+
+  @Test
+  void normalizeFilename_defaultsToNameXml() {
+    assertEquals("custom.xml", SharedFieldsAdaptor.normalizeFilename(null, "custom"));
+    assertEquals("mine.xml", SharedFieldsAdaptor.normalizeFilename("mine", "custom"));
+    assertEquals("Mine.xml", SharedFieldsAdaptor.normalizeFilename("Mine.XML", "custom"));
+  }
+
+  @Test
+  void mapLockConflict_includesLocker() {
+    PSLockErrorException err = new PSLockErrorException(1, "locked", "stack", "alice", 10L);
+    SharedFieldDesignLockException mapped = SharedFieldsAdaptor.mapLockConflict(err);
+    assertEquals("Could not save shared field group; locked by alice", mapped.getMessage());
   }
 }

--- a/rest/src/main/java/com/percussion/rest/sharedfields/ISharedFieldsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/ISharedFieldsAdaptor.java
@@ -61,8 +61,9 @@ public interface ISharedFieldsAdaptor {
    * existing fields ({@code searchable}, occurrence / required). Null {@code fields} leaves fields
    * unchanged. Does not create or delete fields.
    *
-   * @return updated detail, or {@code null} when not found / unsafe name
-   * @throws IllegalArgumentException when input is invalid or a field name is unknown
+   * @return updated detail, or {@code null} when not found / unsafe path name
+   * @throws IllegalArgumentException when the path name is blank, input is invalid, a field name
+   *     is unknown, or {@code occurrence} and {@code required} conflict
    * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin; {@code
    *     409} when the new name already exists
    * @throws SharedFieldDesignLockException when the shared def is locked by another user

--- a/rest/src/main/java/com/percussion/rest/sharedfields/ISharedFieldsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/ISharedFieldsAdaptor.java
@@ -38,4 +38,45 @@ public interface ISharedFieldsAdaptor {
    * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin
    */
   SharedFieldGroupDetail getGroup(URI baseUri, String name);
+
+  /**
+   * Create and persist an empty shared field group (Workbench new shared-field file). Admin only.
+   * Acquires the shared-def design lock for this request and releases it on save.
+   *
+   * @param body {@code name} required; unique case-insensitive; no spaces. Optional {@code
+   *     filename} defaults to {@code {name}.xml}.
+   * @return persisted detail
+   * @throws IllegalArgumentException when the name/filename is invalid
+   * @throws jakarta.ws.rs.WebApplicationException {@code 409} when a group with that name exists;
+   *     {@code 403} when the caller is not Admin
+   * @throws SharedFieldDesignLockException when the shared def is locked by another user
+   */
+  SharedFieldGroupDetail createGroup(URI baseUri, SharedFieldGroupDetail body);
+
+  /**
+   * Update an existing shared field group. Admin only. Acquires the shared-def design lock for this
+   * request and releases it on save.
+   *
+   * <p>Supports filename, rename ({@code body.name} different from the path name), and patches to
+   * existing fields ({@code searchable}, occurrence / required). Null {@code fields} leaves fields
+   * unchanged. Does not create or delete fields.
+   *
+   * @return updated detail, or {@code null} when not found / unsafe name
+   * @throws IllegalArgumentException when input is invalid or a field name is unknown
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin; {@code
+   *     409} when the new name already exists
+   * @throws SharedFieldDesignLockException when the shared def is locked by another user
+   */
+  SharedFieldGroupDetail updateGroup(URI baseUri, String name, SharedFieldGroupDetail body);
+
+  /**
+   * Delete a shared field group. Admin only. Acquires the shared-def design lock for this request
+   * and releases it on save.
+   *
+   * @throws SharedFieldNotFoundException when the group does not exist
+   * @throws IllegalArgumentException when the name is blank or unsafe
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin
+   * @throws SharedFieldDesignLockException when the shared def is locked by another user
+   */
+  void deleteGroup(URI baseUri, String name);
 }

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldDesignLockException.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldDesignLockException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.sharedfields;
+
+/**
+ * Design-session lock conflict for shared-field create, save, or delete.
+ *
+ * <p>Mapped to HTTP 409 by {@code SharedFieldsResource}. Distinct from generic {@link
+ * IllegalStateException} so status is not inferred from message substrings.
+ */
+public class SharedFieldDesignLockException extends IllegalStateException {
+
+  private static final long serialVersionUID = 1L;
+
+  public SharedFieldDesignLockException(String message) {
+    super(message);
+  }
+
+  public SharedFieldDesignLockException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldGroupDetail.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldGroupDetail.java
@@ -24,9 +24,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Read-only detail for one shared field group.
+ * Shared field group detail. Used for GET catalog and POST/PUT write (name, filename, field
+ * patches).
  *
- * <p>Does not support create/update/delete (later CD-15 write slice).
+ * <p>Field create/delete, control/choice write, and system-def remain later slices ({@code
+ * designGaps}).
  */
 @XmlRootElement(name = "SharedFieldGroupDetail")
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldNotFoundException.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.sharedfields;
+
+/** Thrown when a shared field group cannot be resolved for delete. Maps to HTTP 404. */
+public class SharedFieldNotFoundException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public SharedFieldNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldSummary.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldSummary.java
@@ -21,7 +21,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
-/** Read-only field row inside a shared field group. */
+/**
+ * Field row inside a shared field group. GET catalog; PUT may patch {@code searchable} and
+ * occurrence / required on existing fields. {@code readOnly} and {@code dataType} are read-only.
+ */
 @XmlRootElement(name = "SharedField")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "Shared field summary")

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldsResource.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldsResource.java
@@ -24,27 +24,32 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only catalog of content-editor shared field groups for the Developer module (CD-15).
+ * Catalog and write of content-editor shared field groups for the Developer module (CD-15).
  *
  * <p>Registered via {@link PSSiteManageBean} like sibling catalog resources.
  */
 @PSSiteManageBean(value = "restSharedFieldsResource")
 @Path("/sharedfields")
 @XmlRootElement
-@Tag(name = "SharedFields", description = "Shared field group design catalog (read-only)")
+@Tag(name = "SharedFields", description = "Shared field group design catalog and write")
 public class SharedFieldsResource {
 
   private final ISharedFieldsAdaptor adaptor;
@@ -60,13 +65,19 @@ public class SharedFieldsResource {
     this.adaptor = adaptor;
   }
 
+  /** Package-private test hook so unit tests need not reflect on {@code uriInfo}. */
+  void setUriInfo(UriInfo uriInfo) {
+    this.uriInfo = uriInfo;
+  }
+
   @GET
   @Produces({MediaType.APPLICATION_JSON})
   @Operation(
       summary = "List shared field groups",
       description =
           "Lists shared field groups from the content-editor shared definition. Admin (Design)"
-              + " only. Create/edit/delete are later slices.",
+              + " only. Create uses POST /sharedfields; save uses PUT /sharedfields/{name}; delete"
+              + " uses DELETE /sharedfields/{name}.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -95,8 +106,8 @@ public class SharedFieldsResource {
   @Operation(
       summary = "Get shared field group detail",
       description =
-          "Loads one shared field group by name (read-only, Admin/Design only). Includes field"
-              + " catalog; write and system-def editor remain unsupported (see designGaps).",
+          "Loads one shared field group by name (Admin/Design only). Includes field catalog."
+              + " Control/choice write and system-def remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -119,6 +130,135 @@ public class SharedFieldsResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  @POST
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Create a shared field group",
+      description =
+          "Admin. Creates and persists an empty shared field group via"
+              + " IPSContentDesignWs.loadContentEditorSharedDef (lock) then"
+              + " saveContentEditorSharedDef (release). Name is required, must be unique"
+              + " (case-insensitive), and must not contain spaces or path characters. Optional"
+              + " filename defaults to {name}.xml. Duplicate name is 409. Lock held by another"
+              + " user is 409.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created and saved",
+            content = @Content(schema = @Schema(implementation = SharedFieldGroupDetail.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid name or filename"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "A group with that name exists, or shared def locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public SharedFieldGroupDetail createGroup(SharedFieldGroupDetail body) {
+    try {
+      return requireAdaptor().createGroup(uriInfo.getBaseUri(), body);
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{name}")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Update a shared field group",
+      description =
+          "Admin. Saves filename, optional rename (body.name different from path), and patches"
+              + " to existing fields (searchable, occurrence/required). Null fields leaves the"
+              + " catalog unchanged. Does not create or delete fields. Acquires the shared-def"
+              + " design lock for this request and releases it on save. Missing group is 404;"
+              + " lock held by another user is 409.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = SharedFieldGroupDetail.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input or unknown field name"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Group not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Rename target exists, or shared def locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public SharedFieldGroupDetail updateGroup(
+      @PathParam("name") String name, SharedFieldGroupDetail body) {
+    try {
+      SharedFieldGroupDetail detail = requireAdaptor().updateGroup(uriInfo.getBaseUri(), name, body);
+      if (detail == null) {
+        throw new WebApplicationException("Shared field group not found", 404);
+      }
+      return detail;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{name}")
+  @Operation(
+      summary = "Delete a shared field group",
+      description =
+          "Admin. Removes the group from the content-editor shared definition and saves via"
+              + " IPSContentDesignWs.saveContentEditorSharedDef (releases the request lock)."
+              + " Missing group is 404; lock held by another user is 409.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid name"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Group not found"),
+        @ApiResponse(responseCode = "409", description = "Shared def locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteGroup(@PathParam("name") String name) {
+    try {
+      requireAdaptor().deleteGroup(uriInfo.getBaseUri(), name);
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Lock conflicts are always 409 via {@link
+   * SharedFieldDesignLockException}.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof SharedFieldDesignLockException) {
+      return new WebApplicationException(e.getMessage(), 409);
+    }
+    if (e instanceof SharedFieldNotFoundException) {
+      return new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Shared field group not found", 404);
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    if (e instanceof IllegalStateException) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      if (msg.toLowerCase().contains("lock")) {
+        return new WebApplicationException(msg, 409);
+      }
+      return new WebApplicationException(e, 500);
+    }
+    return new WebApplicationException(e, 500);
   }
 
   private ISharedFieldsAdaptor requireAdaptor() {

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldsResource.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldsResource.java
@@ -176,8 +176,10 @@ public class SharedFieldsResource {
           "Admin. Saves filename, optional rename (body.name different from path), and patches"
               + " to existing fields (searchable, occurrence/required). Null fields leaves the"
               + " catalog unchanged. Does not create or delete fields. Acquires the shared-def"
-              + " design lock for this request and releases it on save. Missing group is 404;"
-              + " lock held by another user is 409.",
+              + " design lock for this request and releases it on save. Blank path name is 400;"
+              + " missing or unsafe path name is 404. When a field patch includes both occurrence"
+              + " and required they must agree (else 400); occurrence is applied when present."
+              + " Lock held by another user is 409.",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/test/java/com/percussion/rest/sharedfields/SharedFieldsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sharedfields/SharedFieldsResourceTest.java
@@ -236,6 +236,17 @@ public class SharedFieldsResourceTest {
   }
 
   @Test
+  public void updateGroupBlankNameIs400() {
+    when(adaptor.updateGroup(any(), eq(" "), any()))
+        .thenThrow(new IllegalArgumentException("name is required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateGroup(" ", new SharedFieldGroupDetail()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void updateGroupUnknownFieldIs400() {
     when(adaptor.updateGroup(any(), eq("shared"), any()))
         .thenThrow(new IllegalArgumentException("Unknown field: missing"));
@@ -251,6 +262,16 @@ public class SharedFieldsResourceTest {
     Response out = resource.deleteGroup("shared");
     assertEquals(204, out.getStatus());
     verify(adaptor).deleteGroup(any(), eq("shared"));
+  }
+
+  @Test
+  public void deleteGroupBlankNameIs400() {
+    doThrow(new IllegalArgumentException("name is required"))
+        .when(adaptor)
+        .deleteGroup(any(), eq(" "));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteGroup(" "));
+    assertEquals(400, ex.getResponse().getStatus());
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/sharedfields/SharedFieldsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sharedfields/SharedFieldsResourceTest.java
@@ -23,13 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,14 +44,12 @@ public class SharedFieldsResourceTest {
   private SharedFieldsResource resource;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     adaptor = mock(ISharedFieldsAdaptor.class);
     resource = new SharedFieldsResource(adaptor);
     UriInfo uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/services/"));
-    Field f = SharedFieldsResource.class.getDeclaredField("uriInfo");
-    f.setAccessible(true);
-    f.set(resource, uriInfo);
+    resource.setUriInfo(uriInfo);
   }
 
   @Test
@@ -134,5 +133,160 @@ public class SharedFieldsResourceTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> resource.getGroup("shared"));
     assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createGroupDelegatesToAdaptor() {
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setName("custom");
+    SharedFieldGroupDetail created = new SharedFieldGroupDetail();
+    created.setName("custom");
+    created.setFilename("custom.xml");
+    when(adaptor.createGroup(any(), any())).thenReturn(created);
+
+    assertEquals("custom", resource.createGroup(body).getName());
+    verify(adaptor).createGroup(any(), eq(body));
+  }
+
+  @Test
+  public void createGroupInvalidNameIs400() {
+    when(adaptor.createGroup(any(), any()))
+        .thenThrow(new IllegalArgumentException("name is required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.createGroup(new SharedFieldGroupDetail()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createGroupDuplicateIs409() {
+    when(adaptor.createGroup(any(), any()))
+        .thenThrow(new WebApplicationException("Shared field group already exists: custom", 409));
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setName("custom");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createGroup(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createGroupLockConflictIs409() {
+    when(adaptor.createGroup(any(), any()))
+        .thenThrow(new SharedFieldDesignLockException("Could not save shared field group; locked by other"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.createGroup(new SharedFieldGroupDetail()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createGroupForbiddenWhenNotAdmin() {
+    when(adaptor.createGroup(any(), any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.createGroup(new SharedFieldGroupDetail()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createGroupWrapsUnexpectedFailures() {
+    IllegalStateException boom = new IllegalStateException("design ws down");
+    when(adaptor.createGroup(any(), any())).thenThrow(boom);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.createGroup(new SharedFieldGroupDetail()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void updateGroupDelegatesToAdaptor() {
+    SharedFieldGroupDetail body = new SharedFieldGroupDetail();
+    body.setFilename("renamed.xml");
+    SharedFieldGroupDetail updated = new SharedFieldGroupDetail();
+    updated.setName("shared");
+    updated.setFilename("renamed.xml");
+    when(adaptor.updateGroup(any(), eq("shared"), any())).thenReturn(updated);
+
+    assertEquals("renamed.xml", resource.updateGroup("shared", body).getFilename());
+    verify(adaptor).updateGroup(any(), eq("shared"), eq(body));
+  }
+
+  @Test
+  public void updateGroupNotFoundIsGeneric404() {
+    when(adaptor.updateGroup(any(), eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateGroup("missing", new SharedFieldGroupDetail()));
+    assertEquals(404, ex.getResponse().getStatus());
+    assertEquals("Shared field group not found", ex.getMessage());
+  }
+
+  @Test
+  public void updateGroupLockConflictIs409() {
+    when(adaptor.updateGroup(any(), eq("shared"), any()))
+        .thenThrow(new SharedFieldDesignLockException("design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateGroup("shared", new SharedFieldGroupDetail()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateGroupUnknownFieldIs400() {
+    when(adaptor.updateGroup(any(), eq("shared"), any()))
+        .thenThrow(new IllegalArgumentException("Unknown field: missing"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateGroup("shared", new SharedFieldGroupDetail()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteGroupReturns204() {
+    Response out = resource.deleteGroup("shared");
+    assertEquals(204, out.getStatus());
+    verify(adaptor).deleteGroup(any(), eq("shared"));
+  }
+
+  @Test
+  public void deleteGroupNotFoundIs404() {
+    doThrow(new SharedFieldNotFoundException("Shared field group not found"))
+        .when(adaptor)
+        .deleteGroup(any(), eq("missing"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteGroup("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteGroupLockConflictIs409() {
+    doThrow(new SharedFieldDesignLockException("locked by other"))
+        .when(adaptor)
+        .deleteGroup(any(), eq("shared"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteGroup("shared"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteGroupForbiddenWhenNotAdmin() {
+    doThrow(new WebApplicationException("Admin role required", 403))
+        .when(adaptor)
+        .deleteGroup(any(), eq("shared"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteGroup("shared"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void mapWriteFailureLockMessageOnIllegalStateIs409() {
+    WebApplicationException ex =
+        SharedFieldsResource.mapWriteFailure(new IllegalStateException("object is not locked"));
+    assertEquals(409, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSharedFieldsAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSharedFieldsAdaptor.java
@@ -45,4 +45,20 @@ public class TestSharedFieldsAdaptor implements ISharedFieldsAdaptor {
   public SharedFieldGroupDetail getGroup(URI baseUri, String name) {
     return null;
   }
+
+  @Override
+  public SharedFieldGroupDetail createGroup(URI baseUri, SharedFieldGroupDetail body) {
+    return null;
+  }
+
+  @Override
+  public SharedFieldGroupDetail updateGroup(
+      URI baseUri, String name, SharedFieldGroupDetail body) {
+    return null;
+  }
+
+  @Override
+  public void deleteGroup(URI baseUri, String name) {
+    // no-op for tests
+  }
 }


### PR DESCRIPTION
## Summary

Parent: #1690. Slice leftover after #3929 / PR #3943 (CD-15 catalog GET).

Admin-only public REST **write** for content-editor shared field groups:

- `POST /services/sharedfields` — create an empty group (`name` required, unique, no spaces; optional `filename` defaults to `{name}.xml`)
- `PUT /services/sharedfields/{name}` — save filename, optional rename, and patches to **existing** fields (`searchable`, occurrence / required)
- `DELETE /services/sharedfields/{name}` — **204**

Persistence uses existing `IPSContentDesignWs.loadContentEditorSharedDef` (lock) and `saveContentEditorSharedDef` (release). Does **not** invent SOAP. Lock held by another user is **409**. Non-Admin is **403**. Missing group is **404**. Duplicate name is **409**.

Out of scope (later slices): SPA shared-field editor, field create/delete, control/choice write, system def (CD-16).

Fixes #3944

## Test plan

1. `cd rest && ../mvnw.cmd clean install` (Windows) — Mockito `SharedFieldsResourceTest` plus rest `MainTest` Spring stub.
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — adaptor success / 403 / 404 / duplicate 409 / lock 409.
3. Review OpenAPI annotations on `SharedFieldsResource` POST/PUT/DELETE.
4. Product-docs: `product-docs/8.2/developer/rest.md` Shared fields section.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` and `product-docs/8.2/admin/developer-content-types.md`
- [x] **Unit / module tests** — `SharedFieldsResourceTest` (23), `SharedFieldsAdaptorTest` (29); both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install on `rest` then `projects/sitemanage` (sitemanage is the reverse-dep of the new `ISharedFieldsAdaptor` methods)
- [x] **Cross-platform** — no filesystem I/O; group/filename reject `/`, `\`, `..`

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 686, Failures: 0; `SharedFieldsResourceTest` Tests run: 23, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1690, Failures: 0, Skipped: 125; `SharedFieldsAdaptorTest` Tests run: 29, Failures: 0
  - No new compiler warnings on changed files after generic `PSCollection<PSTableSet>`
- **downstream_checked:** grep `implements ISharedFieldsAdaptor` (production `SharedFieldsAdaptor` + rest `TestSharedFieldsAdaptor`); standalone sitemanage clean install (reverse-dep of new adaptor methods)

### C5 UI proof

N/A — Java REST only; no WebUI / Playwright surface.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
