### PR TITLE
fix(packages): drop DualShip materialize from package-build (#3950)

### DIFF
--- a/docs/ai-generated/code-reviews/3950-drop-dualship-package-build-erlang.md
+++ b/docs/ai-generated/code-reviews/3950-drop-dualship-package-build-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review: #3950 drop DualShip materialize from package-build
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-28 |
+| **Branch** | `fix/issue-3950-drop-dualship-package-build` |
+| **Base** | `origin/main` |
+| **Recommendation** | approve |
+| **Gate** | May commit/push: **yes** |
+
+## Summary
+
+Removes the production package-build call to `PSPageXmlDualShip.materializeInstallTemplateDefs` from `PSPackageBuilder.stageModernPageInstallArtifacts` (parent #2630). Native `PSPageXmlNativeInstall.stageArchiveTemplateDefs` remains the only production TemplateDef emit. Dual-ship mode fails closed (inventory #3675). DualShip helper/CLI kept for tests and one-off ops; `PSLegacyDefinitionXmlShim` untouched.
+
+## Scope
+
+- `modules/perc-packages` package-build path + behavioral builder tests
+- Retirement checklist + module README companions
+- Memory patterns: portable Path/Files; ZIP entries use `/`; fail-closed dual-ship; native archive + ACL mapping
+
+**Cross-platform path review:** builder still uses `Path.resolve` / `Files.walkFileTree`. Tests locate packages via `Path.of("src", "main", "resources", "Packages", …)`, copy with `Path.relativize`/`resolve`, and assert ZIP entry names with `/` (ZIP form, not OS separators). Line splits use `\\R`. TempDir only — no Unix `/tmp` or drive-letter hardcodes.
+
+## Issues
+
+None (bug / missing tests / non-portable I/O).
+
+Behavioral tests cover: native package-build writes `TemplateDef-N/` + ACL mapping and emits native log (no dual-ship marker); explicit dual-ship fails closed without writing `.ppkg` or root templateDefs; packages without `pages/` still build; product `perc.responsiveTemplates` archive + ACL parity.
+
+Change-class companions: builder path + Surefire + inventory still fail-closed + retirement checklist call-site row + README. Product-docs N/A (not operator-facing). Playwright N/A.
+
+C2: private method signature only; `PSPackageBuilder` already `final`; `materializeInstallTemplateDefs` production call site gone (tests/CLI remain). No reverse-dep modules compile against the private builder method.
+
+## Gate
+
+approve — no bug, missing behavioral tests, or non-portable path I/O.

--- a/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
+++ b/docs/ai-generated/tasks/template-assembler-normalization/dual-ship-page-template-retirement.md
@@ -17,7 +17,7 @@ This document is the **operator / engineering checklist** for turning dual-ship 
 
 | Mode | When | Package-build behavior |
 |------|------|------------------------|
-| **dual-ship** (default) | No package-local opt-in; system prop unset | Materialize root `*.templateDef` → reorganize maps to `TemplateDef-N/` |
+| **dual-ship** (default) | No package-local opt-in; system prop unset | Fail closed in `PSPackageBuilder` — does **not** materialize root `*.templateDef` (#3950). Native archive staging is the only production emit. |
 | **native** | `package-install.properties` `page.installMode=native`, or sys props below | Skip root dual-ship; after reorganize, `PSPageXmlNativeInstall.stageArchiveTemplateDefs` writes `TemplateDef-N/<stem>.templateDef` |
 
 ### Configuration knobs
@@ -60,7 +60,7 @@ Dual-ship **code path** can be deleted when **all** hold:
 - [x] Widget leftover binary TemplateDefs inventoried and converted (#3674 / #3680): `perc.fileBinary`, `perc.imageMainBinary`, `perc.imageThumbBinary` are `output-format=Binary` / `binaryAssembler` (not page layouts). Converted to `pages/<id>/component-package.json` + native install (Widget XML emitter cannot emit TemplateDef). Product tree has zero authored root `*.templateDef`.
 - [x] CI / product package build has zero `dual-ship page templateDefs` log lines — Surefire `PSDualShipPageTemplateDefInventory` / #3675. Waiver is **empty** after perc.Test page dual-ship exit (#3737). Leftover binaries are converted on `main` via #3680 (not dual-ship-retained). Package-build also fails closed via `assertDualShipMaterializationAllowed`.
 - [ ] Docs (this file + page inventory + ADR-004) mark dual-ship retired
-- [ ] Follow-up removes `PSPageXmlDualShip.materializeInstallTemplateDefs` call sites when unused
+- [x] Follow-up removes `PSPageXmlDualShip.materializeInstallTemplateDefs` call sites when unused — package-build no longer calls it (#3950). DualShip CLI/tests still exercise the helper. Policy default flip is a sibling slice.
 
 ### CI gate (#3675)
 
@@ -68,7 +68,7 @@ Dual-ship **code path** can be deleted when **all** hold:
 |-------|--------|
 | Inventory + log parser + CLI | `com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory` |
 | Surefire | `PSDualShipPageTemplateDefInventoryTest` |
-| Package-build fail-closed | `PSPackageBuilder.stageModernPageInstallArtifacts` |
+| Package-build fail-closed | `PSPackageBuilder.stageModernPageInstallArtifacts` (native only; dual-ship throws, #3950) |
 
 Scan is **committed** `package-install.properties` only (JVM `perc.packages.page.installMode` must not hide a missing native opt-in). Packages with modern `pages/` + native mode are not dual-ship emitters. Authored root `*.templateDef` without modern `pages/` is out of this gate; leftover binaries were converted (#3674 / #3680). Waiver set is **empty** after perc.Test page dual-ship exit (#3737).
 

--- a/modules/perc-packages/README.md
+++ b/modules/perc-packages/README.md
@@ -46,12 +46,15 @@ materialization. Waiver is **empty** after perc.Test page dual-ship exit (#3737)
 (`perc.Test` never authored `pages/` / page `*.templateDef`). Native packages
 (`package-install.properties` `page.installMode=native`) are not dual-ship emitters.
 #3674 leftover widget binaries are **not** dual-ship-retained (empty retain list).
+Package-build no longer calls `PSPageXmlDualShip.materializeInstallTemplateDefs` (#3950);
+dual-ship mode fails closed. Native `PSPageXmlNativeInstall.stageArchiveTemplateDefs` is
+the only production install emit.
 
 | Piece | Class |
 |-------|--------|
 | Inventory + log parser + CLI | `com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory` |
 | Surefire | `PSDualShipPageTemplateDefInventoryTest` |
-| Package-build fail-closed | `PSPackageBuilder` |
+| Package-build fail-closed | `PSPackageBuilder` (no DualShip materialize; dual-ship mode throws) |
 
 Committed policy ignores JVM `perc.packages.page.installMode` so CI reflects the source tree.
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/PSPackageBuilder.java
@@ -44,15 +44,11 @@ import java.util.zip.ZipOutputStream;
  * haven't changed).
  *
  * <p>Page layout packages that author modern {@code pages/&lt;id&gt;/component-package.json} (ADR-004
- * / #2786 / #2806) are staged for deployer {@code TemplateDef} install:
- *
- * <ul>
- *   <li><strong>Dual-ship</strong> (default): materialize root {@code *.templateDef} before reorganize
- *   <li><strong>Native</strong> (package-local or system property): stage {@code TemplateDef-N/}
- *       archive folders from modern pages without dual-ship root files — see {@link
- *       com.percussion.packages.pagexml.PSPageXmlInstallPolicy} / {@link
- *       com.percussion.packages.pagexml.PSPageXmlNativeInstall}
- * </ul>
+ * / #2786 / #2806) are staged for deployer {@code TemplateDef} install via native archive {@code
+ * TemplateDef-N/} folders ({@link com.percussion.packages.pagexml.PSPageXmlNativeInstall}). Dual-ship
+ * root {@code *.templateDef} materialize is <strong>not</strong> invoked from package-build (#3950);
+ * dual-ship mode fails closed. Policy: {@link
+ * com.percussion.packages.pagexml.PSPageXmlInstallPolicy}.
  *
  * <p>Widget packages that author modern {@code widgets/&lt;stem&gt;/component-package.json} without
  * committed install Widget XML (batch A+B+C ship-exit #2883/#2884/#2885) materialize
@@ -163,9 +159,6 @@ public final class PSPackageBuilder {
       // Step 1a: Modern-only widget packages → install Widget XML (#2883/#2884/#2885 batch A+B+C)
       stageModernWidgetInstallArtifacts(temp1, dirName);
 
-      // Step 1b: Modern page packages → deployer TemplateDef install (#2786 / #2806)
-      stageModernPageInstallArtifacts(temp1, temp2, dirName, true);
-
       // Step 2: Read mapping properties
       var propsFile = packageDir.resolve(dirName + MAPPING_EXT);
       var props = new Properties();
@@ -178,8 +171,8 @@ public final class PSPackageBuilder {
       // Step 3: Reorganize files from temp1 into temp2 using mapping
       reorganizeFiles(dirName, temp1, temp1.toFile(), temp2, props);
 
-      // Step 3b: Native mode stages TemplateDef-N after reorganize (no dual-ship roots)
-      stageModernPageInstallArtifacts(temp1, temp2, dirName, false);
+      // Step 3b: Native archive TemplateDef-N staging (dual-ship materialize removed, #3950)
+      stageModernPageInstallArtifacts(temp1, temp2, dirName);
 
       // Step 4: Zip temp2 into .ppkg
       zipDirectory(temp2, outputFile);
@@ -213,46 +206,34 @@ public final class PSPackageBuilder {
   }
 
   /**
-   * Stage modern page packages for deployer TemplateDef install.
+   * Stage modern page packages for deployer TemplateDef install via native archive folders.
    *
-   * @param preReorganize when {@code true}, run dual-ship root materialization only; when {@code
-   *     false}, run native archive staging only
+   * <p>Dual-ship root {@code *.templateDef} materialize is not used on the production package-build
+   * path (#3950). Dual-ship mode fails closed (inventory gate #3675).
    */
   private static void stageModernPageInstallArtifacts(
-      Path stagingPackageDir, Path archiveRoot, String packageName, boolean preReorganize)
-      throws IOException {
+      Path stagingPackageDir, Path archiveRoot, String packageName) throws IOException {
     try {
       if (!PSPageXmlDualShip.hasModernPageSources(stagingPackageDir)) {
         return;
       }
       PSPageXmlInstallMode mode = PSPageXmlInstallPolicy.resolve(stagingPackageDir);
-      if (preReorganize) {
-        if (mode != PSPageXmlInstallMode.DUAL_SHIP) {
-          return;
-        }
-        // Fail closed: non-waived product packages must not re-introduce dual-ship (#3675).
-        PSDualShipPageTemplateDefInventory.assertDualShipMaterializationAllowed(packageName);
-        int n = PSPageXmlDualShip.materializeInstallTemplateDefs(stagingPackageDir);
-        System.out.println(
-            PSDualShipPageTemplateDefInventory.formatDualShipLogLine(packageName, n));
-        return;
-      }
-      // post-reorganize: native archive staging
       if (mode != PSPageXmlInstallMode.NATIVE) {
-        return;
+        // Fail closed: dual-ship root materialize was removed from package-build (#3950).
+        PSDualShipPageTemplateDefInventory.assertDualShipMaterializationAllowed(packageName);
+        throw new IllegalStateException(
+            "Dual-ship page templateDef materialize was removed from package-build (#3950); package "
+                + packageName
+                + " must use native install ("
+                + PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE
+                + "=native).");
       }
       int n = PSPageXmlNativeInstall.stageArchiveTemplateDefs(stagingPackageDir, archiveRoot);
       System.out.println(
           "  native-install page TemplateDefs for " + packageName + ": " + n + " written");
     } catch (PSPageXmlException | IllegalStateException e) {
       throw new IOException(
-          "Page install staging failed for package "
-              + packageName
-              + " ("
-              + (preReorganize ? "dual-ship" : "native")
-              + "): "
-              + e.getMessage(),
-          e);
+          "Page install staging failed for package " + packageName + ": " + e.getMessage(), e);
     }
   }
 

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventory.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSDualShipPageTemplateDefInventory.java
@@ -205,8 +205,10 @@ public final class PSDualShipPageTemplateDefInventory {
   }
 
   /**
-   * Format the package-build log line for dual-ship materialization (must stay in lockstep with
-   * {@code PSPackageBuilder}).
+   * Format the historical package-build log line for dual-ship materialization.
+   *
+   * <p>{@code PSPackageBuilder} no longer emits this line (#3950). Kept so inventory log scans and
+   * tests can still detect a regression if dual-ship writes reappear.
    *
    * @param packageName package directory name
    * @param written number of templateDefs written

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlCompiler.java
@@ -42,8 +42,8 @@ import java.util.Objects;
  * Package Manifest assembler field; Velocity body is the canonical template source. Dual-ship also
  * preserves mime type, publish-when, and location suffix when present.
  *
- * <p>Product page layout packages author modern {@code pages/&lt;id&gt;/} sources; install dual-ship
- * emits {@code *.templateDef} at package-build time ({@link PSPageXmlDualShip}, issue #2786). This
+ * <p>Product page layout packages author modern {@code pages/&lt;id&gt;/} sources; package-build
+ * stages archive {@code TemplateDef-N/} via {@link PSPageXmlNativeInstall} (issue #3950). This
  * compiler remains the upgrade path for legacy {@code *.templateDef} input.
  */
 public final class PSPageXmlCompiler {

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlDualShip.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlDualShip.java
@@ -45,11 +45,11 @@ import java.util.regex.Pattern;
  * template sources under the product package tree (e.g. {@code perc.baseTemplates}, {@code
  * perc.responsiveTemplates}, {@code perc.Baseline} system assembly templates).
  *
- * <p><strong>Install path (dual-ship mode):</strong> package build materializes root-level {@code
- * *.templateDef} files (legacy {@code TemplateDef} dependency) so reorganize + {@code .ppkg}
- * install parity is preserved. Prefer {@link PSPageXmlNativeInstall} / {@link
- * PSPageXmlInstallMode#NATIVE} (package-local or system property) to stage archive {@code
- * TemplateDef-N/} folders without dual-ship root files — see {@link PSPageXmlInstallPolicy}.
+ * <p><strong>Install path:</strong> production package-build uses {@link PSPageXmlNativeInstall} to
+ * stage archive {@code TemplateDef-N/} folders (issue #3950). {@link
+ * #materializeInstallTemplateDefs} remains a dual-ship helper/CLI and is not called from {@code
+ * PSPackageBuilder}. Dual-ship mode on the builder path fails closed — see {@link
+ * PSPageXmlInstallPolicy}.
  *
  * <p>GUIDs for install templateDefs are derived from {@code &lt;package&gt;.mapping.properties}
  * entries ({@code TemplateDef-N} → {@code 0-4-N}).
@@ -111,6 +111,9 @@ public final class PSPageXmlDualShip {
   /**
    * Materialize install-path {@code *.templateDef} files at the package root from modern {@code
    * pages/&lt;id&gt;/} sources. No-op when no modern pages are present.
+   *
+   * <p>Not invoked from production package-build ({@code PSPackageBuilder}, issue #3950). Prefer
+   * {@link PSPageXmlNativeInstall#stageArchiveTemplateDefs}.
    *
    * @param packageDir product package source (or staging copy)
    * @return number of templateDefs written

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlInstallMode.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlInstallMode.java
@@ -22,14 +22,17 @@ package com.percussion.packages.pagexml;
  * TemplateDef} archive entries (issue #2806 / parent #2630).
  *
  * <ul>
- *   <li>{@link #DUAL_SHIP} — materialize root {@code *.templateDef} before reorganize (legacy dual-ship
- *       bridge from #2786)
+ *   <li>{@link #DUAL_SHIP} — legacy dual-ship bridge from #2786. Package-build no longer
+ *       materializes root {@code *.templateDef} (#3950); this mode fails closed.
  *   <li>{@link #NATIVE} — convert modern pages directly into archive {@code TemplateDef-N/} folders
- *       without dual-ship root files (preferred for converted packages)
+ *       without dual-ship root files (the only production package-build emit)
  * </ul>
  */
 public enum PSPageXmlInstallMode {
-  /** Dual-ship: write root {@code *.templateDef} so existing reorganize mapping picks them up. */
+  /**
+   * Dual-ship: historically wrote root {@code *.templateDef} so reorganize mapping picked them up.
+   * Package-build does not materialize this mode (#3950).
+   */
   DUAL_SHIP,
   /**
    * Native: stage {@code TemplateDef-N/&lt;stem&gt;.templateDef} from modern {@code pages/} after

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlNativeInstall.java
@@ -44,8 +44,8 @@ import java.util.regex.Pattern;
  * root-level {@code *.templateDef} materialization.
  *
  * <p>Aligns with {@link com.percussion.packages.shim.PSLegacyDefinitionXmlShim}: modern packages are
- * preferred; dual-ship is optional and package-local / feature-flag controlled via {@link
- * PSPageXmlInstallPolicy}.
+ * preferred. Package-build uses this native path only (#3950); dual-ship mode fails closed via
+ * {@link PSPageXmlInstallPolicy}.
  *
  * <p>Deployer runtime still consumes legacy assembly-template XML inside the {@code .ppkg}
  * (PSTemplateDefDependencyHandler). This class is the package-build / staging bridge that makes that

--- a/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageCompiler.java
+++ b/modules/perc-packages/src/main/java/com/percussion/packages/pagexml/PSPageXmlPackageCompiler.java
@@ -33,8 +33,8 @@ import java.util.Objects;
  *
  * <p><strong>Authoring preference (ADR-004 / #2786):</strong> modern {@code pages/&lt;id&gt;/}
  * component packages. Falls back to root-level {@code *.templateDef} for upgrade-input / dual-run
- * staging. Package build dual-ships modern → install {@code *.templateDef} via {@link
- * PSPageXmlDualShip}.
+ * staging. Package-build stages archive {@code TemplateDef-N/} via {@link PSPageXmlNativeInstall}
+ * (#3950).
  */
 public final class PSPageXmlPackageCompiler {
 

--- a/modules/perc-packages/src/test/java/com/percussion/packages/PSPackageBuilderPageInstallTest.java
+++ b/modules/perc-packages/src/test/java/com/percussion/packages/PSPackageBuilderPageInstallTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.packages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.packages.pagexml.PSDualShipPageTemplateDefInventory;
+import com.percussion.packages.pagexml.PSPageXmlCompiler;
+import com.percussion.packages.pagexml.PSPageXmlCompileResult;
+import com.percussion.packages.pagexml.PSPageXmlDualShip;
+import com.percussion.packages.pagexml.PSPageXmlInstallPolicy;
+import com.percussion.packages.pagexml.PSPageXmlModel;
+import com.percussion.packages.pagexml.PSPageXmlPackageContext;
+import com.percussion.packages.pagexml.PSPageXmlParser;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Package-build page install: native archive TemplateDefs only; dual-ship materialize removed
+ * (issue #3950 / parent #2630).
+ *
+ * <p>Cross-platform: {@link Path#resolve(String)} / {@link Files}. Zip entry names use {@code /}
+ * (ZIP form), not OS separators.
+ */
+class PSPackageBuilderPageInstallTest {
+
+  private static final String FIXTURE_PLAIN = "/pagexml/perc.base.plain.templateDef";
+  private static final String STEM = "perc.base.plain";
+  private static final String TEMPLATE_DEF = STEM + ".templateDef";
+  private static final String ACL_DEF = TEMPLATE_DEF + ".aclDef";
+
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void clearInstallModeSystemProperties() {
+    System.clearProperty(PSPageXmlInstallPolicy.SYS_PROP_INSTALL_MODE);
+    System.clearProperty(PSPageXmlInstallPolicy.SYS_PROP_DUAL_SHIP);
+  }
+
+  @Test
+  void nativeMode_stagesArchiveTemplateDefsAndKeepsAcl_noDualShipLog() throws Exception {
+    Path packagesDir = tempDir.resolve("packages-native");
+    Path pkg = packagesDir.resolve("perc.baseTemplates");
+    writeNativePagePackage(pkg);
+
+    Path outputDir = tempDir.resolve("out-native");
+    Path buildTemp = tempDir.resolve("tmp-native");
+    String log =
+        captureStdout(
+            () -> new PSPackageBuilder(packagesDir, outputDir, buildTemp).buildAll());
+
+    assertTrue(
+        log.contains("native-install page TemplateDefs for perc.baseTemplates: 1 written"),
+        "native staging log: " + log);
+    assertFalse(
+        log.contains(PSDualShipPageTemplateDefInventory.DUAL_SHIP_LOG_MARKER),
+        "must not emit dual-ship log: " + log);
+    PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipLogLines(List.of(log.split("\\R")));
+
+    Path ppkg = outputDir.resolve("perc.baseTemplates.ppkg");
+    assertTrue(Files.isRegularFile(ppkg));
+    Set<String> entries = zipEntryNames(ppkg);
+    assertTrue(
+        entries.contains("TemplateDef-591/" + TEMPLATE_DEF),
+        "native archive TemplateDef-591/" + TEMPLATE_DEF + " entries=" + entries);
+    assertTrue(
+        entries.contains("AclDef-1/" + ACL_DEF),
+        "mapping ACL side-car must remain in archive; entries=" + entries);
+    assertFalse(entries.contains(TEMPLATE_DEF), "must not dual-ship root " + TEMPLATE_DEF);
+    assertFalse(
+        Files.isRegularFile(pkg.resolve(TEMPLATE_DEF)),
+        "source tree must not gain a dual-ship root templateDef");
+  }
+
+  @Test
+  void dualShipMode_failsClosed_doesNotMaterialize() throws Exception {
+    Path packagesDir = tempDir.resolve("packages-dual");
+    Path pkg = packagesDir.resolve("perc.baseTemplates");
+    writeModernPageWithMapping(pkg);
+    Files.writeString(
+        pkg.resolve(PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS),
+        PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE + "=dual-ship\n",
+        StandardCharsets.UTF_8);
+
+    Path outputDir = tempDir.resolve("out-dual");
+    Path buildTemp = tempDir.resolve("tmp-dual");
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    PrintStream orig = System.out;
+    System.setOut(new PrintStream(buf, true, StandardCharsets.UTF_8));
+    try {
+      IOException ex =
+          assertThrows(
+              IOException.class,
+              () -> new PSPackageBuilder(packagesDir, outputDir, buildTemp).buildAll());
+      String msg = ex.getMessage() == null ? "" : ex.getMessage();
+      assertTrue(
+          msg.contains("#3675") || msg.contains("#3950") || msg.contains("Dual-ship"),
+          "fail-closed message: " + msg);
+    } finally {
+      System.setOut(orig);
+    }
+    String log = buf.toString(StandardCharsets.UTF_8);
+    assertFalse(
+        log.contains(PSDualShipPageTemplateDefInventory.DUAL_SHIP_LOG_MARKER),
+        "must not log dual-ship materialize: " + log);
+    assertFalse(
+        Files.isRegularFile(outputDir.resolve("perc.baseTemplates.ppkg")),
+        "fail-closed dual-ship must not write a .ppkg");
+    assertFalse(
+        Files.isRegularFile(pkg.resolve(TEMPLATE_DEF)),
+        "must not materialize root " + TEMPLATE_DEF + " into the source package");
+  }
+
+  @Test
+  void packageWithoutModernPages_buildsWithoutPageStaging() throws Exception {
+    Path packagesDir = tempDir.resolve("packages-empty");
+    Path pkg = packagesDir.resolve("perc.NoPages");
+    Files.createDirectories(pkg);
+    Files.writeString(pkg.resolve("readme.txt"), "no pages\n", StandardCharsets.UTF_8);
+
+    Path outputDir = tempDir.resolve("out-empty");
+    Path buildTemp = tempDir.resolve("tmp-empty");
+    String log =
+        captureStdout(
+            () -> new PSPackageBuilder(packagesDir, outputDir, buildTemp).buildAll());
+
+    assertFalse(log.contains(PSDualShipPageTemplateDefInventory.DUAL_SHIP_LOG_MARKER));
+    assertFalse(log.contains("native-install page TemplateDefs for perc.NoPages"));
+    assertTrue(Files.isRegularFile(outputDir.resolve("perc.NoPages.ppkg")));
+  }
+
+  @Test
+  void productResponsiveTemplates_nativePackageBuild_archiveAndAcl_noDualShipLog()
+      throws Exception {
+    Path product = locatePackage("perc.responsiveTemplates");
+    if (product == null) {
+      System.err.println(
+          "WARN: perc.responsiveTemplates not found; skipping product package-build test");
+      return;
+    }
+
+    Path packagesDir = tempDir.resolve("packages-product");
+    Path pkg = packagesDir.resolve("perc.responsiveTemplates");
+    copyTree(product, pkg);
+
+    Path outputDir = tempDir.resolve("out-product");
+    Path buildTemp = tempDir.resolve("tmp-product");
+    String log =
+        captureStdout(
+            () -> new PSPackageBuilder(packagesDir, outputDir, buildTemp).buildAll());
+
+    assertTrue(
+        log.contains("native-install page TemplateDefs for perc.responsiveTemplates: 3 written"),
+        "product native log: " + log);
+    assertFalse(
+        log.contains(PSDualShipPageTemplateDefInventory.DUAL_SHIP_LOG_MARKER),
+        "product package-build must have zero dual-ship log lines: " + log);
+    PSDualShipPageTemplateDefInventory.assertNoNonWaivedDualShipLogLines(List.of(log.split("\\R")));
+
+    Path ppkg = outputDir.resolve("perc.responsiveTemplates.ppkg");
+    assertTrue(Files.isRegularFile(ppkg));
+    Set<String> entries = zipEntryNames(ppkg);
+    assertTrue(entries.contains("TemplateDef-597/perc.resp.Banded.templateDef"));
+    assertTrue(entries.contains("TemplateDef-599/perc.resp.Basic.templateDef"));
+    assertTrue(entries.contains("TemplateDef-627/perc.resp.plain.templateDef"));
+    assertTrue(
+        entries.contains("AclDef-4472257021923557487/perc.resp.plain.templateDef.aclDef"),
+        "plain ACL side-car must remain; entries=" + entries);
+    assertFalse(entries.contains("perc.resp.plain.templateDef"));
+    assertFalse(entries.contains("perc.resp.Banded.templateDef"));
+    assertFalse(entries.contains("perc.resp.Basic.templateDef"));
+  }
+
+  private static void writeNativePagePackage(Path pkg) throws Exception {
+    writeModernPageWithMapping(pkg);
+    Files.writeString(
+        pkg.resolve(PSPageXmlInstallPolicy.PACKAGE_INSTALL_PROPS),
+        PSPageXmlInstallPolicy.PROP_PAGE_INSTALL_MODE + "=native\n",
+        StandardCharsets.UTF_8);
+  }
+
+  private static void writeModernPageWithMapping(Path pkg) throws Exception {
+    Files.createDirectories(pkg);
+    Files.writeString(
+        pkg.resolve("perc.baseTemplates.mapping.properties"),
+        TEMPLATE_DEF
+            + "=TemplateDef-591\n"
+            + ACL_DEF
+            + "=AclDef-1\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(pkg.resolve(ACL_DEF), "<Acl/>\n", StandardCharsets.UTF_8);
+
+    Path pageDir = pkg.resolve(PSPageXmlDualShip.PAGES_DIR_NAME).resolve(STEM);
+    Files.createDirectories(pageDir);
+    PSPageXmlModel model = PSPageXmlParser.parse(readClasspath(FIXTURE_PLAIN));
+    model.setSourceFileName(TEMPLATE_DEF);
+    PSPageXmlCompileResult compiled = PSPageXmlCompiler.compile(model, baseTemplatesLikeContext());
+    PSPageXmlCompiler.writeArtifacts(compiled, pageDir);
+  }
+
+  private static PSPageXmlPackageContext baseTemplatesLikeContext() {
+    PSPageXmlPackageContext ctx = new PSPageXmlPackageContext();
+    ctx.setPackageId("perc.baseTemplates");
+    ctx.setPackageName("perc.baseTemplates");
+    ctx.setVersion("1.1.5");
+    ctx.setDescription("Percussion base layout templates.");
+    ctx.setPublisherName("Percussion Software Inc.");
+    ctx.setPublisherUrl("http://www.percussion.com");
+    ctx.setCmsMin("1.0.0");
+    ctx.setCmsMax("9.0.0");
+    return ctx;
+  }
+
+  private static String readClasspath(String resource) throws Exception {
+    try (var in = PSPackageBuilderPageInstallTest.class.getResourceAsStream(resource)) {
+      assertNotNull(in, "missing test resource: " + resource);
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static String captureStdout(ThrowingRunnable action) throws Exception {
+    ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    PrintStream orig = System.out;
+    System.setOut(new PrintStream(buf, true, StandardCharsets.UTF_8));
+    try {
+      action.run();
+    } finally {
+      System.setOut(orig);
+    }
+    return buf.toString(StandardCharsets.UTF_8);
+  }
+
+  private static Path locatePackage(String packageName) {
+    Path candidate = Path.of("src", "main", "resources", "Packages", packageName);
+    if (Files.isDirectory(candidate)) {
+      return candidate.toAbsolutePath().normalize();
+    }
+    Path cwd = Path.of(System.getProperty("user.dir", ".")).toAbsolutePath().normalize();
+    Path alt =
+        cwd.resolve("src")
+            .resolve("main")
+            .resolve("resources")
+            .resolve("Packages")
+            .resolve(packageName);
+    return Files.isDirectory(alt) ? alt : null;
+  }
+
+  /** ZIP entry names always use {@code /}, independent of {@code File.separator}. */
+  private static Set<String> zipEntryNames(Path zipFile) throws IOException {
+    Set<String> names = new LinkedHashSet<>();
+    try (InputStream in = Files.newInputStream(zipFile);
+        ZipInputStream zis = new ZipInputStream(in)) {
+      ZipEntry entry;
+      while ((entry = zis.getNextEntry()) != null) {
+        names.add(entry.getName());
+      }
+    }
+    return names;
+  }
+
+  private static void copyTree(Path source, Path target) throws IOException {
+    try (var walk = Files.walk(source)) {
+      walk.forEach(
+          src -> {
+            try {
+              Path rel = source.relativize(src);
+              Path dst = target.resolve(rel);
+              if (Files.isDirectory(src)) {
+                Files.createDirectories(dst);
+              } else {
+                Files.createDirectories(dst.getParent());
+                Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING);
+              }
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+          });
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+}


### PR DESCRIPTION
## Summary

Drop production **dual-ship root templateDef materialize** from package-build (parent [#2630](https://github.com/intersoftdatalabs-in/percussioncms/issues/2630), slice [#3950](https://github.com/intersoftdatalabs-in/percussioncms/issues/3950)).

`PSPackageBuilder.stageModernPageInstallArtifacts` no longer calls `PSPageXmlDualShip.materializeInstallTemplateDefs`. Native `PSPageXmlNativeInstall.stageArchiveTemplateDefs` is the only production install emit (archive `TemplateDef-N/` + mapping/ACL). Dual-ship mode **fails closed** (inventory gate #3675). DualShip helper/CLI remains for tests/one-off ops. Runtime `PSLegacyDefinitionXmlShim` is untouched (#2852). Policy default flip is sibling #3949 / PR #3955.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3950
Parent: #2630

## Test plan

1. `cd modules/perc-packages` then `..\..\mvnw.cmd clean install` (standalone; tests + package-build).
2. Confirm `PSPackageBuilderPageInstallTest`: native stages archive TemplateDefs + ACL; explicit dual-ship throws without writing `.ppkg` or root templateDefs; packages without `pages/` still build; product `perc.responsiveTemplates` archive + ACL with **no** `dual-ship page templateDefs` log lines.
3. Confirm `PSDualShipPageTemplateDefInventoryTest` still fail-closed (zero product dual-ship emitters).
4. Package-build log: `native-install page TemplateDefs` for Baseline/baseTemplates/responsiveTemplates/FileAssetWidget/widgets.image; **zero** `dual-ship page templateDefs` lines.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): package-build path in perc-packages; no operator/admin/WebUI/REST/install-step change. Engineering notes updated under `docs/ai-generated/tasks/template-assembler-normalization/` and `modules/perc-packages/README.md`.
- [x] **Unit / module tests** — `PSPackageBuilderPageInstallTest` + existing dual-ship inventory/native tests; perc-packages standalone clean install green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — standalone `cd modules/perc-packages && ../../mvnw.cmd clean install`
- [x] **Cross-platform** — tests use `Path.resolve` / `Files`; ZIP entry names use `/` (ZIP form)

### C3 evidence

- **modules_built:** `modules/perc-packages`
- **build_evidence:** `cd modules/perc-packages; ..\..\mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 220, Failures: 0, Errors: 0, Skipped: 0. Package-build: 45 built, 0 up-to-date; native-install page TemplateDefs for Baseline (7), baseTemplates (20), responsiveTemplates (3), FileAssetWidget (1), widgets.image (2); zero `dual-ship page templateDefs` lines.
- **downstream_checked:** none required for C2 (private `stageModernPageInstallArtifacts` signature only; `PSPackageBuilder` already `final`; no public/protected API shape change). Grep: `materializeInstallTemplateDefs` production call site gone from `PSPackageBuilder`; remaining uses are DualShip CLI + perc-packages tests.

### C5 UI proof

N/A — Java package-build only; no WebUI.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
