### PR TITLE
feat(rest): CD-15 shared field field create/delete (#3954)

### DIFF
--- a/docs/ai-generated/code-reviews/3954-shared-field-field-crud-erlang.md
+++ b/docs/ai-generated/code-reviews/3954-shared-field-field-crud-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3954 REST CD-15 shared field field create/delete
+
+**Branch:** `feat/issue-3954-shared-field-field-crud`  
+**Date:** 2026-08-28  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (rest resource + adaptor + Spring stub + sitemanage impl + tests + product-docs); Admin 403 not a global JAX-RS filter; typed lock exception → 409; filename/field-name path-injection rejection; `PSConcurrentIterator` does not support `Iterator.remove()`.
+
+## Scope
+
+Uncommitted CD-15 field create/delete slice vs `origin/main`: `rest` nested POST/DELETE on `SharedFieldsResource` + adaptor interface/stub/tests, `projects/sitemanage` persistable `PSField` + display mapping, `product-docs/8.2` Developer REST + admin content-types, gap map.
+
+## Summary
+
+Admin-only nested REST to add and remove fields on an existing shared field group over existing `IPSContentDesignWs.loadContentEditorSharedDef` / `saveContentEditorSharedDef` (request-scoped lock + release). Peers: group CRUD #3944 / PR #3953. Persistable `TYPE_SHARED` field with backend column locator and default `sys_EditBox` mapping. Duplicate field names (including other groups) are 409. Control/choice write and SPA editor remain later slices (`designGaps`).
+
+## Issues
+
+None that block commit.
+
+Fixed during review/tests: `PSDisplayMapper.removeMapping` uses `Iterator.remove()`, which `PSConcurrentIterator` rejects. Adaptor now removes mappings by index.
+
+## Cross-platform path checklist
+
+- No filesystem I/O. Group and field names reject `/`, `\`, `..`, NUL (same as group catalog).
+- Field name charset is letters/digits/underscore (portable, not a filesystem join).
+
+## Tests / companions
+
+- Mockito `SharedFieldsResourceTest` (37): nested POST/DELETE 200/204/400/403/404/409 + Spring stub methods on `TestSharedFieldsAdaptor`.
+- Adaptor `SharedFieldsAdaptorTest` (50): add/delete success, 403, 404, duplicate 409 (same group and other group), lock 409, persistable XML, invalid name/`dataType`.
+- `MainTest` still loads after new adaptor methods (stub implements interface).
+- Standalone `rest` and `projects/sitemanage` `mvnw clean install` BUILD SUCCESS.
+
+## Product docs
+
+`product-docs/8.2/developer/rest.md` and `admin/developer-content-types.md` updated for nested field POST/DELETE. Gap map CD-15 field create/delete marked shipped.

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -17,6 +17,7 @@
 | Public REST shared-field list     | CD-15 catalog (Admin only)          | `GET /services/sharedfields`                   |
 | Public REST shared-field detail   | CD-15 group fields (Admin only)     | `GET /services/sharedfields/{idOrName}`        |
 | Public REST shared-field write    | CD-15 create/save/delete (Admin)    | `POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}` |
+| Public REST shared-field fields   | CD-15 field create/delete (Admin)   | `POST …/{idOrName}/fields`, `DELETE …/{idOrName}/fields/{fieldName}` |
 | Design SOAP (Workbench)           | Full load/save/lock/create/delete   | `IPSContentDesignWs` / `ContentDesignSOAPImpl` |
 | Item def manager                  | Runtime CE definition cache         | `PSItemDefManager.getItemDef`                  |
 
@@ -55,7 +56,7 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 | Item-level pre/post exits & validations              | CD-09        | Properties tab                                    |
 | Edit workflow/template associations                  | CD-08, CD-12 | **CD-08 REST PUT .../allowedWorkflows** (#3763, held design lock); **CD-12 REST PUT .../allowedTemplates** (#3775, held design lock; full replace, empty list clears) |
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
-| Shared field file **write**                          | CD-15        | **Create/save/delete shipped** (`POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}`, Admin 403, lock 409, #3944). Field create/delete, control/choice write, and SPA editor still open |
+| Shared field file **write**                          | CD-15        | **Group create/save/delete shipped** (`POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}`, #3944). **Field create/delete shipped** (`POST …/fields`, `DELETE …/fields/{fieldName}`, persistable `PSField` + display mapping, Admin 403, lock 409, #3954). Control/choice write and SPA editor still open |
 | System def                                           | CD-16        | Separate object                                   |
 | Create / rename / delete                             | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Rename / delete still SOAP design only; lock + PUT save via REST |
 | Import/export CT                                     | CD-14        | Workbench wizards                                 |
@@ -69,7 +70,7 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 3. ~~Design-session lock + `PUT` save via thin REST over `IPSContentDesignWs`~~ **Lock** (#3742) + **PUT save requires held lock** (#3743)
 4. ~~Keyword create/update/delete~~ **Done CD-17** (REST write + design WS + SPA editor)
 5. ~~Control property value/choice catalogs~~ **Done CD-07 REST** (#3786). Field-rule write/save still open
-6. ~~Shared field catalog read~~ **Done CD-15 read** (`GET /services/sharedfields`, Admin 403). ~~Write~~ **Done CD-15 group create/save/delete** (`POST`/`PUT`/`DELETE`). Field create/delete + SPA editor still open
+6. ~~Shared field catalog read~~ **Done CD-15 read** (`GET /services/sharedfields`, Admin 403). ~~Write~~ **Done CD-15 group create/save/delete** (`POST`/`PUT`/`DELETE`, #3944). ~~Field create/delete~~ **Done** (`POST …/fields`, `DELETE …/fields/{fieldName}`, #3954). Control/choice write + SPA editor still open
 7. Templates/slots design editors
 
 ## Client behavior

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -22,8 +22,11 @@ object: Admin-only `GET /services/sharedfields` and
 `GET /services/sharedfields/{idOrName}` (catalog), plus
 `POST /services/sharedfields`, `PUT /services/sharedfields/{idOrName}`, and
 `DELETE /services/sharedfields/{idOrName}` (create / save / delete; the shared
-definition is locked for the request). Field create/delete and the SPA editor
-are not in this chrome. See [REST API](id:developer-rest).
+definition is locked for the request). Nested
+`POST /services/sharedfields/{idOrName}/fields` and
+`DELETE /services/sharedfields/{idOrName}/fields/{fieldName}` add or remove
+fields (backend column + display mapping). The SPA editor is not in this
+chrome. See [REST API](id:developer-rest).
 
 This is **not** the full Workbench field-rule editor. The detail table still
 shows rule **flags** (validation / visibility / transforms present). After

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -523,16 +523,19 @@ previously held lock).
 
 **Admin (Design) only.** There is no global JAX-RS Admin filter on this path — the
 sitemanage adaptor checks `IPSUserService.isAdminUser` for the current user and maps
-a non-Admin caller to **403**. Field **create/delete**, control/choice write, and
-system-def (CD-16) remain unsupported.
+a non-Admin caller to **403**. Control/choice write and system-def (CD-16) remain
+unsupported. Nested field create/delete persist a backend column mapping and a
+default `sys_EditBox` display mapping.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/sharedfields` | List shared field groups (`name`, `filename`, `fieldCount`) |
 | `GET` | `/services/sharedfields/{idOrName}` | Load one group by **name** (case-insensitive). Shared groups have no numeric design id on this catalog. |
 | `POST` | `/services/sharedfields` | Create an empty shared field group (`name` required, unique, no spaces). Optional `filename` defaults to `{name}.xml`. |
-| `PUT` | `/services/sharedfields/{idOrName}` | Save filename, optional rename (`body.name`), and patches to **existing** fields (`searchable`, occurrence / required). Null `fields` leaves the catalog unchanged. |
+| `PUT` | `/services/sharedfields/{idOrName}` | Save filename, optional rename (`body.name`), and patches to **existing** fields (`searchable`, occurrence / required). Null `fields` leaves the catalog unchanged. Does not create or delete fields. |
 | `DELETE` | `/services/sharedfields/{idOrName}` | Delete the group (**204**). |
+| `POST` | `/services/sharedfields/{idOrName}/fields` | Add a field to an existing group (`name` required, unique across shared groups). Optional `dataType` defaults to `text`. Optional `searchable` and occurrence / required use the same rules as PUT patches. |
+| `DELETE` | `/services/sharedfields/{idOrName}/fields/{fieldName}` | Remove a field and its display mapping (**204**). |
 
 `{idOrName}` is the shared field group name (for example a product set such as
 `shared`). Path separators and `..` are rejected as not found (**404**), not as a
@@ -549,11 +552,26 @@ Create body is a `SharedFieldGroupDetail`:
 ```
 
 PUT may include `fields[]` to patch existing fields by `name`. Unknown field names
-are **400**. New fields cannot be added on this slice. `occurrence` and `required`
-map to the same dimension: when both are sent they must agree (`required=true`
-with `required` / `oneOrMore`; `required=false` with `optional` / `zeroOrMore` /
-`count`) or the request is **400**. `occurrence` is applied when present;
-`required` is used only when `occurrence` is omitted.
+are **400**. PUT does **not** create or delete fields — use nested POST/DELETE
+`.../fields`. Field `name` on create must start with a letter and may contain
+letters, digits, or underscore (no spaces or path characters). Duplicate field
+names (case-insensitive, including names already defined in another shared group)
+are **409**. `occurrence` and `required` map to the same dimension: when both are
+sent they must agree (`required=true` with `required` / `oneOrMore`;
+`required=false` with `optional` / `zeroOrMore` / `count`) or the request is
+**400**. `occurrence` is applied when present; `required` is used only when
+`occurrence` is omitted.
+
+Add-field body is a `SharedFieldSummary`:
+
+```json
+{
+  "name": "rx_note",
+  "dataType": "text",
+  "searchable": true,
+  "required": false
+}
+```
 
 ### Response shape
 
@@ -562,8 +580,7 @@ List entries use `SharedFieldGroupSummary`. Detail uses `SharedFieldGroupDetail`
 - `name`, `filename`
 - `fields[]`: `name`, `dataType`, `searchable`, `required`, `readOnly`, `occurrence`
   (`optional` / `required` / `oneOrMore` / `zeroOrMore` / `count` / `unknown`)
-- `designGaps[]` strings — field create/delete, control/choice edit, and system-def
-  remain later slices
+- `designGaps[]` strings — control/choice edit and system-def remain later slices
 
 Prefer the generated OpenAPI schema as the integration source of truth.
 
@@ -571,12 +588,12 @@ Prefer the generated OpenAPI schema as the integration source of truth.
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | List (possibly empty), group detail, create, or save |
-| `204` | Deleted |
-| `400` | Invalid name/filename (including blank path name on PUT/DELETE), unknown field, or conflicting `occurrence`/`required` on PUT |
+| `200` | List (possibly empty), group detail, create, save, or add-field |
+| `204` | Group or field deleted |
+| `400` | Invalid name/filename (including blank path name on PUT/DELETE), unknown field on PUT, invalid field name/`dataType`, or conflicting `occurrence`/`required` |
 | `403` | Caller is not Admin, or the request has no session/user (writes) |
-| `404` | Group not found (unknown or unsafe name). Non-Admin callers receive **403**, not 404 |
-| `409` | Duplicate group name, or the shared definition is locked by another user |
+| `404` | Group or field not found (unknown or unsafe name). Non-Admin callers receive **403**, not 404 |
+| `409` | Duplicate group or field name, or the shared definition is locked by another user |
 | `500` | Design service or server failure |
 
 Authenticated non-Admin sessions (Editor, Contributor, and similar) must not read or

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
@@ -17,18 +17,25 @@
 
 package com.percussion.apibridge;
 
+import com.percussion.design.objectstore.PSBackEndColumn;
 import com.percussion.design.objectstore.PSBackEndCredential;
+import com.percussion.design.objectstore.PSBackEndTable;
 import com.percussion.design.objectstore.PSContainerLocator;
 import com.percussion.design.objectstore.PSContentEditorSharedDef;
+import com.percussion.design.objectstore.PSControlRef;
 import com.percussion.design.objectstore.PSDisplayMapper;
+import com.percussion.design.objectstore.PSDisplayMapping;
+import com.percussion.design.objectstore.PSDisplayText;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.design.objectstore.PSSearchProperties;
 import com.percussion.design.objectstore.PSSharedFieldGroup;
 import com.percussion.design.objectstore.PSSystemValidationException;
 import com.percussion.design.objectstore.PSTableLocator;
 import com.percussion.design.objectstore.PSTableRef;
 import com.percussion.design.objectstore.PSTableSet;
 import com.percussion.design.objectstore.PSUIDefinition;
+import com.percussion.design.objectstore.PSUISet;
 import com.percussion.rest.sharedfields.ISharedFieldsAdaptor;
 import com.percussion.rest.sharedfields.SharedFieldDesignLockException;
 import com.percussion.rest.sharedfields.SharedFieldGroupDetail;
@@ -79,9 +86,12 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
 
   private static final List<String> DESIGN_GAPS =
       List.of(
-          "Field create / delete not supported via this API",
           "Field control / choice write not supported via this API",
           "System def (global fields) is a separate catalog (later slice)");
+
+  private static final int MAX_FIELD_NAME_LENGTH = 50;
+
+  private static final String DEFAULT_TEXT_CONTROL = "sys_EditBox";
 
   private final IPSContentDesignWs designWs;
   private final Supplier<PSContentEditorSharedDef> sharedDefLoader;
@@ -248,8 +258,8 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
   }
 
   /**
-   * Persistable empty group: locator + empty field set + empty display mapper. Field create is a
-   * later slice.
+   * Persistable empty group: locator + empty field set + empty display mapper. Fields are added
+   * with {@link #addPersistableField}.
    */
   static PSSharedFieldGroup newEmptyGroup(String name, String filename) {
     PSBackEndCredential cred = new PSBackEndCredential("contentCredential");
@@ -279,6 +289,194 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
       }
     }
     return sb.length() == 0 ? "SHARED_FIELDS" : sb.toString();
+  }
+
+  static String validateFieldName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String trimmed = name.trim();
+    if (containsWhitespace(trimmed)) {
+      throw new IllegalArgumentException("name cannot contain spaces");
+    }
+    if (trimmed.length() > MAX_FIELD_NAME_LENGTH) {
+      throw new IllegalArgumentException("name exceeds maximum length");
+    }
+    if (!isSafeGroupName(trimmed)) {
+      throw new IllegalArgumentException("name contains invalid path characters");
+    }
+    char first = trimmed.charAt(0);
+    if (!Character.isLetter(first)) {
+      throw new IllegalArgumentException("name must start with a letter");
+    }
+    for (int i = 1; i < trimmed.length(); i++) {
+      char c = trimmed.charAt(i);
+      if (!Character.isLetterOrDigit(c) && c != '_') {
+        throw new IllegalArgumentException("name must be letters, digits, or underscore");
+      }
+    }
+    return trimmed;
+  }
+
+  static String columnNameForField(String fieldName) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < fieldName.length(); i++) {
+      char c = fieldName.charAt(i);
+      if (Character.isLetterOrDigit(c) || c == '_') {
+        sb.append(Character.toUpperCase(c));
+      }
+    }
+    if (sb.length() == 0) {
+      throw new IllegalArgumentException("name does not yield a valid column");
+    }
+    return sb.toString();
+  }
+
+  static String tableAliasForGroup(PSSharedFieldGroup group) {
+    if (group == null || group.getLocator() == null) {
+      return tableNameForGroup(group != null ? group.getName() : "SHARED");
+    }
+    Iterator<?> sets = group.getLocator().getTableSets();
+    if (sets != null) {
+      while (sets.hasNext()) {
+        Object o = sets.next();
+        if (!(o instanceof PSTableSet ts)) {
+          continue;
+        }
+        Iterator<?> refs = ts.getTableRefs();
+        if (refs == null) {
+          continue;
+        }
+        while (refs.hasNext()) {
+          Object r = refs.next();
+          if (r instanceof PSTableRef ref) {
+            if (StringUtils.isNotBlank(ref.getAlias())) {
+              return ref.getAlias();
+            }
+            if (StringUtils.isNotBlank(ref.getName())) {
+              return ref.getName();
+            }
+          }
+        }
+      }
+    }
+    return tableNameForGroup(group.getName());
+  }
+
+  /**
+   * Persistable TYPE_SHARED field with backend column locator, default text mapping, and display
+   * mapping ({@code sys_EditBox}). Control/choice write is a later slice.
+   */
+  static PSField addPersistableField(PSSharedFieldGroup group, SharedFieldSummary body) {
+    if (group == null) {
+      throw new IllegalArgumentException("group is required");
+    }
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String fieldName = validateFieldName(body.getName());
+    PSFieldSet fieldSet = group.getFieldSet();
+    if (fieldSet == null) {
+      throw new IllegalArgumentException("Shared field group has no field set");
+    }
+    PSField field = newPersistableSharedField(group, fieldName, body);
+    fieldSet.add(field);
+    applyOccurrenceOrRequired(field, body);
+    appendDefaultDisplayMapping(group, fieldName);
+    return field;
+  }
+
+  static PSField newPersistableSharedField(
+      PSSharedFieldGroup group, String fieldName, SharedFieldSummary body) {
+    String tableAlias = tableAliasForGroup(group);
+    PSBackEndTable table = new PSBackEndTable(tableAlias);
+    PSField field =
+        new PSField(
+            PSField.TYPE_SHARED, fieldName, new PSBackEndColumn(table, columnNameForField(fieldName)));
+    String dataType =
+        body == null || StringUtils.isBlank(body.getDataType())
+            ? PSField.DT_TEXT
+            : body.getDataType().trim();
+    try {
+      field.setDataType(dataType);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid dataType for field " + fieldName + ": " + dataType, e);
+    }
+    if (PSField.DT_TEXT.equals(field.getDataType())) {
+      field.setMimeType("text/plain");
+      field.setDataFormat("50");
+    }
+    boolean searchable =
+        body == null || body.getSearchable() == null || Boolean.TRUE.equals(body.getSearchable());
+    field.setSearchProperties(new PSSearchProperties(searchable));
+    try {
+      field.setOccurrenceDimension(PSField.OCCURRENCE_DIMENSION_OPTIONAL, null);
+    } catch (PSSystemValidationException e) {
+      throw new IllegalArgumentException("Invalid occurrence for field " + fieldName, e);
+    }
+    return field;
+  }
+
+  static void appendDefaultDisplayMapping(PSSharedFieldGroup group, String fieldName) {
+    PSUIDefinition ui = group.getUIDefinition();
+    if (ui == null) {
+      throw new IllegalArgumentException("Shared field group has no UI definition");
+    }
+    PSDisplayMapper mapper = ui.getDisplayMapper();
+    if (mapper == null) {
+      throw new IllegalArgumentException("Shared field group has no display mapper");
+    }
+    if (ui.getMapping(fieldName) != null) {
+      return;
+    }
+    PSUISet uiSet = new PSUISet();
+    uiSet.setLabel(new PSDisplayText(fieldName + ":"));
+    uiSet.setErrorLabel(new PSDisplayText(fieldName + ":"));
+    uiSet.setControl(new PSControlRef(DEFAULT_TEXT_CONTROL));
+    ui.appendMapping(mapper, new PSDisplayMapping(fieldName, uiSet));
+  }
+
+  static boolean removeFieldAndMapping(PSSharedFieldGroup group, String fieldName) {
+    if (group == null || group.getFieldSet() == null || StringUtils.isBlank(fieldName)) {
+      return false;
+    }
+    PSField field = group.getFieldSet().findFieldByName(fieldName, false);
+    if (field == null) {
+      return false;
+    }
+    String actual = field.getSubmitName();
+    group.getFieldSet().remove(actual);
+    PSUIDefinition ui = group.getUIDefinition();
+    if (ui != null) {
+      removeDisplayMapping(ui.getDisplayMapper(), actual);
+    }
+    return true;
+  }
+
+  /**
+   * Index-based mapping removal. {@link PSDisplayMapper#removeMapping} uses {@code
+   * Iterator.remove()}, which {@code PSConcurrentIterator} rejects.
+   */
+  static boolean removeDisplayMapping(PSDisplayMapper mapper, String fieldRef) {
+    if (mapper == null || StringUtils.isBlank(fieldRef)) {
+      return false;
+    }
+    for (int i = 0; i < mapper.size(); i++) {
+      Object o = mapper.get(i);
+      if (!(o instanceof PSDisplayMapping mapping)) {
+        continue;
+      }
+      if (fieldRef.equals(mapping.getFieldRef())) {
+        mapper.remove(i);
+        return true;
+      }
+      if (mapping.getDisplayMapper() != null
+          && removeDisplayMapping(mapping.getDisplayMapper(), fieldRef)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -474,6 +672,63 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
     saveSharedDef(def, session, user);
   }
 
+  @Override
+  public SharedFieldGroupDetail addField(URI baseUri, String groupName, SharedFieldSummary body) {
+    requireAdmin();
+    requireDesignWs();
+    requireSessionUserForWrite();
+    if (StringUtils.isBlank(groupName)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    if (!isSafeGroupName(groupName)) {
+      return null;
+    }
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String fieldName = validateFieldName(body.getName());
+    String session = currentSession();
+    String user = currentUser();
+    PSContentEditorSharedDef def = loadSharedDefLocked(session, user);
+    PSSharedFieldGroup group = findGroup(def, groupName.trim());
+    if (group == null) {
+      return null;
+    }
+    if (findSharedField(def, fieldName) != null) {
+      throw new WebApplicationException("Shared field already exists: " + fieldName, 409);
+    }
+    addPersistableField(group, body);
+    saveSharedDef(def, session, user);
+    return toDetail(group);
+  }
+
+  @Override
+  public void deleteField(URI baseUri, String groupName, String fieldName) {
+    requireAdmin();
+    requireDesignWs();
+    requireSessionUserForWrite();
+    if (StringUtils.isBlank(groupName) || StringUtils.isBlank(fieldName)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    if (!isSafeGroupName(groupName)) {
+      throw new SharedFieldNotFoundException("Shared field group not found");
+    }
+    if (!isSafeGroupName(fieldName)) {
+      throw new SharedFieldNotFoundException("Shared field not found");
+    }
+    String session = currentSession();
+    String user = currentUser();
+    PSContentEditorSharedDef def = loadSharedDefLocked(session, user);
+    PSSharedFieldGroup group = findGroup(def, groupName.trim());
+    if (group == null) {
+      throw new SharedFieldNotFoundException("Shared field group not found");
+    }
+    if (!removeFieldAndMapping(group, fieldName.trim())) {
+      throw new SharedFieldNotFoundException("Shared field not found");
+    }
+    saveSharedDef(def, session, user);
+  }
+
   private void requireAdmin() {
     boolean allowed;
     try {
@@ -564,6 +819,23 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
       Object o = it.next();
       if (o instanceof PSSharedFieldGroup group && name.equalsIgnoreCase(group.getName())) {
         return group;
+      }
+    }
+    return null;
+  }
+
+  static PSField findSharedField(PSContentEditorSharedDef def, String fieldName) {
+    if (def == null || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    for (Iterator<?> it = def.getFieldGroups(); it.hasNext(); ) {
+      Object o = it.next();
+      if (!(o instanceof PSSharedFieldGroup group) || group.getFieldSet() == null) {
+        continue;
+      }
+      PSField found = group.getFieldSet().findFieldByName(fieldName, false);
+      if (found != null) {
+        return found;
       }
     }
     return null;

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SharedFieldsAdaptorTest.java
@@ -561,4 +561,251 @@ class SharedFieldsAdaptorTest {
     SharedFieldDesignLockException mapped = SharedFieldsAdaptor.mapLockConflict(err);
     assertEquals("Could not save shared field group; locked by alice", mapped.getMessage());
   }
+
+  @Test
+  void addField_addsPersistableFieldAndSaves() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    body.setSearchable(true);
+    SharedFieldGroupDetail out = adaptor.addField(null, "shared", body);
+
+    assertEquals("shared", out.getName());
+    assertEquals(1, out.getFields().size());
+    assertEquals("rx_note", out.getFields().get(0).getName());
+    assertEquals("text", out.getFields().get(0).getDataType());
+    assertEquals(Boolean.TRUE, out.getFields().get(0).getSearchable());
+    verify(designWs).saveContentEditorSharedDef(eq(def), eq(true), eq("test-session"), eq("Admin"));
+    assertNotNull(group.getFieldSet().findFieldByName("rx_note", false));
+    assertNotNull(group.getUIDefinition().getMapping("rx_note"));
+  }
+
+  @Test
+  void addField_duplicateIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    SharedFieldSummary existing = new SharedFieldSummary();
+    existing.setName("rx_note");
+    SharedFieldsAdaptor.addPersistableField(group, existing);
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.addField(null, "shared", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveContentEditorSharedDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addField_duplicateInOtherGroupIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSSharedFieldGroup other = SharedFieldsAdaptor.newEmptyGroup("other", "other.xml");
+    SharedFieldSummary existing = new SharedFieldSummary();
+    existing.setName("rx_note");
+    SharedFieldsAdaptor.addPersistableField(other, existing);
+    PSSharedFieldGroup target = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(other);
+    def.addFieldGroup(target);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.addField(null, "shared", body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void addField_forbiddenWhenNotAdmin() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor denied = new SharedFieldsAdaptor(designWs, () -> false);
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.addField(null, "shared", body));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).loadContentEditorSharedDef(anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addField_missingGroupReturnsNull() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin"))
+        .thenReturn(new PSContentEditorSharedDef());
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    assertNull(adaptor.addField(null, "missing", body));
+    verify(designWs, never()).saveContentEditorSharedDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addField_lockConflictIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSLockErrorException lockErr =
+        new PSLockErrorException(1, "locked", "stack", "other", 1000L);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin"))
+        .thenThrow(lockErr);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    SharedFieldDesignLockException ex =
+        assertThrows(SharedFieldDesignLockException.class, () -> adaptor.addField(null, "shared", body));
+    assertTrue(ex.getMessage().contains("locked by other"));
+  }
+
+  @Test
+  void addField_invalidNameIs400() {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addField(null, "shared", body));
+    assertTrue(ex.getMessage().contains("spaces"));
+  }
+
+  @Test
+  void addField_blankGroupNameIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addField(null, "  ", body));
+    assertTrue(ex.getMessage().contains("name is required"));
+    verify(designWs, never()).loadContentEditorSharedDef(anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addField_invalidDataTypeIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    body.setDataType("not-a-type");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addField(null, "shared", body));
+    assertTrue(ex.getMessage().contains("dataType"));
+    verify(designWs, never()).saveContentEditorSharedDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteField_removesAndSaves() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    SharedFieldSummary existing = new SharedFieldSummary();
+    existing.setName("rx_note");
+    SharedFieldsAdaptor.addPersistableField(group, existing);
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+
+    adaptor.deleteField(null, "shared", "rx_note");
+
+    verify(designWs).saveContentEditorSharedDef(eq(def), eq(true), eq("test-session"), eq("Admin"));
+    assertNull(group.getFieldSet().findFieldByName("rx_note", false));
+    assertNull(group.getUIDefinition().getMapping("rx_note"));
+  }
+
+  @Test
+  void deleteField_missingFieldThrowsNotFound() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    assertThrows(
+        SharedFieldNotFoundException.class, () -> adaptor.deleteField(null, "shared", "missing"));
+    verify(designWs, never()).saveContentEditorSharedDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteField_missingGroupThrowsNotFound() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin"))
+        .thenReturn(new PSContentEditorSharedDef());
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldNotFoundException ex =
+        assertThrows(
+            SharedFieldNotFoundException.class,
+            () -> adaptor.deleteField(null, "missing", "rx_note"));
+    assertTrue(ex.getMessage().contains("group"));
+    verify(designWs, never()).saveContentEditorSharedDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteField_forbiddenWhenNotAdmin() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SharedFieldsAdaptor denied = new SharedFieldsAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> denied.deleteField(null, "shared", "rx_note"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void deleteField_saveLockConflictIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("shared", "shared.xml");
+    SharedFieldSummary existing = new SharedFieldSummary();
+    existing.setName("rx_note");
+    SharedFieldsAdaptor.addPersistableField(group, existing);
+    PSContentEditorSharedDef def = new PSContentEditorSharedDef();
+    def.addFieldGroup(group);
+    when(designWs.loadContentEditorSharedDef(true, false, "test-session", "Admin")).thenReturn(def);
+    doThrow(new PSLockErrorException(1, "not locked", "stack"))
+        .when(designWs)
+        .saveContentEditorSharedDef(any(), eq(true), eq("test-session"), eq("Admin"));
+    SharedFieldsAdaptor adaptor = new SharedFieldsAdaptor(designWs, () -> true);
+    SharedFieldDesignLockException ex =
+        assertThrows(
+            SharedFieldDesignLockException.class,
+            () -> adaptor.deleteField(null, "shared", "rx_note"));
+    assertTrue(ex.getMessage().contains("design lock required"));
+  }
+
+  @Test
+  void addPersistableField_isPersistableXml() {
+    PSSharedFieldGroup group = SharedFieldsAdaptor.newEmptyGroup("custom", "custom.xml");
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    SharedFieldsAdaptor.addPersistableField(group, body);
+    org.w3c.dom.Document doc = com.percussion.xml.PSXmlDocumentBuilder.createXmlDocument();
+    org.w3c.dom.Element xml = group.toXml(doc);
+    String serialized = com.percussion.xml.PSXmlDocumentBuilder.toString(xml);
+    assertTrue(serialized.contains("rx_note"));
+    assertTrue(serialized.contains("RX_NOTE") || serialized.contains("rx_note"));
+    assertNotNull(group.getUIDefinition().getMapping("rx_note"));
+  }
+
+  @Test
+  void validateFieldName_rejectsInvalid() {
+    assertEquals("rx_note", SharedFieldsAdaptor.validateFieldName("rx_note"));
+    assertThrows(IllegalArgumentException.class, () -> SharedFieldsAdaptor.validateFieldName(" "));
+    assertThrows(
+        IllegalArgumentException.class, () -> SharedFieldsAdaptor.validateFieldName("has space"));
+    assertThrows(
+        IllegalArgumentException.class, () -> SharedFieldsAdaptor.validateFieldName("a/b"));
+    assertThrows(
+        IllegalArgumentException.class, () -> SharedFieldsAdaptor.validateFieldName("1start"));
+  }
 }

--- a/rest/src/main/java/com/percussion/rest/sharedfields/ISharedFieldsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/ISharedFieldsAdaptor.java
@@ -80,4 +80,31 @@ public interface ISharedFieldsAdaptor {
    * @throws SharedFieldDesignLockException when the shared def is locked by another user
    */
   void deleteGroup(URI baseUri, String name);
+
+  /**
+   * Add a persistable field (backend column + display mapping) to an existing shared field group.
+   * Admin only. Acquires the shared-def design lock for this request and releases it on save.
+   *
+   * @param body {@code name} required; unique case-insensitive across shared groups. Optional {@code
+   *     dataType} defaults to {@code text}. Optional {@code searchable}, {@code occurrence} /
+   *     {@code required} as on PUT patches.
+   * @return updated group detail, or {@code null} when the group is not found / unsafe path name
+   * @throws IllegalArgumentException when the group path is blank, field name/dataType is invalid,
+   *     or occurrence/required conflict
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin; {@code
+   *     409} when a field with that name already exists
+   * @throws SharedFieldDesignLockException when the shared def is locked by another user
+   */
+  SharedFieldGroupDetail addField(URI baseUri, String groupName, SharedFieldSummary body);
+
+  /**
+   * Remove a field (backend column mapping + display mapping) from an existing shared field group.
+   * Admin only. Acquires the shared-def design lock for this request and releases it on save.
+   *
+   * @throws SharedFieldNotFoundException when the group or field does not exist
+   * @throws IllegalArgumentException when a path name is blank
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin
+   * @throws SharedFieldDesignLockException when the shared def is locked by another user
+   */
+  void deleteField(URI baseUri, String groupName, String fieldName);
 }

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldGroupDetail.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldGroupDetail.java
@@ -24,11 +24,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Shared field group detail. Used for GET catalog and POST/PUT write (name, filename, field
- * patches).
+ * Shared field group detail. Used for GET catalog, POST/PUT group write, and nested field
+ * create/delete responses.
  *
- * <p>Field create/delete, control/choice write, and system-def remain later slices ({@code
- * designGaps}).
+ * <p>Control/choice write and system-def remain later slices ({@code designGaps}).
  */
 @XmlRootElement(name = "SharedFieldGroupDetail")
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldSummary.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldSummary.java
@@ -23,7 +23,9 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Field row inside a shared field group. GET catalog; PUT may patch {@code searchable} and
- * occurrence / required on existing fields. {@code readOnly} and {@code dataType} are read-only.
+ * occurrence / required on existing fields. POST {@code /sharedfields/{name}/fields} uses {@code
+ * name} (required) plus optional {@code dataType}, {@code searchable}, and occurrence / required.
+ * {@code readOnly} is read-only on write.
  */
 @XmlRootElement(name = "SharedField")
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldsResource.java
+++ b/rest/src/main/java/com/percussion/rest/sharedfields/SharedFieldsResource.java
@@ -77,7 +77,8 @@ public class SharedFieldsResource {
       description =
           "Lists shared field groups from the content-editor shared definition. Admin (Design)"
               + " only. Create uses POST /sharedfields; save uses PUT /sharedfields/{name}; delete"
-              + " uses DELETE /sharedfields/{name}.",
+              + " uses DELETE /sharedfields/{name}. Add a field with POST /sharedfields/{name}/fields;"
+              + " remove one with DELETE /sharedfields/{name}/fields/{fieldName}.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -107,7 +108,8 @@ public class SharedFieldsResource {
       summary = "Get shared field group detail",
       description =
           "Loads one shared field group by name (Admin/Design only). Includes field catalog."
-              + " Control/choice write and system-def remain unsupported (see designGaps).",
+              + " Field add/remove use nested POST/DELETE .../fields. Control/choice write and"
+              + " system-def remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -227,6 +229,77 @@ public class SharedFieldsResource {
   public Response deleteGroup(@PathParam("name") String name) {
     try {
       requireAdaptor().deleteGroup(uriInfo.getBaseUri(), name);
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @POST
+  @Path("/{name}/fields")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Add a field to a shared field group",
+      description =
+          "Admin. Adds a persistable field (backend column + display mapping) to an existing"
+              + " shared field group via IPSContentDesignWs.loadContentEditorSharedDef (lock) then"
+              + " saveContentEditorSharedDef (release). Body name is required, unique"
+              + " case-insensitive across shared groups, and must be a letter followed by letters,"
+              + " digits, or underscore. Optional dataType defaults to text. Optional searchable"
+              + " and occurrence/required use the same rules as PUT field patches. Duplicate field"
+              + " is 409. Missing group is 404. Lock held by another user is 409. Control/choice"
+              + " write remains unsupported.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Field added and saved",
+            content = @Content(schema = @Schema(implementation = SharedFieldGroupDetail.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid group or field input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Group not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "A field with that name exists, or shared def locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public SharedFieldGroupDetail addField(
+      @PathParam("name") String name, SharedFieldSummary body) {
+    try {
+      SharedFieldGroupDetail detail = requireAdaptor().addField(uriInfo.getBaseUri(), name, body);
+      if (detail == null) {
+        throw new WebApplicationException("Shared field group not found", 404);
+      }
+      return detail;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{name}/fields/{fieldName}")
+  @Operation(
+      summary = "Delete a field from a shared field group",
+      description =
+          "Admin. Removes the field and its display mapping from the group and saves via"
+              + " IPSContentDesignWs.saveContentEditorSharedDef (releases the request lock)."
+              + " Missing group or field is 404; lock held by another user is 409.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid name"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Group or field not found"),
+        @ApiResponse(responseCode = "409", description = "Shared def locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteField(
+      @PathParam("name") String name, @PathParam("fieldName") String fieldName) {
+    try {
+      requireAdaptor().deleteField(uriInfo.getBaseUri(), name, fieldName);
       return Response.noContent().build();
     } catch (RuntimeException e) {
       throw mapWriteFailure(e);

--- a/rest/src/test/java/com/percussion/rest/sharedfields/SharedFieldsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/sharedfields/SharedFieldsResourceTest.java
@@ -305,6 +305,135 @@ public class SharedFieldsResourceTest {
   }
 
   @Test
+  public void addFieldDelegatesToAdaptor() {
+    SharedFieldSummary body = new SharedFieldSummary();
+    body.setName("rx_note");
+    SharedFieldGroupDetail updated = new SharedFieldGroupDetail();
+    updated.setName("shared");
+    when(adaptor.addField(any(), eq("shared"), any())).thenReturn(updated);
+
+    assertEquals("shared", resource.addField("shared", body).getName());
+    verify(adaptor).addField(any(), eq("shared"), eq(body));
+  }
+
+  @Test
+  public void addFieldInvalidNameIs400() {
+    when(adaptor.addField(any(), eq("shared"), any()))
+        .thenThrow(new IllegalArgumentException("name is required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addField("shared", new SharedFieldSummary()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addFieldNotFoundIsGeneric404() {
+    when(adaptor.addField(any(), eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addField("missing", new SharedFieldSummary()));
+    assertEquals(404, ex.getResponse().getStatus());
+    assertEquals("Shared field group not found", ex.getMessage());
+  }
+
+  @Test
+  public void addFieldDuplicateIs409() {
+    when(adaptor.addField(any(), eq("shared"), any()))
+        .thenThrow(new WebApplicationException("Shared field already exists: rx_note", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addField("shared", new SharedFieldSummary()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addFieldLockConflictIs409() {
+    when(adaptor.addField(any(), eq("shared"), any()))
+        .thenThrow(new SharedFieldDesignLockException("locked by other"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addField("shared", new SharedFieldSummary()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addFieldForbiddenWhenNotAdmin() {
+    when(adaptor.addField(any(), eq("shared"), any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addField("shared", new SharedFieldSummary()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addFieldWrapsUnexpectedFailures() {
+    IllegalStateException boom = new IllegalStateException("design ws down");
+    when(adaptor.addField(any(), eq("shared"), any())).thenThrow(boom);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addField("shared", new SharedFieldSummary()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void deleteFieldReturns204() {
+    Response out = resource.deleteField("shared", "rx_note");
+    assertEquals(204, out.getStatus());
+    verify(adaptor).deleteField(any(), eq("shared"), eq("rx_note"));
+  }
+
+  @Test
+  public void deleteFieldBlankNameIs400() {
+    doThrow(new IllegalArgumentException("name is required"))
+        .when(adaptor)
+        .deleteField(any(), eq(" "), eq("rx_note"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteField(" ", "rx_note"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteFieldNotFoundIs404() {
+    doThrow(new SharedFieldNotFoundException("Shared field not found"))
+        .when(adaptor)
+        .deleteField(any(), eq("shared"), eq("missing"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteField("shared", "missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteFieldLockConflictIs409() {
+    doThrow(new SharedFieldDesignLockException("locked by other"))
+        .when(adaptor)
+        .deleteField(any(), eq("shared"), eq("rx_note"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteField("shared", "rx_note"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteFieldForbiddenWhenNotAdmin() {
+    doThrow(new WebApplicationException("Admin role required", 403))
+        .when(adaptor)
+        .deleteField(any(), eq("shared"), eq("rx_note"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteField("shared", "rx_note"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void mapWriteFailureLockMessageOnIllegalStateIs409() {
     WebApplicationException ex =
         SharedFieldsResource.mapWriteFailure(new IllegalStateException("object is not locked"));

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSharedFieldsAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSharedFieldsAdaptor.java
@@ -20,6 +20,7 @@ package com.percussion.rest.test.apibridge;
 import com.percussion.rest.sharedfields.ISharedFieldsAdaptor;
 import com.percussion.rest.sharedfields.SharedFieldGroupDetail;
 import com.percussion.rest.sharedfields.SharedFieldGroupSummary;
+import com.percussion.rest.sharedfields.SharedFieldSummary;
 import java.net.URI;
 import java.util.List;
 import org.springframework.context.annotation.Lazy;
@@ -59,6 +60,16 @@ public class TestSharedFieldsAdaptor implements ISharedFieldsAdaptor {
 
   @Override
   public void deleteGroup(URI baseUri, String name) {
+    // no-op for tests
+  }
+
+  @Override
+  public SharedFieldGroupDetail addField(URI baseUri, String groupName, SharedFieldSummary body) {
+    return null;
+  }
+
+  @Override
+  public void deleteField(URI baseUri, String groupName, String fieldName) {
     // no-op for tests
   }
 }


### PR DESCRIPTION
## Summary

Parent: #1690. Slice leftover after #3944 / PR #3953 (CD-15 group create/save/delete).

Admin-only public REST to **add and remove fields** on an existing shared field group:

- `POST /services/sharedfields/{name}/fields` — persist a `TYPE_SHARED` `PSField` (backend column locator) plus a default `sys_EditBox` display mapping. `name` required, unique case-insensitive across shared groups; optional `dataType` defaults to `text`.
- `DELETE /services/sharedfields/{name}/fields/{fieldName}` — **204** (removes field + mapping).

Persistence uses existing `IPSContentDesignWs.loadContentEditorSharedDef` (lock) and `saveContentEditorSharedDef` (release). Does **not** invent SOAP. PUT group save still does not create or delete fields.

Unknown group **404**. Non-Admin **403**. Duplicate field name **409**. Lock held by another user **409**. Invalid name/dataType **400**.

Out of scope: SPA shared-field editor, control/choice write, system def (CD-16).

Fixes #3954

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — Mockito `SharedFieldsResourceTest` plus rest `MainTest` Spring stub.
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — adaptor success / 403 / 404 / duplicate 409 / lock 409 / persistable XML.
3. Review OpenAPI annotations on `SharedFieldsResource` nested POST/DELETE.
4. Product-docs: `product-docs/8.2/developer/rest.md` Shared fields section.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` and `product-docs/8.2/admin/developer-content-types.md`
- [x] **Unit / module tests** — `SharedFieldsResourceTest` (37), `SharedFieldsAdaptorTest` (50); both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install on `rest` then `projects/sitemanage` (sitemanage is the reverse-dep of the new `ISharedFieldsAdaptor` methods)
- [x] **Cross-platform** — no filesystem I/O; group/field names reject `/`, `\`, `..`

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 700, Failures: 0; `SharedFieldsResourceTest` Tests run: 37, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1639, Failures: 0, Skipped: 125; `SharedFieldsAdaptorTest` Tests run: 50, Failures: 0
- **downstream_checked:** grep `implements ISharedFieldsAdaptor` (production `SharedFieldsAdaptor` + rest `TestSharedFieldsAdaptor`); standalone sitemanage clean install (reverse-dep of new adaptor methods)

### C5 UI proof

N/A — Java REST only; no WebUI / Playwright surface.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.