### PR TITLE
Fix #3940 leftover system security IPS*Errors typed ErrorCodes

### DIFF
--- a/docs/ai-generated/code-reviews/3940-security-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3940-security-errorcodes-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3940 system security leftover IPS*Errors typed ErrorCodes
+
+**Scope:** uncommitted branch `fix/issue-3940-security-errorcodes` vs `origin/main`  
+**Memory patterns hit:** typed `*ErrorCodes` + `IPSErrorCode` constructors; dual-write skip for `isAuditable()==false`; additive constructors (C2); do not delete `IPS*Errors` interfaces; `getErrorCode() == IPS*Errors.X` comparisons remain int-equal via `.numericCode()`; int-only APIs (`PSLogServerWarning`, `PSErrorManager.createMessage`/`getErrorText`, `PSConsole.printMsg`) use `.numericCode()`.  
+**Cross-platform path checklist:** N/A (no new filesystem path joins; tests construct exceptions in-memory).
+
+## Summary
+
+Parent #2616 leftover slice: 31 `system/src/main/java/com/percussion/security/` production `IPS*Errors` sites now construct typed `SecurityErrorCodes` / `ServerErrorCodes`. Additive `IPSErrorCode` constructors on `PSSecurityException`. Residual allow-list shrunk by those exact 31 paths. Dual-write skip tests cover leftover non-auditable catalog codes; leftover auditable SEC codes remain dual-write eligible. Production exception types retain typed codes. No product UI/config surface.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None.
+
+## Verification
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2578, Failures: 0, Skipped: 246 (`PSSecurityLeftoverErrorCodesSliceTest` 3/3)
+- `python scripts/verify-no-bare-ipserrors.py` — PASS
+- `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 19 passed
+
+## Notes
+
+- C2: constructors are additive. No `final`/`sealed`. Grep found no `extends PSSecurityException` and no anonymous `new PSSecurityException() {`.
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- `IPSSecurityErrors.DATA_ENCRYPTION_ERROR_MSG` maps to `SecurityErrorCodes.DATA_ENCRYPTION_ERROR` (same 9017).
+- `IPSServerErrors.RAW_DUMP` / `RESPONSE_SEND_ERROR` on the two ACL exits and encryption handler map to `ServerErrorCodes`.
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); dual-write skip when non-auditable.

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -17,6 +17,7 @@
 #   #3884 leftover cms.objectstore (non-server) + client call sites
 #   #3900 leftover cms.objectstore.server call sites
 #   #3939 leftover system/src/main com.percussion.data (+ macro/vfs)
+#   #3940 leftover system/src/main com.percussion.security call sites
 # Converted (no longer listed): extensions-main #3756/#3938 (allow-list
 # shrink after #3793 re-listed already-typed production paths).
 #
@@ -139,37 +140,6 @@ system/src/main/java/com/percussion/search/PSSearchEngine.java
 system/src/main/java/com/percussion/search/lucene/PSSearchEngineImpl.java
 system/src/main/java/com/percussion/search/lucene/PSSearchIndexerImpl.java
 system/src/main/java/com/percussion/search/lucene/PSSearchQueryImpl.java
-system/src/main/java/com/percussion/security/PSAuthenticationFailedExException.java
-system/src/main/java/com/percussion/security/PSAuthenticationFailedException.java
-system/src/main/java/com/percussion/security/PSAuthenticationRequiredException.java
-system/src/main/java/com/percussion/security/PSAuthenticationUnsupportedException.java
-system/src/main/java/com/percussion/security/PSAuthorizationException.java
-system/src/main/java/com/percussion/security/PSBackEndTableDirectoryCataloger.java
-system/src/main/java/com/percussion/security/PSBackEndTableProvider.java
-system/src/main/java/com/percussion/security/PSBackEndTableProviderMetaData.java
-system/src/main/java/com/percussion/security/PSCataloger.java
-system/src/main/java/com/percussion/security/PSDataEncryptionError.java
-system/src/main/java/com/percussion/security/PSDataEncryptionHandler.java
-system/src/main/java/com/percussion/security/PSDirectoryCataloger.java
-system/src/main/java/com/percussion/security/PSDirectoryConnProvider.java
-system/src/main/java/com/percussion/security/PSDirectoryConnProviderMetaData.java
-system/src/main/java/com/percussion/security/PSDirectoryServerCataloger.java
-system/src/main/java/com/percussion/security/PSExitCreateDefaultCommunityAcl.java
-system/src/main/java/com/percussion/security/PSExitDeleteObjectAcl.java
-system/src/main/java/com/percussion/security/PSFiltersNotSupportedException.java
-system/src/main/java/com/percussion/security/PSGroupsNotSupportedException.java
-system/src/main/java/com/percussion/security/PSJndiGroupProvider.java
-system/src/main/java/com/percussion/security/PSJndiUtils.java
-system/src/main/java/com/percussion/security/PSNativeMethodException.java
-system/src/main/java/com/percussion/security/PSOdbcProviderMetaData.java
-system/src/main/java/com/percussion/security/PSRoleAlreadyDefinedException.java
-system/src/main/java/com/percussion/security/PSRoleCataloger.java
-system/src/main/java/com/percussion/security/PSRoleNotDefinedException.java
-system/src/main/java/com/percussion/security/PSSecurityException.java
-system/src/main/java/com/percussion/security/PSSecurityProvider.java
-system/src/main/java/com/percussion/security/PSSecurityProviderPool.java
-system/src/main/java/com/percussion/security/PSUnsupportedProviderException.java
-system/src/main/java/com/percussion/security/PSUsersNotSupportedException.java
 system/src/main/java/com/percussion/server/PSApplicationHandler.java
 system/src/main/java/com/percussion/server/PSBaseResponse.java
 system/src/main/java/com/percussion/server/PSConsole.java

--- a/scripts/test_verify_no_bare_ipserrors.py
+++ b/scripts/test_verify_no_bare_ipserrors.py
@@ -34,7 +34,8 @@ DEPLOYER_RESIDUAL = (
 # system/webservices SOAP/ws rows were removed from the allow-list; cms builders
 # converted in #3882, cms handlers in #3883, cms.objectstore+client in #3884;
 # cms.objectstore.server converted in #3900; extensions-main converted in
-# #3756/#3938; com.percussion.data (+ macro/vfs) in #3939.
+# #3756/#3938; com.percussion.data (+ macro/vfs) in #3939; com.percussion.security
+# in #3940.
 # Keep an exact residual that is still frozen (system debug leftover).
 SYSTEM_CMS_RESIDUAL = (
     "system/src/main/java/com/percussion/debug/PSDebugLogHandler.java"
@@ -393,6 +394,7 @@ def test_residual_allowlist_is_exact_paths_only() -> None:
         assert "\\" not in entry, entry
         assert entry.endswith(".java"), entry
         assert not entry.startswith("modules/extensions-main/"), entry
+        assert not entry.startswith("system/src/main/java/com/percussion/security/"), entry
 
 
 def test_extensions_main_converted_paths_not_allowlisted() -> None:
@@ -404,6 +406,20 @@ def test_extensions_main_converted_paths_not_allowlisted() -> None:
         if ln.strip() and not ln.strip().startswith("#")
     ]
     resurrected = [e for e in entries if e.startswith("modules/extensions-main/")]
+    assert resurrected == [], resurrected
+
+
+def test_system_security_converted_paths_not_allowlisted() -> None:
+    """#3940 typed leftover com.percussion.security production call-sites."""
+    text = ALLOWLIST.read_text(encoding="utf-8")
+    entries = [
+        ln.strip()
+        for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+    resurrected = [
+        e for e in entries if e.startswith("system/src/main/java/com/percussion/security/")
+    ]
     assert resurrected == [], resurrected
 
 

--- a/system/src/main/java/com/percussion/security/PSAuthenticationFailedExException.java
+++ b/system/src/main/java/com/percussion/security/PSAuthenticationFailedExException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import java.util.Iterator;
 
 /**
@@ -51,7 +52,7 @@ public class PSAuthenticationFailedExException extends PSAuthenticationFailedExc
     /* Note: Iterator was used instead of [] for future extensibility.
     We may want to return different kinds of objects with more info at a
     later time. */
-    super(IPSSecurityErrors.MULTI_AUTHENTICATION_FAILED, new Object[1]);
+    super(SecurityErrorCodes.MULTI_AUTHENTICATION_FAILED, new Object[1]);
     if (null == failedSPExceptions || !failedSPExceptions.hasNext()) {
       throw new IllegalArgumentException("Must provide at least 1 security provider.");
     }

--- a/system/src/main/java/com/percussion/security/PSAuthenticationFailedException.java
+++ b/system/src/main/java/com/percussion/security/PSAuthenticationFailedException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
@@ -31,14 +32,14 @@ import com.percussion.error.PSException;
 public class PSAuthenticationFailedException extends PSException {
   /** Constructs an authentication failed exception with the default message. */
   public PSAuthenticationFailedException(String type, String instanceName, String uid) {
-    super(IPSSecurityErrors.AUTHENTICATION_FAILED, new Object[] {type, instanceName, uid});
+    super(SecurityErrorCodes.AUTHENTICATION_FAILED, new Object[] {type, instanceName, uid});
   }
 
   /** Constructs an authentication failed exception describing the cause of the failure. */
   public PSAuthenticationFailedException(
       String type, String instanceName, String uid, String failureMessage) {
     super(
-        IPSSecurityErrors.AUTHENTICATION_FAILED_WITH_MSG,
+        SecurityErrorCodes.AUTHENTICATION_FAILED_WITH_MSG,
         new Object[] {type, instanceName, uid, failureMessage});
   }
 

--- a/system/src/main/java/com/percussion/security/PSAuthenticationRequiredException.java
+++ b/system/src/main/java/com/percussion/security/PSAuthenticationRequiredException.java
@@ -17,6 +17,8 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+
 /**
  * PSAuthenticationRequiredException is thrown to indicate that a user must login (authenticate) to
  * gain access to a resource. This usually occurs when the user has not attempted any form of
@@ -41,6 +43,6 @@ public class PSAuthenticationRequiredException extends PSAuthorizationException 
   /** Constructs an authentication required exception with the default message. */
   public PSAuthenticationRequiredException(
       java.lang.String resourceType, java.lang.String resourceName) {
-    super(IPSSecurityErrors.AUTHENTICATION_REQUIRED, new Object[] {resourceType, resourceName});
+    super(SecurityErrorCodes.AUTHENTICATION_REQUIRED, new Object[] {resourceType, resourceName});
   }
 }

--- a/system/src/main/java/com/percussion/security/PSAuthenticationUnsupportedException.java
+++ b/system/src/main/java/com/percussion/security/PSAuthenticationUnsupportedException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -31,6 +32,6 @@ import com.percussion.error.PSException;
 public class PSAuthenticationUnsupportedException extends PSException {
   /** Constructs an authentication unsupported exception with the default message. */
   public PSAuthenticationUnsupportedException(java.lang.String provider) {
-    super(IPSSecurityErrors.AUTHENTICATION_NOT_SUPPORTED, new Object[] {provider});
+    super(SecurityErrorCodes.AUTHENTICATION_NOT_SUPPORTED, new Object[] {provider});
   }
 }

--- a/system/src/main/java/com/percussion/security/PSAuthorizationException.java
+++ b/system/src/main/java/com/percussion/security/PSAuthorizationException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
@@ -40,7 +41,7 @@ public class PSAuthorizationException extends PSException {
    */
   public PSAuthorizationException(String resourceType, String resourceName, String sessionId) {
     super(
-        IPSSecurityErrors.SESS_NOT_AUTHORIZED,
+        SecurityErrorCodes.SESS_NOT_AUTHORIZED,
         new Object[] {resourceType, resourceName, sessionId});
   }
 
@@ -57,7 +58,7 @@ public class PSAuthorizationException extends PSException {
       String language, String resourceType, String resourceName, String sessionId) {
     super(
         language,
-        IPSSecurityErrors.SESS_NOT_AUTHORIZED,
+        SecurityErrorCodes.SESS_NOT_AUTHORIZED,
         new Object[] {resourceType, resourceName, sessionId});
   }
 
@@ -77,7 +78,7 @@ public class PSAuthorizationException extends PSException {
       String userName) {
     super(
         language,
-        IPSSecurityErrors.USER_NOT_AUTHORIZED,
+        SecurityErrorCodes.USER_NOT_AUTHORIZED,
         new Object[] {resourceType, resourceName, securityProvider, userName});
   }
 

--- a/system/src/main/java/com/percussion/security/PSBackEndTableDirectoryCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndTableDirectoryCataloger.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.PSAttribute;
 import com.percussion.design.objectstore.PSAttributeList;
 import com.percussion.design.objectstore.PSConditional;
@@ -142,7 +143,7 @@ public class PSBackEndTableDirectoryCataloger extends PSDirectoryCataloger {
     } catch (SQLException e) {
       throw new RuntimeException(
           PSErrorManager.createMessage(
-              IPSSecurityErrors.BETABLE_DIRECTORY_CATALOGER_ERROR, e.toString()));
+              SecurityErrorCodes.BETABLE_DIRECTORY_CATALOGER_ERROR.numericCode(), e.toString()));
     } finally {
       if (result != null)
         try {

--- a/system/src/main/java/com/percussion/security/PSBackEndTableProvider.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndTableProvider.java
@@ -17,6 +17,7 @@
 package com.percussion.security;
 
 import com.intsof.percussioncms.auditlog.AuditOutcome;
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.PSAttributeList;
 import com.percussion.services.audit.PSSystemAuditLogger;
 import com.percussion.design.objectstore.PSProvider;
@@ -134,7 +135,7 @@ public class PSBackEndTableProvider extends PSSecurityProvider {
         Object[] args = {m_spInstance, uid};
 
         throw new PSAuthenticationFailedException(
-            IPSSecurityErrors.BETABLE_ERROR_UID_NOT_UNIQUE, args);
+            SecurityErrorCodes.BETABLE_ERROR_UID_NOT_UNIQUE, args);
       }
 
       // check that the password matches

--- a/system/src/main/java/com/percussion/security/PSBackEndTableProviderMetaData.java
+++ b/system/src/main/java/com/percussion/security/PSBackEndTableProviderMetaData.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.data.PSResultSet;
 import com.percussion.data.PSResultSetWrapper;
 import com.percussion.data.jdbc.PSOdbcDriverMetaData;
@@ -143,7 +144,7 @@ public class PSBackEndTableProviderMetaData extends PSSecurityProviderMetaData {
 
       PSLogManager.write(
           new PSLogServerWarning(
-              IPSSecurityErrors.PROVIDER_INIT_CATALOG_DISABLED,
+              SecurityErrorCodes.PROVIDER_INIT_CATALOG_DISABLED.numericCode(),
               args,
               true,
               "Odbc Driver - getServers"));

--- a/system/src/main/java/com/percussion/security/PSCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSCataloger.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.IPSGroupProviderInstance;
 import com.percussion.design.objectstore.PSAttribute;
 import com.percussion.design.objectstore.PSAttributeList;
@@ -148,7 +149,7 @@ public abstract class PSCataloger {
     if (m_directorySet == null) {
       Object[] args = {name};
 
-      throw new PSSecurityException(IPSSecurityErrors.DIR_REFERENCED_DIRECTORYSET_NOT_FOUND, args);
+      throw new PSSecurityException(SecurityErrorCodes.DIR_REFERENCED_DIRECTORYSET_NOT_FOUND, args);
     }
 
     // load and validate all referenced directories/authentications
@@ -159,7 +160,7 @@ public abstract class PSCataloger {
       if (directory == null) {
         Object[] args = {directoryRef.getName()};
 
-        throw new PSSecurityException(IPSSecurityErrors.DIR_REFERENCED_DIRECTORY_NOT_FOUND, args);
+        throw new PSSecurityException(SecurityErrorCodes.DIR_REFERENCED_DIRECTORY_NOT_FOUND, args);
       }
 
       PSAuthentication authentication =
@@ -168,7 +169,7 @@ public abstract class PSCataloger {
         Object[] args = {directory.getAuthenticationRef().getName()};
 
         throw new PSSecurityException(
-            IPSSecurityErrors.DIR_REFERENCED_AUTHENTICATION_NOT_FOUND, args);
+            SecurityErrorCodes.DIR_REFERENCED_AUTHENTICATION_NOT_FOUND, args);
       }
 
       directory = ensureReturnAttribute(directory, getEmailAddressAttributeName());
@@ -185,7 +186,7 @@ public abstract class PSCataloger {
 
         if (gpInst == null) {
           Object[] args = {groupName};
-          throw new PSSecurityException(IPSSecurityErrors.GROUP_PROVIDER_MISSING, args);
+          throw new PSSecurityException(SecurityErrorCodes.GROUP_PROVIDER_MISSING, args);
         }
 
         int type = gpInst.getType();
@@ -203,7 +204,7 @@ public abstract class PSCataloger {
           addGroupProvider(gp);
         } else {
           Object[] args = {groupName};
-          throw new PSSecurityException(IPSSecurityErrors.GROUP_PROVIDER_MISSING, args);
+          throw new PSSecurityException(SecurityErrorCodes.GROUP_PROVIDER_MISSING, args);
         }
       }
     }
@@ -434,7 +435,7 @@ public abstract class PSCataloger {
       Object args[] = {e.toString()};
       Throwable rootCause = PSExceptionHelper.findRootCause(e, false);
 
-      throw new PSSecurityException(IPSSecurityErrors.UNKNOWN_NAMING_ERROR, args, rootCause);
+      throw new PSSecurityException(SecurityErrorCodes.UNKNOWN_NAMING_ERROR, args, rootCause);
     } finally {
       if (results != null)
         try {

--- a/system/src/main/java/com/percussion/security/PSDataEncryptionError.java
+++ b/system/src/main/java/com/percussion/security/PSDataEncryptionError.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.PSErrorManager;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
@@ -49,8 +50,9 @@ public class PSDataEncryptionError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSSecurityErrors.DATA_ENCRYPTION_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSSecurityErrors.DATA_ENCRYPTION_ERROR_MSG, false, loc));
+            SecurityErrorCodes.DATA_ENCRYPTION_ERROR.numericCode(),
+            PSErrorManager.getErrorText(
+                SecurityErrorCodes.DATA_ENCRYPTION_ERROR.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/security/PSDataEncryptionHandler.java
+++ b/system/src/main/java/com/percussion/security/PSDataEncryptionHandler.java
@@ -17,6 +17,8 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.design.objectstore.PSDataEncryptor;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSResponse;
@@ -83,7 +85,7 @@ public class PSDataEncryptionHandler {
         };
         com.percussion.log.PSLogManager.write(
             new com.percussion.log.PSLogServerWarning(
-                com.percussion.server.IPSServerErrors.RESPONSE_SEND_ERROR,
+                ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(),
                 args,
                 true,
                 "DataEncryptionHandler"));
@@ -104,10 +106,16 @@ public class PSDataEncryptionHandler {
         Object[] args = {request.getUserSessionId(), "" + keyStrength, "" + userKeyStrength};
         com.percussion.log.PSLogManager.write(
             new com.percussion.log.PSLogServerWarning(
-                IPSSecurityErrors.SSL_KEY_STRENGTH_TOO_WEAK, args, true, "DataEncryptionHandler"));
+                SecurityErrorCodes.SSL_KEY_STRENGTH_TOO_WEAK.numericCode(),
+                args,
+                true,
+                "DataEncryptionHandler"));
 
         // send a response to through the request
-        sendErrorResponse(request.getResponse(), IPSSecurityErrors.SSL_KEY_STRENGTH_TOO_WEAK, args);
+        sendErrorResponse(
+            request.getResponse(),
+            SecurityErrorCodes.SSL_KEY_STRENGTH_TOO_WEAK.numericCode(),
+            args);
       }
     }
 

--- a/system/src/main/java/com/percussion/security/PSDirectoryCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSDirectoryCataloger.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.design.objectstore.PSAttributeList;
 import com.percussion.design.objectstore.PSConditional;
@@ -94,7 +95,7 @@ public abstract class PSDirectoryCataloger extends PSCataloger implements IPSDir
     String emailAttributeName = getEmailAddressAttributeName();
     if (emailAttributeName == null)
       throw new UnsupportedOperationException(
-          PSErrorManager.getErrorText(IPSSecurityErrors.NO_EMAIL_ATTRIBUTE_NAME));
+          PSErrorManager.getErrorText(SecurityErrorCodes.NO_EMAIL_ATTRIBUTE_NAME.numericCode()));
 
     return getAttribute(user, emailAttributeName);
   }
@@ -220,7 +221,7 @@ public abstract class PSDirectoryCataloger extends PSCataloger implements IPSDir
       }
     } catch (NamingException e) {
       Object args[] = {e.toString()};
-      throw new PSSecurityException(IPSSecurityErrors.UNKNOWN_NAMING_ERROR, args);
+      throw new PSSecurityException(SecurityErrorCodes.UNKNOWN_NAMING_ERROR, args);
     } finally {
       if (results != null)
         try {
@@ -310,7 +311,7 @@ public abstract class PSDirectoryCataloger extends PSCataloger implements IPSDir
             + e.toString()
       };
 
-      throw new PSSecurityException(IPSSecurityErrors.UNKNOWN_NAMING_ERROR, args);
+      throw new PSSecurityException(SecurityErrorCodes.UNKNOWN_NAMING_ERROR, args);
     } finally {
       if (values != null)
         try {

--- a/system/src/main/java/com/percussion/security/PSDirectoryConnProvider.java
+++ b/system/src/main/java/com/percussion/security/PSDirectoryConnProvider.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.PSAttributeList;
 import com.percussion.design.objectstore.PSAuthentication;
 import com.percussion.design.objectstore.PSDirectory;
@@ -99,7 +100,7 @@ public class PSDirectoryConnProvider extends PSJndiProvider {
     if (directorySet == null) {
       String[] args = {provider.getReference().getName()};
       throw new PSAuthenticationFailedException(
-          IPSSecurityErrors.DIR_REFERENCED_DIRECTORYSET_NOT_FOUND, args);
+          SecurityErrorCodes.DIR_REFERENCED_DIRECTORYSET_NOT_FOUND, args);
     }
 
     StringBuffer errorMessage = new StringBuffer();
@@ -110,7 +111,7 @@ public class PSDirectoryConnProvider extends PSJndiProvider {
         if (directory == null) {
           String[] args = {"Directory is null."};
           throw new PSAuthenticationFailedException(
-              IPSSecurityErrors.REFERENCED_DIRECTORY_NOT_FOUND, args);
+              SecurityErrorCodes.REFERENCED_DIRECTORY_NOT_FOUND, args);
         }
 
         PSAuthentication authentication =
@@ -118,7 +119,7 @@ public class PSDirectoryConnProvider extends PSJndiProvider {
         if (authentication == null) {
           String[] args = {"Authentication for Directory " + directory.getName() + " is null."};
           throw new PSAuthenticationFailedException(
-              IPSSecurityErrors.REFERENCED_AUTHENTICATION_NOT_FOUND, args);
+              SecurityErrorCodes.REFERENCED_AUTHENTICATION_NOT_FOUND, args);
         }
 
         setProviderProperties(directory, authentication);
@@ -144,7 +145,7 @@ public class PSDirectoryConnProvider extends PSJndiProvider {
         if (encryptedPassword.length() == 0
             && !getAuthenticationScheme().equals(AUTH_SCHEME_NONE)) {
           Object[] args = {getInstance()};
-          throw new PSAuthenticationFailedException(IPSSecurityErrors.DIR_PASSWORD_REQUIRED, args);
+          throw new PSAuthenticationFailedException(SecurityErrorCodes.DIR_PASSWORD_REQUIRED, args);
         }
 
         DirContext context = null;
@@ -212,7 +213,7 @@ public class PSDirectoryConnProvider extends PSJndiProvider {
           String[] args = {directory.getName(), authentication.getName(), e.toString()};
 
           throw new PSAuthenticationFailedException(
-              IPSSecurityErrors.DIRECTORY_AUTHENTICATION_FAILED, args);
+              SecurityErrorCodes.DIRECTORY_AUTHENTICATION_FAILED, args);
         } finally {
           if (context != null)
             try {

--- a/system/src/main/java/com/percussion/security/PSDirectoryConnProviderMetaData.java
+++ b/system/src/main/java/com/percussion/security/PSDirectoryConnProviderMetaData.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.data.PSResultSet;
 import com.percussion.design.objectstore.PSAuthentication;
 import com.percussion.design.objectstore.PSDirectory;
@@ -221,11 +222,11 @@ public class PSDirectoryConnProviderMetaData extends PSJndiProviderMetaData {
           }
         } catch (NamingException e) {
           // convert to SQLException and re-throw
-          throw new PSSqlException(IPSSecurityErrors.DIR_GET_OBJECTS_FAILED, e.toString(), "0");
+          throw new PSSqlException(SecurityErrorCodes.DIR_GET_OBJECTS_FAILED, e.toString(), "0");
         } catch (PSSecurityException e) {
           // convert to SQLException and re-throw
           throw new PSSqlException(
-              IPSSecurityErrors.DIR_GET_OBJECTS_FAILED, e.getLocalizedMessage(), "0");
+              SecurityErrorCodes.DIR_GET_OBJECTS_FAILED, e.getLocalizedMessage(), "0");
         } finally {
           if (attVals != null)
             try {

--- a/system/src/main/java/com/percussion/security/PSDirectoryServerCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSDirectoryServerCataloger.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.PSAttributeList;
 import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSServerConfiguration;
@@ -207,7 +208,7 @@ public class PSDirectoryServerCataloger extends PSDirectoryCataloger {
       // then just log the error.
       if (dirSize != 0 && dirSize == errorLoadingDir) {
         throw new PSSecurityException(
-            IPSSecurityErrors.UNKNOWN_NAMING_ERROR,
+            SecurityErrorCodes.UNKNOWN_NAMING_ERROR,
             new String[] {PSExceptionUtils.getDebugMessageForLog(ex)},
             ex);
       }

--- a/system/src/main/java/com/percussion/security/PSExitCreateDefaultCommunityAcl.java
+++ b/system/src/main/java/com/percussion/security/PSExitCreateDefaultCommunityAcl.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSDefaultExtension;
@@ -24,7 +25,6 @@ import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.security.IPSTypedPrincipal.PrincipalTypes;
 import com.percussion.security.shim.acl.NotOwnerException;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.IPSGuidManager;
 import com.percussion.services.guidmgr.PSGuidManagerLocator;
@@ -93,7 +93,7 @@ public class PSExitCreateDefaultCommunityAcl extends PSDefaultExtension
     } catch (NumberFormatException e) {
       String msg = "The object type id ''{0}'' could not be parsed. ";
       MessageFormat.format(msg, objectType);
-      throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, msg);
+      throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, msg);
     }
 
     PSTypeEnum objectTypeEnum = PSTypeEnum.valueOf(objectTypeId);
@@ -160,7 +160,7 @@ public class PSExitCreateDefaultCommunityAcl extends PSDefaultExtension
       request.printTraceMessage(
           MessageFormat.format(
               "{0} {1}", errorMsg, "The created object was not added to a community."));
-      throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, errorMsg);
+      throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, errorMsg);
     }
     return resultDoc;
   }

--- a/system/src/main/java/com/percussion/security/PSExitDeleteObjectAcl.java
+++ b/system/src/main/java/com/percussion/security/PSExitDeleteObjectAcl.java
@@ -16,13 +16,13 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.extension.IPSResultDocumentProcessor;
 import com.percussion.extension.PSDefaultExtension;
 import com.percussion.extension.PSExtensionParams;
 import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.IPSGuidManager;
 import com.percussion.services.guidmgr.PSGuidManagerLocator;
@@ -82,7 +82,7 @@ public class PSExitDeleteObjectAcl extends PSDefaultExtension
     } catch (NumberFormatException e) {
       String msg = "The object type id ''{0}'' could not be parsed. ";
       MessageFormat.format(msg, objectType);
-      throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, msg);
+      throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, msg);
     }
 
     PSTypeEnum objectTypeEnum = PSTypeEnum.valueOf(objectTypeId);
@@ -118,7 +118,7 @@ public class PSExitDeleteObjectAcl extends PSDefaultExtension
 
     if (errorMsg != null) {
       request.printTraceMessage(errorMsg);
-      throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, errorMsg);
+      throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, errorMsg);
     }
     return resultDoc;
   }

--- a/system/src/main/java/com/percussion/security/PSFiltersNotSupportedException.java
+++ b/system/src/main/java/com/percussion/security/PSFiltersNotSupportedException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -30,6 +31,6 @@ import com.percussion.error.PSException;
 public class PSFiltersNotSupportedException extends PSException {
   /** Constructs a filters not supported exception with the default message. */
   public PSFiltersNotSupportedException(java.lang.String provider) {
-    super(IPSSecurityErrors.FILTERS_NOT_SUPPORTED, new Object[] {provider});
+    super(SecurityErrorCodes.FILTERS_NOT_SUPPORTED, new Object[] {provider});
   }
 }

--- a/system/src/main/java/com/percussion/security/PSGroupsNotSupportedException.java
+++ b/system/src/main/java/com/percussion/security/PSGroupsNotSupportedException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -30,6 +31,6 @@ import com.percussion.error.PSException;
 public class PSGroupsNotSupportedException extends PSException {
   /** Constructs a groups not supported exception with the default message. */
   public PSGroupsNotSupportedException(java.lang.String provider) {
-    super(IPSSecurityErrors.GROUPS_NOT_SUPPORTED, new Object[] {provider});
+    super(SecurityErrorCodes.GROUPS_NOT_SUPPORTED, new Object[] {provider});
   }
 }

--- a/system/src/main/java/com/percussion/security/PSJndiGroupProvider.java
+++ b/system/src/main/java/com/percussion/security/PSJndiGroupProvider.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.PSJndiGroupProviderInstance;
 import com.percussion.design.objectstore.PSJndiObjectClass;
 import com.percussion.services.security.PSTypedPrincipal;
@@ -219,7 +220,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
       Object[] args = {
         m_groupProviderInstance.getName(), m_directoryDef.getDirectory().getName(), e.toString()
       };
-      throw new PSSecurityException(IPSSecurityErrors.GET_GROUPS_FAILURE, args);
+      throw new PSSecurityException(SecurityErrorCodes.GET_GROUPS_FAILURE, args);
     } finally {
       if (results != null)
         try {
@@ -281,7 +282,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
       Object[] args = {
         m_groupProviderInstance.getName(), m_directoryDef.getDirectory().getName(), e.toString()
       };
-      throw new PSSecurityException(IPSSecurityErrors.GET_GROUPS_FAILURE, args);
+      throw new PSSecurityException(SecurityErrorCodes.GET_GROUPS_FAILURE, args);
     } finally {
       if (results != null)
         try {
@@ -435,7 +436,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
       Object[] args = {
         m_groupProviderInstance.getName(), m_directoryDef.getDirectory().getName(), e.toString()
       };
-      throw new PSSecurityException(IPSSecurityErrors.GET_GROUPS_FAILURE, args);
+      throw new PSSecurityException(SecurityErrorCodes.GET_GROUPS_FAILURE, args);
     } finally {
       if (attVals != null)
         try {
@@ -798,7 +799,7 @@ public class PSJndiGroupProvider implements IPSGroupProvider {
       Object[] args = {
         m_groupProviderInstance.getName(), m_directoryDef.getDirectory().getName(), e.toString()
       };
-      throw new PSSecurityException(IPSSecurityErrors.GET_GROUPS_FAILURE, args);
+      throw new PSSecurityException(SecurityErrorCodes.GET_GROUPS_FAILURE, args);
     } finally {
       if (attVals != null)
         try {

--- a/system/src/main/java/com/percussion/security/PSJndiUtils.java
+++ b/system/src/main/java/com/percussion/security/PSJndiUtils.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.PSAuthentication;
 import com.percussion.design.objectstore.PSDirectory;
 import com.percussion.design.objectstore.PSServerConfiguration;
@@ -127,7 +128,7 @@ public class PSJndiUtils {
         return defaultFilter;
       }
       throw new PSRuntimeException(
-          IPSSecurityErrors.DIR_PASSWORD_FILTER_INIT_ERROR,
+          SecurityErrorCodes.DIR_PASSWORD_FILTER_INIT_ERROR,
           new Object[] {extensionName, e.toString()});
     }
   }
@@ -640,7 +641,8 @@ public class PSJndiUtils {
     } catch (Exception e) {
       throw new NamingException(
           PSErrorManager.createMessage(
-              IPSSecurityErrors.PARSE_JNDI_PROVIDER_URL_ERROR, e.getLocalizedMessage()));
+              SecurityErrorCodes.PARSE_JNDI_PROVIDER_URL_ERROR.numericCode(),
+              e.getLocalizedMessage()));
     }
   }
 

--- a/system/src/main/java/com/percussion/security/PSNativeMethodException.java
+++ b/system/src/main/java/com/percussion/security/PSNativeMethodException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -30,7 +31,7 @@ import com.percussion.error.PSException;
 public class PSNativeMethodException extends PSException {
   /** This one should only be used when logon failed. */
   public PSNativeMethodException(String message) {
-    super(IPSSecurityErrors.NATIVE_AUTHENTICATION_FAILURE, new Object[] {message});
+    super(SecurityErrorCodes.NATIVE_AUTHENTICATION_FAILURE, new Object[] {message});
   }
 
   /**

--- a/system/src/main/java/com/percussion/security/PSOdbcProviderMetaData.java
+++ b/system/src/main/java/com/percussion/security/PSOdbcProviderMetaData.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.data.PSResultSet;
 import com.percussion.error.PSSqlException;
 
@@ -118,7 +119,7 @@ public class PSOdbcProviderMetaData extends PSSecurityProviderMetaData {
 
       com.percussion.log.PSLogManager.write(
           new com.percussion.log.PSLogServerWarning(
-              IPSSecurityErrors.PROVIDER_INIT_CATALOG_DISABLED,
+              SecurityErrorCodes.PROVIDER_INIT_CATALOG_DISABLED.numericCode(),
               args,
               true,
               "Odbc Driver - getServers"));

--- a/system/src/main/java/com/percussion/security/PSRoleAlreadyDefinedException.java
+++ b/system/src/main/java/com/percussion/security/PSRoleAlreadyDefinedException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -35,7 +36,7 @@ public class PSRoleAlreadyDefinedException extends PSException {
    * @param roleName the name of the role
    */
   public PSRoleAlreadyDefinedException(java.lang.String appName, java.lang.String roleName) {
-    super(IPSSecurityErrors.LOCAL_ROLE_ALREADY_DEFINED, new Object[] {roleName, appName});
+    super(SecurityErrorCodes.LOCAL_ROLE_ALREADY_DEFINED, new Object[] {roleName, appName});
   }
 
   /**
@@ -46,6 +47,6 @@ public class PSRoleAlreadyDefinedException extends PSException {
    * @param roleName the name of the role
    */
   public PSRoleAlreadyDefinedException(java.lang.String roleName) {
-    super(IPSSecurityErrors.GLOBAL_ROLE_ALREADY_DEFINED, new Object[] {roleName});
+    super(SecurityErrorCodes.GLOBAL_ROLE_ALREADY_DEFINED, new Object[] {roleName});
   }
 }

--- a/system/src/main/java/com/percussion/security/PSRoleCataloger.java
+++ b/system/src/main/java/com/percussion/security/PSRoleCataloger.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.PSDirectorySet;
 import com.percussion.design.objectstore.PSGlobalSubject;
 import com.percussion.design.objectstore.PSRoleProvider;
@@ -81,7 +82,8 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
     if (m_roleProvider == null) {
       Object[] args = {roleProviderName};
 
-      throw new PSSecurityException(IPSSecurityErrors.DIR_REFERENCED_ROLEPROVIDER_NOT_FOUND, args);
+      throw new PSSecurityException(
+          SecurityErrorCodes.DIR_REFERENCED_ROLEPROVIDER_NOT_FOUND, args);
     }
 
     // load and validate the specified directory set
@@ -170,7 +172,8 @@ public class PSRoleCataloger extends PSCataloger implements IPSInternalRoleCatal
         // print the error to the console and return an empty list
         Object args[] = {e.toString()};
 
-        PSConsole.printMsg("Security", IPSSecurityErrors.UNKNOWN_NAMING_ERROR, args);
+        PSConsole.printMsg(
+            "Security", SecurityErrorCodes.UNKNOWN_NAMING_ERROR.numericCode(), args);
       } finally {
         if (values != null)
           try {

--- a/system/src/main/java/com/percussion/security/PSRoleNotDefinedException.java
+++ b/system/src/main/java/com/percussion/security/PSRoleNotDefinedException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -35,7 +36,7 @@ public class PSRoleNotDefinedException extends PSException {
    * @param roleName the name of the role
    */
   public PSRoleNotDefinedException(java.lang.String appName, java.lang.String roleName) {
-    super(IPSSecurityErrors.LOCAL_ROLE_NOT_DEFINED, new Object[] {roleName, appName});
+    super(SecurityErrorCodes.LOCAL_ROLE_NOT_DEFINED, new Object[] {roleName, appName});
   }
 
   /**
@@ -46,6 +47,6 @@ public class PSRoleNotDefinedException extends PSException {
    * @param roleName the name of the role
    */
   public PSRoleNotDefinedException(java.lang.String roleName) {
-    super(IPSSecurityErrors.GLOBAL_ROLE_NOT_DEFINED, new Object[] {roleName});
+    super(SecurityErrorCodes.GLOBAL_ROLE_NOT_DEFINED, new Object[] {roleName});
   }
 }

--- a/system/src/main/java/com/percussion/security/PSSecurityException.java
+++ b/system/src/main/java/com/percussion/security/PSSecurityException.java
@@ -17,6 +17,8 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.IPSException;
 import com.percussion.error.PSRuntimeException;
 
@@ -52,11 +54,43 @@ public class PSSecurityException extends PSRuntimeException {
   }
 
   /**
+   * Typed construction from a catalogued {@link IPSErrorCode}.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSSecurityException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param messageArgs the array of arguments to use as the arguments in the error message; may be
+   *     {@code null}
+   */
+  public PSSecurityException(IPSErrorCode code, Object[] messageArgs) {
+    super(code, messageArgs);
+  }
+
+  /**
+   * Typed construction with message arguments and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param messageArgs the array of arguments to use as the arguments in the error message; may be
+   *     {@code null}
+   * @param cause causal throwable; may be {@code null}
+   */
+  public PSSecurityException(IPSErrorCode code, Object[] messageArgs, Throwable cause) {
+    super(code, messageArgs, cause);
+  }
+
+  /**
    * Creates an exception that indicates cataloging for some type of security object failed.
    *
    * @param detailMsg The text describing the problem.
    */
   public PSSecurityException(String detailMsg) {
-    super(IPSSecurityErrors.METADATA_UNAVAILABLE, new Object[] {detailMsg});
+    super(SecurityErrorCodes.METADATA_UNAVAILABLE, new Object[] {detailMsg});
   }
 }

--- a/system/src/main/java/com/percussion/security/PSSecurityProvider.java
+++ b/system/src/main/java/com/percussion/security/PSSecurityProvider.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.data.PSDataExtractionException;
 import com.percussion.design.objectstore.PSLiteral;
 import com.percussion.design.objectstore.PSLiteralSet;
@@ -322,31 +323,40 @@ public abstract class PSSecurityProvider implements IPSSecurityProvider {
 
       PSLogManager.write(
           new PSLogServerWarning(
-              IPSSecurityErrors.CATALOG_PROVIDER_CLASS_NOT_FOUND, args, true, origin));
+              SecurityErrorCodes.CATALOG_PROVIDER_CLASS_NOT_FOUND.numericCode(),
+              args,
+              true,
+              origin));
     } catch (InstantiationException e) {
       Object[] args = {provider.getClassName(), PSException.getStackTraceAsString(e)};
 
       PSLogManager.write(
           new PSLogServerWarning(
-              IPSSecurityErrors.CATALOG_PROVIDER_INSTANTIATION_FAILED, args, true, origin));
+              SecurityErrorCodes.CATALOG_PROVIDER_INSTANTIATION_FAILED.numericCode(),
+              args,
+              true,
+              origin));
     } catch (IllegalAccessException e) {
       Object[] args = {provider.getClassName(), PSException.getStackTraceAsString(e)};
 
       PSLogManager.write(
           new PSLogServerWarning(
-              IPSSecurityErrors.CATALOG_PROVIDER_ILLEGAL_ACCESS, args, true, origin));
+              SecurityErrorCodes.CATALOG_PROVIDER_ILLEGAL_ACCESS.numericCode(), args, true, origin));
     } catch (InvocationTargetException e) {
       Object[] args = {provider.getClassName(), PSException.getStackTraceAsString(e)};
 
       PSLogManager.write(
           new PSLogServerWarning(
-              IPSSecurityErrors.CATALOG_PROVIDER_INVOCATION_TARGET_ERROR, args, true, origin));
+              SecurityErrorCodes.CATALOG_PROVIDER_INVOCATION_TARGET_ERROR.numericCode(),
+              args,
+              true,
+              origin));
     } catch (NoSuchMethodException e) {
       Object[] args = {provider.getClassName(), PSException.getStackTraceAsString(e)};
 
       PSLogManager.write(
           new PSLogServerWarning(
-              IPSSecurityErrors.CATALOG_PROVIDER_NO_SUCH_METHOD, args, true, origin));
+              SecurityErrorCodes.CATALOG_PROVIDER_NO_SUCH_METHOD.numericCode(), args, true, origin));
     }
 
     return cataloger;

--- a/system/src/main/java/com/percussion/security/PSSecurityProviderPool.java
+++ b/system/src/main/java/com/percussion/security/PSSecurityProviderPool.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.design.objectstore.PSDirectorySet;
 import com.percussion.design.objectstore.PSProvider;
 import com.percussion.design.objectstore.PSReference;
@@ -317,7 +318,10 @@ public class PSSecurityProviderPool {
 
           PSLogManager.write(
               new PSLogServerWarning(
-                  IPSSecurityErrors.PROVIDER_INIT_EXCEPTION, args, true, "SecurityProviderPool"));
+                  SecurityErrorCodes.PROVIDER_INIT_EXCEPTION.numericCode(),
+                  args,
+                  true,
+                  "SecurityProviderPool"));
 
           return;
         }
@@ -326,7 +330,10 @@ public class PSSecurityProviderPool {
         Object[] args = {String.valueOf(spType), spInstName};
         PSLogManager.write(
             new PSLogServerWarning(
-                IPSSecurityErrors.PROVIDER_UNKNOWN, args, true, "SecurityProviderPool"));
+                SecurityErrorCodes.PROVIDER_UNKNOWN.numericCode(),
+                args,
+                true,
+                "SecurityProviderPool"));
         return;
     } // end switch
 
@@ -337,7 +344,7 @@ public class PSSecurityProviderPool {
       Object[] args = {spInstName};
       PSLogManager.write(
           new PSLogServerWarning(
-              IPSSecurityErrors.PROVIDER_INSTANCE_NAME_DUPLICATED,
+              SecurityErrorCodes.PROVIDER_INSTANCE_NAME_DUPLICATED.numericCode(),
               args,
               false,
               "SecurityProviderPool"));

--- a/system/src/main/java/com/percussion/security/PSUnsupportedProviderException.java
+++ b/system/src/main/java/com/percussion/security/PSUnsupportedProviderException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -36,6 +37,6 @@ public class PSUnsupportedProviderException extends PSException {
    */
   public PSUnsupportedProviderException(java.lang.String providerClass, java.lang.String provider) {
     super(
-        IPSSecurityErrors.PROVIDER_NOT_SUPPORTED_BY_CLASS, new Object[] {providerClass, provider});
+        SecurityErrorCodes.PROVIDER_NOT_SUPPORTED_BY_CLASS, new Object[] {providerClass, provider});
   }
 }

--- a/system/src/main/java/com/percussion/security/PSUsersNotSupportedException.java
+++ b/system/src/main/java/com/percussion/security/PSUsersNotSupportedException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.security;
 
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -30,6 +31,6 @@ import com.percussion.error.PSException;
 public class PSUsersNotSupportedException extends PSException {
   /** Constructs a users not supported exception with the default message. */
   public PSUsersNotSupportedException(java.lang.String provider) {
-    super(IPSSecurityErrors.USERS_NOT_SUPPORTED, new Object[] {provider});
+    super(SecurityErrorCodes.USERS_NOT_SUPPORTED, new Object[] {provider});
   }
 }

--- a/system/src/test/java/com/percussion/security/PSSecurityLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/security/PSSecurityLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.SecurityErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.error.PSRuntimeException;
+import com.percussion.error.PSSqlException;
+import com.percussion.extension.PSExtensionProcessingException;
+import com.percussion.server.IPSServerErrors;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3940 (parent #2616): leftover {@code com.percussion.security} production sites throw typed
+ * {@code *ErrorCodes} (not bare {@code IPS*Errors} ints). Dual-write is skipped where the catalog
+ * is non-auditable; leftover auditable SEC codes remain dual-write eligible.
+ */
+@Tag("UnitTest")
+class PSSecurityLeftoverErrorCodesSliceTest {
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWriteWhereNonAuditable() {
+    assertEquals(
+        IPSSecurityErrors.AUTHENTICATION_NOT_SUPPORTED,
+        SecurityErrorCodes.AUTHENTICATION_NOT_SUPPORTED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.AUTHENTICATION_FAILED,
+        SecurityErrorCodes.AUTHENTICATION_FAILED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.PROVIDER_NOT_SUPPORTED_BY_CLASS,
+        SecurityErrorCodes.PROVIDER_NOT_SUPPORTED_BY_CLASS.numericCode());
+    assertEquals(
+        IPSSecurityErrors.FILTERS_NOT_SUPPORTED,
+        SecurityErrorCodes.FILTERS_NOT_SUPPORTED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.USERS_NOT_SUPPORTED, SecurityErrorCodes.USERS_NOT_SUPPORTED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.GROUPS_NOT_SUPPORTED,
+        SecurityErrorCodes.GROUPS_NOT_SUPPORTED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.AUTHENTICATION_REQUIRED,
+        SecurityErrorCodes.AUTHENTICATION_REQUIRED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.SESS_NOT_AUTHORIZED, SecurityErrorCodes.SESS_NOT_AUTHORIZED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.USER_NOT_AUTHORIZED, SecurityErrorCodes.USER_NOT_AUTHORIZED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.PROVIDER_INIT_EXCEPTION,
+        SecurityErrorCodes.PROVIDER_INIT_EXCEPTION.numericCode());
+    assertEquals(
+        IPSSecurityErrors.PROVIDER_UNKNOWN, SecurityErrorCodes.PROVIDER_UNKNOWN.numericCode());
+    assertEquals(
+        IPSSecurityErrors.AUTHENTICATION_FAILED_WITH_MSG,
+        SecurityErrorCodes.AUTHENTICATION_FAILED_WITH_MSG.numericCode());
+    assertEquals(
+        IPSSecurityErrors.PROVIDER_INIT_CATALOG_DISABLED,
+        SecurityErrorCodes.PROVIDER_INIT_CATALOG_DISABLED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.PROVIDER_INSTANCE_NAME_DUPLICATED,
+        SecurityErrorCodes.PROVIDER_INSTANCE_NAME_DUPLICATED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.NATIVE_AUTHENTICATION_FAILURE,
+        SecurityErrorCodes.NATIVE_AUTHENTICATION_FAILURE.numericCode());
+    assertEquals(
+        IPSSecurityErrors.SSL_KEY_STRENGTH_TOO_WEAK,
+        SecurityErrorCodes.SSL_KEY_STRENGTH_TOO_WEAK.numericCode());
+    assertEquals(
+        IPSSecurityErrors.DATA_ENCRYPTION_ERROR_MSG,
+        SecurityErrorCodes.DATA_ENCRYPTION_ERROR.numericCode());
+    assertEquals(
+        IPSSecurityErrors.MULTI_AUTHENTICATION_FAILED,
+        SecurityErrorCodes.MULTI_AUTHENTICATION_FAILED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.METADATA_UNAVAILABLE,
+        SecurityErrorCodes.METADATA_UNAVAILABLE.numericCode());
+    assertEquals(
+        IPSSecurityErrors.GET_GROUPS_FAILURE, SecurityErrorCodes.GET_GROUPS_FAILURE.numericCode());
+    assertEquals(
+        IPSSecurityErrors.GROUP_PROVIDER_MISSING,
+        SecurityErrorCodes.GROUP_PROVIDER_MISSING.numericCode());
+    assertEquals(
+        IPSSecurityErrors.LOCAL_ROLE_NOT_DEFINED,
+        SecurityErrorCodes.LOCAL_ROLE_NOT_DEFINED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.GLOBAL_ROLE_NOT_DEFINED,
+        SecurityErrorCodes.GLOBAL_ROLE_NOT_DEFINED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.LOCAL_ROLE_ALREADY_DEFINED,
+        SecurityErrorCodes.LOCAL_ROLE_ALREADY_DEFINED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.GLOBAL_ROLE_ALREADY_DEFINED,
+        SecurityErrorCodes.GLOBAL_ROLE_ALREADY_DEFINED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.DIR_PASSWORD_FILTER_INIT_ERROR,
+        SecurityErrorCodes.DIR_PASSWORD_FILTER_INIT_ERROR.numericCode());
+    assertEquals(
+        IPSSecurityErrors.DIR_PASSWORD_REQUIRED,
+        SecurityErrorCodes.DIR_PASSWORD_REQUIRED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.DIR_GET_OBJECTS_FAILED,
+        SecurityErrorCodes.DIR_GET_OBJECTS_FAILED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.DIR_REFERENCED_DIRECTORYSET_NOT_FOUND,
+        SecurityErrorCodes.DIR_REFERENCED_DIRECTORYSET_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSSecurityErrors.DIR_REFERENCED_DIRECTORY_NOT_FOUND,
+        SecurityErrorCodes.DIR_REFERENCED_DIRECTORY_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSSecurityErrors.DIR_REFERENCED_AUTHENTICATION_NOT_FOUND,
+        SecurityErrorCodes.DIR_REFERENCED_AUTHENTICATION_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSSecurityErrors.DIR_REFERENCED_ROLEPROVIDER_NOT_FOUND,
+        SecurityErrorCodes.DIR_REFERENCED_ROLEPROVIDER_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSSecurityErrors.BETABLE_ERROR_UID_NOT_UNIQUE,
+        SecurityErrorCodes.BETABLE_ERROR_UID_NOT_UNIQUE.numericCode());
+    assertEquals(
+        IPSSecurityErrors.NO_EMAIL_ATTRIBUTE_NAME,
+        SecurityErrorCodes.NO_EMAIL_ATTRIBUTE_NAME.numericCode());
+    assertEquals(
+        IPSSecurityErrors.BETABLE_DIRECTORY_CATALOGER_ERROR,
+        SecurityErrorCodes.BETABLE_DIRECTORY_CATALOGER_ERROR.numericCode());
+    assertEquals(
+        IPSSecurityErrors.CATALOG_PROVIDER_CLASS_NOT_FOUND,
+        SecurityErrorCodes.CATALOG_PROVIDER_CLASS_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSSecurityErrors.REFERENCED_DIRECTORY_NOT_FOUND,
+        SecurityErrorCodes.REFERENCED_DIRECTORY_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSSecurityErrors.REFERENCED_AUTHENTICATION_NOT_FOUND,
+        SecurityErrorCodes.REFERENCED_AUTHENTICATION_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSSecurityErrors.DIRECTORY_AUTHENTICATION_FAILED,
+        SecurityErrorCodes.DIRECTORY_AUTHENTICATION_FAILED.numericCode());
+    assertEquals(
+        IPSSecurityErrors.UNKNOWN_NAMING_ERROR,
+        SecurityErrorCodes.UNKNOWN_NAMING_ERROR.numericCode());
+    assertEquals(
+        IPSSecurityErrors.PARSE_JNDI_PROVIDER_URL_ERROR,
+        SecurityErrorCodes.PARSE_JNDI_PROVIDER_URL_ERROR.numericCode());
+    assertEquals(IPSServerErrors.RAW_DUMP, ServerErrorCodes.RAW_DUMP.numericCode());
+    assertEquals(
+        IPSServerErrors.RESPONSE_SEND_ERROR, ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode());
+
+    leftoverNonAuditable(SecurityErrorCodes.AUTHENTICATION_NOT_SUPPORTED);
+    leftoverNonAuditable(SecurityErrorCodes.PROVIDER_NOT_SUPPORTED_BY_CLASS);
+    leftoverNonAuditable(SecurityErrorCodes.FILTERS_NOT_SUPPORTED);
+    leftoverNonAuditable(SecurityErrorCodes.USERS_NOT_SUPPORTED);
+    leftoverNonAuditable(SecurityErrorCodes.GROUPS_NOT_SUPPORTED);
+    leftoverNonAuditable(SecurityErrorCodes.PROVIDER_INIT_EXCEPTION);
+    leftoverNonAuditable(SecurityErrorCodes.PROVIDER_UNKNOWN);
+    leftoverNonAuditable(SecurityErrorCodes.PROVIDER_INIT_CATALOG_DISABLED);
+    leftoverNonAuditable(SecurityErrorCodes.PROVIDER_INSTANCE_NAME_DUPLICATED);
+    leftoverNonAuditable(SecurityErrorCodes.METADATA_UNAVAILABLE);
+    leftoverNonAuditable(SecurityErrorCodes.GET_GROUPS_FAILURE);
+    leftoverNonAuditable(SecurityErrorCodes.GROUP_PROVIDER_MISSING);
+    leftoverNonAuditable(SecurityErrorCodes.LOCAL_ROLE_NOT_DEFINED);
+    leftoverNonAuditable(SecurityErrorCodes.GLOBAL_ROLE_NOT_DEFINED);
+    leftoverNonAuditable(SecurityErrorCodes.DIR_PASSWORD_FILTER_INIT_ERROR);
+    leftoverNonAuditable(SecurityErrorCodes.DIR_GET_OBJECTS_FAILED);
+    leftoverNonAuditable(SecurityErrorCodes.DIR_REFERENCED_DIRECTORYSET_NOT_FOUND);
+    leftoverNonAuditable(SecurityErrorCodes.NO_EMAIL_ATTRIBUTE_NAME);
+    leftoverNonAuditable(SecurityErrorCodes.BETABLE_DIRECTORY_CATALOGER_ERROR);
+    leftoverNonAuditable(SecurityErrorCodes.CATALOG_PROVIDER_CLASS_NOT_FOUND);
+    leftoverNonAuditable(SecurityErrorCodes.UNKNOWN_NAMING_ERROR);
+    leftoverNonAuditable(SecurityErrorCodes.PARSE_JNDI_PROVIDER_URL_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.RAW_DUMP);
+    leftoverNonAuditable(ServerErrorCodes.RESPONSE_SEND_ERROR);
+
+    leftoverAuditable(SecurityErrorCodes.AUTHENTICATION_FAILED);
+    leftoverAuditable(SecurityErrorCodes.AUTHENTICATION_FAILED_WITH_MSG);
+    leftoverAuditable(SecurityErrorCodes.AUTHENTICATION_REQUIRED);
+    leftoverAuditable(SecurityErrorCodes.SESS_NOT_AUTHORIZED);
+    leftoverAuditable(SecurityErrorCodes.USER_NOT_AUTHORIZED);
+    leftoverAuditable(SecurityErrorCodes.NATIVE_AUTHENTICATION_FAILURE);
+    leftoverAuditable(SecurityErrorCodes.SSL_KEY_STRENGTH_TOO_WEAK);
+    leftoverAuditable(SecurityErrorCodes.DATA_ENCRYPTION_ERROR);
+    leftoverAuditable(SecurityErrorCodes.MULTI_AUTHENTICATION_FAILED);
+    leftoverAuditable(SecurityErrorCodes.LOCAL_ROLE_ALREADY_DEFINED);
+    leftoverAuditable(SecurityErrorCodes.GLOBAL_ROLE_ALREADY_DEFINED);
+    leftoverAuditable(SecurityErrorCodes.DIR_PASSWORD_REQUIRED);
+    leftoverAuditable(SecurityErrorCodes.BETABLE_ERROR_UID_NOT_UNIQUE);
+    leftoverAuditable(SecurityErrorCodes.DIRECTORY_AUTHENTICATION_FAILED);
+  }
+
+  @Test
+  void leftoverProductionExceptionTypesRetainTypedCodes() {
+    PSAuthenticationFailedException authFailed =
+        new PSAuthenticationFailedException("Directory", "ldap1", "alice");
+    assertSame(SecurityErrorCodes.AUTHENTICATION_FAILED, authFailed.getTypedErrorCode());
+    assertEquals(SecurityErrorCodes.AUTHENTICATION_FAILED.numericCode(), authFailed.getErrorCode());
+    assertTrue(authFailed.isAuditable());
+
+    PSAuthenticationFailedException withMsg =
+        new PSAuthenticationFailedException("Directory", "ldap1", "alice", "bad password");
+    assertSame(SecurityErrorCodes.AUTHENTICATION_FAILED_WITH_MSG, withMsg.getTypedErrorCode());
+    assertTrue(withMsg.isAuditable());
+
+    PSAuthenticationFailedException dirSet =
+        new PSAuthenticationFailedException(
+            SecurityErrorCodes.DIR_REFERENCED_DIRECTORYSET_NOT_FOUND, new Object[] {"corp"});
+    assertSame(
+        SecurityErrorCodes.DIR_REFERENCED_DIRECTORYSET_NOT_FOUND, dirSet.getTypedErrorCode());
+    assertFalse(dirSet.isAuditable());
+
+    PSAuthenticationFailedException uidDup =
+        new PSAuthenticationFailedException(
+            SecurityErrorCodes.BETABLE_ERROR_UID_NOT_UNIQUE, new Object[] {"rx", "alice"});
+    assertSame(SecurityErrorCodes.BETABLE_ERROR_UID_NOT_UNIQUE, uidDup.getTypedErrorCode());
+    assertTrue(uidDup.isAuditable());
+
+    PSAuthenticationFailedExException multi =
+        new PSAuthenticationFailedExException(List.of(authFailed).iterator());
+    assertSame(SecurityErrorCodes.MULTI_AUTHENTICATION_FAILED, multi.getTypedErrorCode());
+    assertTrue(multi.isAuditable());
+
+    PSAuthenticationRequiredException required =
+        new PSAuthenticationRequiredException("Application", "rx");
+    assertSame(SecurityErrorCodes.AUTHENTICATION_REQUIRED, required.getTypedErrorCode());
+    assertTrue(required.isAuditable());
+
+    PSAuthorizationException session =
+        new PSAuthorizationException("Application", "rx", "sess-1");
+    assertSame(SecurityErrorCodes.SESS_NOT_AUTHORIZED, session.getTypedErrorCode());
+    assertTrue(session.isAuditable());
+
+    PSAuthorizationException user =
+        new PSAuthorizationException("en-us", "Application", "rx", "Directory", "alice");
+    assertSame(SecurityErrorCodes.USER_NOT_AUTHORIZED, user.getTypedErrorCode());
+    assertTrue(user.isAuditable());
+
+    PSAuthenticationUnsupportedException unsupported =
+        new PSAuthenticationUnsupportedException("ODBC");
+    assertSame(SecurityErrorCodes.AUTHENTICATION_NOT_SUPPORTED, unsupported.getTypedErrorCode());
+    assertFalse(unsupported.isAuditable());
+
+    PSFiltersNotSupportedException filters = new PSFiltersNotSupportedException("ODBC");
+    assertSame(SecurityErrorCodes.FILTERS_NOT_SUPPORTED, filters.getTypedErrorCode());
+    assertFalse(filters.isAuditable());
+
+    PSGroupsNotSupportedException groups = new PSGroupsNotSupportedException("ODBC");
+    assertSame(SecurityErrorCodes.GROUPS_NOT_SUPPORTED, groups.getTypedErrorCode());
+    assertFalse(groups.isAuditable());
+
+    PSUsersNotSupportedException users = new PSUsersNotSupportedException("ODBC");
+    assertSame(SecurityErrorCodes.USERS_NOT_SUPPORTED, users.getTypedErrorCode());
+    assertFalse(users.isAuditable());
+
+    PSNativeMethodException nativeAuth = new PSNativeMethodException("impersonate failed");
+    assertSame(SecurityErrorCodes.NATIVE_AUTHENTICATION_FAILURE, nativeAuth.getTypedErrorCode());
+    assertTrue(nativeAuth.isAuditable());
+
+    PSUnsupportedProviderException provider =
+        new PSUnsupportedProviderException("com.example.Sp", "ODBC");
+    assertSame(SecurityErrorCodes.PROVIDER_NOT_SUPPORTED_BY_CLASS, provider.getTypedErrorCode());
+    assertFalse(provider.isAuditable());
+
+    PSRoleAlreadyDefinedException localRole = new PSRoleAlreadyDefinedException("rx", "Editor");
+    assertSame(SecurityErrorCodes.LOCAL_ROLE_ALREADY_DEFINED, localRole.getTypedErrorCode());
+    assertTrue(localRole.isAuditable());
+
+    PSRoleAlreadyDefinedException globalRole = new PSRoleAlreadyDefinedException("Admin");
+    assertSame(SecurityErrorCodes.GLOBAL_ROLE_ALREADY_DEFINED, globalRole.getTypedErrorCode());
+    assertTrue(globalRole.isAuditable());
+
+    PSRoleNotDefinedException localMissing = new PSRoleNotDefinedException("rx", "Missing");
+    assertSame(SecurityErrorCodes.LOCAL_ROLE_NOT_DEFINED, localMissing.getTypedErrorCode());
+    assertFalse(localMissing.isAuditable());
+
+    PSRoleNotDefinedException globalMissing = new PSRoleNotDefinedException("Missing");
+    assertSame(SecurityErrorCodes.GLOBAL_ROLE_NOT_DEFINED, globalMissing.getTypedErrorCode());
+    assertFalse(globalMissing.isAuditable());
+
+    PSSecurityException meta = new PSSecurityException("catalog unavailable");
+    assertSame(SecurityErrorCodes.METADATA_UNAVAILABLE, meta.getTypedErrorCode());
+    assertFalse(meta.isAuditable());
+
+    RuntimeException cause = new RuntimeException("naming");
+    PSSecurityException naming =
+        new PSSecurityException(
+            SecurityErrorCodes.UNKNOWN_NAMING_ERROR, new Object[] {"ldap boom"}, cause);
+    assertSame(SecurityErrorCodes.UNKNOWN_NAMING_ERROR, naming.getTypedErrorCode());
+    assertSame(cause, naming.getCause());
+    assertFalse(naming.isAuditable());
+
+    PSRuntimeException filterInit =
+        new PSRuntimeException(
+            SecurityErrorCodes.DIR_PASSWORD_FILTER_INIT_ERROR,
+            new Object[] {"sys_default", "missing"});
+    assertSame(SecurityErrorCodes.DIR_PASSWORD_FILTER_INIT_ERROR, filterInit.getTypedErrorCode());
+    assertFalse(filterInit.isAuditable());
+
+    PSSqlException dirObjects =
+        new PSSqlException(SecurityErrorCodes.DIR_GET_OBJECTS_FAILED, "ldap timeout", "0");
+    assertSame(SecurityErrorCodes.DIR_GET_OBJECTS_FAILED, dirObjects.getTypedErrorCode());
+    assertFalse(dirObjects.isAuditable());
+
+    PSExtensionProcessingException raw =
+        new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, "ACL create failed");
+    assertSame(ServerErrorCodes.RAW_DUMP, raw.getTypedErrorCode());
+    assertEquals(IPSServerErrors.RAW_DUMP, raw.getErrorCode());
+    assertFalse(raw.isAuditable());
+  }
+
+  @Test
+  void typedProductionCtorsRejectNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSSecurityException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSSecurityException((IPSErrorCode) null, new Object[] {"x"}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new PSSecurityException(
+                (IPSErrorCode) null, new Object[] {"x"}, new RuntimeException("c")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSAuthenticationFailedException((IPSErrorCode) null, new Object[] {"x"}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSAuthorizationException((IPSErrorCode) null, new Object[] {"x"}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSExtensionProcessingException((IPSErrorCode) null, "sql"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSSqlException((IPSErrorCode) null, "ldap", "0"));
+  }
+
+  private static void leftoverNonAuditable(SystemErrorCode code) {
+    assertFalse(code.isAuditable(), code.toString());
+  }
+
+  private static void leftoverAuditable(SystemErrorCode code) {
+    assertTrue(code.isAuditable(), code.toString());
+  }
+}


### PR DESCRIPTION
## Summary

Parent leftover slice of #2616. Converts remaining `system/src/main/java/com/percussion/security/` production `IPS*Errors` call-sites to typed `SecurityErrorCodes` / `ServerErrorCodes`. Additive `IPSErrorCode` constructors on `PSSecurityException`. Residual allow-list shrunk by those exact 31 paths.

Int-only APIs (`PSLogServerWarning`, `PSErrorManager.createMessage`/`getErrorText`, `PSConsole.printMsg`) use `.numericCode()`. Dual-write skip for leftover non-auditable SEC codes; leftover auditable SEC codes remain dual-write eligible. `IPS*Errors` interfaces are not deleted.

Fixes #3940
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2578, Failures: 0, Skipped: 246 (`PSSecurityLeftoverErrorCodesSliceTest` 3/3)
2. `python scripts/verify-no-bare-ipserrors.py` — PASS
3. `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 19 passed
4. Review leftover production exception construction: typed codes retained, null-code ctors rejected

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal error-catalog retype; no operator/API/UX/config change
- [x] **Unit / module tests** — behavioral leftover slice test for exact production exception types + dual-write skip/auditable; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` (no skipTests)
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- `modules_built=system`
- `build_evidence=cd system && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2578, Failures: 0, Skipped: 246 (`PSSecurityLeftoverErrorCodesSliceTest` 3/3). `python scripts/verify-no-bare-ipserrors.py` PASS. pytest `scripts/test_verify_no_bare_ipserrors.py` 19 passed.
- `downstream_checked=C2 additive only: public IPSErrorCode constructors on PSSecurityException (no existing signature change, not final/sealed). Grep: no extends PSSecurityException; no anonymous new PSSecurityException() {. No reverse-dep module rebuild required.`

### C5 UI proof

N/A — Java backend leftover retype; no UI surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
