### PR TITLE
feat(rest): CD-16 system def field-property write (#3958)

### DIFF
--- a/docs/ai-generated/code-reviews/3958-systemdef-write-erlang.md
+++ b/docs/ai-generated/code-reviews/3958-systemdef-write-erlang.md
@@ -1,0 +1,37 @@
+# Erlang review — #3958 REST CD-16 system def write
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-28 |
+| **Branch** | `feat/issue-3958-systemdef-write` |
+| **Scope** | Uncommitted vs `HEAD` / `origin/main` |
+| **Recommendation** | **approve** |
+| **Gate** | **May commit/push: yes** |
+| **Memory patterns hit** | Change-class closure (rest resource + adaptor + Spring stub + sitemanage impl); Admin 403 not a global JAX-RS filter; lock mapped to typed 409 not message-sniffing |
+
+## Summary
+
+Admin PUT `/services/systemdef` patches existing system-field properties (`searchable`, occurrence/required) via `IPSContentDesignWs.loadContentEditorSystemDef(lock=true)` then `saveContentEditorSystemDef(release=true)`, matching CD-15 `#3944`. GET remains. No new SOAP; no field create/delete; no SPA.
+
+## Issues
+
+None that block.
+
+## Notes (non-blocking)
+
+- GET now requires Admin (same tightening CD-15 applied to `/sharedfields`). Documented in product-docs.
+- `dataType` / `readOnly` / `cacheTimeoutMinutes` are not written (no objectstore setters used).
+- Cross-platform path checklist: N/A (no file I/O).
+
+## Tests / companions
+
+- Mockito `SystemDefResourceTest` (GET/PUT 400/403/409/500)
+- Spring `TestSystemDefAdaptor` implements new `updateSystemDef`
+- `SystemDefAdaptorTest` success / 403 / load-lock 409 / save-lock 409 / unknown field / occurrence conflict
+- product-docs 8.2 Developer REST + admin content-types + gap map CD-16 write
+
+## Builds
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 714, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1661, Failures: 0
+- Downstream: grepped `implements ISystemDefAdaptor` (stub + adaptor); sitemanage standalone install

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -18,6 +18,8 @@
 | Public REST shared-field detail   | CD-15 group fields (Admin only)     | `GET /services/sharedfields/{idOrName}`        |
 | Public REST shared-field write    | CD-15 create/save/delete (Admin)    | `POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}` |
 | Public REST shared-field fields   | CD-15 field create/delete (Admin)   | `POST …/{idOrName}/fields`, `DELETE …/{idOrName}/fields/{fieldName}` |
+| Public REST system-def catalog    | CD-16 GET (Admin only)              | `GET /services/systemdef`                      |
+| Public REST system-def write      | CD-16 field-property save (Admin)   | `PUT /services/systemdef` (request lock, release on save) |
 | Design SOAP (Workbench)           | Full load/save/lock/create/delete   | `IPSContentDesignWs` / `ContentDesignSOAPImpl` |
 | Item def manager                  | Runtime CE definition cache         | `PSItemDefManager.getItemDef`                  |
 
@@ -57,7 +59,7 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 | Edit workflow/template associations                  | CD-08, CD-12 | **CD-08 REST PUT .../allowedWorkflows** (#3763, held design lock); **CD-12 REST PUT .../allowedTemplates** (#3775, held design lock; full replace, empty list clears) |
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
 | Shared field file **write**                          | CD-15        | **Group create/save/delete shipped** (`POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}`, #3944). **Field create/delete shipped** (`POST …/fields`, `DELETE …/fields/{fieldName}`, persistable `PSField` + display mapping, Admin 403, lock 409, #3954). Control/choice write and SPA editor still open |
-| System def                                           | CD-16        | Separate object                                   |
+| System def **write** (existing field properties)     | CD-16        | **PUT `/services/systemdef` shipped** (#3958, Admin 403, lock 409). Field create/delete, control/stylesheet/flow, and SPA editor still SOAP |
 | Create / delete                                      | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Delete still SOAP design only; lock + PUT save via REST |
 | Rename                                               | CD-01, §5.2  | **REST `PUT /contenttypes/{id}/name`** (#3914, held design lock; unique, no spaces; bulk PUT does not rename) |
 | Import/export CT                                     | CD-14        | Workbench wizards                                 |
@@ -72,7 +74,8 @@ design locks + session user). Companion tests: `KeywordsResourceCrudTest`,
 4. ~~Keyword create/update/delete~~ **Done CD-17** (REST write + design WS + SPA editor)
 5. ~~Control property value/choice catalogs~~ **Done CD-07 REST** (#3786). Field-rule write/save still open
 6. ~~Shared field catalog read~~ **Done CD-15 read** (`GET /services/sharedfields`, Admin 403). ~~Write~~ **Done CD-15 group create/save/delete** (`POST`/`PUT`/`DELETE`, #3944). ~~Field create/delete~~ **Done** (`POST …/fields`, `DELETE …/fields/{fieldName}`, #3954). Control/choice write + SPA editor still open
-7. Templates/slots design editors
+7. ~~System def field-property write~~ **Done CD-16 PUT** (`PUT /services/systemdef`, Admin 403, request lock + release on save, #3958). Field create/delete + SPA still open
+8. Templates/slots design editors
 
 ## Client behavior
 

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -29,7 +29,11 @@ definition is locked for the request). Nested
 `POST /services/sharedfields/{idOrName}/fields` and
 `DELETE /services/sharedfields/{idOrName}/fields/{fieldName}` add or remove
 fields (backend column + display mapping). The SPA editor is not in this
-chrome. See [REST API](id:developer-rest).
+chrome. The content-editor **system definition** (global system fields) is a
+separate singleton: Admin-only `GET /services/systemdef` and
+`PUT /services/systemdef` (patch existing field properties under a request lock).
+System-field create/delete and an SPA editor are not in this chrome. See
+[REST API](id:developer-rest).
 
 This is **not** the full Workbench field-rule editor. The detail table still
 shows rule **flags** (validation / visibility / transforms present). After

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -558,9 +558,10 @@ previously held lock).
 
 **Admin (Design) only.** There is no global JAX-RS Admin filter on this path — the
 sitemanage adaptor checks `IPSUserService.isAdminUser` for the current user and maps
-a non-Admin caller to **403**. Control/choice write and system-def (CD-16) remain
-unsupported. Nested field create/delete persist a backend column mapping and a
-default `sys_EditBox` display mapping.
+a non-Admin caller to **403**. Control/choice write remains unsupported. Nested
+field create/delete persist a backend column mapping and a default `sys_EditBox`
+display mapping. System-def field-property save is a separate catalog
+(`PUT /services/systemdef`, CD-16).
 
 | Method | Path | Purpose |
 |--------|------|---------|
@@ -615,7 +616,8 @@ List entries use `SharedFieldGroupSummary`. Detail uses `SharedFieldGroupDetail`
 - `name`, `filename`
 - `fields[]`: `name`, `dataType`, `searchable`, `required`, `readOnly`, `occurrence`
   (`optional` / `required` / `oneOrMore` / `zeroOrMore` / `count` / `unknown`)
-- `designGaps[]` strings — control/choice edit and system-def remain later slices
+- `designGaps[]` strings — control/choice edit remain later slices. System-def
+  field-property save is `PUT /services/systemdef`.
 
 Prefer the generated OpenAPI schema as the integration source of truth.
 
@@ -635,6 +637,71 @@ Authenticated non-Admin sessions (Editor, Contributor, and similar) must not rea
 write this catalog. Callers should treat 403 as “no Design Admin rights,” not as a
 missing group. Treat 409 as “retry after the other designer releases the shared-def
 lock” (Workbench also locks the whole shared definition, not one group).
+
+## System definition (design catalog)
+
+Content-editor **system definition** (Workbench global / system fields, CD-16) is a
+singleton design object. Public REST exposes a catalog **and field-property write**
+under `/services/systemdef`. Load and save use the same content **design** web
+service as Workbench (`IPSContentDesignWs.loadContentEditorSystemDef` /
+`saveContentEditorSystemDef`). Writes acquire the system-definition design lock for
+the request and **release** it on save (same request-lock pattern as shared-field
+PUT; unlike content-type PUT, which requires a previously held lock).
+
+**Admin (Design) only.** There is no global JAX-RS Admin filter on this path — the
+sitemanage adaptor checks `IPSUserService.isAdminUser` for the current user and maps
+a non-Admin caller to **403**. Field **create/delete**, control properties,
+stylesheets, and application flow remain unsupported.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/systemdef` | Load the system definition field catalog (`fieldCount`, `cacheTimeoutMinutes`, `fields[]`) |
+| `PUT` | `/services/systemdef` | Patch **existing** fields (`searchable`, occurrence / required). Null or empty `fields` leaves the catalog unchanged. |
+
+PUT may include `fields[]` to patch existing fields by `name`. Unknown field names
+are **400**. New fields cannot be added on this slice. `occurrence` and `required`
+map to the same dimension: when both are sent they must agree (`required=true`
+with `required` / `oneOrMore`; `required=false` with `optional` / `zeroOrMore` /
+`count`) or the request is **400**. `occurrence` is applied when present;
+`required` is used only when `occurrence` is omitted. `dataType`, `readOnly`, and
+`cacheTimeoutMinutes` are read-only on this slice.
+
+Example PUT body:
+
+```json
+{
+  "fields": [
+    { "name": "sys_title", "searchable": true, "occurrence": "required" }
+  ]
+}
+```
+
+### Response shape
+
+Detail uses `SystemDefDetail`:
+
+- `fieldCount`, `cacheTimeoutMinutes` (read-only)
+- `fields[]`: `name`, `dataType`, `searchable`, `required`, `readOnly`, `occurrence`
+  (`optional` / `required` / `oneOrMore` / `zeroOrMore` / `count` / `unknown`)
+- `designGaps[]` strings — field create/delete, control/stylesheet/application flow,
+  and shared-field groups (separate catalog)
+
+Prefer the generated OpenAPI schema as the integration source of truth.
+
+### Status codes and authorization
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | Catalog or save |
+| `400` | Missing body, unknown field, invalid occurrence, or conflicting `occurrence`/`required` |
+| `403` | Caller is not Admin, or the request has no session/user (writes) |
+| `409` | System definition locked by another user, or design lock required for save |
+| `500` | Design service or server failure |
+
+Authenticated non-Admin sessions (Editor, Contributor, and similar) must not read or
+write this catalog. Callers should treat 403 as “no Design Admin rights.” Treat 409
+as “retry after the other designer releases the system-def lock” (Workbench locks
+the whole system definition).
 
 ## Templates (assembly catalog)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SharedFieldsAdaptor.java
@@ -87,7 +87,7 @@ public class SharedFieldsAdaptor implements ISharedFieldsAdaptor {
   private static final List<String> DESIGN_GAPS =
       List.of(
           "Field control / choice write not supported via this API",
-          "System def (global fields) is a separate catalog (later slice)");
+          "System def (global fields) is a separate catalog (Developer System Def)");
 
   private static final int MAX_FIELD_NAME_LENGTH = 50;
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
@@ -19,54 +19,97 @@ package com.percussion.apibridge;
 import com.percussion.design.objectstore.PSContentEditorSystemDef;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.design.objectstore.PSSystemValidationException;
 import com.percussion.rest.systemdef.ISystemDefAdaptor;
+import com.percussion.rest.systemdef.SystemDefDesignLockException;
 import com.percussion.rest.systemdef.SystemDefDetail;
 import com.percussion.rest.systemdef.SystemDefFieldSummary;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import com.percussion.webservices.content.PSContentWsLocator;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only content-editor system definition field catalog ({@link PSContentEditorSystemDef}).
+ * Catalog and write of the content-editor system definition ({@link PSContentEditorSystemDef}).
  *
- * <p>Workbench parity: loads via {@link IPSContentDesignWs#loadContentEditorSystemDef} (same design
- * web service SOAP uses), not {@code PSServer.getContentEditorSystemDef()} alone.
+ * <p>Workbench parity: loads and saves via {@link IPSContentDesignWs#loadContentEditorSystemDef} /
+ * {@link IPSContentDesignWs#saveContentEditorSystemDef} (same design web service SOAP uses), not
+ * {@code PSServer.getContentEditorSystemDef()} alone.
+ *
+ * <p>Admin (Design) only — same {@link IPSUserService#isAdminUser} gate as shared-field design
+ * mutations. There is no global JAX-RS Admin filter on {@code /services/systemdef}. Writes acquire
+ * the system-def design lock for the request and release it on save.
  */
 @PSSiteManageBean
 public class SystemDefAdaptor implements ISystemDefAdaptor {
 
   private static final Logger log = LogManager.getLogger(SystemDefAdaptor.class);
 
+  static final String ADMIN_REQUIRED = "Admin role required to read or write the system definition";
+
   private static final List<String> DESIGN_GAPS =
       List.of(
-          "System def field create / edit / delete not supported via this API",
+          "System def field create / delete not supported via this API",
           "Control properties, stylesheets, and application flow not exposed",
           "Shared field groups are a separate catalog (Developer Shared Fields)");
 
+  private final IPSContentDesignWs designWs;
   private final Supplier<PSContentEditorSystemDef> systemDefLoader;
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   public SystemDefAdaptor() {
-    this(
-        () ->
-            loadSystemDefFromDesignWs(
-                PSContentWsLocator.getContentDesignWebservice(),
-                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID),
-                (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER)));
+    this(PSContentWsLocator.getContentDesignWebservice(), null);
   }
 
-  /** Package-visible for unit tests that inject a fake system def source. */
+  /**
+   * Package-visible for unit tests that inject a fake design web service. {@code null} adminChecker
+   * uses {@link #isCurrentUserAdmin()}.
+   */
+  SystemDefAdaptor(IPSContentDesignWs designWs, BooleanSupplier adminChecker) {
+    this.designWs = designWs;
+    this.systemDefLoader =
+        () -> loadSystemDefFromDesignWs(designWs, currentSession(), currentUser());
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
+  }
+
+  /**
+   * Package-visible for unit tests that inject a fake system def source. Admin is allowed so
+   * mapping tests can focus on catalog shape. Writes require {@link IPSContentDesignWs}.
+   */
   SystemDefAdaptor(Supplier<PSContentEditorSystemDef> systemDefLoader) {
+    this(systemDefLoader, () -> true);
+  }
+
+  /**
+   * Package-visible for unit tests that inject a fake system def source and Admin gate. {@code
+   * null} adminChecker uses {@link #isCurrentUserAdmin()}.
+   */
+  SystemDefAdaptor(
+      Supplier<PSContentEditorSystemDef> systemDefLoader, BooleanSupplier adminChecker) {
+    this.designWs = null;
     this.systemDefLoader = systemDefLoader;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   /**
@@ -84,10 +127,208 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
     }
   }
 
+  private void requireDesignWs() {
+    if (designWs == null) {
+      throw new IllegalStateException("System def design web service is not available");
+    }
+  }
+
+  private static void requireSessionUserForWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for system def design write", Response.Status.FORBIDDEN);
+    }
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+
+  private PSContentEditorSystemDef loadSystemDefLocked(String session, String user) {
+    try {
+      PSContentEditorSystemDef def =
+          designWs.loadContentEditorSystemDef(true, false, session, user);
+      if (def == null) {
+        throw new IllegalStateException("Failed to load system def for write");
+      }
+      return def;
+    } catch (PSLockErrorException e) {
+      throw mapLockConflict(e);
+    } catch (PSErrorException e) {
+      log.error("Failed to load content editor system def for write", e);
+      throw new IllegalStateException("Failed to load system def for write", e);
+    }
+  }
+
+  private void saveSystemDef(PSContentEditorSystemDef def, String session, String user) {
+    try {
+      designWs.saveContentEditorSystemDef(def, true, session, user);
+    } catch (PSLockErrorException e) {
+      throw mapLockConflict(e);
+    } catch (PSErrorException e) {
+      log.error("Failed to save content editor system def", e);
+      throw new IllegalStateException("Failed to save system def", e);
+    }
+  }
+
+  static SystemDefDesignLockException mapLockConflict(PSLockErrorException e) {
+    String locker = e != null ? e.getLocker() : null;
+    if (StringUtils.isNotBlank(locker)) {
+      return new SystemDefDesignLockException(
+          "Could not save system definition; locked by " + locker, e);
+    }
+    return new SystemDefDesignLockException(
+        "Could not save system definition; design lock required", e);
+  }
+
+  /**
+   * Apply {@code searchable} then occurrence. {@code occurrence} and {@code required} both map to
+   * the same object-store dimension. When both are present they must agree ({@code required=true}
+   * with {@code required}/{@code oneOrMore}; {@code required=false} with {@code
+   * optional}/{@code zeroOrMore}/{@code count}); otherwise this throws {@link
+   * IllegalArgumentException}. When they agree, {@code occurrence} is applied. {@code required} is
+   * used only when {@code occurrence} is omitted.
+   */
+  static void applyFieldPatches(PSFieldSet fieldSet, List<SystemDefFieldSummary> patches) {
+    if (patches == null || patches.isEmpty()) {
+      return;
+    }
+    if (fieldSet == null) {
+      throw new IllegalArgumentException("System def has no field set");
+    }
+    for (SystemDefFieldSummary patch : patches) {
+      if (patch == null || StringUtils.isBlank(patch.getName())) {
+        continue;
+      }
+      PSField field = fieldSet.findFieldByName(patch.getName(), false);
+      if (field == null) {
+        throw new IllegalArgumentException("Unknown field: " + patch.getName());
+      }
+      if (patch.getSearchable() != null) {
+        field.setUserSearchable(patch.getSearchable());
+      }
+      applyOccurrenceOrRequired(field, patch);
+    }
+  }
+
+  static void applyOccurrenceOrRequired(PSField field, SystemDefFieldSummary patch) {
+    boolean hasOccurrence = StringUtils.isNotBlank(patch.getOccurrence());
+    boolean hasRequired = patch.getRequired() != null;
+    if (hasOccurrence) {
+      Integer dim = occurrenceFromApi(patch.getOccurrence());
+      if (dim == null) {
+        throw new IllegalArgumentException(
+            "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence());
+      }
+      if (hasRequired
+          && Boolean.TRUE.equals(patch.getRequired()) != occurrenceImpliesRequired(dim)) {
+        throw new IllegalArgumentException(
+            "occurrence and required conflict for field " + patch.getName());
+      }
+      setOccurrenceDimension(field, dim, patch.getName(), patch.getOccurrence());
+    } else if (hasRequired) {
+      int dim =
+          Boolean.TRUE.equals(patch.getRequired())
+              ? PSField.OCCURRENCE_DIMENSION_REQUIRED
+              : PSField.OCCURRENCE_DIMENSION_OPTIONAL;
+      try {
+        field.setOccurrenceDimension(dim, null);
+      } catch (PSSystemValidationException e) {
+        throw new IllegalArgumentException(
+            "Invalid required flag for field " + patch.getName(), e);
+      }
+    }
+  }
+
+  static boolean occurrenceImpliesRequired(int dimension) {
+    return dimension == PSField.OCCURRENCE_DIMENSION_REQUIRED
+        || dimension == PSField.OCCURRENCE_DIMENSION_ONE_OR_MORE;
+  }
+
+  private static void setOccurrenceDimension(
+      PSField field, int dim, String fieldName, String occurrenceLabel) {
+    try {
+      field.setOccurrenceDimension(dim, null);
+    } catch (PSSystemValidationException e) {
+      throw new IllegalArgumentException(
+          "Invalid occurrence for field " + fieldName + ": " + occurrenceLabel, e);
+    }
+  }
+
+  static Integer occurrenceFromApi(String occurrence) {
+    if (occurrence == null) {
+      return null;
+    }
+    return switch (occurrence) {
+      case "optional" -> PSField.OCCURRENCE_DIMENSION_OPTIONAL;
+      case "required" -> PSField.OCCURRENCE_DIMENSION_REQUIRED;
+      case "oneOrMore" -> PSField.OCCURRENCE_DIMENSION_ONE_OR_MORE;
+      case "zeroOrMore" -> PSField.OCCURRENCE_DIMENSION_ZERO_OR_MORE;
+      case "count" -> PSField.OCCURRENCE_DIMENSION_COUNT;
+      default -> null;
+    };
+  }
+
   @Override
   public SystemDefDetail getSystemDef(URI baseUri) {
+    requireAdmin();
     // baseUri reserved for HATEOAS; exceptions propagate to JAX-RS mappers
     return toDetail(systemDefLoader.get());
+  }
+
+  @Override
+  public SystemDefDetail updateSystemDef(URI baseUri, SystemDefDetail body) {
+    requireAdmin();
+    requireDesignWs();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String session = currentSession();
+    String user = currentUser();
+    PSContentEditorSystemDef def = loadSystemDefLocked(session, user);
+    applyFieldPatches(def.getFieldSet(), body.getFields());
+    saveSystemDef(def, session, user);
+    return toDetail(def);
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  /**
+   * Production Admin check via {@link IPSUserService}. Used when Spring wires the no-arg ctor and
+   * {@link #adminChecker} is the instance method reference.
+   */
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
   }
 
   /** Package-visible for unit tests. */

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
@@ -23,23 +23,49 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.design.objectstore.PSContentEditorSystemDef;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.rest.systemdef.SystemDefDesignLockException;
 import com.percussion.rest.systemdef.SystemDefDetail;
+import com.percussion.rest.systemdef.SystemDefFieldSummary;
+import com.percussion.utils.request.PSRequestInfoBase;
 import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.content.IPSContentDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("UnitTest")
 class SystemDefAdaptorTest {
+
+  @BeforeEach
+  void setRequestInfo() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+  }
+
+  @AfterEach
+  void clearRequestInfo() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
 
   @Test
   void toDetail_mapsFieldsAndMeta() {
@@ -133,5 +159,181 @@ class SystemDefAdaptorTest {
     SystemDefDetail detail = adaptor.getSystemDef(null);
     assertNotNull(detail);
     assertEquals(0, detail.getFieldCount());
+  }
+
+  @Test
+  void getSystemDef_forbiddenWhenNotAdmin() {
+    AtomicInteger loads = new AtomicInteger();
+    SystemDefAdaptor denied =
+        new SystemDefAdaptor(
+            () -> {
+              loads.incrementAndGet();
+              return mock(PSContentEditorSystemDef.class);
+            },
+            () -> false);
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.getSystemDef(null));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertEquals(SystemDefAdaptor.ADMIN_REQUIRED, ex.getMessage());
+    assertEquals(0, loads.get());
+  }
+
+  @Test
+  void updateSystemDef_patchesSearchableAndSavesWithLockRelease() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSField field = mock(PSField.class);
+    when(field.getSubmitName()).thenReturn("sys_title");
+    when(field.getDataType()).thenReturn("text");
+    when(field.isUserSearchable()).thenReturn(true);
+    when(field.isReadOnly()).thenReturn(false);
+    when(field.getOccurrenceDimension(null)).thenReturn(PSField.OCCURRENCE_DIMENSION_OPTIONAL);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.getAllFields()).thenReturn(new PSField[] {field});
+    when(set.findFieldByName("sys_title", false)).thenReturn(field);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(def.getFieldSet()).thenReturn(set);
+    when(def.getCacheTimeout()).thenReturn(15);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+
+    SystemDefFieldSummary patch = new SystemDefFieldSummary();
+    patch.setName("sys_title");
+    patch.setSearchable(true);
+    SystemDefDetail body = new SystemDefDetail();
+    body.setFields(List.of(patch));
+
+    SystemDefDetail out = adaptor.updateSystemDef(null, body);
+    assertEquals(1, out.getFieldCount());
+    verify(field).setUserSearchable(true);
+    verify(designWs).saveContentEditorSystemDef(eq(def), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void updateSystemDef_unknownFieldIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.findFieldByName("missing", false)).thenReturn(null);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(def.getFieldSet()).thenReturn(set);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+
+    SystemDefFieldSummary patch = new SystemDefFieldSummary();
+    patch.setName("missing");
+    SystemDefDetail body = new SystemDefDetail();
+    body.setFields(List.of(patch));
+
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.updateSystemDef(null, body));
+    assertTrue(ex.getMessage().contains("Unknown field"));
+    verify(designWs, never()).saveContentEditorSystemDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void updateSystemDef_nullBodyIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.updateSystemDef(null, null));
+    assertTrue(ex.getMessage().contains("body is required"));
+    verify(designWs, never()).loadContentEditorSystemDef(anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void updateSystemDef_forbiddenWhenNotAdmin() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefAdaptor denied = new SystemDefAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> denied.updateSystemDef(null, new SystemDefDetail()));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).loadContentEditorSystemDef(anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void updateSystemDef_lockConflictIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSLockErrorException lockErr = new PSLockErrorException(1, "locked", "stack", "other", 1000L);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin"))
+        .thenThrow(lockErr);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    SystemDefDesignLockException ex =
+        assertThrows(
+            SystemDefDesignLockException.class,
+            () -> adaptor.updateSystemDef(null, new SystemDefDetail()));
+    assertTrue(ex.getMessage().contains("locked by other"));
+  }
+
+  @Test
+  void updateSystemDef_saveLockConflictIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(def.getFieldSet()).thenReturn(null);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    doThrow(new PSLockErrorException(1, "not locked", "stack"))
+        .when(designWs)
+        .saveContentEditorSystemDef(any(), eq(true), eq("test-session"), eq("Admin"));
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    SystemDefDesignLockException ex =
+        assertThrows(
+            SystemDefDesignLockException.class,
+            () -> adaptor.updateSystemDef(null, new SystemDefDetail()));
+    assertTrue(ex.getMessage().contains("design lock required"));
+  }
+
+  @Test
+  void applyFieldPatches_occurrenceWinsWhenRequiredAgrees() throws Exception {
+    PSField field = mock(PSField.class);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.findFieldByName("sys_title", false)).thenReturn(field);
+
+    SystemDefFieldSummary patch = new SystemDefFieldSummary();
+    patch.setName("sys_title");
+    patch.setOccurrence("oneOrMore");
+    patch.setRequired(true);
+
+    SystemDefAdaptor.applyFieldPatches(set, List.of(patch));
+    verify(field).setOccurrenceDimension(eq(PSField.OCCURRENCE_DIMENSION_ONE_OR_MORE), isNull());
+  }
+
+  @Test
+  void applyFieldPatches_occurrenceAndRequiredConflictIs400() {
+    PSField field = mock(PSField.class);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.findFieldByName("sys_title", false)).thenReturn(field);
+
+    SystemDefFieldSummary patch = new SystemDefFieldSummary();
+    patch.setName("sys_title");
+    patch.setOccurrence("optional");
+    patch.setRequired(true);
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> SystemDefAdaptor.applyFieldPatches(set, List.of(patch)));
+    assertTrue(ex.getMessage().contains("conflict"));
+  }
+
+  @Test
+  void applyFieldPatches_requiredOnlyWhenOccurrenceOmitted() throws Exception {
+    PSField field = mock(PSField.class);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.findFieldByName("sys_title", false)).thenReturn(field);
+
+    SystemDefFieldSummary patch = new SystemDefFieldSummary();
+    patch.setName("sys_title");
+    patch.setRequired(true);
+
+    SystemDefAdaptor.applyFieldPatches(set, List.of(patch));
+    verify(field).setOccurrenceDimension(eq(PSField.OCCURRENCE_DIMENSION_REQUIRED), isNull());
+  }
+
+  @Test
+  void mapLockConflict_includesLocker() {
+    PSLockErrorException err = new PSLockErrorException(1, "locked", "stack", "alice", 10L);
+    SystemDefDesignLockException mapped = SystemDefAdaptor.mapLockConflict(err);
+    assertEquals("Could not save system definition; locked by alice", mapped.getMessage());
   }
 }

--- a/rest/src/main/java/com/percussion/rest/systemdef/ISystemDefAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/ISystemDefAdaptor.java
@@ -26,6 +26,24 @@ public interface ISystemDefAdaptor {
    *
    * @param baseUri reserved for HATEOAS
    * @return detail, never {@code null} (empty fields when def missing)
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin
    */
   SystemDefDetail getSystemDef(URI baseUri);
+
+  /**
+   * Persist patches to existing system-def field properties. Admin only. Acquires the system-def
+   * design lock for this request and releases it on save.
+   *
+   * <p>Supports patches to existing fields ({@code searchable}, occurrence / required). Null or
+   * empty {@code fields} leaves the catalog unchanged. Does not create or delete fields. {@code
+   * dataType}, {@code readOnly}, and {@code cacheTimeoutMinutes} are not written.
+   *
+   * @return persisted detail, never {@code null}
+   * @throws IllegalArgumentException when input is invalid, a field name is unknown, or {@code
+   *     occurrence} and {@code required} conflict
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin
+   * @throws SystemDefDesignLockException when the system def is locked by another user or is not
+   *     locked for this session
+   */
+  SystemDefDetail updateSystemDef(URI baseUri, SystemDefDetail body);
 }

--- a/rest/src/main/java/com/percussion/rest/systemdef/SystemDefDesignLockException.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/SystemDefDesignLockException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.systemdef;
+
+/**
+ * Design-session lock conflict for system-def save.
+ *
+ * <p>Mapped to HTTP 409 by {@code SystemDefResource}. Distinct from generic {@link
+ * IllegalStateException} so status is not inferred from message substrings.
+ */
+public class SystemDefDesignLockException extends IllegalStateException {
+
+  private static final long serialVersionUID = 1L;
+
+  public SystemDefDesignLockException(String message) {
+    super(message);
+  }
+
+  public SystemDefDesignLockException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/systemdef/SystemDefDetail.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/SystemDefDetail.java
@@ -24,9 +24,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Read-only content-editor system definition (global system fields).
- *
- * <p>Does not support write (later CD-16 write slice).
+ * Content-editor system definition (global system fields). GET catalog; PUT may patch existing
+ * field properties ({@code searchable}, occurrence / required). Field create/delete remain
+ * unsupported ({@code designGaps}).
  */
 @XmlRootElement(name = "SystemDefDetail")
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/src/main/java/com/percussion/rest/systemdef/SystemDefFieldSummary.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/SystemDefFieldSummary.java
@@ -21,7 +21,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
-/** Read-only field row from the content-editor system definition. */
+/**
+ * Field row from the content-editor system definition. GET catalog; PUT may patch {@code
+ * searchable} and occurrence / required on existing fields. {@code readOnly} and {@code dataType}
+ * are read-only.
+ */
 @XmlRootElement(name = "SystemDefField")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Schema(description = "System definition field summary")

--- a/rest/src/main/java/com/percussion/rest/systemdef/SystemDefResource.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/SystemDefResource.java
@@ -23,7 +23,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
@@ -34,14 +36,15 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only content-editor system definition catalog for the Developer module (CD-16).
+ * Content-editor system definition catalog and field-property write for the Developer module
+ * (CD-16).
  *
  * <p>Registered via {@link PSSiteManageBean} like sibling catalog resources.
  */
 @PSSiteManageBean(value = "restSystemDefResource")
 @Path("/systemdef")
 @XmlRootElement
-@Tag(name = "SystemDef", description = "Content editor system definition (read-only field catalog)")
+@Tag(name = "SystemDef", description = "Content editor system definition catalog and write")
 public class SystemDefResource {
 
   private final ISystemDefAdaptor adaptor;
@@ -57,18 +60,25 @@ public class SystemDefResource {
     this.adaptor = adaptor;
   }
 
+  /** Package-private test hook so unit tests need not reflect on {@code uriInfo}. */
+  void setUriInfo(UriInfo uriInfo) {
+    this.uriInfo = uriInfo;
+  }
+
   @GET
   @Produces({MediaType.APPLICATION_JSON})
   @Operation(
       summary = "Get system definition field catalog",
       description =
           "Loads the content-editor system definition field catalog (global system fields)."
-              + " Write and control configuration remain unsupported (see designGaps).",
+              + " Admin (Design) only. Save uses PUT /systemdef to patch existing field properties."
+              + " Field create/delete remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
             description = "OK",
             content = @Content(schema = @Schema(implementation = SystemDefDetail.class))),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public SystemDefDetail getSystemDef() {
@@ -79,6 +89,64 @@ public class SystemDefResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  @PUT
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Update system definition field properties",
+      description =
+          "Admin. Saves patches to existing system fields (searchable, occurrence/required) via"
+              + " IPSContentDesignWs.loadContentEditorSystemDef (lock) then"
+              + " saveContentEditorSystemDef (release). Null or empty fields leaves the catalog"
+              + " unchanged. Does not create or delete fields. When a field patch includes both"
+              + " occurrence and required they must agree (else 400); occurrence is applied when"
+              + " present. Lock held by another user, or no lock for this session, is 409.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = SystemDefDetail.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input or unknown field name"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "System def locked by another user, or design lock required"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public SystemDefDetail updateSystemDef(SystemDefDetail body) {
+    try {
+      return requireAdaptor().updateSystemDef(uriInfo.getBaseUri(), body);
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Lock conflicts are always 409 via {@link
+   * SystemDefDesignLockException}.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof SystemDefDesignLockException) {
+      return new WebApplicationException(e.getMessage(), 409);
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    if (e instanceof IllegalStateException) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      if (msg.toLowerCase().contains("lock")) {
+        return new WebApplicationException(msg, 409);
+      }
+      return new WebApplicationException(e, 500);
+    }
+    return new WebApplicationException(e, 500);
   }
 
   private ISystemDefAdaptor requireAdaptor() {

--- a/rest/src/test/java/com/percussion/rest/systemdef/SystemDefResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/systemdef/SystemDefResourceTest.java
@@ -22,13 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.UriInfo;
-import java.lang.reflect.Field;
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -41,14 +41,12 @@ public class SystemDefResourceTest {
   private SystemDefResource resource;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() {
     adaptor = mock(ISystemDefAdaptor.class);
     resource = new SystemDefResource(adaptor);
     UriInfo uriInfo = mock(UriInfo.class);
     when(uriInfo.getBaseUri()).thenReturn(URI.create("http://localhost/services/"));
-    Field f = SystemDefResource.class.getDeclaredField("uriInfo");
-    f.setAccessible(true);
-    f.set(resource, uriInfo);
+    resource.setUriInfo(uriInfo);
   }
 
   @Test
@@ -78,5 +76,75 @@ public class SystemDefResourceTest {
     WebApplicationException ex = assertThrows(WebApplicationException.class, bare::getSystemDef);
     assertEquals(500, ex.getResponse().getStatus());
     assertInstanceOf(IllegalStateException.class, ex.getCause());
+  }
+
+  @Test
+  public void getSystemDefForbiddenWhenNotAdmin() {
+    when(adaptor.getSystemDef(any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getSystemDef());
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateSystemDefDelegatesToAdaptor() {
+    SystemDefDetail body = new SystemDefDetail();
+    SystemDefDetail updated = new SystemDefDetail();
+    updated.setFieldCount(2);
+    when(adaptor.updateSystemDef(any(), any())).thenReturn(updated);
+
+    assertEquals(2, resource.updateSystemDef(body).getFieldCount());
+    verify(adaptor).updateSystemDef(any(), eq(body));
+  }
+
+  @Test
+  public void updateSystemDefInvalidFieldIs400() {
+    when(adaptor.updateSystemDef(any(), any()))
+        .thenThrow(new IllegalArgumentException("Unknown field: missing"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateSystemDef(new SystemDefDetail()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateSystemDefLockConflictIs409() {
+    when(adaptor.updateSystemDef(any(), any()))
+        .thenThrow(
+            new SystemDefDesignLockException("Could not save system definition; locked by other"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateSystemDef(new SystemDefDetail()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateSystemDefForbiddenWhenNotAdmin() {
+    when(adaptor.updateSystemDef(any(), any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateSystemDef(new SystemDefDetail()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateSystemDefWrapsUnexpectedFailures() {
+    IllegalStateException boom = new IllegalStateException("design ws down");
+    when(adaptor.updateSystemDef(any(), any())).thenThrow(boom);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateSystemDef(new SystemDefDetail()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void mapWriteFailureLockMessageOnIllegalStateIs409() {
+    WebApplicationException ex =
+        SystemDefResource.mapWriteFailure(new IllegalStateException("object is not locked"));
+    assertEquals(409, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSystemDefAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSystemDefAdaptor.java
@@ -26,6 +26,9 @@ import org.springframework.stereotype.Component;
 /**
  * Spring test stub for {@link ISystemDefAdaptor}. Required for ApplicationContext load after
  * constructor injection on {@code SystemDefResource}.
+ *
+ * <p>Admin 403 is <em>not</em> a global JAX-RS filter; production {@code SystemDefAdaptor}
+ * enforces it. This stub is only a Spring bean for {@code MainTest} and does not model AuthZ.
  */
 @Component
 @Lazy
@@ -34,5 +37,10 @@ public class TestSystemDefAdaptor implements ISystemDefAdaptor {
   @Override
   public SystemDefDetail getSystemDef(URI baseUri) {
     return new SystemDefDetail();
+  }
+
+  @Override
+  public SystemDefDetail updateSystemDef(URI baseUri, SystemDefDetail body) {
+    return body != null ? body : new SystemDefDetail();
   }
 }


### PR DESCRIPTION
## Summary

Parent: #1690 (CD-16). Admin REST **write** for the singleton content-editor system definition.

`PUT /services/systemdef` patches **existing** system-field properties (`searchable`, occurrence / required) via `IPSContentDesignWs.loadContentEditorSystemDef(lock=true)` then `saveContentEditorSystemDef(release=true)` — held request lock, released on save like CD-15 (#3944 / PR #3953). GET stays (Admin 403, same catalog gate as `/sharedfields`). 400 / 403 / 409 match peers. No new SOAP; no field create/delete; no SPA.

Fixes #3958

## Test plan

1. Standalone `cd rest && ../mvnw.cmd clean install` (Tests run: 714, Failures: 0) including `SystemDefResourceTest` (10).
2. Standalone `cd projects/sitemanage && ../../mvnw.cmd clean install` (Tests run: 1661, Failures: 0) including `SystemDefAdaptorTest` (18: success, 403, load-lock 409, save-lock 409, unknown field, occurrence conflict).
3. Integrator: Admin `GET /services/systemdef` then `PUT /services/systemdef` with `fields[]` patches; non-Admin 403; lock held by another user 409.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/rest.md` System definition section; `admin/developer-content-types.md`)
- [x] **Unit / module tests** — Mockito resource, Spring stub, adaptor success/403/conflict; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change; SPA system-def editor is out of scope)
- [x] **Build gates** — standalone clean install on `rest` then `projects/sitemanage`; reverse-dep sitemanage built after adaptor interface method add
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### Product-docs pointers

- Gate: root `AGENTS.md` → **Product documentation (HARD GATE)**
- Tree: `product-docs/README.md`

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 714, Failures: 0 (`SystemDefResourceTest` 10)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 1661, Failures: 0 (`SystemDefAdaptorTest` 18)
- **downstream_checked:** grepped `implements ISystemDefAdaptor` (production adaptor + rest `TestSystemDefAdaptor` stub); sitemanage standalone clean install after rest install

## C5 UI proof

N/A — REST/backend only; no Playwright surface.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
