### PR TITLE
feat(rest): CD-03 local field create/delete (#3960)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3960-rest-cd03-local-field-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3960-rest-cd03-local-field-erlang.md
@@ -1,0 +1,41 @@
+# Erlang review — issue #3960 REST CD-03 local field create/delete
+
+**Branch:** `feat/issue-3960-rest-cd03-local-field-create-delete`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (rest resource + adaptor interface + sitemanage impl + Spring stub + Mockito resource tests + adaptor tests); C2 interface implementors; product-docs REST companion
+
+## Summary
+
+Admin REST adds `POST/DELETE /contenttypes/{idOrName}/fields` for persistable local fields via existing `IPSContentDesignWs` load/save under a held design-session lock. Optional `fieldSet` targets or creates a named complex child. Status mapping matches content-type write peers (400/403/404/409). No SPA. No new SOAP.
+
+## Scope
+
+Uncommitted vs `HEAD` on this branch (rest, sitemanage, product-docs/8.2). C5 Playwright N/A (no WebUI). Cross-platform path I/O: N/A (identifier sanitization only; `/` `\\` `..` rejected on field names).
+
+## Issues
+
+None that block. Duplicate `containsWhitespace` on `ContentTypeAdaptor` was caught at sitemanage compile and removed before this review.
+
+## Companions
+
+| Companion | Status |
+|-----------|--------|
+| rest resource + OpenAPI | yes |
+| `IContentTypesAdaptor` | yes |
+| sitemanage `ContentTypeAdaptor` | yes |
+| rest Spring stub `TestContentTypeAdaptor` | yes |
+| `ContentTypesTestAdaptor` | yes |
+| Mockito resource tests | yes |
+| adaptor success/403/404/409 | yes |
+| product-docs 8.2 REST + admin CT | yes |
+| designGaps `CT_FIELD_CREATE_DELETE` | yes |
+
+## C2
+
+Grep `implements IContentTypesAdaptor`: 3 types (ContentTypeAdaptor + two rest test stubs), all updated. No anonymous subclasses. sitemanage standalone `mvnw clean install` green.
+
+## Build
+
+- `rest`: standalone `mvnw clean install` BUILD SUCCESS; ContentTypesResourceDetailTest 91/0; module ~731 tests
+- `projects/sitemanage`: standalone `mvnw clean install` BUILD SUCCESS; ContentTypeAdaptorLocalFieldTest 17/0; module 1683 tests

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, enable or disable, rename via REST, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
+description: Lock, enable or disable, rename via REST, add or delete local fields via REST, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -20,7 +20,13 @@ That call persists the type (Workbench Finish). A successful create is then
 `GET /services/contenttypes/{name}` **200**. Duplicate or reserved system names
 (for example **Folder**) are **409**. Invalid names (blank, spaces, wildcard)
 are **400**. Non-Admin callers are **403**. This chrome does **not** include a
-create wizard; rename and delete are REST-only (no SPA chrome). Shared field
+create wizard; rename, delete, and **local field create/delete** are REST-only
+(no SPA field editor). After a held lock, integrators add a local field with
+`POST /services/contenttypes/{idOrName}/fields` (JSON `name` required) and
+remove one with `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}`.
+Duplicate field names are **409**. System and shared fields cannot be removed
+here (**400**). Optional `fieldSet` targets or creates a named child field set.
+Shared field
 **files** are a separate design object: Admin-only `GET /services/sharedfields` and
 `GET /services/sharedfields/{idOrName}` (catalog), plus
 `POST /services/sharedfields`, `PUT /services/sharedfields/{idOrName}`, and

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -201,6 +201,8 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` | **Admin** (CD-08 design action). Requires a held design-session lock (`POST .../lock` first). Does **not** acquire or release the lock. Full replace of `allowedWorkflows` (empty list clears). Optional `defaultWorkflow`. Workflow name/guid must exist. `200` + `ContentTypeDetail` with the new `allowedWorkflows` / `defaultWorkflow` (lock still held). |
 | Enable/disable | `PUT /services/contenttypes/{idOrName}/enabled` | **Admin** (CD-13 design action). Requires a held design-session lock — `POST .../lock` first, then `PUT .../enabled`, then `POST .../unlock` when done. Does **not** acquire or release the lock. `200` + `ContentTypeDetail` with the new `enabled` value (lock still held). |
 | Rename | `PUT /services/contenttypes/{idOrName}/name` | **Admin** (CD-01). Requires a **held** design-session lock. Sets the internal name. Unique (case-insensitive); **no spaces** or wildcards. Bulk `PUT .../{idOrName}` does **not** change name. After success, `GET` by the previous name is **404**; `GET` by id returns the new name. Does not acquire or release the lock. |
+| Add local field | `POST /services/contenttypes/{idOrName}/fields` | **Admin** (CD-03). Requires a **held** design-session lock. Adds a persistable **local** field (backend column + display mapping) via `IPSContentDesignWs.saveContentTypes`. Body `name` is required (letter, then letters/digits/underscore; unique case-insensitive on the type). Optional `dataType` defaults to `text`. Optional `searchable` and `occurrence`/`required` use the same rules as PUT field patches. Optional `fieldSet` names an existing child field set, or **creates** a named complex child when missing. Duplicate field is **409**. System/shared inclusion is out of scope (CD-04). Does not acquire or release the lock. |
+| Delete local field | `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}` | **Admin** (CD-03). Requires a **held** design-session lock. Removes a **local** field and its display mapping. System/shared fields are **400**. Missing type or field is **404**. Does not acquire or release the lock. `204` on success (lock still held). |
 | Field control properties | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | Control parameter **name/value** pairs and the choice catalog for one field (CD-07). No lock required. Empty `properties` means none. `choices` omitted when none. |
 | Replace field control properties | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | **Admin** (CD-07). Requires a **held** design-session lock. Full replace of `properties` (empty clears). `choices` omitted leaves the catalog unchanged; `type: none` clears. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | Field-level validation, visibility, and input/output translation expressions (CD-05–07). No lock required. Empty lists mean none. Unknown field is **404**. Jackson root wrap is `ContentTypeFieldRuleExpressions`. |
@@ -208,18 +210,18 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 | Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
 
 Lock / save / unlock / create / rename / delete status codes:
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / rename succeeded (lock still held), or POST create succeeded (`ContentTypeDetail`) |
-| `204` | Unlock success, or content type deleted |
-| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid or colliding rename), invalid create name (blank, spaces, wildcard), or DELETE rejected because the type has dependents |
+| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / rename succeeded (lock still held), POST create succeeded (`ContentTypeDetail`), or POST local field succeeded |
+| `204` | Unlock success, content type deleted, or local field deleted |
+| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid or colliding rename), invalid create name (blank, spaces, wildcard), invalid local-field name/`dataType`/origin, DELETE field of a system/shared field, or DELETE type rejected because the type has dependents |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found |
-| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time), including reserved system types such as Folder |
+| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time), including reserved system types such as Folder; POST local field when the field name already exists on the type |
 | `500` | Design service or server failure |
 
 ### Rename (CD-01)
@@ -252,7 +254,33 @@ Jackson root wrap:
 }
 ```
 
-Create and delete of content types remain unsupported on this REST surface.
+### Local fields (CD-03)
+
+`POST /services/contenttypes/{idOrName}/fields` adds a **local** field to an
+existing content type. `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}`
+removes one. Both require a **held** design-session lock (`POST .../lock` first).
+The lock is **not** released. Including system or shared fields into a type
+(CD-04) is a different surface.
+
+Typical flow: `POST .../lock` → `POST .../fields` (or `DELETE .../fields/{name}`)
+→ (optional further design writes) → `POST .../unlock`.
+
+Add-field body is a `ContentTypeField`:
+
+```json
+{
+  "name": "rx_note",
+  "label": "Note",
+  "dataType": "text",
+  "searchable": true,
+  "required": false
+}
+```
+
+Optional `fieldSet` names an existing child field set, or creates a named
+complex child when missing. Duplicate field names on the type are **409**.
+Unknown field on DELETE is **404**. Deleting a system or shared field is
+**400**. Field **order** in the editor remains Workbench-only.
 
 ### Enable or disable (CD-13)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -21,6 +21,8 @@ import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.design.objectstore.PSApplyWhen;
+import com.percussion.design.objectstore.PSBackEndColumn;
+import com.percussion.design.objectstore.PSBackEndTable;
 import com.percussion.design.objectstore.PSChoiceTableInfo;
 import com.percussion.design.objectstore.PSChoices;
 import com.percussion.design.objectstore.PSConditional;
@@ -46,6 +48,7 @@ import com.percussion.design.objectstore.PSOutputTranslations;
 import com.percussion.design.objectstore.PSParam;
 import com.percussion.design.objectstore.PSPipe;
 import com.percussion.design.objectstore.PSRule;
+import com.percussion.design.objectstore.PSSearchProperties;
 import com.percussion.design.objectstore.PSSystemValidationException;
 import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUISet;
@@ -131,6 +134,10 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
 
   /** Typical design-session lock duration in minutes ({@link PSObjectLock#LOCK_INTERVAL}). */
   static final long DESIGN_LOCK_MINUTES = PSObjectLock.LOCK_INTERVAL / 60_000L;
+
+  static final String DEFAULT_TEXT_CONTROL = "sys_EditBox";
+
+  private static final int MAX_FIELD_NAME_LENGTH = 50;
 
   private final IPSContentDesignWs designSvc;
   private final PSItemDefManager itemDefManager;
@@ -445,6 +452,13 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
                 + " design lock. PUT save requires a held design lock for"
                 + " label/description/enabled, field searchable/occurrence, workflows (+ default),"
                 + " and templates"));
+    gaps.add(
+        DesignGap.of(
+            "CT_FIELD_CREATE_DELETE",
+            "Local field create/delete: POST/DELETE /contenttypes/{idOrName}/fields"
+                + " (held lock). Optional fieldSet names an existing child or creates a named"
+                + " complex child. System/shared inclusion is CD-04. Field order remains"
+                + " Workbench"));
     gaps.add(
         DesignGap.of(
             "CT_SHARED_FIELD_INCLUSION", "Shared/system field inclusion editing not supported"));
@@ -1168,6 +1182,131 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (Exception e) {
       log.error("Failed to replace field rule expressions for {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to replace field rule expressions", e);
+    }
+  }
+
+  @Override
+  public ContentTypeDetail addLocalField(URI baseUri, String idOrName, ContentTypeField body) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String fieldName = validateFieldName(body.getName());
+    if (StringUtils.isNotBlank(body.getFieldType())
+        && !"local".equalsIgnoreCase(body.getFieldType().trim())) {
+      throw new IllegalArgumentException("Only local fields can be created");
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    requireSessionUserForLock();
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      IPSGuid ctGuid = resolveExistingContentTypeGuid(trimmed);
+      if (ctGuid == null) {
+        return null;
+      }
+      requireHeldLock(ctGuid, "Could not add content type field");
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not add content type field");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      if (findField(def, fieldName) != null) {
+        throw new WebApplicationException("Field already exists: " + fieldName, 409);
+      }
+      addPersistableLocalField(def, body);
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not add content type field");
+        }
+        log.error("Failed to save new local field for {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save new local field", e);
+      }
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
+      return reloaded != null ? toDetail(reloaded) : toDetail(def);
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to add local field for {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to add local field", e);
+    }
+  }
+
+  @Override
+  public Boolean deleteLocalField(URI baseUri, String idOrName, String fieldName) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    if (StringUtils.isBlank(fieldName)) {
+      throw new IllegalArgumentException("fieldName is required");
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String field = fieldName.trim();
+    if (field.contains("..") || field.indexOf('/') >= 0 || field.indexOf('\\') >= 0) {
+      throw new WebApplicationException("Unknown field: " + field, 404);
+    }
+    requireSessionUserForLock();
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      IPSGuid ctGuid = resolveExistingContentTypeGuid(trimmed);
+      if (ctGuid == null) {
+        return null;
+      }
+      requireHeldLock(ctGuid, "Could not delete content type field");
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not delete content type field");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      if (!removeLocalFieldAndMapping(def, field)) {
+        throw new WebApplicationException("Unknown field: " + field, 404);
+      }
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not delete content type field");
+        }
+        log.error("Failed to save local field delete for {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save local field delete", e);
+      }
+      return Boolean.TRUE;
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to delete local field for {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to delete local field", e);
     }
   }
 
@@ -2377,6 +2516,418 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       }
     }
     return null;
+  }
+
+  /**
+   * Persistable TYPE_LOCAL field with backend column locator, default text mapping, and display
+   * mapping ({@code sys_EditBox}). Optional {@code fieldSet} targets or creates a named complex
+   * child. Package-visible for unit tests.
+   */
+  static PSField addPersistableLocalField(PSItemDefinition def, ContentTypeField body) {
+    if (def == null) {
+      throw new IllegalArgumentException("content type is required");
+    }
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String fieldName = validateFieldName(body.getName());
+    PSFieldSet parent = def.getFieldSet();
+    if (parent == null) {
+      throw new IllegalArgumentException("Content type has no field set");
+    }
+    PSDisplayMapper parentMapper = displayMapperOfStatic(def);
+    PSFieldSet target = ensureChildFieldSet(def, parent, parentMapper, body.getFieldSet());
+    PSBackEndTable table = tableForFieldSet(def, target);
+    PSField field = newPersistableLocalField(table, fieldName, body);
+    target.add(field);
+    applyOccurrenceOrRequired(field, body);
+    appendDefaultDisplayMapping(mapperForFieldSet(def, parentMapper, target), fieldName, body);
+    return field;
+  }
+
+  static PSField newPersistableLocalField(
+      PSBackEndTable table, String fieldName, ContentTypeField body) {
+    if (table == null || StringUtils.isBlank(table.getAlias())) {
+      throw new IllegalArgumentException("content type has no backend table");
+    }
+    PSField field =
+        new PSField(
+            PSField.TYPE_LOCAL, fieldName, new PSBackEndColumn(table, columnNameForField(fieldName)));
+    String dataType =
+        body == null || StringUtils.isBlank(body.getDataType())
+            ? PSField.DT_TEXT
+            : body.getDataType().trim();
+    try {
+      field.setDataType(dataType);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid dataType for field " + fieldName + ": " + dataType, e);
+    }
+    if (PSField.DT_TEXT.equals(field.getDataType())) {
+      field.setMimeType("text/plain");
+      field.setDataFormat("50");
+    }
+    boolean searchable =
+        body == null || body.getSearchable() == null || Boolean.TRUE.equals(body.getSearchable());
+    field.setSearchProperties(new PSSearchProperties(searchable));
+    try {
+      field.setOccurrenceDimension(PSField.OCCURRENCE_DIMENSION_OPTIONAL, null);
+    } catch (PSSystemValidationException e) {
+      throw new IllegalArgumentException("Invalid occurrence for field " + fieldName, e);
+    }
+    return field;
+  }
+
+  static boolean removeLocalFieldAndMapping(PSItemDefinition def, String fieldName) {
+    if (def == null || StringUtils.isBlank(fieldName)) {
+      return false;
+    }
+    PSField field = findField(def, fieldName);
+    if (field == null) {
+      return false;
+    }
+    if (field.getType() != PSField.TYPE_LOCAL) {
+      throw new IllegalArgumentException("Only local fields can be deleted");
+    }
+    String actual = field.getSubmitName();
+    PSFieldSet containing = fieldSetContaining(def.getFieldSet(), actual);
+    if (containing == null) {
+      List<PSFieldSet> children = def.getComplexChildren();
+      if (children != null) {
+        for (PSFieldSet child : children) {
+          containing = fieldSetContaining(child, actual);
+          if (containing != null) {
+            break;
+          }
+        }
+      }
+    }
+    if (containing == null) {
+      return false;
+    }
+    containing.remove(actual);
+    removeDisplayMapping(displayMapperOfStatic(def), actual);
+    return true;
+  }
+
+  static PSFieldSet fieldSetContaining(PSFieldSet root, String fieldName) {
+    if (root == null || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    var it = root.getAll();
+    while (it.hasNext()) {
+      Object o = it.next();
+      if (o instanceof PSFieldSet nested) {
+        PSFieldSet found = fieldSetContaining(nested, fieldName);
+        if (found != null) {
+          return found;
+        }
+      } else if (o instanceof PSField field
+          && fieldName.equalsIgnoreCase(field.getSubmitName())) {
+        return root;
+      }
+    }
+    return null;
+  }
+
+  static PSFieldSet ensureChildFieldSet(
+      PSItemDefinition def,
+      PSFieldSet parent,
+      PSDisplayMapper parentMapper,
+      String fieldSetName) {
+    if (StringUtils.isBlank(fieldSetName) || fieldSetName.equalsIgnoreCase(parent.getName())) {
+      return parent;
+    }
+    String name = validateFieldName(fieldSetName);
+    Object existing = parent.get(name);
+    if (existing instanceof PSFieldSet fs) {
+      return fs;
+    }
+    Iterator<?> names = parent.getNames();
+    while (names != null && names.hasNext()) {
+      Object n = names.next();
+      if (n instanceof String key
+          && name.equalsIgnoreCase(key)
+          && parent.get(key) instanceof PSFieldSet fs) {
+        return fs;
+      }
+    }
+    List<PSFieldSet> children = def.getComplexChildren();
+    if (children != null) {
+      for (PSFieldSet child : children) {
+        if (child != null && name.equalsIgnoreCase(child.getName())) {
+          return child;
+        }
+      }
+    }
+    PSFieldSet child = new PSFieldSet(name);
+    child.setType(PSFieldSet.TYPE_COMPLEX_CHILD);
+    child.setSourceType(PSField.TYPE_LOCAL);
+    parent.add(child);
+    appendChildDisplayMapper(parentMapper, name);
+    return child;
+  }
+
+  static void appendChildDisplayMapper(PSDisplayMapper parentMapper, String fieldSetName) {
+    if (parentMapper == null) {
+      throw new IllegalArgumentException("Content type has no display mapper");
+    }
+    PSDisplayMapping existing = findDisplayMapping(parentMapper, fieldSetName);
+    if (existing != null) {
+      if (existing.getDisplayMapper() == null) {
+        existing.setDisplayMapper(new PSDisplayMapper(fieldSetName));
+      }
+      return;
+    }
+    PSUISet uiSet = new PSUISet();
+    uiSet.setLabel(new PSDisplayText(fieldSetName + ":"));
+    uiSet.setErrorLabel(new PSDisplayText(fieldSetName + ":"));
+    PSDisplayMapping mapping = new PSDisplayMapping(fieldSetName, uiSet);
+    mapping.setDisplayMapper(new PSDisplayMapper(fieldSetName));
+    parentMapper.add(mapping);
+  }
+
+  static PSDisplayMapper mapperForFieldSet(
+      PSItemDefinition def, PSDisplayMapper parentMapper, PSFieldSet fieldSet) {
+    if (fieldSet == null || parentMapper == null) {
+      return parentMapper;
+    }
+    try {
+      PSDisplayMapper named = def.getDisplayMapper(fieldSet.getName());
+      if (named != null) {
+        return named;
+      }
+    } catch (RuntimeException ignore) {
+      // mocked defs may not implement getDisplayMapper
+    }
+    PSDisplayMapping mapping = findDisplayMapping(parentMapper, fieldSet.getName());
+    if (mapping != null && mapping.getDisplayMapper() != null) {
+      return mapping.getDisplayMapper();
+    }
+    return parentMapper;
+  }
+
+  static void appendDefaultDisplayMapping(
+      PSDisplayMapper mapper, String fieldName, ContentTypeField body) {
+    if (mapper == null) {
+      throw new IllegalArgumentException("Content type has no display mapper");
+    }
+    if (findDisplayMapping(mapper, fieldName) != null) {
+      return;
+    }
+    String label =
+        body != null && StringUtils.isNotBlank(body.getLabel())
+            ? body.getLabel().trim()
+            : fieldName;
+    if (!label.endsWith(":")) {
+      label = label + ":";
+    }
+    String control =
+        body != null && StringUtils.isNotBlank(body.getControl())
+            ? body.getControl().trim()
+            : DEFAULT_TEXT_CONTROL;
+    PSUISet uiSet = new PSUISet();
+    uiSet.setLabel(new PSDisplayText(label));
+    uiSet.setErrorLabel(new PSDisplayText(label));
+    uiSet.setControl(new PSControlRef(control));
+    mapper.add(new PSDisplayMapping(fieldName, uiSet));
+  }
+
+  /**
+   * Index-based mapping removal. {@link PSDisplayMapper#removeMapping} uses {@code
+   * Iterator.remove()}, which {@code PSConcurrentIterator} rejects.
+   */
+  static boolean removeDisplayMapping(PSDisplayMapper mapper, String fieldRef) {
+    if (mapper == null || StringUtils.isBlank(fieldRef)) {
+      return false;
+    }
+    for (int i = 0; i < mapper.size(); i++) {
+      Object o = mapper.get(i);
+      if (!(o instanceof PSDisplayMapping mapping)) {
+        continue;
+      }
+      if (fieldRef.equalsIgnoreCase(mapping.getFieldRef())) {
+        mapper.remove(i);
+        return true;
+      }
+      if (mapping.getDisplayMapper() != null
+          && removeDisplayMapping(mapping.getDisplayMapper(), fieldRef)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static PSBackEndTable tableForFieldSet(PSItemDefinition def, PSFieldSet fieldSet) {
+    if (fieldSet != null) {
+      PSField[] all = fieldSet.getAllFields();
+      if (all != null) {
+        for (PSField f : all) {
+          if (f != null
+              && f.getType() == PSField.TYPE_LOCAL
+              && f.getLocator() instanceof PSBackEndColumn col
+              && col.getTable() != null
+              && StringUtils.isNotBlank(col.getTable().getAlias())) {
+            return col.getTable();
+          }
+        }
+      }
+    }
+    return tableForLocalFields(def);
+  }
+
+  static PSBackEndTable tableForLocalFields(PSItemDefinition def) {
+    if (def == null) {
+      throw new IllegalArgumentException("content type is required");
+    }
+    try {
+      List<PSBackEndTable> tables = def.getTypeTables();
+      if (tables != null) {
+        for (PSBackEndTable t : tables) {
+          if (t != null && StringUtils.isNotBlank(t.getAlias())) {
+            return t;
+          }
+        }
+      }
+    } catch (RuntimeException ignore) {
+      // mocked defs may not implement getTypeTables
+    }
+    PSFieldSet parent = def.getFieldSet();
+    if (parent != null) {
+      PSField[] all = parent.getAllFields();
+      if (all != null) {
+        for (PSField f : all) {
+          if (f != null
+              && f.getType() == PSField.TYPE_LOCAL
+              && f.getLocator() instanceof PSBackEndColumn col
+              && col.getTable() != null
+              && StringUtils.isNotBlank(col.getTable().getAlias())) {
+            return col.getTable();
+          }
+        }
+      }
+    }
+    String name = StringUtils.defaultIfBlank(def.getName(), "CONTENTTYPE");
+    return new PSBackEndTable(columnNameForField(name));
+  }
+
+  static String validateFieldName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String trimmed = name.trim();
+    if (containsWhitespace(trimmed)) {
+      throw new IllegalArgumentException("name cannot contain spaces");
+    }
+    if (trimmed.length() > MAX_FIELD_NAME_LENGTH) {
+      throw new IllegalArgumentException("name exceeds maximum length");
+    }
+    if (trimmed.contains("..")
+        || trimmed.indexOf('/') >= 0
+        || trimmed.indexOf('\\') >= 0
+        || trimmed.indexOf('\0') >= 0) {
+      throw new IllegalArgumentException("name contains invalid path characters");
+    }
+    char first = trimmed.charAt(0);
+    if (!Character.isLetter(first)) {
+      throw new IllegalArgumentException("name must start with a letter");
+    }
+    for (int i = 1; i < trimmed.length(); i++) {
+      char c = trimmed.charAt(i);
+      if (!Character.isLetterOrDigit(c) && c != '_') {
+        throw new IllegalArgumentException("name must be letters, digits, or underscore");
+      }
+    }
+    return trimmed;
+  }
+
+  static String columnNameForField(String fieldName) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < fieldName.length(); i++) {
+      char c = fieldName.charAt(i);
+      if (Character.isLetterOrDigit(c) || c == '_') {
+        sb.append(Character.toUpperCase(c));
+      }
+    }
+    if (sb.length() == 0) {
+      throw new IllegalArgumentException("name does not yield a valid column");
+    }
+    return sb.toString();
+  }
+
+  static void applyOccurrenceOrRequired(PSField field, ContentTypeField patch) {
+    if (field == null || patch == null) {
+      return;
+    }
+    boolean hasOccurrence = StringUtils.isNotBlank(patch.getOccurrence());
+    boolean hasRequired = patch.getRequired() != null;
+    if (hasOccurrence) {
+      Integer dim = occurrenceFromApi(patch.getOccurrence());
+      if (dim == null) {
+        throw new IllegalArgumentException(
+            "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence());
+      }
+      if (hasRequired
+          && Boolean.TRUE.equals(patch.getRequired()) != occurrenceImpliesRequired(dim)) {
+        throw new IllegalArgumentException(
+            "occurrence and required conflict for field " + patch.getName());
+      }
+      try {
+        field.setOccurrenceDimension(dim, null);
+      } catch (PSSystemValidationException e) {
+        throw new IllegalArgumentException(
+            "Invalid occurrence for field " + patch.getName() + ": " + patch.getOccurrence(), e);
+      }
+    } else if (hasRequired) {
+      int dim =
+          Boolean.TRUE.equals(patch.getRequired())
+              ? PSField.OCCURRENCE_DIMENSION_REQUIRED
+              : PSField.OCCURRENCE_DIMENSION_OPTIONAL;
+      try {
+        field.setOccurrenceDimension(dim, null);
+      } catch (PSSystemValidationException e) {
+        throw new IllegalArgumentException(
+            "Invalid required flag for field " + patch.getName(), e);
+      }
+    }
+  }
+
+  static boolean occurrenceImpliesRequired(int dimension) {
+    return dimension == PSField.OCCURRENCE_DIMENSION_REQUIRED
+        || dimension == PSField.OCCURRENCE_DIMENSION_ONE_OR_MORE;
+  }
+
+  /**
+   * Package-visible so tests can stub a real display mapper without walking a mocked pipe.
+   */
+  static PSDisplayMapper displayMapperOfStatic(PSItemDefinition def) {
+    if (def == null) {
+      return null;
+    }
+    try {
+      PSDisplayMapper named =
+          def.getFieldSet() != null ? def.getDisplayMapper(def.getFieldSet().getName()) : null;
+      if (named != null) {
+        return named;
+      }
+    } catch (RuntimeException ignore) {
+      // fall through to pipe walk
+    }
+    try {
+      if (def.getContentEditor() == null) {
+        return null;
+      }
+      Object pipeObj = def.getContentEditor().getPipe();
+      if (!(pipeObj instanceof PSContentEditorPipe pipe)) {
+        return null;
+      }
+      if (pipe.getMapper() == null || pipe.getMapper().getUIDefinition() == null) {
+        return null;
+      }
+      return pipe.getMapper().getUIDefinition().getDisplayMapper();
+    } catch (RuntimeException e) {
+      return null;
+    }
   }
 
   private ContentTypeFieldRuleExpressions loadFieldRuleExpressions(

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorLocalFieldTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorLocalFieldTest.java
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSBackEndTable;
+import com.percussion.design.objectstore.PSDisplayMapper;
+import com.percussion.design.objectstore.PSField;
+import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeField;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CD-03 local field create/delete: POST/DELETE persist via {@code saveContentTypes} under a held
+ * design-session lock.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorLocalFieldTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void addPersistableLocalField_addsFieldAndMapping() {
+    PSItemDefinition def = stubDefinition();
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    body.setSearchable(true);
+    PSField field = ContentTypeAdaptor.addPersistableLocalField(def, body);
+    assertEquals("rx_note", field.getSubmitName());
+    assertEquals(PSField.TYPE_LOCAL, field.getType());
+    assertEquals(PSField.DT_TEXT, field.getDataType());
+    assertTrue(field.isUserSearchable());
+    assertNotNull(def.getFieldSet().findFieldByName("rx_note", false));
+    assertNotNull(
+        ContentTypeAdaptor.findDisplayMapping(def.getDisplayMapper("percPage"), "rx_note"));
+  }
+
+  @Test
+  void addPersistableLocalField_namedChildCreatesComplexChild() {
+    PSItemDefinition def = stubDefinition();
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_child_note");
+    body.setFieldSet("childset");
+    ContentTypeAdaptor.addPersistableLocalField(def, body);
+    Object nested = def.getFieldSet().get("childset");
+    assertTrue(nested instanceof PSFieldSet);
+    PSFieldSet child = (PSFieldSet) nested;
+    assertEquals(PSFieldSet.TYPE_COMPLEX_CHILD, child.getType());
+    assertNotNull(child.findFieldByName("rx_child_note", false));
+    assertNotNull(
+        ContentTypeAdaptor.findDisplayMapping(def.getDisplayMapper("percPage"), "childset"));
+  }
+
+  @Test
+  void addLocalField_savesWhenLockHeld() throws Exception {
+    stubHeldLock();
+    PSItemDefinition def = stubDefinition();
+    stubLockedLoad(def);
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    adaptor.addLocalField(null, "311", body);
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertNotNull(def.getFieldSet().findFieldByName("rx_note", false));
+  }
+
+  @Test
+  void addLocalField_duplicateIs409() throws Exception {
+    stubHeldLock();
+    PSItemDefinition def = stubDefinition();
+    ContentTypeField existing = new ContentTypeField();
+    existing.setName("rx_note");
+    ContentTypeAdaptor.addPersistableLocalField(def, existing);
+    stubLockedLoad(def);
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.addLocalField(null, "311", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addLocalField_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.addLocalField(null, "311", body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void addLocalField_unknownTypeReturnsNull() throws Exception {
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of());
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    assertNull(adaptor.addLocalField(null, "999", body));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addLocalField_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of());
+    stubDefinition();
+    stubLockedLoad(stubDefinition());
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class, () -> adaptor.addLocalField(null, "311", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addLocalField_invalidNameIs400() {
+    ContentTypeField body = new ContentTypeField();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addLocalField(null, "311", body));
+    assertTrue(ex.getMessage().contains("spaces"));
+  }
+
+  @Test
+  void addLocalField_nonLocalTypeIs400() {
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    body.setFieldType("shared");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addLocalField(null, "311", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("local"));
+  }
+
+  @Test
+  void addLocalField_invalidDataTypeIs400() throws Exception {
+    stubHeldLock();
+    PSItemDefinition def = stubDefinition();
+    stubLockedLoad(def);
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    body.setDataType("not-a-type");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addLocalField(null, "311", body));
+    assertTrue(ex.getMessage().contains("dataType"));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteLocalField_removesAndSaves() throws Exception {
+    stubHeldLock();
+    PSItemDefinition def = stubDefinition();
+    ContentTypeField existing = new ContentTypeField();
+    existing.setName("rx_note");
+    ContentTypeAdaptor.addPersistableLocalField(def, existing);
+    stubLockedLoad(def);
+    Boolean out = adaptor.deleteLocalField(null, "311", "rx_note");
+    assertEquals(Boolean.TRUE, out);
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertNull(def.getFieldSet().findFieldByName("rx_note", false));
+    assertNull(ContentTypeAdaptor.findDisplayMapping(def.getDisplayMapper("percPage"), "rx_note"));
+  }
+
+  @Test
+  void deleteLocalField_unknownFieldIs404() throws Exception {
+    stubHeldLock();
+    stubLockedLoad(stubDefinition());
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.deleteLocalField(null, "311", "nope"));
+    assertEquals(404, ex.getResponse().getStatus());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteLocalField_systemFieldIs400() throws Exception {
+    stubHeldLock();
+    PSItemDefinition def = stubDefinition();
+    PSField system = new PSField(PSField.TYPE_SYSTEM, "sys_title", null);
+    def.getFieldSet().add(system);
+    stubLockedLoad(def);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.deleteLocalField(null, "311", "sys_title"));
+    assertTrue(ex.getMessage().toLowerCase().contains("local"));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteLocalField_unknownTypeReturnsNull() throws Exception {
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of());
+    assertNull(adaptor.deleteLocalField(null, "999", "rx_note"));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteLocalField_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> denied.deleteLocalField(null, "311", "rx_note"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void deleteLocalField_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of());
+    stubLockedLoad(stubDefinition());
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.deleteLocalField(null, "311", "rx_note"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void validateFieldName_rejectsPathAndLeadingDigit() {
+    assertThrows(IllegalArgumentException.class, () -> ContentTypeAdaptor.validateFieldName("../x"));
+    assertThrows(IllegalArgumentException.class, () -> ContentTypeAdaptor.validateFieldName("1abc"));
+    assertEquals("rx_note", ContentTypeAdaptor.validateFieldName(" rx_note "));
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private void stubLockedLoad(PSItemDefinition def) throws Exception {
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(def));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+  }
+
+  private PSItemDefinition stubDefinition() {
+    PSFieldSet parent = new PSFieldSet("percPage");
+    PSDisplayMapper mapper = new PSDisplayMapper("percPage");
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn("percPage");
+    when(def.getLabel()).thenReturn("Page");
+    when(def.getDescription()).thenReturn("");
+    when(def.isEnabled()).thenReturn(true);
+    when(def.isHidden()).thenReturn(false);
+    when(def.getAppName()).thenReturn("rx_cePage");
+    when(def.getEditorUrl()).thenReturn("/Rhythmyx/rx_cePage/percPage.html");
+    when(def.getTypeId()).thenReturn(311);
+    when(def.getFieldSet()).thenReturn(parent);
+    when(def.getComplexChildren()).thenReturn(List.of());
+    when(def.getDisplayMapper("percPage")).thenReturn(mapper);
+    when(def.getTypeTables()).thenReturn(List.of(new PSBackEndTable("PERCPAGE")));
+    when(def.getContentEditor()).thenReturn(null);
+    return def;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -41,6 +41,7 @@ class DesignGapsStructuredTest {
     assertTrue(codes.contains("CT_FIELD_RULE_EXPR"));
     assertTrue(codes.contains("CT_ITEM_EXITS"));
     assertTrue(codes.contains("CT_CREATE_DELETE"));
+    assertTrue(codes.contains("CT_FIELD_CREATE_DELETE"));
     assertTrue(
         gaps.stream()
             .anyMatch(
@@ -51,6 +52,15 @@ class DesignGapsStructuredTest {
                         && g.getMessage().contains("DELETE")
                         && g.getMessage().toLowerCase().contains("held")
                         && !g.getMessage().startsWith("Create / delete not supported")),
+        () -> gaps.toString());
+    assertTrue(
+        gaps.stream()
+            .anyMatch(
+                g ->
+                    "CT_FIELD_CREATE_DELETE".equals(g.getCode())
+                        && g.getMessage().contains("POST/DELETE")
+                        && g.getMessage().contains("/fields")
+                        && g.getMessage().toLowerCase().contains("held")),
         () -> gaps.toString());
     assertFalse(codes.contains("CT_CONTROL_RESOLUTION"));
     for (DesignGap g : gaps) {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeDetail.java
@@ -32,7 +32,8 @@ import java.util.List;
  * no spaces) plus optional label, description, and enabled, then persists it (Workbench Finish).
  * Field rule expressions use {@code GET/PUT .../fields/{fieldName}/ruleExpressions} (held
  * design lock for write). Control properties use {@code GET/PUT
- * .../fields/{fieldName}/controlProperties}. Partial update supports label, description, enabled,
+ * .../fields/{fieldName}/controlProperties}. Local field create/delete uses {@code
+ * POST/DELETE .../fields} (held lock). Partial update supports label, description, enabled,
  * field searchable / occurrence, allowed workflows (+ default), and allowed templates. PUT
  * does not change name (use {@code PUT .../name}). PUT
  * requires a design-session lock already held by the current user ({@code POST}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
@@ -22,10 +22,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
-/** Read-only field summary for a content type (Developer module design view). */
+/**
+ * Field summary for a content type (Developer module design view). GET catalog rows are read-only
+ * except searchable/occurrence on PUT detail. Create uses POST {@code
+ * /contenttypes/{idOrName}/fields} (held design lock); delete uses DELETE {@code
+ * .../fields/{fieldName}}.
+ */
 @XmlRootElement(name = "ContentTypeField")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(description = "Content type field summary (read-only design catalog)")
+@Schema(description = "Content type field summary; POST .../fields creates a local field")
 public class ContentTypeField {
 
   @Schema(description = "Field submit name (system name)")
@@ -34,7 +39,10 @@ public class ContentTypeField {
   @Schema(description = "Display label when known")
   private String label;
 
-  @Schema(description = "Field origin: local | system | shared | unknown")
+  @Schema(
+      description =
+          "Field origin: local | system | shared | unknown. POST .../fields always creates"
+              + " local; other origins are rejected")
   private String fieldType;
 
   @Schema(description = "Storage / data type (text, integer, date, binary, …)")
@@ -106,7 +114,11 @@ public class ContentTypeField {
               + " Writable via PUT .../fields/{fieldName}/controlProperties (held design lock).")
   private List<ContentTypeControlProperty> controlProperties;
 
-  @Schema(description = "Child field-set name when this field is nested; null for parent fields")
+  @Schema(
+      description =
+          "Child field-set name when this field is nested; null for parent fields. On POST"
+              + " .../fields, omit to add to the parent set; a missing name creates a named"
+              + " complex child field set")
   private String fieldSet;
 
   public ContentTypeField() {}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -888,7 +888,8 @@ public class ContentTypesResource {
           "Content type detail including field catalog. Field rows include control property"
               + " names and values. Choice catalogs and property write use"
               + " GET/PUT .../fields/{fieldName}/controlProperties. Field rule expressions use"
-              + " GET/PUT .../fields/{fieldName}/ruleExpressions (see designGaps).",
+              + " GET/PUT .../fields/{fieldName}/ruleExpressions. Local field create/delete uses"
+              + " POST/DELETE .../fields (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -933,7 +934,8 @@ public class ContentTypesResource {
               + " structure are not changed — rename uses PUT .../name. Field rule expressions"
               + " use PUT"
               + " .../fields/{fieldName}/ruleExpressions. Control property values use PUT"
-              + " .../fields/{fieldName}/controlProperties. Create uses POST /contenttypes."
+              + " .../fields/{fieldName}/controlProperties. Local field create/delete uses"
+              + " POST/DELETE .../fields (held lock). Create uses POST /contenttypes."
               + " Rename uses PUT .../name. Delete uses DELETE .../{idOrName} with a held lock.",
       responses = {
         @ApiResponse(
@@ -1400,6 +1402,87 @@ public class ContentTypesResource {
         throw new WebApplicationException("Content type not found: " + idOrName, 404);
       }
       return out;
+    } catch (RuntimeException e) {
+      throw mapMutationFailure(e);
+    } catch (Exception e) {
+      throw mapWriteFailure(e);
+    }
+  }
+
+  @POST
+  @Path("/{idOrName}/fields")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Add a local field to a content type",
+      description =
+          "CD-03. Admin. Adds a persistable local field (backend column + display mapping) via"
+              + " IPSContentDesignWs.loadContentTypes / saveContentTypes. Requires a held"
+              + " design-session lock (POST .../lock). Does not acquire or release the lock. Body"
+              + " name is required, unique case-insensitive on the type, and must be a letter"
+              + " followed by letters, digits, or underscore. Optional dataType defaults to text."
+              + " Optional searchable and occurrence/required use the same rules as PUT field"
+              + " patches. Optional fieldSet names an existing child field set, or creates a named"
+              + " complex child when missing. Duplicate field is 409. Missing type is 404."
+              + " Including system/shared fields is out of scope (CD-04).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Field added (lock is still held)",
+            content = @Content(schema = @Schema(implementation = ContentTypeDetail.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid field input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "A field with that name exists, or design lock not held by the current user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeDetail addLocalField(
+      @PathParam("idOrName") String idOrName, ContentTypeField body) {
+    try {
+      ContentTypeDetail detail =
+          requireAdaptor().addLocalField(uriInfo.getBaseUri(), idOrName, body);
+      if (detail == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return detail;
+    } catch (RuntimeException e) {
+      throw mapMutationFailure(e);
+    } catch (Exception e) {
+      throw mapWriteFailure(e);
+    }
+  }
+
+  @DELETE
+  @Path("/{idOrName}/fields/{fieldName}")
+  @Operation(
+      summary = "Delete a local field from a content type",
+      description =
+          "CD-03. Admin. Removes a local field and its display mapping via"
+              + " IPSContentDesignWs.saveContentTypes. Requires a held design-session lock (POST"
+              + " .../lock). Does not acquire or release the lock. System and shared fields are"
+              + " not removed (400). Missing type or field is 404.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted (lock is still held)"),
+        @ApiResponse(responseCode = "400", description = "Invalid name, or field is not local"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type or field not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock not held by the current user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteLocalField(
+      @PathParam("idOrName") String idOrName, @PathParam("fieldName") String fieldName) {
+    try {
+      Boolean deleted =
+          requireAdaptor().deleteLocalField(uriInfo.getBaseUri(), idOrName, fieldName);
+      if (deleted == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return Response.noContent().build();
     } catch (RuntimeException e) {
       throw mapMutationFailure(e);
     } catch (Exception e) {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -84,7 +84,8 @@ public interface IContentTypesAdaptor {
    * lists use full-replace semantics when non-null; omit them to leave associations unchanged.
    * Does not change name — use {@link #renameContentType}. Field rule expressions use {@link
    * #replaceFieldRuleExpressions}. Control property values use
-   * {@link #replaceFieldControlProperties}.
+   * {@link #replaceFieldControlProperties}. Local field create/delete uses {@link #addLocalField}
+   * / {@link #deleteLocalField}.
    *
    * @return updated detail, or {@code null} when not found
    * @throws ContentTypeDesignLockException when no lock is held or the lock is owned by another
@@ -258,4 +259,33 @@ public interface IContentTypesAdaptor {
    */
   ContentTypeFieldRuleExpressions replaceFieldRuleExpressions(
       URI baseUri, String idOrName, String fieldName, ContentTypeFieldRuleExpressions body);
+
+  /**
+   * Add a persistable local field (backend column + display mapping) to an existing content type
+   * (CD-03). Requires a design-session lock already held by the current user. Does not acquire or
+   * release the lock. Optional {@code fieldSet} names an existing child field set, or creates a
+   * named complex child when missing.
+   *
+   * @param body {@code name} required; unique case-insensitive on the type. Optional {@code
+   *     dataType} defaults to {@code text}. Optional {@code searchable}, {@code occurrence} /
+   *     {@code required} as on PUT field patches.
+   * @return updated detail, or {@code null} when the content type is not found
+   * @throws ContentTypeDesignLockException when no lock is held or another user owns the lock
+   * @throws IllegalArgumentException when input is invalid
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin; {@code
+   *     409} when a field with that name already exists
+   */
+  ContentTypeDetail addLocalField(URI baseUri, String idOrName, ContentTypeField body);
+
+  /**
+   * Remove a local field (backend column mapping + display mapping) from an existing content
+   * type (CD-03). Requires a design-session lock already held by the current user. Does not acquire
+   * or release the lock. System and shared fields are not removed (CD-04).
+   *
+   * @return {@code Boolean.TRUE} when deleted; {@code null} when the content type is not found
+   * @throws ContentTypeDesignLockException when no lock is held or another user owns the lock
+   * @throws IllegalArgumentException when the field is not local
+   * @throws jakarta.ws.rs.WebApplicationException {@code 404} when the field name is unknown
+   */
+  Boolean deleteLocalField(URI baseUri, String idOrName, String fieldName);
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -1043,4 +1043,137 @@ public class ContentTypesResourceDetailTest {
             () -> resource.renameContentType("percPage", new ContentTypeName("percRenamed")));
     assertEquals(403, ex.getResponse().getStatus());
   }
+
+  @Test
+  public void addLocalFieldSuccess() {
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    ContentTypeDetail updated = new ContentTypeDetail();
+    updated.setName("percPage");
+    ContentTypeField created = new ContentTypeField();
+    created.setName("rx_note");
+    updated.setFields(List.of(created));
+    when(adaptor.addLocalField(any(), eq("percPage"), any())).thenReturn(updated);
+    ContentTypeDetail out = resource.addLocalField("percPage", body);
+    assertEquals("percPage", out.getName());
+    assertEquals(1, out.getFields().size());
+    assertEquals("rx_note", out.getFields().get(0).getName());
+    verify(adaptor).addLocalField(any(), eq("percPage"), eq(body));
+  }
+
+  @Test
+  public void addLocalFieldNotFound() {
+    when(adaptor.addLocalField(any(), eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addLocalField("missing", new ContentTypeField()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addLocalFieldInvalidName400() {
+    when(adaptor.addLocalField(any(), eq("percPage"), any()))
+        .thenThrow(new IllegalArgumentException("name cannot contain spaces"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addLocalField("percPage", new ContentTypeField()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addLocalFieldDuplicate409() {
+    when(adaptor.addLocalField(any(), eq("percPage"), any()))
+        .thenThrow(new WebApplicationException("Field already exists: rx_note", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addLocalField("percPage", new ContentTypeField()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addLocalFieldRequiresLock() {
+    when(adaptor.addLocalField(any(), eq("percPage"), any()))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not add content type field; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addLocalField("percPage", new ContentTypeField()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addLocalFieldForbiddenWhenNotAdmin() {
+    when(adaptor.addLocalField(any(), eq("percPage"), any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.addLocalField("percPage", new ContentTypeField()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteLocalFieldReturns204() {
+    when(adaptor.deleteLocalField(any(), eq("percPage"), eq("rx_note"))).thenReturn(Boolean.TRUE);
+    Response out = resource.deleteLocalField("percPage", "rx_note");
+    assertEquals(204, out.getStatus());
+    verify(adaptor).deleteLocalField(any(), eq("percPage"), eq("rx_note"));
+  }
+
+  @Test
+  public void deleteLocalFieldTypeNotFound() {
+    when(adaptor.deleteLocalField(any(), eq("missing"), eq("rx_note"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteLocalField("missing", "rx_note"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteLocalFieldUnknownField404() {
+    when(adaptor.deleteLocalField(any(), eq("percPage"), eq("nope")))
+        .thenThrow(new WebApplicationException("Unknown field: nope", 404));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteLocalField("percPage", "nope"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteLocalFieldNotLocal400() {
+    when(adaptor.deleteLocalField(any(), eq("percPage"), eq("sys_title")))
+        .thenThrow(new IllegalArgumentException("Only local fields can be deleted"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.deleteLocalField("percPage", "sys_title"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteLocalFieldRequiresLock() {
+    when(adaptor.deleteLocalField(any(), eq("percPage"), eq("rx_note")))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not delete content type field; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteLocalField("percPage", "rx_note"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteLocalFieldForbiddenWhenNotAdmin() {
+    when(adaptor.deleteLocalField(any(), eq("percPage"), eq("rx_note")))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteLocalField("percPage", "rx_note"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -174,4 +174,14 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
       URI baseUri, String idOrName, String fieldName, ContentTypeFieldRuleExpressions body) {
     return body;
   }
+
+  @Override
+  public ContentTypeDetail addLocalField(URI baseUri, String idOrName, ContentTypeField body) {
+    return getContentType(baseUri, idOrName);
+  }
+
+  @Override
+  public Boolean deleteLocalField(URI baseUri, String idOrName, String fieldName) {
+    return Boolean.TRUE;
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -24,6 +24,7 @@ import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
+import com.percussion.rest.contenttypes.ContentTypeField;
 import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
 import com.percussion.rest.contenttypes.ContentTypeFieldRuleExpressions;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
@@ -192,5 +193,15 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   public ContentTypeFieldRuleExpressions replaceFieldRuleExpressions(
       URI baseUri, String idOrName, String fieldName, ContentTypeFieldRuleExpressions body) {
     return body;
+  }
+
+  @Override
+  public ContentTypeDetail addLocalField(URI baseUri, String idOrName, ContentTypeField body) {
+    return getContentType(baseUri, idOrName);
+  }
+
+  @Override
+  public Boolean deleteLocalField(URI baseUri, String idOrName, String fieldName) {
+    return Boolean.TRUE;
   }
 }


### PR DESCRIPTION
## Summary

Parent: #1690 (CD-03 Define local fields and child field sets with order). Slice: #3960.

Admin REST can **add and remove local fields** on an existing content type under a held design-session lock. Persistence uses existing `IPSContentDesignWs.loadContentTypes` / `saveContentTypes` (no new SOAP). Optional `fieldSet` names an existing child field set, or creates a named complex child when missing. System/shared inclusion remains CD-04 / out of scope. No SPA field editor.

- `POST /services/contenttypes/{idOrName}/fields` — persistable local field (backend column + display mapping)
- `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}` — local only; system/shared is **400**
- Status: **400** invalid input; **403** non-Admin; **404** unknown type/field; **409** duplicate field or lock not held

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3960

## Test plan

1. Mockito resource tests in `ContentTypesResourceDetailTest` (success / 400 / 403 / 404 / 409 / 204).
2. Adaptor tests in `ContentTypeAdaptorLocalFieldTest` (save, duplicate 409, lock 409, Admin 403, unknown type/field, non-local delete 400, named child field set).
3. Spring MainTest companion: `TestContentTypeAdaptor` implements the new adaptor methods.
4. Standalone `mvnw clean install` in `rest` then `projects/sitemanage`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (CD-03 table + Local fields section + `designGaps` code `CT_FIELD_CREATE_DELETE`) and `product-docs/8.2/admin/developer-content-types.md`
- [x] **Unit / module tests** — behavioral tests; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps for new `IContentTypesAdaptor` methods
- [x] **Cross-platform** — N/A (no path/file I/O; field names reject `/` `\` `..`)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS**. Tests run: 731, Failures: 0. `ContentTypesResourceDetailTest` Tests run: 91, Failures: 0.
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**. Tests run: 1683, Failures: 0. `ContentTypeAdaptorLocalFieldTest` Tests run: 17, Failures: 0.
- **downstream_checked:** grep `implements IContentTypesAdaptor` — 3 types (`ContentTypeAdaptor`, `TestContentTypeAdaptor`, `ContentTypesTestAdaptor`), all updated; sitemanage standalone install green. C2 `final`/signature-break not applied beyond additive interface methods.
- **C5:** N/A (REST adaptor; no UI/Playwright)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
