### PR TITLE
feat(rest): CD-16 system def field create/delete (#3964)

### DIFF
--- a/docs/ai-generated/code-reviews/3964-systemdef-field-create-delete-erlang.md
+++ b/docs/ai-generated/code-reviews/3964-systemdef-field-create-delete-erlang.md
@@ -1,0 +1,38 @@
+# Erlang review — #3964 REST CD-16 system def field create/delete
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-28 |
+| **Branch** | `feat/issue-3964-systemdef-field-create-delete` |
+| **Scope** | Uncommitted vs `HEAD` / `origin/main` |
+| **Recommendation** | **approve** |
+| **Gate** | **May commit/push: yes** |
+| **Memory patterns hit** | Change-class closure (rest resource + adaptor + Spring stub + sitemanage impl); Admin 403 not a global JAX-RS filter; lock mapped to typed 409 not message-sniffing |
+
+## Summary
+
+Admin POST `/services/systemdef/fields` and DELETE `/services/systemdef/fields/{fieldName}` create and delete persistable TYPE_SYSTEM fields (backend column + `sys_EditBox` display mapping) via `IPSContentDesignWs.loadContentEditorSystemDef(lock=true)` then `saveContentEditorSystemDef(release=true)`, matching CD-15 `#3954` nested fields. PUT remains patch-only. No new SOAP; no SPA; control/stylesheet/flow still `designGaps`.
+
+## Issues
+
+None that block.
+
+## Notes (non-blocking)
+
+- Unknown DELETE field is **400** (singleton catalog; same as PUT unknown field), not 404.
+- System-mandatory / system-internal fields cannot be deleted (**400**).
+- Duplicate create is **409** (`WebApplicationException`).
+- Cross-platform path checklist: N/A (no file I/O). Name validation rejects `/`, `\\`, `..`, NUL as invalid (**400**).
+
+## Tests / companions
+
+- Mockito `SystemDefResourceTest` (POST/DELETE 400/403/409/204/500)
+- Spring `TestSystemDefAdaptor` implements `addField` / `deleteField`
+- `SystemDefAdaptorTest` success / 403 / lock 409 / duplicate 409 / unknown 400 / mandatory 400 / persistable XML
+- product-docs 8.2 Developer REST + admin content-types + gap map CD-16 field create/delete
+
+## Builds
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 767, Failures: 0 (`SystemDefResourceTest` 21)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1798, Failures: 0, Skipped: 125 (`SystemDefAdaptorTest` 32)
+- Downstream: grepped `implements ISystemDefAdaptor` (stub + adaptor); sitemanage standalone install

--- a/docs/ai-generated/code-reviews/3973-systemdef-field-create-delete-review-erlang.md
+++ b/docs/ai-generated/code-reviews/3973-systemdef-field-create-delete-review-erlang.md
@@ -1,0 +1,22 @@
+# Erlang review — PR #3973 review-thread follow-up
+
+**Scope:** uncommitted review-thread fixes on `fix/issue-3964-systemdef-field-create-delete` vs `HEAD`.
+**Recommendation:** approve
+**Gate:** May commit/push: yes
+**Memory patterns hit:** missing behavioral tests for new/changed non-trivial logic; Public helper Javadoc that contradicts implementation (not applicable here)
+
+## Summary
+
+Kilo threads on #3973: add a behavioral companion for `isSystemInternal()` delete 400; drop redundant `isSafeFieldName` after the letter/digit/underscore loop.
+
+## Issues
+
+None. `deleteField_systemInternalIs400` exercises the documented 400 path with `isSystemMandatory=false` and asserts no save. Path characters (`/`, `\`, `..`, NUL) remain rejected by the remaining character-class loop (tests extended). No product-docs change (review-only). No file I/O.
+
+## Cross-platform path checklist
+
+N/A — no path/file I/O in this diff.
+
+## Evidence
+
+`cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS. Tests run: 1799, Failures: 0, Skipped: 125. `SystemDefAdaptorTest` 33/33 including `deleteField_systemInternalIs400`.

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -22,6 +22,7 @@
 | Public REST include field         | CD-04 include system/shared (Admin) | `POST /services/contenttypes/{idOrName}/fields/include` |
 | Public REST system-def catalog    | CD-16 GET (Admin only)              | `GET /services/systemdef`                      |
 | Public REST system-def write      | CD-16 field-property save (Admin)   | `PUT /services/systemdef` (request lock, release on save) |
+| Public REST system-def fields     | CD-16 field create/delete (Admin)   | `POST /services/systemdef/fields`, `DELETE /services/systemdef/fields/{fieldName}` |
 | Design SOAP (Workbench)           | Full load/save/lock/create/delete   | `IPSContentDesignWs` / `ContentDesignSOAPImpl` |
 | Item def manager                  | Runtime CE definition cache         | `PSItemDefManager.getItemDef`                  |
 
@@ -80,7 +81,7 @@ slices.
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
 | Content type **icon strategy**                       | CD-11        | **REST `GET/PUT /contenttypes/{id}/icon`** (#3997, held design lock for PUT; `none` clears value; blank non-none value 400; no binary upload; SPA picker still Workbench) |
 | Shared field file **write**                          | CD-15        | **Group create/save/delete shipped** (`POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}`, #3944). **Field create/delete shipped** (`POST …/fields`, `DELETE …/fields/{fieldName}`, persistable `PSField` + display mapping, Admin 403, lock 409, #3954). Control/choice write and SPA editor still open |
-| System def **write** (existing field properties)     | CD-16        | **PUT `/services/systemdef` shipped** (#3958, Admin 403, lock 409). Field create/delete, control/stylesheet/flow, and SPA editor still SOAP |
+| System def **write** (existing field properties)     | CD-16        | **PUT `/services/systemdef` shipped** (#3958, Admin 403, lock 409). **Field create/delete shipped** (`POST /services/systemdef/fields`, `DELETE …/fields/{fieldName}`, persistable `PSField` + display mapping, Admin 403, lock 409, #3964). Control/stylesheet/flow and SPA editor still SOAP |
 | Create / delete                                      | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Delete still SOAP design only; lock + PUT save via REST |
 | Rename                                               | CD-01, §5.2  | **REST `PUT /contenttypes/{id}/name`** (#3914, held design lock; unique, no spaces; bulk PUT does not rename) |
 | Import/export CT                                     | CD-14        | Workbench wizards                                 |
@@ -97,7 +98,7 @@ slices.
 4. ~~Keyword create/update/delete~~ **Done CD-17** (REST write + design WS + SPA editor)
 5. ~~Control property value/choice catalogs~~ **Done CD-07 REST** (#3786). ~~Choice filter / null-entry / default-selected write~~ **Done** (#3995). Field-rule write/save still open. SPA Choices tab still later. Shared-field control properties are #3984
 6. ~~Shared field catalog read~~ **Done CD-15 read** (`GET /services/sharedfields`, Admin 403). ~~Write~~ **Done CD-15 group create/save/delete** (`POST`/`PUT`/`DELETE`, #3944). ~~Field create/delete~~ **Done** (`POST …/fields`, `DELETE …/fields/{fieldName}`, #3954). Control/choice write + SPA editor still open
-7. ~~System def field-property write~~ **Done CD-16 PUT** (`PUT /services/systemdef`, Admin 403, request lock + release on save, #3958). Field create/delete + SPA still open
+7. ~~System def field-property write~~ **Done CD-16 PUT** (`PUT /services/systemdef`, Admin 403, request lock + release on save, #3958). ~~Field create/delete~~ **Done** (`POST /services/systemdef/fields`, `DELETE …/fields/{fieldName}`, #3964). Control/stylesheet/flow + SPA still open
 8. ~~Include system/shared fields~~ **Done CD-04 REST** (`POST /contenttypes/{id}/fields/include`, Admin 403, held lock 409, origin stays system/shared, #3985). SPA field picker still open
 9. Templates/slots design editors
 10. CD-18 remainder: auto-translation set editor + SPA locale editor (REST locale CRUD shipped #3959)

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -43,7 +43,11 @@ fields (backend column + display mapping). The SPA editor is not in this
 chrome. The content-editor **system definition** (global system fields) is a
 separate singleton: Admin-only `GET /services/systemdef` and
 `PUT /services/systemdef` (patch existing field properties under a request lock).
-System-field create/delete and an SPA editor are not in this chrome. See
+Nested `POST /services/systemdef/fields` and
+`DELETE /services/systemdef/fields/{fieldName}` add or remove system fields
+(backend column + display mapping). Duplicate field names are **409**.
+System-mandatory and system-internal fields cannot be deleted (**400**). An SPA
+editor is not in this chrome. See
 [REST API](id:developer-rest).
 
 This is **not** the full Workbench field-rule editor. The detail table still

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -804,8 +804,9 @@ previously held lock).
 sitemanage adaptor checks `IPSUserService.isAdminUser` for the current user and maps
 a non-Admin caller to **403**. Control/choice write remains unsupported. Nested
 field create/delete persist a backend column mapping and a default `sys_EditBox`
-display mapping. System-def field-property save is a separate catalog
-(`PUT /services/systemdef`, CD-16).
+display mapping. System-def field-property save and field create/delete are a
+separate catalog (`PUT /services/systemdef`, `POST /services/systemdef/fields`,
+`DELETE /services/systemdef/fields/{fieldName}`, CD-16).
 
 | Method | Path | Purpose |
 |--------|------|---------|
@@ -861,7 +862,8 @@ List entries use `SharedFieldGroupSummary`. Detail uses `SharedFieldGroupDetail`
 - `fields[]`: `name`, `dataType`, `searchable`, `required`, `readOnly`, `occurrence`
   (`optional` / `required` / `oneOrMore` / `zeroOrMore` / `count` / `unknown`)
 - `designGaps[]` strings — control/choice edit remain later slices. System-def
-  field-property save is `PUT /services/systemdef`.
+  field-property save is `PUT /services/systemdef`; field create/delete are
+  `POST /services/systemdef/fields` and `DELETE /services/systemdef/fields/{fieldName}`.
 
 Prefer the generated OpenAPI schema as the integration source of truth.
 
@@ -885,8 +887,8 @@ lock” (Workbench also locks the whole shared definition, not one group).
 ## System definition (design catalog)
 
 Content-editor **system definition** (Workbench global / system fields, CD-16) is a
-singleton design object. Public REST exposes a catalog **and field-property write**
-under `/services/systemdef`. Load and save use the same content **design** web
+singleton design object. Public REST exposes a catalog **and write** under
+`/services/systemdef`. Load and save use the same content **design** web
 service as Workbench (`IPSContentDesignWs.loadContentEditorSystemDef` /
 `saveContentEditorSystemDef`). Writes acquire the system-definition design lock for
 the request and **release** it on save (same request-lock pattern as shared-field
@@ -894,21 +896,28 @@ PUT; unlike content-type PUT, which requires a previously held lock).
 
 **Admin (Design) only.** There is no global JAX-RS Admin filter on this path — the
 sitemanage adaptor checks `IPSUserService.isAdminUser` for the current user and maps
-a non-Admin caller to **403**. Field **create/delete**, control properties,
-stylesheets, and application flow remain unsupported.
+a non-Admin caller to **403**. Nested field create/delete persist a backend column
+mapping (default table `CONTENTSTATUS`) and a default `sys_EditBox` display
+mapping. Control properties, stylesheets, and application flow remain unsupported.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/systemdef` | Load the system definition field catalog (`fieldCount`, `cacheTimeoutMinutes`, `fields[]`) |
-| `PUT` | `/services/systemdef` | Patch **existing** fields (`searchable`, occurrence / required). Null or empty `fields` leaves the catalog unchanged. |
+| `PUT` | `/services/systemdef` | Patch **existing** fields (`searchable`, occurrence / required). Null or empty `fields` leaves the catalog unchanged. Does not create or delete fields. |
+| `POST` | `/services/systemdef/fields` | Add a field (`name` required, unique). Optional `dataType` defaults to `text`. Optional `searchable` and occurrence / required use the same rules as PUT patches. |
+| `DELETE` | `/services/systemdef/fields/{fieldName}` | Remove a field and its display mapping (**204**). |
 
 PUT may include `fields[]` to patch existing fields by `name`. Unknown field names
-are **400**. New fields cannot be added on this slice. `occurrence` and `required`
+are **400**. PUT does **not** create or delete fields — use nested POST/DELETE
+`.../fields`. Field `name` on create must start with a letter and may contain
+letters, digits, or underscore (no spaces or path characters). Duplicate field
+names (case-insensitive) are **409**. `occurrence` and `required`
 map to the same dimension: when both are sent they must agree (`required=true`
 with `required` / `oneOrMore`; `required=false` with `optional` / `zeroOrMore` /
 `count`) or the request is **400**. `occurrence` is applied when present;
 `required` is used only when `occurrence` is omitted. `dataType`, `readOnly`, and
-`cacheTimeoutMinutes` are read-only on this slice.
+`cacheTimeoutMinutes` are read-only on PUT. System-mandatory and system-internal
+fields cannot be deleted (**400**). Unknown `{fieldName}` on DELETE is **400**.
 
 Example PUT body:
 
@@ -920,6 +929,17 @@ Example PUT body:
 }
 ```
 
+Add-field body is a `SystemDefFieldSummary`:
+
+```json
+{
+  "name": "sys_custom",
+  "dataType": "text",
+  "searchable": true,
+  "required": false
+}
+```
+
 ### Response shape
 
 Detail uses `SystemDefDetail`:
@@ -927,8 +947,8 @@ Detail uses `SystemDefDetail`:
 - `fieldCount`, `cacheTimeoutMinutes` (read-only)
 - `fields[]`: `name`, `dataType`, `searchable`, `required`, `readOnly`, `occurrence`
   (`optional` / `required` / `oneOrMore` / `zeroOrMore` / `count` / `unknown`)
-- `designGaps[]` strings — field create/delete, control/stylesheet/application flow,
-  and shared-field groups (separate catalog)
+- `designGaps[]` strings — control/stylesheet/application flow, and shared-field
+  groups (separate catalog)
 
 Prefer the generated OpenAPI schema as the integration source of truth.
 
@@ -936,10 +956,11 @@ Prefer the generated OpenAPI schema as the integration source of truth.
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Catalog or save |
-| `400` | Missing body, unknown field, invalid occurrence, or conflicting `occurrence`/`required` |
+| `200` | Catalog, save, or add-field |
+| `204` | Field deleted |
+| `400` | Missing body, unknown field, invalid name/`dataType`, conflicting `occurrence`/`required`, or delete of a system-mandatory / system-internal field |
 | `403` | Caller is not Admin, or the request has no session/user (writes) |
-| `409` | System definition locked by another user, or design lock required for save |
+| `409` | Duplicate field name, system definition locked by another user, or design lock required for save |
 | `500` | Design service or server failure |
 
 Authenticated non-Admin sessions (Editor, Contributor, and similar) must not read or

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
@@ -288,9 +288,6 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
     if (trimmed.length() > MAX_FIELD_NAME_LENGTH) {
       throw new IllegalArgumentException("name exceeds maximum length");
     }
-    if (!isSafeFieldName(trimmed)) {
-      throw new IllegalArgumentException("name contains invalid path characters");
-    }
     char first = trimmed.charAt(0);
     if (!Character.isLetter(first)) {
       throw new IllegalArgumentException("name must start with a letter");
@@ -302,16 +299,6 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
       }
     }
     return trimmed;
-  }
-
-  static boolean isSafeFieldName(String name) {
-    if (StringUtils.isBlank(name)) {
-      return false;
-    }
-    return !name.contains("..")
-        && name.indexOf('/') < 0
-        && name.indexOf('\\') < 0
-        && name.indexOf('\0') < 0;
   }
 
   private static boolean containsWhitespace(String name) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
@@ -16,10 +16,22 @@
 
 package com.percussion.apibridge;
 
+import com.percussion.design.objectstore.PSBackEndColumn;
+import com.percussion.design.objectstore.PSBackEndTable;
+import com.percussion.design.objectstore.PSContainerLocator;
 import com.percussion.design.objectstore.PSContentEditorSystemDef;
+import com.percussion.design.objectstore.PSControlRef;
+import com.percussion.design.objectstore.PSDisplayMapper;
+import com.percussion.design.objectstore.PSDisplayMapping;
+import com.percussion.design.objectstore.PSDisplayText;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.design.objectstore.PSSearchProperties;
 import com.percussion.design.objectstore.PSSystemValidationException;
+import com.percussion.design.objectstore.PSTableRef;
+import com.percussion.design.objectstore.PSTableSet;
+import com.percussion.design.objectstore.PSUIDefinition;
+import com.percussion.design.objectstore.PSUISet;
 import com.percussion.rest.systemdef.ISystemDefAdaptor;
 import com.percussion.rest.systemdef.SystemDefDesignLockException;
 import com.percussion.rest.systemdef.SystemDefDetail;
@@ -38,6 +50,7 @@ import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
@@ -66,9 +79,14 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
 
   private static final List<String> DESIGN_GAPS =
       List.of(
-          "System def field create / delete not supported via this API",
           "Control properties, stylesheets, and application flow not exposed",
           "Shared field groups are a separate catalog (Developer Shared Fields)");
+
+  private static final int MAX_FIELD_NAME_LENGTH = 50;
+
+  private static final String DEFAULT_TEXT_CONTROL = "sys_EditBox";
+
+  private static final String DEFAULT_TABLE_ALIAS = "CONTENTSTATUS";
 
   private final IPSContentDesignWs designWs;
   private final Supplier<PSContentEditorSystemDef> systemDefLoader;
@@ -259,6 +277,220 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
     }
   }
 
+  static String validateFieldName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String trimmed = name.trim();
+    if (containsWhitespace(trimmed)) {
+      throw new IllegalArgumentException("name cannot contain spaces");
+    }
+    if (trimmed.length() > MAX_FIELD_NAME_LENGTH) {
+      throw new IllegalArgumentException("name exceeds maximum length");
+    }
+    if (!isSafeFieldName(trimmed)) {
+      throw new IllegalArgumentException("name contains invalid path characters");
+    }
+    char first = trimmed.charAt(0);
+    if (!Character.isLetter(first)) {
+      throw new IllegalArgumentException("name must start with a letter");
+    }
+    for (int i = 1; i < trimmed.length(); i++) {
+      char c = trimmed.charAt(i);
+      if (!Character.isLetterOrDigit(c) && c != '_') {
+        throw new IllegalArgumentException("name must be letters, digits, or underscore");
+      }
+    }
+    return trimmed;
+  }
+
+  static boolean isSafeFieldName(String name) {
+    if (StringUtils.isBlank(name)) {
+      return false;
+    }
+    return !name.contains("..")
+        && name.indexOf('/') < 0
+        && name.indexOf('\\') < 0
+        && name.indexOf('\0') < 0;
+  }
+
+  private static boolean containsWhitespace(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isWhitespace(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static String columnNameForField(String fieldName) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < fieldName.length(); i++) {
+      char c = fieldName.charAt(i);
+      if (Character.isLetterOrDigit(c) || c == '_') {
+        sb.append(Character.toUpperCase(c));
+      }
+    }
+    if (sb.length() == 0) {
+      throw new IllegalArgumentException("name does not yield a valid column");
+    }
+    return sb.toString();
+  }
+
+  static String tableAliasForSystemDef(PSContentEditorSystemDef def) {
+    if (def == null || def.getContainerLocator() == null) {
+      return DEFAULT_TABLE_ALIAS;
+    }
+    PSContainerLocator loc = def.getContainerLocator();
+    Iterator<?> sets = loc.getTableSets();
+    if (sets != null) {
+      while (sets.hasNext()) {
+        Object o = sets.next();
+        if (!(o instanceof PSTableSet ts)) {
+          continue;
+        }
+        Iterator<?> refs = ts.getTableRefs();
+        if (refs == null) {
+          continue;
+        }
+        while (refs.hasNext()) {
+          Object r = refs.next();
+          if (r instanceof PSTableRef ref) {
+            if (StringUtils.isNotBlank(ref.getAlias())) {
+              return ref.getAlias();
+            }
+            if (StringUtils.isNotBlank(ref.getName())) {
+              return ref.getName();
+            }
+          }
+        }
+      }
+    }
+    return DEFAULT_TABLE_ALIAS;
+  }
+
+  /**
+   * Persistable TYPE_SYSTEM field with backend column locator, default text mapping, and display
+   * mapping ({@code sys_EditBox}). Control/stylesheet/flow write is a later slice.
+   */
+  static PSField addPersistableField(PSContentEditorSystemDef def, SystemDefFieldSummary body) {
+    if (def == null) {
+      throw new IllegalArgumentException("system def is required");
+    }
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String fieldName = validateFieldName(body.getName());
+    PSFieldSet fieldSet = def.getFieldSet();
+    if (fieldSet == null) {
+      throw new IllegalArgumentException("System def has no field set");
+    }
+    PSField field = newPersistableSystemField(def, fieldName, body);
+    fieldSet.add(field);
+    applyOccurrenceOrRequired(field, body);
+    appendDefaultDisplayMapping(def, fieldName);
+    return field;
+  }
+
+  static PSField newPersistableSystemField(
+      PSContentEditorSystemDef def, String fieldName, SystemDefFieldSummary body) {
+    String tableAlias = tableAliasForSystemDef(def);
+    PSBackEndTable table = new PSBackEndTable(tableAlias);
+    PSField field =
+        new PSField(
+            PSField.TYPE_SYSTEM, fieldName, new PSBackEndColumn(table, columnNameForField(fieldName)));
+    String dataType =
+        body == null || StringUtils.isBlank(body.getDataType())
+            ? PSField.DT_TEXT
+            : body.getDataType().trim();
+    try {
+      field.setDataType(dataType);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid dataType for field " + fieldName + ": " + dataType, e);
+    }
+    if (PSField.DT_TEXT.equals(field.getDataType())) {
+      field.setMimeType("text/plain");
+      field.setDataFormat("50");
+    }
+    boolean searchable =
+        body == null || body.getSearchable() == null || Boolean.TRUE.equals(body.getSearchable());
+    field.setSearchProperties(new PSSearchProperties(searchable));
+    try {
+      field.setOccurrenceDimension(PSField.OCCURRENCE_DIMENSION_OPTIONAL, null);
+    } catch (PSSystemValidationException e) {
+      throw new IllegalArgumentException("Invalid occurrence for field " + fieldName, e);
+    }
+    return field;
+  }
+
+  static void appendDefaultDisplayMapping(PSContentEditorSystemDef def, String fieldName) {
+    PSUIDefinition ui = def.getUIDefinition();
+    if (ui == null) {
+      throw new IllegalArgumentException("System def has no UI definition");
+    }
+    PSDisplayMapper mapper = ui.getDisplayMapper();
+    if (mapper == null) {
+      throw new IllegalArgumentException("System def has no display mapper");
+    }
+    if (ui.getMapping(fieldName) != null) {
+      return;
+    }
+    PSUISet uiSet = new PSUISet();
+    uiSet.setLabel(new PSDisplayText(fieldName + ":"));
+    uiSet.setErrorLabel(new PSDisplayText(fieldName + ":"));
+    uiSet.setControl(new PSControlRef(DEFAULT_TEXT_CONTROL));
+    ui.appendMapping(mapper, new PSDisplayMapping(fieldName, uiSet));
+  }
+
+  static boolean removeFieldAndMapping(PSContentEditorSystemDef def, String fieldName) {
+    if (def == null || def.getFieldSet() == null || StringUtils.isBlank(fieldName)) {
+      return false;
+    }
+    PSField field = def.getFieldSet().getFieldByName(fieldName);
+    if (field == null) {
+      return false;
+    }
+    if (field.isSystemMandatory()) {
+      throw new IllegalArgumentException("System-mandatory field cannot be deleted");
+    }
+    if (field.isSystemInternal()) {
+      throw new IllegalArgumentException("System-internal field cannot be deleted");
+    }
+    String actual = field.getSubmitName();
+    def.getFieldSet().remove(actual);
+    PSUIDefinition ui = def.getUIDefinition();
+    if (ui != null) {
+      removeDisplayMapping(ui.getDisplayMapper(), actual);
+    }
+    return true;
+  }
+
+  /**
+   * Index-based mapping removal. {@link PSDisplayMapper#removeMapping} uses {@code
+   * Iterator.remove()}, which {@code PSConcurrentIterator} rejects.
+   */
+  static boolean removeDisplayMapping(PSDisplayMapper mapper, String fieldRef) {
+    if (mapper == null || StringUtils.isBlank(fieldRef)) {
+      return false;
+    }
+    for (int i = 0; i < mapper.size(); i++) {
+      Object o = mapper.get(i);
+      if (!(o instanceof PSDisplayMapping mapping)) {
+        continue;
+      }
+      if (fieldRef.equals(mapping.getFieldRef())) {
+        mapper.remove(i);
+        return true;
+      }
+      if (mapping.getDisplayMapper() != null
+          && removeDisplayMapping(mapping.getDisplayMapper(), fieldRef)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   static Integer occurrenceFromApi(String occurrence) {
     if (occurrence == null) {
       return null;
@@ -294,6 +526,45 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
     applyFieldPatches(def.getFieldSet(), body.getFields());
     saveSystemDef(def, session, user);
     return toDetail(def);
+  }
+
+  @Override
+  public SystemDefDetail addField(URI baseUri, SystemDefFieldSummary body) {
+    requireAdmin();
+    requireDesignWs();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String fieldName = validateFieldName(body.getName());
+    String session = currentSession();
+    String user = currentUser();
+    PSContentEditorSystemDef def = loadSystemDefLocked(session, user);
+    PSFieldSet fieldSet = def.getFieldSet();
+    if (fieldSet == null) {
+      throw new IllegalArgumentException("System def has no field set");
+    }
+    if (fieldSet.getFieldByName(fieldName) != null) {
+      throw new WebApplicationException("System field already exists: " + fieldName, 409);
+    }
+    addPersistableField(def, body);
+    saveSystemDef(def, session, user);
+    return toDetail(def);
+  }
+
+  @Override
+  public void deleteField(URI baseUri, String fieldName) {
+    requireAdmin();
+    requireDesignWs();
+    requireSessionUserForWrite();
+    String validated = validateFieldName(fieldName);
+    String session = currentSession();
+    String user = currentUser();
+    PSContentEditorSystemDef def = loadSystemDefLocked(session, user);
+    if (!removeFieldAndMapping(def, validated)) {
+      throw new IllegalArgumentException("Unknown field: " + validated);
+    }
+    saveSystemDef(def, session, user);
   }
 
   private void requireAdmin() {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
@@ -489,6 +489,26 @@ class SystemDefAdaptorTest {
   }
 
   @Test
+  void deleteField_systemInternalIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSField field = mock(PSField.class);
+    when(field.getSubmitName()).thenReturn("sys_internal");
+    when(field.isSystemMandatory()).thenReturn(false);
+    when(field.isSystemInternal()).thenReturn(true);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.getFieldByName("sys_internal")).thenReturn(field);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(def.getFieldSet()).thenReturn(set);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.deleteField(null, "sys_internal"));
+    assertTrue(ex.getMessage().contains("internal"));
+    verify(designWs, never()).saveContentEditorSystemDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
   void deleteField_forbiddenWhenNotAdmin() throws Exception {
     IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
     SystemDefAdaptor denied = new SystemDefAdaptor(designWs, () -> false);
@@ -536,6 +556,10 @@ class SystemDefAdaptorTest {
     assertThrows(
         IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("has space"));
     assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("a/b"));
+    assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("a\\b"));
+    assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("a..b"));
+    assertThrows(
+        IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("a\0b"));
     assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("1start"));
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
@@ -20,6 +20,7 @@ package com.percussion.apibridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,8 +35,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.design.objectstore.PSContentEditorSystemDef;
+import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.design.objectstore.PSUIDefinition;
 import com.percussion.rest.systemdef.SystemDefDesignLockException;
 import com.percussion.rest.systemdef.SystemDefDetail;
 import com.percussion.rest.systemdef.SystemDefFieldSummary;
@@ -335,5 +338,219 @@ class SystemDefAdaptorTest {
     PSLockErrorException err = new PSLockErrorException(1, "locked", "stack", "alice", 10L);
     SystemDefDesignLockException mapped = SystemDefAdaptor.mapLockConflict(err);
     assertEquals("Could not save system definition; locked by alice", mapped.getMessage());
+  }
+
+  @Test
+  void addField_addsPersistableFieldAndSaves() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("sys_custom");
+    body.setSearchable(true);
+    SystemDefDetail out = adaptor.addField(null, body);
+
+    assertEquals(1, out.getFieldCount());
+    assertEquals("sys_custom", out.getFields().get(0).getName());
+    assertEquals("text", out.getFields().get(0).getDataType());
+    assertEquals(Boolean.TRUE, out.getFields().get(0).getSearchable());
+    verify(designWs).saveContentEditorSystemDef(eq(def), eq(true), eq("test-session"), eq("Admin"));
+    assertNotNull(def.getFieldSet().getFieldByName("sys_custom"));
+    assertNotNull(def.getUIDefinition().getMapping("sys_custom"));
+  }
+
+  @Test
+  void addField_duplicateIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    SystemDefFieldSummary existing = new SystemDefFieldSummary();
+    existing.setName("sys_custom");
+    SystemDefAdaptor.addPersistableField(def, existing);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("sys_custom");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.addField(null, body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveContentEditorSystemDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addField_forbiddenWhenNotAdmin() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefAdaptor denied = new SystemDefAdaptor(designWs, () -> false);
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("sys_custom");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.addField(null, body));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).loadContentEditorSystemDef(anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addField_lockConflictIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSLockErrorException lockErr = new PSLockErrorException(1, "locked", "stack", "other", 1000L);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin"))
+        .thenThrow(lockErr);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("sys_custom");
+    SystemDefDesignLockException ex =
+        assertThrows(SystemDefDesignLockException.class, () -> adaptor.addField(null, body));
+    assertTrue(ex.getMessage().contains("locked by other"));
+  }
+
+  @Test
+  void addField_invalidNameIs400() {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addField(null, body));
+    assertTrue(ex.getMessage().contains("spaces"));
+  }
+
+  @Test
+  void addField_nullBodyIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addField(null, null));
+    assertTrue(ex.getMessage().contains("body is required"));
+    verify(designWs, never()).loadContentEditorSystemDef(anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void addField_invalidDataTypeIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("sys_custom");
+    body.setDataType("not-a-type");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.addField(null, body));
+    assertTrue(ex.getMessage().contains("dataType"));
+    verify(designWs, never()).saveContentEditorSystemDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteField_removesAndSaves() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    SystemDefFieldSummary existing = new SystemDefFieldSummary();
+    existing.setName("sys_custom");
+    SystemDefAdaptor.addPersistableField(def, existing);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+
+    adaptor.deleteField(null, "sys_custom");
+
+    verify(designWs).saveContentEditorSystemDef(eq(def), eq(true), eq("test-session"), eq("Admin"));
+    assertNull(def.getFieldSet().getFieldByName("sys_custom"));
+    assertNull(def.getUIDefinition().getMapping("sys_custom"));
+  }
+
+  @Test
+  void deleteField_unknownFieldIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.deleteField(null, "missing"));
+    assertTrue(ex.getMessage().contains("Unknown field"));
+    verify(designWs, never()).saveContentEditorSystemDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteField_systemMandatoryIs400() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSField field = mock(PSField.class);
+    when(field.getSubmitName()).thenReturn("sys_title");
+    when(field.isSystemMandatory()).thenReturn(true);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.getFieldByName("sys_title")).thenReturn(field);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(def.getFieldSet()).thenReturn(set);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.deleteField(null, "sys_title"));
+    assertTrue(ex.getMessage().contains("mandatory"));
+    verify(designWs, never()).saveContentEditorSystemDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteField_forbiddenWhenNotAdmin() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefAdaptor denied = new SystemDefAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.deleteField(null, "sys_custom"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void deleteField_saveLockConflictIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    SystemDefFieldSummary existing = new SystemDefFieldSummary();
+    existing.setName("sys_custom");
+    SystemDefAdaptor.addPersistableField(def, existing);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    doThrow(new PSLockErrorException(1, "not locked", "stack"))
+        .when(designWs)
+        .saveContentEditorSystemDef(any(), eq(true), eq("test-session"), eq("Admin"));
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    SystemDefDesignLockException ex =
+        assertThrows(
+            SystemDefDesignLockException.class, () -> adaptor.deleteField(null, "sys_custom"));
+    assertTrue(ex.getMessage().contains("design lock required"));
+  }
+
+  @Test
+  void addPersistableField_isPersistableXml() {
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("sys_custom");
+    SystemDefAdaptor.addPersistableField(def, body);
+    org.w3c.dom.Document doc = com.percussion.xml.PSXmlDocumentBuilder.createXmlDocument();
+    org.w3c.dom.Element xml = def.getFieldSet().toXml(doc);
+    String serialized = com.percussion.xml.PSXmlDocumentBuilder.toString(xml);
+    assertTrue(serialized.contains("sys_custom"));
+    assertTrue(serialized.contains("SYS_CUSTOM") || serialized.contains("sys_custom"));
+    assertNotNull(def.getUIDefinition().getMapping("sys_custom"));
+  }
+
+  @Test
+  void validateFieldName_rejectsInvalid() {
+    assertEquals("sys_custom", SystemDefAdaptor.validateFieldName("sys_custom"));
+    assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName(" "));
+    assertThrows(
+        IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("has space"));
+    assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("a/b"));
+    assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("1start"));
+  }
+
+  /**
+   * Mocked system def with a real empty field set and display mapper so persist/remove can run
+   * without loading ContentEditorSystemDef XML.
+   */
+  private static PSContentEditorSystemDef newSystemDefWithEmptyFields() {
+    PSFieldSet fieldSet = new PSFieldSet("systemFieldset");
+    PSUIDefinition ui = new PSUIDefinition(new PSDisplayMapper("systemFieldset"));
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(def.getFieldSet()).thenReturn(fieldSet);
+    when(def.getUIDefinition()).thenReturn(ui);
+    when(def.getContainerLocator()).thenReturn(null);
+    when(def.getCacheTimeout()).thenReturn(15);
+    return def;
   }
 }

--- a/rest/src/main/java/com/percussion/rest/systemdef/ISystemDefAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/ISystemDefAdaptor.java
@@ -46,4 +46,35 @@ public interface ISystemDefAdaptor {
    *     locked for this session
    */
   SystemDefDetail updateSystemDef(URI baseUri, SystemDefDetail body);
+
+  /**
+   * Add a persistable TYPE_SYSTEM field (backend column + display mapping) to the content-editor
+   * system definition. Admin only. Acquires the system-def design lock for this request and
+   * releases it on save.
+   *
+   * @param body {@code name} required; unique case-insensitive. Optional {@code dataType} defaults
+   *     to {@code text}. Optional {@code searchable}, {@code occurrence} / {@code required} as on
+   *     PUT patches.
+   * @return persisted detail, never {@code null}
+   * @throws IllegalArgumentException when field name/dataType is invalid or occurrence/required
+   *     conflict
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin; {@code
+   *     409} when a field with that name already exists
+   * @throws SystemDefDesignLockException when the system def is locked by another user or is not
+   *     locked for this session
+   */
+  SystemDefDetail addField(URI baseUri, SystemDefFieldSummary body);
+
+  /**
+   * Remove a field (backend column mapping + display mapping) from the content-editor system
+   * definition. Admin only. Acquires the system-def design lock for this request and releases it on
+   * save.
+   *
+   * @throws IllegalArgumentException when the name is blank, unknown, or the field is
+   *     system-mandatory / system-internal
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin
+   * @throws SystemDefDesignLockException when the system def is locked by another user or is not
+   *     locked for this session
+   */
+  void deleteField(URI baseUri, String fieldName);
 }

--- a/rest/src/main/java/com/percussion/rest/systemdef/SystemDefDetail.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/SystemDefDetail.java
@@ -25,8 +25,8 @@ import java.util.List;
 
 /**
  * Content-editor system definition (global system fields). GET catalog; PUT may patch existing
- * field properties ({@code searchable}, occurrence / required). Field create/delete remain
- * unsupported ({@code designGaps}).
+ * field properties ({@code searchable}, occurrence / required). POST {@code /systemdef/fields} and
+ * DELETE {@code /systemdef/fields/{fieldName}} create and delete fields.
  */
 @XmlRootElement(name = "SystemDefDetail")
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/src/main/java/com/percussion/rest/systemdef/SystemDefFieldSummary.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/SystemDefFieldSummary.java
@@ -23,8 +23,9 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * Field row from the content-editor system definition. GET catalog; PUT may patch {@code
- * searchable} and occurrence / required on existing fields. {@code readOnly} and {@code dataType}
- * are read-only.
+ * searchable} and occurrence / required on existing fields. POST {@code /systemdef/fields} uses
+ * {@code name} (required) plus optional {@code dataType}, {@code searchable}, and occurrence /
+ * required. {@code readOnly} is read-only.
  */
 @XmlRootElement(name = "SystemDefField")
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/rest/src/main/java/com/percussion/rest/systemdef/SystemDefResource.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/SystemDefResource.java
@@ -24,13 +24,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +48,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 @PSSiteManageBean(value = "restSystemDefResource")
 @Path("/systemdef")
 @XmlRootElement
-@Tag(name = "SystemDef", description = "Content editor system definition catalog and write")
+@Tag(
+    name = "SystemDef",
+    description = "Content editor system definition catalog, field-property write, and field create/delete")
 public class SystemDefResource {
 
   private final ISystemDefAdaptor adaptor;
@@ -72,7 +78,8 @@ public class SystemDefResource {
       description =
           "Loads the content-editor system definition field catalog (global system fields)."
               + " Admin (Design) only. Save uses PUT /systemdef to patch existing field properties."
-              + " Field create/delete remain unsupported (see designGaps).",
+              + " Add a field with POST /systemdef/fields; remove one with DELETE"
+              + " /systemdef/fields/{fieldName}.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -100,9 +107,10 @@ public class SystemDefResource {
           "Admin. Saves patches to existing system fields (searchable, occurrence/required) via"
               + " IPSContentDesignWs.loadContentEditorSystemDef (lock) then"
               + " saveContentEditorSystemDef (release). Null or empty fields leaves the catalog"
-              + " unchanged. Does not create or delete fields. When a field patch includes both"
-              + " occurrence and required they must agree (else 400); occurrence is applied when"
-              + " present. Lock held by another user, or no lock for this session, is 409.",
+              + " unchanged. Does not create or delete fields — use nested POST/DELETE .../fields."
+              + " When a field patch includes both occurrence and required they must agree (else"
+              + " 400); occurrence is applied when present. Lock held by another user, or no lock"
+              + " for this session, is 409.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -118,6 +126,72 @@ public class SystemDefResource {
   public SystemDefDetail updateSystemDef(SystemDefDetail body) {
     try {
       return requireAdaptor().updateSystemDef(uriInfo.getBaseUri(), body);
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @POST
+  @Path("/fields")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Add a field to the system definition",
+      description =
+          "Admin. Adds a persistable TYPE_SYSTEM field (backend column + display mapping) via"
+              + " IPSContentDesignWs.loadContentEditorSystemDef (lock) then"
+              + " saveContentEditorSystemDef (release). Body name is required, unique"
+              + " case-insensitive, and must be a letter followed by letters, digits, or"
+              + " underscore. Optional dataType defaults to text. Optional searchable and"
+              + " occurrence/required use the same rules as PUT field patches. Duplicate field is"
+              + " 409. Lock held by another user is 409. Control/stylesheet/flow remain"
+              + " unsupported.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Field added and saved",
+            content = @Content(schema = @Schema(implementation = SystemDefDetail.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid field input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "A field with that name exists, or system def locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public SystemDefDetail addField(SystemDefFieldSummary body) {
+    try {
+      return requireAdaptor().addField(uriInfo.getBaseUri(), body);
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/fields/{fieldName}")
+  @Operation(
+      summary = "Delete a field from the system definition",
+      description =
+          "Admin. Removes the field and its display mapping and saves via"
+              + " IPSContentDesignWs.saveContentEditorSystemDef (releases the request lock)."
+              + " Unknown, blank, system-mandatory, or system-internal field is 400; lock held by"
+              + " another user is 409.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid, unknown, system-mandatory, or system-internal field name"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "409", description = "System def locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteField(@PathParam("fieldName") String fieldName) {
+    try {
+      requireAdaptor().deleteField(uriInfo.getBaseUri(), fieldName);
+      return Response.noContent().build();
     } catch (RuntimeException e) {
       throw mapWriteFailure(e);
     } catch (Exception e) {

--- a/rest/src/test/java/com/percussion/rest/systemdef/SystemDefResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/systemdef/SystemDefResourceTest.java
@@ -23,11 +23,13 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
@@ -146,5 +148,116 @@ public class SystemDefResourceTest {
     WebApplicationException ex =
         SystemDefResource.mapWriteFailure(new IllegalStateException("object is not locked"));
     assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addFieldDelegatesToAdaptor() {
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("sys_custom");
+    SystemDefDetail updated = new SystemDefDetail();
+    updated.setFieldCount(1);
+    when(adaptor.addField(any(), any())).thenReturn(updated);
+
+    assertEquals(1, resource.addField(body).getFieldCount());
+    verify(adaptor).addField(any(), eq(body));
+  }
+
+  @Test
+  public void addFieldInvalidNameIs400() {
+    when(adaptor.addField(any(), any()))
+        .thenThrow(new IllegalArgumentException("name is required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.addField(new SystemDefFieldSummary()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addFieldDuplicateIs409() {
+    when(adaptor.addField(any(), any()))
+        .thenThrow(new WebApplicationException("System field already exists: sys_custom", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.addField(new SystemDefFieldSummary()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addFieldLockConflictIs409() {
+    when(adaptor.addField(any(), any()))
+        .thenThrow(
+            new SystemDefDesignLockException("Could not save system definition; locked by other"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.addField(new SystemDefFieldSummary()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addFieldForbiddenWhenNotAdmin() {
+    when(adaptor.addField(any(), any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.addField(new SystemDefFieldSummary()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void addFieldWrapsUnexpectedFailures() {
+    IllegalStateException boom = new IllegalStateException("design ws down");
+    when(adaptor.addField(any(), any())).thenThrow(boom);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.addField(new SystemDefFieldSummary()));
+    assertEquals(500, ex.getResponse().getStatus());
+    assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void deleteFieldReturns204() {
+    Response out = resource.deleteField("sys_custom");
+    assertEquals(204, out.getStatus());
+    verify(adaptor).deleteField(any(), eq("sys_custom"));
+  }
+
+  @Test
+  public void deleteFieldBlankNameIs400() {
+    doThrow(new IllegalArgumentException("name is required"))
+        .when(adaptor)
+        .deleteField(any(), eq(" "));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteField(" "));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteFieldUnknownIs400() {
+    doThrow(new IllegalArgumentException("Unknown field: missing"))
+        .when(adaptor)
+        .deleteField(any(), eq("missing"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteField("missing"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteFieldLockConflictIs409() {
+    doThrow(new SystemDefDesignLockException("Could not save system definition; locked by other"))
+        .when(adaptor)
+        .deleteField(any(), eq("sys_custom"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteField("sys_custom"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteFieldForbiddenWhenNotAdmin() {
+    doThrow(new WebApplicationException("Admin role required", 403))
+        .when(adaptor)
+        .deleteField(any(), eq("sys_custom"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteField("sys_custom"));
+    assertEquals(403, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSystemDefAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSystemDefAdaptor.java
@@ -19,6 +19,7 @@ package com.percussion.rest.test.apibridge;
 
 import com.percussion.rest.systemdef.ISystemDefAdaptor;
 import com.percussion.rest.systemdef.SystemDefDetail;
+import com.percussion.rest.systemdef.SystemDefFieldSummary;
 import java.net.URI;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -42,5 +43,15 @@ public class TestSystemDefAdaptor implements ISystemDefAdaptor {
   @Override
   public SystemDefDetail updateSystemDef(URI baseUri, SystemDefDetail body) {
     return body != null ? body : new SystemDefDetail();
+  }
+
+  @Override
+  public SystemDefDetail addField(URI baseUri, SystemDefFieldSummary body) {
+    return new SystemDefDetail();
+  }
+
+  @Override
+  public void deleteField(URI baseUri, String fieldName) {
+    // no-op for tests
   }
 }


### PR DESCRIPTION
## Summary

Admin REST **create and delete** of content-editor system-def fields (CD-16), as a follow-on to `PUT /services/systemdef` field-property save (#3958 / PR #3963).

- `POST /services/systemdef/fields` adds a persistable `TYPE_SYSTEM` field (backend column + default `sys_EditBox` display mapping).
- `DELETE /services/systemdef/fields/{fieldName}` removes the field and mapping (**204**).
- Persist via existing `IPSContentDesignWs.loadContentEditorSystemDef(lock=true)` + `saveContentEditorSystemDef` (held request lock, release on save) — same pattern as PUT. **No new SOAP.**
- **400** unknown/invalid (including system-mandatory / system-internal delete); **403** non-Admin; **409** lock conflict or duplicate name.

Out of scope: SPA system-def editor, control/stylesheet/flow, shared field groups.

Parent: #1690
Fixes #3964

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Mockito `SystemDefResourceTest` — POST/DELETE 200/204/400/403/409/500.
2. Spring `TestSystemDefAdaptor` implements the exact `ISystemDefAdaptor` (shared rest `ApplicationContext`).
3. `SystemDefAdaptorTest` — success persist/remove, 403, lock 409, duplicate 409, unknown 400, mandatory 400.
4. Standalone module clean install (see Build gates).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` and `product-docs/8.2/admin/developer-content-types.md`; gap map CD-16 field create/delete
- [x] **Unit / module tests** — behavioral tests for new/changed logic; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST only)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 767, Failures: 0 (`SystemDefResourceTest` 21)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1798, Failures: 0, Skipped: 125 (`SystemDefAdaptorTest` 32)
  - No new compiler/surefire warnings attributable to this change (pre-existing javadoc/analyze warnings only)
- **downstream_checked:** grepped `implements ISystemDefAdaptor` (rest `TestSystemDefAdaptor` + sitemanage `SystemDefAdaptor`); sitemanage standalone install as rest reverse-dep
- **C5 UI proof:** N/A (no WebUI / Playwright surface)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
