### PR TITLE
Fix #3971 leftover system error IPS*Errors typed ErrorCodes

### DIFF
--- a/docs/ai-generated/code-reviews/3971-system-error-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3971-system-error-errorcodes-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review — #3971 system error leftover IPS*Errors typed ErrorCodes
+
+**Scope:** uncommitted branch `fix/issue-3971-system-error-ipserrors-errorcodes` vs `origin/main`  
+**Memory patterns hit:** typed `*ErrorCodes` + `IPSErrorCode` constructors; dual-write skip for `isAuditable()==false`; do not delete `IPS*Errors` interfaces; int-only APIs (`PSLogSubMessage`, `PSErrorManager.createMessage`/`getErrorText`, `PSLogServerWarning`) use `.numericCode()`; exact production exception types in tests (not supertypes); incomplete change-class closure (allow-list companion).  
+**Cross-platform path checklist:** N/A (no new filesystem path joins; tests construct exceptions in-memory).
+
+## Summary
+
+Parent #2616 leftover slice: 26 `system/src/main/java/com/percussion/error/` production `IPS*Errors` sites now use typed `ServerErrorCodes` / `BackEndErrorCodes` / `DataErrorCodes` / `CatalogErrorCodes` / `HttpErrorCodes` / `XmlErrorCodes`. `PSErrorException` constructs with typed `ServerErrorCodes.WRAPPED_LOG_ERROR`. Residual allow-list shrunk by those exact 26 paths. Dual-write skip tests cover leftover non-auditable catalog codes; leftover auditable authorization codes remain dual-write eligible. Production exception type `PSErrorException` retains typed code. No product UI/config surface.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None.
+
+## Verification
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2582, Failures: 0, Skipped: 246 (`PSErrorLeftoverErrorCodesSliceTest` 4/4)
+- `python scripts/verify-no-bare-ipserrors.py` — PASS
+- `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 19 passed
+
+## Notes
+
+- C2: no public/protected signature change, not `final`/`sealed`. Existing `extends PSErrorException` webservices types still use the same `PSLogError` constructors.
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- Comment-only historical `IPS*Errors` mentions in leftover log-error builders are ignored by the freeze gate.
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); dual-write skip when non-auditable.

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -18,6 +18,7 @@
 #   #3900 leftover cms.objectstore.server call sites
 #   #3939 leftover system/src/main com.percussion.data (+ macro/vfs)
 #   #3940 leftover system/src/main com.percussion.security call sites
+#   #3971 leftover system/src/main com.percussion.error call sites
 # Converted (no longer listed): extensions-main #3756/#3938 (allow-list
 # shrink after #3793 re-listed already-typed production paths).
 #
@@ -77,32 +78,6 @@ system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
 system/src/main/java/com/percussion/design/objectstore/PSObjectStore.java
 system/src/main/java/com/percussion/design/objectstore/server/PSXmlObjectStoreHandler.java
 system/src/main/java/com/percussion/design/server/PSDesignerConnectionHandler.java
-system/src/main/java/com/percussion/error/PSApplicationAuthorizationError.java
-system/src/main/java/com/percussion/error/PSApplicationDesignError.java
-system/src/main/java/com/percussion/error/PSBackEndAuthorizationError.java
-system/src/main/java/com/percussion/error/PSBackEndQueryProcessingError.java
-system/src/main/java/com/percussion/error/PSBackEndServerDownError.java
-system/src/main/java/com/percussion/error/PSBackEndUpdateProcessingError.java
-system/src/main/java/com/percussion/error/PSCatalogRequestError.java
-system/src/main/java/com/percussion/error/PSDataConversionError.java
-system/src/main/java/com/percussion/error/PSErrorException.java
-system/src/main/java/com/percussion/error/PSErrorHandler.java
-system/src/main/java/com/percussion/error/PSErrorHttpCodes.java
-system/src/main/java/com/percussion/error/PSFatalError.java
-system/src/main/java/com/percussion/error/PSHookRequestError.java
-system/src/main/java/com/percussion/error/PSHtmlProcessingError.java
-system/src/main/java/com/percussion/error/PSInternalError.java
-system/src/main/java/com/percussion/error/PSLargeBackEndRequestQueueError.java
-system/src/main/java/com/percussion/error/PSLargeRequestQueueError.java
-system/src/main/java/com/percussion/error/PSPoorResponseTimeError.java
-system/src/main/java/com/percussion/error/PSRemoteConsoleError.java
-system/src/main/java/com/percussion/error/PSRequestPreProcessingError.java
-system/src/main/java/com/percussion/error/PSRequestWaitTooLongError.java
-system/src/main/java/com/percussion/error/PSResponseSendError.java
-system/src/main/java/com/percussion/error/PSServerUnavailableError.java
-system/src/main/java/com/percussion/error/PSUnknownProcessingError.java
-system/src/main/java/com/percussion/error/PSValidationError.java
-system/src/main/java/com/percussion/error/PSXmlProcessingError.java
 system/src/main/java/com/percussion/extension/PSExtensionHandler.java
 system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java
 system/src/main/java/com/percussion/extension/PSExtensionParams.java

--- a/scripts/test_verify_no_bare_ipserrors.py
+++ b/scripts/test_verify_no_bare_ipserrors.py
@@ -35,7 +35,7 @@ DEPLOYER_RESIDUAL = (
 # converted in #3882, cms handlers in #3883, cms.objectstore+client in #3884;
 # cms.objectstore.server converted in #3900; extensions-main converted in
 # #3756/#3938; com.percussion.data (+ macro/vfs) in #3939; com.percussion.security
-# in #3940.
+# in #3940; com.percussion.error in #3971.
 # Keep an exact residual that is still frozen (system debug leftover).
 SYSTEM_CMS_RESIDUAL = (
     "system/src/main/java/com/percussion/debug/PSDebugLogHandler.java"

--- a/system/src/main/java/com/percussion/error/PSApplicationAuthorizationError.java
+++ b/system/src/main/java/com/percussion/error/PSApplicationAuthorizationError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -82,15 +82,17 @@ public class PSApplicationAuthorizationError extends PSLogError {
     Object[] args = {m_host, m_uid};
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.AUTHORIZATION_ERROR,
-            PSErrorManager.createMessage(IPSServerErrors.AUTHORIZATION_ERROR, args, loc));
+            ServerErrorCodes.AUTHORIZATION_ERROR.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.AUTHORIZATION_ERROR.numericCode(), args, loc));
 
     /* use the errorCode/errorString to format the second submessage */
     Object[] nativeArgs = {Integer.valueOf(m_errorCode), m_errorString};
     msgs[1] =
         new PSLogSubMessage(
             m_errorCode,
-            PSErrorManager.createMessage(IPSServerErrors.NATIVE_ERROR, nativeArgs, loc));
+            PSErrorManager.createMessage(
+                ServerErrorCodes.NATIVE_ERROR.numericCode(), nativeArgs, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSApplicationDesignError.java
+++ b/system/src/main/java/com/percussion/error/PSApplicationDesignError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.Locale;
 import java.util.Objects;
@@ -81,8 +81,9 @@ public final class PSApplicationDesignError extends PSLogError {
     if (msgCount == 2) {
       msgs[1] =
           new PSLogSubMessage(
-              IPSServerErrors.RAW_DUMP,
-              PSErrorManager.createMessage(IPSServerErrors.RAW_DUMP, new Object[] {m_source}, loc));
+              ServerErrorCodes.RAW_DUMP.numericCode(),
+              PSErrorManager.createMessage(
+                  ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_source}, loc));
     }
 
     return msgs;

--- a/system/src/main/java/com/percussion/error/PSBackEndAuthorizationError.java
+++ b/system/src/main/java/com/percussion/error/PSBackEndAuthorizationError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSBackEndErrors;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -92,8 +92,9 @@ public class PSBackEndAuthorizationError extends PSBackEndError {
     Object[] params = {m_host, m_uid, m_driver, m_server};
     msgs[0] =
         new PSLogSubMessage(
-            IPSBackEndErrors.AUTHORIZATION_ERROR,
-            PSErrorManager.createMessage(IPSBackEndErrors.AUTHORIZATION_ERROR, params, loc));
+            BackEndErrorCodes.AUTHORIZATION_ERROR.numericCode(),
+            PSErrorManager.createMessage(
+                BackEndErrorCodes.AUTHORIZATION_ERROR.numericCode(), params, loc));
 
     /* use IPSServerErrors.NATIVE_ERROR along with
      *    [0] = errorCode
@@ -104,7 +105,8 @@ public class PSBackEndAuthorizationError extends PSBackEndError {
     msgs[1] =
         new PSLogSubMessage(
             m_errorCode,
-            PSErrorManager.createMessage(IPSServerErrors.NATIVE_ERROR, nativeArgs, loc));
+            PSErrorManager.createMessage(
+                ServerErrorCodes.NATIVE_ERROR.numericCode(), nativeArgs, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSBackEndQueryProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSBackEndQueryProcessingError.java
@@ -18,9 +18,9 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.error;
 
-import com.percussion.data.IPSDataErrors;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.Locale;
 import org.w3c.dom.Element;
@@ -61,7 +61,7 @@ public class PSBackEndQueryProcessingError extends PSBackEndError {
     this(
         applId,
         sessionId,
-        IPSServerErrors.NATIVE_ERROR,
+        ServerErrorCodes.NATIVE_ERROR.numericCode(),
         new Object[] {
           Integer.valueOf(errorCode),
           // REFACTORED: CP-JAVA11
@@ -140,9 +140,11 @@ public class PSBackEndQueryProcessingError extends PSBackEndError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSDataErrors.QUERY_PROCESSING_ERROR,
+            DataErrorCodes.QUERY_PROCESSING_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSDataErrors.QUERY_PROCESSING_ERROR, new Object[] {m_sessId}, loc));
+                DataErrorCodes.QUERY_PROCESSING_ERROR.numericCode(),
+                new Object[] {m_sessId},
+                loc));
 
     /* use the errorCode/errorParams to format the second submessage
      */
@@ -155,8 +157,9 @@ public class PSBackEndQueryProcessingError extends PSBackEndError {
      */
     msgs[2] =
         new PSLogSubMessage(
-            IPSServerErrors.RAW_DUMP,
-            PSErrorManager.createMessage(IPSServerErrors.RAW_DUMP, new Object[] {m_source}, loc));
+            ServerErrorCodes.RAW_DUMP.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_source}, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSBackEndServerDownError.java
+++ b/system/src/main/java/com/percussion/error/PSBackEndServerDownError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSBackEndErrors;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -73,9 +73,11 @@ public class PSBackEndServerDownError extends PSBackEndError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSBackEndErrors.SERVER_DOWN_ERROR,
+            BackEndErrorCodes.SERVER_DOWN_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSBackEndErrors.SERVER_DOWN_ERROR, new String[] {m_driver, m_server}, loc));
+                BackEndErrorCodes.SERVER_DOWN_ERROR.numericCode(),
+                new String[] {m_driver, m_server},
+                loc));
 
     /* use IPSServerErrors.NATIVE_ERROR along with
      *    [0] = errorCode
@@ -86,7 +88,7 @@ public class PSBackEndServerDownError extends PSBackEndError {
         new PSLogSubMessage(
             m_errorCode,
             PSErrorManager.createMessage(
-                IPSServerErrors.NATIVE_ERROR,
+                ServerErrorCodes.NATIVE_ERROR.numericCode(),
                 new Object[] {Integer.valueOf(m_errorCode), m_errorArgs[0]},
                 loc));
 

--- a/system/src/main/java/com/percussion/error/PSBackEndUpdateProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSBackEndUpdateProcessingError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSDataErrors;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 import org.w3c.dom.Element;
 
@@ -59,7 +59,7 @@ public class PSBackEndUpdateProcessingError extends PSBackEndError {
     this(
         applId,
         sessionId,
-        IPSServerErrors.NATIVE_ERROR,
+        ServerErrorCodes.NATIVE_ERROR.numericCode(),
         new Object[] {
           Integer.valueOf(errorCode),
           // REFACTORED: CP-JAVA11
@@ -198,9 +198,11 @@ public class PSBackEndUpdateProcessingError extends PSBackEndError {
        */
       msgs[errorCount++] =
           new PSLogSubMessage(
-              IPSDataErrors.UPDATE_PROCESSING_ERROR,
+              DataErrorCodes.UPDATE_PROCESSING_ERROR.numericCode(),
               PSErrorManager.createMessage(
-                  IPSDataErrors.UPDATE_PROCESSING_ERROR, new Object[] {m_sessId}, loc));
+                  DataErrorCodes.UPDATE_PROCESSING_ERROR.numericCode(),
+                  new Object[] {m_sessId},
+                  loc));
 
       /* use the errorCode/errorParams to format the second submessage
        */
@@ -213,9 +215,9 @@ public class PSBackEndUpdateProcessingError extends PSBackEndError {
        */
       msgs[errorCount++] =
           new PSLogSubMessage(
-              IPSServerErrors.RAW_DUMP,
+              ServerErrorCodes.RAW_DUMP.numericCode(),
               PSErrorManager.createMessage(
-                  IPSServerErrors.RAW_DUMP,
+                  ServerErrorCodes.RAW_DUMP.numericCode(),
                   new Object[] {((m_sourceSql == null) ? "" : m_sourceSql)},
                   loc));
     }

--- a/system/src/main/java/com/percussion/error/PSCatalogRequestError.java
+++ b/system/src/main/java/com/percussion/error/PSCatalogRequestError.java
@@ -18,7 +18,7 @@
 
 package com.percussion.error;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
 import java.util.Locale;
@@ -70,9 +70,9 @@ public class PSCatalogRequestError extends PSLogError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSCatalogErrors.CATALOG_ERROR,
+            CatalogErrorCodes.CATALOG_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSCatalogErrors.CATALOG_ERROR,
+                CatalogErrorCodes.CATALOG_ERROR.numericCode(),
                 new Object[] {m_sessId, m_reqCategory, m_reqType},
                 loc));
 

--- a/system/src/main/java/com/percussion/error/PSDataConversionError.java
+++ b/system/src/main/java/com/percussion/error/PSDataConversionError.java
@@ -18,9 +18,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -84,9 +84,9 @@ public class PSDataConversionError extends PSLogError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.DATA_CONV_ERROR,
+            ServerErrorCodes.DATA_CONV_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.DATA_CONV_ERROR,
+                ServerErrorCodes.DATA_CONV_ERROR.numericCode(),
                 new Object[] {m_sessId, m_sourceType, m_targetType},
                 loc));
 
@@ -96,9 +96,9 @@ public class PSDataConversionError extends PSLogError {
      */
     msgs[1] =
         new PSLogSubMessage(
-            IPSServerErrors.RAW_DUMP,
+            ServerErrorCodes.RAW_DUMP.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.RAW_DUMP, new Object[] {m_sourceData}, loc));
+                ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_sourceData}, loc));
 
     /* use the errorCode/errorParams to format the third submessage */
     msgs[2] =

--- a/system/src/main/java/com/percussion/error/PSErrorException.java
+++ b/system/src/main/java/com/percussion/error/PSErrorException.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 
 /**
  * The PSErrorException class provides a wrapper to throw PSLogError objects which contain more
@@ -35,15 +35,15 @@ public class PSErrorException extends PSException {
   /**
    * Constructs a new <code>PSErrorException</code> to allow the specified <code>PSLogError</code>
    * to be thrown. This exception will use the code {@link
-   * com.percussion.server.IPSServerErrors#WRAPPED_LOG_ERROR WRAPPED_LOG_ERROR} and the exception
-   * text will consist of all the log error's sub-messages concatenated together.
+   * com.intsof.percussioncms.auditlog.codes.ServerErrorCodes#WRAPPED_LOG_ERROR WRAPPED_LOG_ERROR}
+   * and the exception text will consist of all the log error's sub-messages concatenated together.
    *
    * @param err the error object to wrap; if <code>null</code>, the text of this exception will be
    *     empty.
    */
   public PSErrorException(PSLogError err) {
     super(
-        IPSServerErrors.WRAPPED_LOG_ERROR,
+        ServerErrorCodes.WRAPPED_LOG_ERROR,
         new Object[] {getMessageText(err), Integer.valueOf(getMessageCode(err))});
     m_errorObject = err;
   }
@@ -58,7 +58,7 @@ public class PSErrorException extends PSException {
    */
   public PSErrorException(PSLogError err, Throwable cause) {
     super(
-        IPSServerErrors.WRAPPED_LOG_ERROR,
+        ServerErrorCodes.WRAPPED_LOG_ERROR,
         new Object[] {getMessageText(err), Integer.valueOf(getMessageCode(err))},
         cause);
     m_errorObject = err;

--- a/system/src/main/java/com/percussion/error/PSErrorHandler.java
+++ b/system/src/main/java/com/percussion/error/PSErrorHandler.java
@@ -19,6 +19,8 @@ package com.percussion.error;
 
 import com.intsof.percussioncms.auditlog.AuditContext;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.content.IPSMimeContentTypes;
 import com.percussion.data.PSConversionException;
 import com.percussion.data.PSStyleSheetMerger;
@@ -30,7 +32,6 @@ import com.percussion.design.objectstore.PSRecipient;
 import com.percussion.log.PSLogError;
 import com.percussion.mail.PSMailSendException;
 import com.percussion.mail.PSSmtpMailProvider;
-import com.percussion.server.IPSHttpErrors;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSResponse;
@@ -339,7 +340,7 @@ public class PSErrorHandler {
 
     int statusCode = PSErrorHttpCodes.getHttpCode(err, loc);
     response.setStatus(statusCode);
-    if (statusCode == IPSHttpErrors.HTTP_UNAUTHORIZED) {
+    if (statusCode == HttpErrorCodes.HTTP_UNAUTHORIZED.numericCode()) {
       /* *TODO*
        *
        * We do not currently support realms, though we probably
@@ -453,7 +454,7 @@ public class PSErrorHandler {
       Object[] args = {null, e.toString()};
       com.percussion.log.PSLogManager.write(
           new com.percussion.log.PSLogServerWarning(
-              com.percussion.server.IPSServerErrors.RESPONSE_SEND_ERROR,
+              ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(),
               args,
               true,
               "PSErrorHandler"));

--- a/system/src/main/java/com/percussion/error/PSErrorHandlerTest.java
+++ b/system/src/main/java/com/percussion/error/PSErrorHandlerTest.java
@@ -16,10 +16,10 @@
  */
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.design.objectstore.PSNotifier;
 import com.percussion.design.objectstore.PSRecipient;
 import com.percussion.log.PSLogError;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.util.PSCollection;
 import com.percussion.util.PSMapClassToObject;
 import org.apache.logging.log4j.LogManager;
@@ -85,7 +85,7 @@ public class PSErrorHandlerTest {
 
       PSErrorHandler errHandler = new PSErrorHandler(errPage, true, notify);
 
-      errCode = IPSServerErrors.AUTHORIZATION_ERROR;
+      errCode = ServerErrorCodes.AUTHORIZATION_ERROR.numericCode();
       ip = "38.131.120.53";
       login = "zzz";
       PSApplicationAuthorizationError appAuthErr =
@@ -99,13 +99,13 @@ public class PSErrorHandlerTest {
       appAuthErr = new PSApplicationAuthorizationError(22, ip, login, errCode, null);
       errHandler.notifyAdmins((PSLogError) appAuthErr);
 
-      errCode = IPSServerErrors.DATA_CONV_ERROR;
+      errCode = ServerErrorCodes.DATA_CONV_ERROR.numericCode();
       sessId = "session_dataConversion";
       PSDataConversionError conversionErr =
           new PSDataConversionError(31, sessId, errCode, null, null, null, null);
       errHandler.notifyAdmins((PSLogError) conversionErr);
 
-      errCode = IPSServerErrors.VALIDATION_ERROR;
+      errCode = ServerErrorCodes.VALIDATION_ERROR.numericCode();
       sessId = "session_validation";
       PSValidationError validErr = new PSValidationError(41, sessId, errCode, null, null);
       errHandler.notifyAdmins((PSLogError) validErr);
@@ -118,13 +118,13 @@ public class PSErrorHandlerTest {
       PSPoorResponseTimeError respErr = new PSPoorResponseTimeError(61, sessId, 1500);
       errHandler.notifyAdmins((PSLogError) respErr);
 
-      errCode = IPSServerErrors.AUTHORIZATION_ERROR;
+      errCode = ServerErrorCodes.AUTHORIZATION_ERROR.numericCode();
       ip = "38.131.120.53";
       login = "zzz";
       appAuthErr = new PSApplicationAuthorizationError(12, ip, login, errCode, null);
       errHandler.notifyAdmins((PSLogError) appAuthErr);
 
-      errCode = IPSServerErrors.DATA_CONV_ERROR;
+      errCode = ServerErrorCodes.DATA_CONV_ERROR.numericCode();
       sessId = "session_dataConversion";
       conversionErr = new PSDataConversionError(101, sessId, errCode, null, null, null, null);
       errHandler.notifyAdmins((PSLogError) conversionErr);

--- a/system/src/main/java/com/percussion/error/PSErrorHttpCodes.java
+++ b/system/src/main/java/com/percussion/error/PSErrorHttpCodes.java
@@ -17,6 +17,7 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.log.PSLogInformation;
 import com.percussion.util.PSMapClassToObject;
@@ -81,7 +82,7 @@ public class PSErrorHttpCodes {
             Object[] args = {key, com.percussion.error.PSException.getStackTraceAsString(nfe)};
             com.percussion.log.PSLogManager.write(
                 new com.percussion.log.PSLogServerWarning(
-                    com.percussion.server.IPSHttpErrors.HTTP_NOT_FOUND,
+                    HttpErrorCodes.HTTP_NOT_FOUND.numericCode(),
                     args,
                     true,
                     "HttpErrorCodesLoader"));

--- a/system/src/main/java/com/percussion/error/PSFatalError.java
+++ b/system/src/main/java/com/percussion/error/PSFatalError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -53,8 +53,9 @@ public class PSFatalError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.FATAL_SERVER_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.FATAL_SERVER_ERROR_MSG, false, loc));
+            ServerErrorCodes.FATAL_SERVER_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.FATAL_SERVER_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSHookRequestError.java
+++ b/system/src/main/java/com/percussion/error/PSHookRequestError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -52,8 +52,9 @@ public class PSHookRequestError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.HOOK_REQUEST_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.HOOK_REQUEST_ERROR_MSG, false, loc));
+            ServerErrorCodes.HOOK_REQUEST_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.HOOK_REQUEST_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSHtmlProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSHtmlProcessingError.java
@@ -17,7 +17,7 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSDataErrors;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
 import java.util.Locale;
@@ -91,9 +91,11 @@ public class PSHtmlProcessingError extends PSLogError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSDataErrors.HTML_GENERATION_ERROR,
+            DataErrorCodes.HTML_GENERATION_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSDataErrors.HTML_GENERATION_ERROR, new Object[] {m_sessId, m_styleSheet}, loc));
+                DataErrorCodes.HTML_GENERATION_ERROR.numericCode(),
+                new Object[] {m_sessId, m_styleSheet},
+                loc));
 
     /* use m_errorCode/m_errorArgs to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSInternalError.java
+++ b/system/src/main/java/com/percussion/error/PSInternalError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -66,8 +66,9 @@ public class PSInternalError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.INTERNAL_SERVER_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.INTERNAL_SERVER_ERROR_MSG, false, loc));
+            ServerErrorCodes.INTERNAL_SERVER_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.INTERNAL_SERVER_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSLargeBackEndRequestQueueError.java
+++ b/system/src/main/java/com/percussion/error/PSLargeBackEndRequestQueueError.java
@@ -17,7 +17,7 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSBackEndErrors;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
 import com.percussion.log.PSLogSubMessage;
 import java.util.Locale;
 
@@ -80,8 +80,9 @@ public class PSLargeBackEndRequestQueueError extends PSLargeRequestQueueError {
     Object[] args = {m_sessId, Integer.valueOf(m_size), m_driver, m_server};
     msgs[0] =
         new PSLogSubMessage(
-            IPSBackEndErrors.REQUEST_QUEUE_FULL,
-            PSErrorManager.createMessage(IPSBackEndErrors.REQUEST_QUEUE_FULL, args, loc));
+            BackEndErrorCodes.REQUEST_QUEUE_FULL.numericCode(),
+            PSErrorManager.createMessage(
+                BackEndErrorCodes.REQUEST_QUEUE_FULL.numericCode(), args, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSLargeRequestQueueError.java
+++ b/system/src/main/java/com/percussion/error/PSLargeRequestQueueError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -81,8 +81,9 @@ public class PSLargeRequestQueueError extends PSLogError {
     Object[] args = {m_sessId, Integer.valueOf(m_size)};
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.REQUEST_QUEUE_FULL,
-            PSErrorManager.createMessage(IPSServerErrors.REQUEST_QUEUE_FULL, args, loc));
+            ServerErrorCodes.REQUEST_QUEUE_FULL.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.REQUEST_QUEUE_FULL.numericCode(), args, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSPoorResponseTimeError.java
+++ b/system/src/main/java/com/percussion/error/PSPoorResponseTimeError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -82,8 +82,9 @@ public class PSPoorResponseTimeError extends PSLogError {
     Object[] args = {m_sessId, new Double((double) ((double) m_timeMS / 1000.0))};
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.POOR_RESPONSE_TIME,
-            PSErrorManager.createMessage(IPSServerErrors.POOR_RESPONSE_TIME, args, loc));
+            ServerErrorCodes.POOR_RESPONSE_TIME.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.POOR_RESPONSE_TIME.numericCode(), args, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSRemoteConsoleError.java
+++ b/system/src/main/java/com/percussion/error/PSRemoteConsoleError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -40,12 +40,12 @@ public class PSRemoteConsoleError extends PSLogError {
   public PSRemoteConsoleError(String command, Throwable t) {
     super(0);
     if (command != null) {
-      m_errorCode = IPSServerErrors.RCONSOLE_EXEC_EXCEPTION;
+      m_errorCode = ServerErrorCodes.RCONSOLE_EXEC_EXCEPTION.numericCode();
       m_errorArgs = new Object[2];
       m_errorArgs[0] = command;
       m_errorArgs[1] = t.getMessage();
     } else {
-      m_errorCode = IPSServerErrors.RCONSOLE_COMMAND_EXCEPTION;
+      m_errorCode = ServerErrorCodes.RCONSOLE_COMMAND_EXCEPTION.numericCode();
       m_errorArgs = new Object[1];
       m_errorArgs[0] = t.getMessage();
     }
@@ -58,8 +58,9 @@ public class PSRemoteConsoleError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.RCONSOLE_COMMAND_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.RCONSOLE_COMMAND_ERROR_MSG, false, loc));
+            ServerErrorCodes.RCONSOLE_COMMAND_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.RCONSOLE_COMMAND_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSRequestPreProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSRequestPreProcessingError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSRequestParsingException;
 import java.net.InetAddress;
 import java.util.Locale;
@@ -77,9 +77,11 @@ public class PSRequestPreProcessingError extends PSLogError {
     /* the generic submessage first (contains host address) */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.REQUEST_PREPROC_ERROR,
+            ServerErrorCodes.REQUEST_PREPROC_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.REQUEST_PREPROC_ERROR, new Object[] {m_host}, loc));
+                ServerErrorCodes.REQUEST_PREPROC_ERROR.numericCode(),
+                new Object[] {m_host},
+                loc));
 
     /* the submessage containing m_errorCode/m_errorArgs */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSRequestWaitTooLongError.java
+++ b/system/src/main/java/com/percussion/error/PSRequestWaitTooLongError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -70,8 +70,9 @@ public class PSRequestWaitTooLongError extends PSLogError {
     Object[] args = {m_sessId, Integer.valueOf(m_size)};
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.REQUEST_WAIT_TOO_LONG,
-            PSErrorManager.createMessage(IPSServerErrors.REQUEST_WAIT_TOO_LONG, args, loc));
+            ServerErrorCodes.REQUEST_WAIT_TOO_LONG.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.REQUEST_WAIT_TOO_LONG.numericCode(), args, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSResponseSendError.java
+++ b/system/src/main/java/com/percussion/error/PSResponseSendError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -69,9 +69,11 @@ public class PSResponseSendError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.RESPONSE_SEND_ERROR,
+            ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.RESPONSE_SEND_ERROR, new Object[] {m_sessId}, loc));
+                ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(),
+                new Object[] {m_sessId},
+                loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSServerUnavailableError.java
+++ b/system/src/main/java/com/percussion/error/PSServerUnavailableError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -52,8 +52,9 @@ public class PSServerUnavailableError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.SERVER_UNAVAILABLE_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.SERVER_UNAVAILABLE_ERROR_MSG, false, loc));
+            ServerErrorCodes.SERVER_UNAVAILABLE_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.SERVER_UNAVAILABLE_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSUnknownProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSUnknownProcessingError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -69,9 +69,11 @@ public class PSUnknownProcessingError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.UNKNOWN_PROCESSING_ERROR,
+            ServerErrorCodes.UNKNOWN_PROCESSING_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.UNKNOWN_PROCESSING_ERROR, new Object[] {m_sessId}, loc));
+                ServerErrorCodes.UNKNOWN_PROCESSING_ERROR.numericCode(),
+                new Object[] {m_sessId},
+                loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSValidationError.java
+++ b/system/src/main/java/com/percussion/error/PSValidationError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.Locale;
 import org.w3c.dom.Element;
@@ -80,9 +80,9 @@ public class PSValidationError extends PSLogError {
     /* the generic submessage first (contains session id) */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.VALIDATION_ERROR,
+            ServerErrorCodes.VALIDATION_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.VALIDATION_ERROR, new Object[] {m_sessId}, loc));
+                ServerErrorCodes.VALIDATION_ERROR.numericCode(), new Object[] {m_sessId}, loc));
 
     /* the submessage containing m_errorCode/m_errorArgs */
     msgs[1] =
@@ -92,8 +92,9 @@ public class PSValidationError extends PSLogError {
     if (msgCount == 3) /* write the source data */
       msgs[2] =
           new PSLogSubMessage(
-              IPSServerErrors.RAW_DUMP,
-              PSErrorManager.createMessage(IPSServerErrors.RAW_DUMP, new Object[] {m_source}, loc));
+              ServerErrorCodes.RAW_DUMP.numericCode(),
+              PSErrorManager.createMessage(
+                  ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_source}, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSXmlProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSXmlProcessingError.java
@@ -17,10 +17,10 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
-import com.percussion.xml.IPSXmlErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.Locale;
 import org.w3c.dom.Element;
@@ -85,9 +85,11 @@ public class PSXmlProcessingError extends PSLogError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSXmlErrors.XML_PROCESSING_ERROR,
+            XmlErrorCodes.XML_PROCESSING_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSXmlErrors.XML_PROCESSING_ERROR, new Object[] {m_sessId}, loc));
+                XmlErrorCodes.XML_PROCESSING_ERROR.numericCode(),
+                new Object[] {m_sessId},
+                loc));
 
     /* the next submessage contains m_errorCode/m_errorArgs */
     msgs[1] =
@@ -97,8 +99,9 @@ public class PSXmlProcessingError extends PSLogError {
     if (msgCount == 3) /* write the source data */
       msgs[2] =
           new PSLogSubMessage(
-              IPSServerErrors.RAW_DUMP,
-              PSErrorManager.createMessage(IPSServerErrors.RAW_DUMP, new Object[] {m_source}, loc));
+              ServerErrorCodes.RAW_DUMP.numericCode(),
+              PSErrorManager.createMessage(
+                  ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_source}, loc));
 
     return msgs;
   }

--- a/system/src/test/java/com/percussion/error/PSErrorLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/error/PSErrorLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.error;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
+import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
+import com.percussion.data.IPSBackEndErrors;
+import com.percussion.data.IPSDataErrors;
+import com.percussion.design.catalog.IPSCatalogErrors;
+import com.percussion.server.IPSHttpErrors;
+import com.percussion.server.IPSServerErrors;
+import com.percussion.xml.IPSXmlErrors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3971 (parent #2616): leftover {@code com.percussion.error} production sites use typed
+ * {@code *ErrorCodes} (not bare {@code IPS*Errors} ints). Dual-write is skipped where the catalog
+ * is non-auditable; leftover auditable authorization codes remain dual-write eligible.
+ */
+@Tag("UnitTest")
+class PSErrorLeftoverErrorCodesSliceTest {
+
+  @BeforeEach
+  void setUp() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @AfterEach
+  void tearDown() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWriteWhereNonAuditable() {
+    assertEquals(
+        IPSServerErrors.NATIVE_ERROR, ServerErrorCodes.NATIVE_ERROR.numericCode());
+    assertEquals(IPSServerErrors.RAW_DUMP, ServerErrorCodes.RAW_DUMP.numericCode());
+    assertEquals(
+        IPSServerErrors.DATA_CONV_ERROR, ServerErrorCodes.DATA_CONV_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.UNKNOWN_PROCESSING_ERROR,
+        ServerErrorCodes.UNKNOWN_PROCESSING_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.RESPONSE_SEND_ERROR,
+        ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.WRAPPED_LOG_ERROR, ServerErrorCodes.WRAPPED_LOG_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.AUTHORIZATION_ERROR,
+        ServerErrorCodes.AUTHORIZATION_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.POOR_RESPONSE_TIME, ServerErrorCodes.POOR_RESPONSE_TIME.numericCode());
+    assertEquals(
+        IPSServerErrors.REQUEST_QUEUE_FULL, ServerErrorCodes.REQUEST_QUEUE_FULL.numericCode());
+    assertEquals(
+        IPSServerErrors.VALIDATION_ERROR, ServerErrorCodes.VALIDATION_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.REQUEST_PREPROC_ERROR,
+        ServerErrorCodes.REQUEST_PREPROC_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.FATAL_SERVER_ERROR_MSG,
+        ServerErrorCodes.FATAL_SERVER_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSServerErrors.INTERNAL_SERVER_ERROR_MSG,
+        ServerErrorCodes.INTERNAL_SERVER_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSServerErrors.SERVER_UNAVAILABLE_ERROR_MSG,
+        ServerErrorCodes.SERVER_UNAVAILABLE_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSServerErrors.REQUEST_WAIT_TOO_LONG,
+        ServerErrorCodes.REQUEST_WAIT_TOO_LONG.numericCode());
+    assertEquals(
+        IPSServerErrors.RCONSOLE_EXEC_EXCEPTION,
+        ServerErrorCodes.RCONSOLE_EXEC_EXCEPTION.numericCode());
+    assertEquals(
+        IPSServerErrors.RCONSOLE_COMMAND_EXCEPTION,
+        ServerErrorCodes.RCONSOLE_COMMAND_EXCEPTION.numericCode());
+    assertEquals(
+        IPSServerErrors.RCONSOLE_COMMAND_ERROR_MSG,
+        ServerErrorCodes.RCONSOLE_COMMAND_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSServerErrors.HOOK_REQUEST_ERROR_MSG,
+        ServerErrorCodes.HOOK_REQUEST_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSBackEndErrors.AUTHORIZATION_ERROR,
+        BackEndErrorCodes.AUTHORIZATION_ERROR.numericCode());
+    assertEquals(
+        IPSBackEndErrors.REQUEST_QUEUE_FULL,
+        BackEndErrorCodes.REQUEST_QUEUE_FULL.numericCode());
+    assertEquals(
+        IPSBackEndErrors.SERVER_DOWN_ERROR, BackEndErrorCodes.SERVER_DOWN_ERROR.numericCode());
+    assertEquals(
+        IPSDataErrors.QUERY_PROCESSING_ERROR,
+        DataErrorCodes.QUERY_PROCESSING_ERROR.numericCode());
+    assertEquals(
+        IPSDataErrors.UPDATE_PROCESSING_ERROR,
+        DataErrorCodes.UPDATE_PROCESSING_ERROR.numericCode());
+    assertEquals(
+        IPSDataErrors.HTML_GENERATION_ERROR,
+        DataErrorCodes.HTML_GENERATION_ERROR.numericCode());
+    assertEquals(
+        IPSCatalogErrors.CATALOG_ERROR, CatalogErrorCodes.CATALOG_ERROR.numericCode());
+    assertEquals(
+        IPSXmlErrors.XML_PROCESSING_ERROR, XmlErrorCodes.XML_PROCESSING_ERROR.numericCode());
+    assertEquals(
+        IPSHttpErrors.HTTP_UNAUTHORIZED, HttpErrorCodes.HTTP_UNAUTHORIZED.numericCode());
+    assertEquals(IPSHttpErrors.HTTP_NOT_FOUND, HttpErrorCodes.HTTP_NOT_FOUND.numericCode());
+
+    leftoverNonAuditable(ServerErrorCodes.NATIVE_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.RAW_DUMP);
+    leftoverNonAuditable(ServerErrorCodes.DATA_CONV_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.UNKNOWN_PROCESSING_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.RESPONSE_SEND_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.WRAPPED_LOG_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.POOR_RESPONSE_TIME);
+    leftoverNonAuditable(ServerErrorCodes.REQUEST_QUEUE_FULL);
+    leftoverNonAuditable(ServerErrorCodes.VALIDATION_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.REQUEST_PREPROC_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.FATAL_SERVER_ERROR_MSG);
+    leftoverNonAuditable(ServerErrorCodes.INTERNAL_SERVER_ERROR_MSG);
+    leftoverNonAuditable(ServerErrorCodes.SERVER_UNAVAILABLE_ERROR_MSG);
+    leftoverNonAuditable(ServerErrorCodes.REQUEST_WAIT_TOO_LONG);
+    leftoverNonAuditable(ServerErrorCodes.RCONSOLE_EXEC_EXCEPTION);
+    leftoverNonAuditable(ServerErrorCodes.RCONSOLE_COMMAND_EXCEPTION);
+    leftoverNonAuditable(ServerErrorCodes.RCONSOLE_COMMAND_ERROR_MSG);
+    leftoverNonAuditable(ServerErrorCodes.HOOK_REQUEST_ERROR_MSG);
+    leftoverNonAuditable(BackEndErrorCodes.REQUEST_QUEUE_FULL);
+    leftoverNonAuditable(BackEndErrorCodes.SERVER_DOWN_ERROR);
+    leftoverNonAuditable(DataErrorCodes.QUERY_PROCESSING_ERROR);
+    leftoverNonAuditable(DataErrorCodes.UPDATE_PROCESSING_ERROR);
+    leftoverNonAuditable(DataErrorCodes.HTML_GENERATION_ERROR);
+    leftoverNonAuditable(CatalogErrorCodes.CATALOG_ERROR);
+    leftoverNonAuditable(XmlErrorCodes.XML_PROCESSING_ERROR);
+    leftoverNonAuditable(HttpErrorCodes.HTTP_UNAUTHORIZED);
+    leftoverNonAuditable(HttpErrorCodes.HTTP_NOT_FOUND);
+
+    leftoverAuditable(ServerErrorCodes.AUTHORIZATION_ERROR);
+    leftoverAuditable(BackEndErrorCodes.AUTHORIZATION_ERROR);
+  }
+
+  @Test
+  void leftoverProductionExceptionTypeRetainsTypedCodeAndSkipsDualWrite() {
+    PSErrorException wrapped = new PSErrorException(null);
+    assertSame(ServerErrorCodes.WRAPPED_LOG_ERROR, wrapped.getTypedErrorCode());
+    assertEquals(ServerErrorCodes.WRAPPED_LOG_ERROR.numericCode(), wrapped.getErrorCode());
+    assertFalse(wrapped.isAuditable());
+
+    RuntimeException cause = new RuntimeException("wrap");
+    PSErrorException withCause = new PSErrorException(null, cause);
+    assertSame(ServerErrorCodes.WRAPPED_LOG_ERROR, withCause.getTypedErrorCode());
+    assertSame(cause, withCause.getCause());
+    assertFalse(withCause.isAuditable());
+
+    PSErrorHandler.logLegacyExceptionIfAuditable(wrapped);
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  void leftoverAuditableAuthorizationIntsStillDualWrite() {
+    PSException serverAuth =
+        new PSException(ServerErrorCodes.AUTHORIZATION_ERROR, new Object[] {"sess-1", "rx"});
+    assertSame(ServerErrorCodes.AUTHORIZATION_ERROR, serverAuth.getTypedErrorCode());
+    assertTrue(serverAuth.isAuditable());
+
+    PSErrorHandler.logLegacyExceptionIfAuditable(serverAuth);
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    assertEquals(
+        ServerErrorCodes.AUTHORIZATION_ERROR,
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).code());
+
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+
+    PSException backEndAuth =
+        new PSException(
+            BackEndErrorCodes.AUTHORIZATION_ERROR,
+            new Object[] {"host", "uid", "jdbc", "server"});
+    assertSame(BackEndErrorCodes.AUTHORIZATION_ERROR, backEndAuth.getTypedErrorCode());
+    assertTrue(backEndAuth.isAuditable());
+
+    PSErrorHandler.logLegacyExceptionIfAuditable(backEndAuth);
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    assertEquals(
+        BackEndErrorCodes.AUTHORIZATION_ERROR,
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).code());
+  }
+
+  @Test
+  void leftoverLogErrorTypesConstructWithTypedNumericCodes() {
+    PSApplicationAuthorizationError appAuth =
+        new PSApplicationAuthorizationError(
+            11,
+            "127.0.0.1",
+            "zzz",
+            ServerErrorCodes.AUTHORIZATION_ERROR.numericCode(),
+            "denied");
+    assertEquals("127.0.0.1", appAuth.getHost());
+    assertEquals(11, appAuth.getApplicationId());
+
+    PSResponseSendError send =
+        new PSResponseSendError(
+            7, "sess-1", ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(), "io");
+    assertEquals(7, send.getApplicationId());
+
+    PSRemoteConsoleError console = new PSRemoteConsoleError("trace", new RuntimeException("boom"));
+    assertEquals(0, console.getApplicationId());
+  }
+
+  private static void leftoverNonAuditable(SystemErrorCode code) {
+    assertFalse(code.isAuditable(), code.toString());
+  }
+
+  private static void leftoverAuditable(SystemErrorCode code) {
+    assertTrue(code.isAuditable(), code.toString());
+  }
+}


### PR DESCRIPTION
## Summary

Parent leftover slice of #2616. Converts remaining `system/src/main/java/com/percussion/error/` production `IPS*Errors` call-sites to typed `ServerErrorCodes` / `BackEndErrorCodes` / `DataErrorCodes` / `CatalogErrorCodes` / `HttpErrorCodes` / `XmlErrorCodes`. `PSErrorException` constructs with typed `ServerErrorCodes.WRAPPED_LOG_ERROR`. Residual allow-list shrunk by those exact 26 paths.

Int-only APIs (`PSLogSubMessage`, `PSErrorManager.createMessage`/`getErrorText`, `PSLogServerWarning`) use `.numericCode()`. Dual-write skip for leftover non-auditable codes; leftover auditable authorization codes remain dual-write eligible. `IPS*Errors` interfaces are not deleted.

Fixes #3971
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2582, Failures: 0, Skipped: 246 (`PSErrorLeftoverErrorCodesSliceTest` 4/4)
2. `python scripts/verify-no-bare-ipserrors.py` — PASS
3. `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 19 passed
4. Review leftover production exception construction: typed `WRAPPED_LOG_ERROR` retained; catalog ints match; dual-write skip/auditable flags asserted

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal error-catalog retype; no operator/API/UX/config change
- [x] **Unit / module tests** — behavioral leftover slice test for exact production exception type + dual-write skip/auditable; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` (no skipTests)
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- `modules_built=system`
- `build_evidence=cd system && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2582, Failures: 0, Skipped: 246 (`PSErrorLeftoverErrorCodesSliceTest` 4/4). `python scripts/verify-no-bare-ipserrors.py` PASS. pytest `scripts/test_verify_no_bare_ipserrors.py` 19 passed.
- `downstream_checked=C2 did not apply: no public/protected signature change, not final/sealed. Existing extends PSErrorException webservices types still use the same PSLogError constructors.`

### C5 UI proof

N/A — Java backend leftover retype; no UI surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.