### PR TITLE
Fix #3970 leftover system extension IPS*Errors typed ErrorCodes

### DIFF
--- a/docs/ai-generated/code-reviews/3970-extension-leftover-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3970-extension-leftover-errorcodes-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — #3970 system extension leftover IPS*Errors typed ErrorCodes
+
+- Branch: `fix/issue-3970-extension-typed-errorcodes`
+- Base: `origin/main`
+- Date: 2026-08-28
+- Recommendation: **approve**
+- Gate: **May commit/push: yes**
+- Memory patterns hit: behavioral tests for changed logic; incomplete change-class closure (typed exception ctors + allow-list shrink + dual-write skip); non-portable path/file I/O (checklist N/A)
+
+## Summary
+
+Parent #2616 leftover slice. Nine `system/src/main/java/com/percussion/extension` production `IPS*Errors` call-sites now construct typed catalogs (`ExtensionErrorCodes`, plus `ServerErrorCodes.ARGUMENT_ERROR` / `DataErrorCodes.UNSUPPORTED_CONVERSION` on `PSJavaScriptUdfExtension`). Additive `logMessage(IPSErrorCode, Object[])` on `PSExtensionHandler` keeps the int overload for `logMessage(0, …)`. Residual allow-list shrunk by those exact 9 paths. Dual-write skip is `isAuditable()==false` on leftover operational catalog codes. No product UI/config surface.
+
+## Change class
+
+Typed ErrorCodes production call-site conversion (leftover extension package).
+
+Companions present: existing IPSErrorCode constructors (no new public exception signatures); allow-list shrink; freeze-gate pytest so the 9 paths stay off the list; dual-write skip tests; production throw tests (`PSExtensionParams`, handler init, handler config missing file, JS UDF param/type/conversion).
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] New path logic uses `Path` / `Files` (`@TempDir Path` + `Files.writeString`)
+- [x] Tests do not assert Unix-only absolute path shapes
+- [x] Temp files use `@TempDir` (portable)
+
+## Issues
+
+None.
+
+## Verification
+
+- `python scripts/verify-no-bare-ipserrors.py` — PASS
+- `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 20 passed
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2587, Failures: 0, Skipped: 246 (`PSExtensionLeftoverErrorCodesSliceTest` 9/9)
+
+## Notes
+
+- C2: `logMessage(IPSErrorCode, Object[])` is additive protected. Grep `extends PSExtensionHandler` found `PSJavaExtensionHandler`, `PSJavaScriptExtensionHandler`, and the package test stub. No `new PSExtensionHandler() {`. No reverse-dep module install required (existing int overload unchanged; exception int ctors remain).
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- Dual-write skip tests go through the enum (`isAuditable()`), not `LegacyErrorCodeRegistry.find(int)`.
+- Did not delete `IPSExtensionErrors` (int bridge remains).
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); dual-write skip for `isAuditable()==false`.

--- a/docs/ai-generated/code-reviews/3975-extension-typed-errorcodes-review-erlang.md
+++ b/docs/ai-generated/code-reviews/3975-extension-typed-errorcodes-review-erlang.md
@@ -1,0 +1,22 @@
+# Erlang review — PR #3975 review-thread follow-up
+
+**Scope:** uncommitted review-thread fix on `fix/issue-3970-extension-typed-errorcodes-wt` vs `HEAD`.
+**Recommendation:** approve
+**Gate:** May commit/push: yes
+**Memory patterns hit:** Public helper Javadoc that contradicts implementation; missing behavioral tests
+
+## Summary
+
+Kilo suggested the new `logMessage(IPSErrorCode, Object[])` Javadoc requires non-null `args` but only `errorCode` was validated. Enforced with `Objects.requireNonNull(args)` (matches Javadoc; int overload unchanged). Added `typedLogMessageRejectsNullArgs`.
+
+## Issues
+
+None. No signature change. No file I/O. Product-docs N/A (internal error-catalog helper).
+
+## Cross-platform path checklist
+
+N/A — no path/file I/O in this diff.
+
+## Evidence
+
+`cd system && ../mvnw.cmd clean install` → BUILD SUCCESS. Tests run: 2588, Failures: 0, Skipped: 246. `PSExtensionLeftoverErrorCodesSliceTest` 10/10 including `typedLogMessageRejectsNullArgs`.

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -103,15 +103,6 @@ system/src/main/java/com/percussion/error/PSServerUnavailableError.java
 system/src/main/java/com/percussion/error/PSUnknownProcessingError.java
 system/src/main/java/com/percussion/error/PSValidationError.java
 system/src/main/java/com/percussion/error/PSXmlProcessingError.java
-system/src/main/java/com/percussion/extension/PSExtensionHandler.java
-system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java
-system/src/main/java/com/percussion/extension/PSExtensionParams.java
-system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
-system/src/main/java/com/percussion/extension/PSJavaExtensionHandler.java
-system/src/main/java/com/percussion/extension/PSJavaScriptCallException.java
-system/src/main/java/com/percussion/extension/PSJavaScriptCompileException.java
-system/src/main/java/com/percussion/extension/PSJavaScriptUdfExtension.java
-system/src/main/java/com/percussion/extension/PSParameterMismatchException.java
 system/src/main/java/com/percussion/fastforward/managednav/PSManagedNavService.java
 system/src/main/java/com/percussion/fastforward/utils/PSUtils.java
 system/src/main/java/com/percussion/i18n/PSLocale.java

--- a/scripts/test_verify_no_bare_ipserrors.py
+++ b/scripts/test_verify_no_bare_ipserrors.py
@@ -395,6 +395,7 @@ def test_residual_allowlist_is_exact_paths_only() -> None:
         assert entry.endswith(".java"), entry
         assert not entry.startswith("modules/extensions-main/"), entry
         assert not entry.startswith("system/src/main/java/com/percussion/security/"), entry
+        assert not entry.startswith("system/src/main/java/com/percussion/extension/"), entry
 
 
 def test_extensions_main_converted_paths_not_allowlisted() -> None:
@@ -420,6 +421,29 @@ def test_system_security_converted_paths_not_allowlisted() -> None:
     resurrected = [
         e for e in entries if e.startswith("system/src/main/java/com/percussion/security/")
     ]
+    assert resurrected == [], resurrected
+
+
+def test_system_extension_converted_paths_not_allowlisted() -> None:
+    """#3970 typed leftover com.percussion.extension production call-sites."""
+    converted = (
+        "system/src/main/java/com/percussion/extension/PSExtensionHandler.java",
+        "system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java",
+        "system/src/main/java/com/percussion/extension/PSExtensionParams.java",
+        "system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java",
+        "system/src/main/java/com/percussion/extension/PSJavaExtensionHandler.java",
+        "system/src/main/java/com/percussion/extension/PSJavaScriptCallException.java",
+        "system/src/main/java/com/percussion/extension/PSJavaScriptCompileException.java",
+        "system/src/main/java/com/percussion/extension/PSJavaScriptUdfExtension.java",
+        "system/src/main/java/com/percussion/extension/PSParameterMismatchException.java",
+    )
+    text = ALLOWLIST.read_text(encoding="utf-8")
+    entries = {
+        ln.strip()
+        for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    }
+    resurrected = [p for p in converted if p in entries]
     assert resurrected == [], resurrected
 
 

--- a/system/src/main/java/com/percussion/extension/PSExtensionHandler.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionHandler.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -848,6 +849,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
    * @param args The error arguments corresponding to {@code errorCode}. Must not be {@code null}.
    */
   protected void logMessage(IPSErrorCode errorCode, Object[] args) {
+    Objects.requireNonNull(args, "args cannot be null");
     logMessage(requireErrorCode(errorCode).numericCode(), args);
   }
 

--- a/system/src/main/java/com/percussion/extension/PSExtensionHandler.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionHandler.java
@@ -16,7 +16,9 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.content.IPSMimeContent;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.log.PSLogHandler;
 import com.percussion.log.PSLogServerWarning;
@@ -72,13 +74,13 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     if (!codeRoot.isDirectory()) {
       Object[] args = new Object[] {getName(), codeRoot.toString() + " must be a directory."};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_HANDLER_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, args);
     }
 
     if (!codeRoot.canRead()) {
       Object[] args = new Object[] {getName(), codeRoot.toString() + " must be readable."};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_HANDLER_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, args);
     }
 
     try {
@@ -86,14 +88,14 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     } catch (IOException e) {
       Object[] args = new Object[] {getName(), e.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_HANDLER_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, args);
     }
 
     String cfgFileName = def.getInitParameter(IPSExtensionHandler.INIT_PARAM_CONFIG_FILENAME);
     if (cfgFileName == null || cfgFileName.trim().length() == 0) {
       Object[] args = new Object[] {getName(), "configFile must be specified"};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_HANDLER_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, args);
     }
 
     m_configFile = new File(m_rootDir, cfgFileName);
@@ -115,7 +117,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
             e.toString() // reason
           };
 
-      logMessage(IPSExtensionErrors.EXT_RESOURCE_DELETE_ERROR, args);
+      logMessage(ExtensionErrorCodes.EXT_RESOURCE_DELETE_ERROR, args);
     }
   }
 
@@ -191,7 +193,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
 
     IPSExtensionDef def = m_config.getExtensionDef(ref);
     if (def == null) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     try {
@@ -237,7 +239,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
 
     IPSExtensionDef def = m_config.getExtensionDef(ref);
     if (def == null) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     // see if an instance has already been loaded
@@ -300,7 +302,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
 
     PSExtensionRef ref = def.getRef();
     if (m_config.isExtensionDefined(ref)) {
-      throw new PSExtensionException(IPSExtensionErrors.EXT_ALREADY_EXISTS, ref.toString());
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_ALREADY_EXISTS, ref.toString());
     }
 
     // save all the extension resources and add extension to config
@@ -329,7 +331,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     } catch (IOException e) {
       Object[] args = new Object[] {ref.toString(), e.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INSTALL_UPDATE_ERROR, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INSTALL_UPDATE_ERROR, args);
     }
   }
 
@@ -366,7 +368,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     PSExtensionRef ref = def.getRef();
     IPSExtensionDef oldDef = m_config.getExtensionDef(ref);
     if (oldDef == null) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     // increment the version on the new def to old ver + 1
@@ -396,7 +398,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     if (ref == null) throw new IllegalArgumentException("ref cannot be null");
 
     if (!m_config.isExtensionDefined(ref)) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     // get the def and the code base of the extension
@@ -413,7 +415,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     } catch (IOException e) {
       Object[] args = new Object[] {ref.toString(), extDir, e.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_RESOURCE_DELETE_ERROR, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_RESOURCE_DELETE_ERROR, args);
     }
 
     m_liveExtensions.remove(ref);
@@ -459,7 +461,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     } catch (MalformedURLException e) {
       Object[] args = new Object[] {def.getRef().toString(), e.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.CATALOG_EXT_RESOURCE_ERROR, args);
+      throw new PSExtensionException(ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR, args);
     }
 
     return resources.iterator();
@@ -635,7 +637,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
             "could not create extension code root" // reason
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR, args);
     }
 
     while (resources.hasNext()) {
@@ -658,7 +660,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
               "empty path" // reason
             };
 
-        logMessage(IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR, args);
+        logMessage(ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR, args);
         continue;
       }
 
@@ -666,14 +668,14 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
       if (f.isAbsolute()) {
         Object[] args = new Object[] {def.getRef().toString(), resName, "absolute path"};
 
-        logMessage(IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR, args);
+        logMessage(ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR, args);
         continue;
       }
 
       if (f.toString().indexOf("..") >= 0) {
         Object[] args = new Object[] {def.getRef().toString(), resName, "contains .."};
 
-        logMessage(IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR, args);
+        logMessage(ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR, args);
         continue;
       }
 
@@ -833,10 +835,27 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
         PSExtensionHandlerConfiguration.createShellConfigFile(configFile, getName());
       }
     } catch (IOException e) {
-      throw new PSExtensionException(IPSExtensionErrors.EXT_MANAGER_INIT_FAILED, e.toString());
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED, e.toString());
     }
 
     m_config = new PSExtensionHandlerConfiguration(configFile, new PSExtensionDefFactory());
+  }
+
+  /**
+   * Logs the given catalogued message to the server logging mechanism (if available) or stdout.
+   *
+   * @param errorCode catalogued error code, never {@code null}
+   * @param args The error arguments corresponding to {@code errorCode}. Must not be {@code null}.
+   */
+  protected void logMessage(IPSErrorCode errorCode, Object[] args) {
+    logMessage(requireErrorCode(errorCode).numericCode(), args);
+  }
+
+  private static IPSErrorCode requireErrorCode(IPSErrorCode errorCode) {
+    if (errorCode == null) {
+      throw new IllegalArgumentException("errorCode cannot be null");
+    }
+    return errorCode;
   }
 
   /**

--- a/system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.io.BufferedInputStream;
@@ -371,7 +372,7 @@ class PSExtensionHandlerConfiguration {
       }
     } catch (FileNotFoundException e) {
       throw new PSExtensionException(
-          IPSExtensionErrors.EXT_INSTALL_UPDATE_ERROR,
+          ExtensionErrorCodes.EXT_INSTALL_UPDATE_ERROR,
           "Cannot find extension file "
               + fromFile.getAbsolutePath()
               + " or folder for output "
@@ -380,7 +381,7 @@ class PSExtensionHandlerConfiguration {
               + e.getLocalizedMessage());
     } catch (IOException e) {
       throw new PSExtensionException(
-          IPSExtensionErrors.EXT_INSTALL_UPDATE_ERROR,
+          ExtensionErrorCodes.EXT_INSTALL_UPDATE_ERROR,
           "Cannot wite to Extension file "
               + toFile.getAbsolutePath()
               + ": "
@@ -422,7 +423,7 @@ class PSExtensionHandlerConfiguration {
       try {
         createShellConfigFile(configFile, "");
       } catch (IOException e) {
-        throw new PSExtensionException(IPSExtensionErrors.EXT_MANAGER_INIT_FAILED, e.toString());
+        throw new PSExtensionException(ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED, e.toString());
       }
     }
 
@@ -435,11 +436,11 @@ class PSExtensionHandlerConfiguration {
       load(doc);
     } catch (IOException e) {
       throw new PSExtensionException(
-          IPSExtensionErrors.EXT_MANAGER_INIT_FAILED,
+          ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED,
           e,
           "Error loading config xml for " + configFile.getAbsolutePath() + ":" + e.toString());
     } catch (SAXException e) {
-      throw new PSExtensionException(IPSExtensionErrors.EXT_MANAGER_INIT_FAILED, e, e.toString());
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED, e, e.toString());
     } finally {
       if (in != null) {
         try {
@@ -630,7 +631,7 @@ class PSExtensionHandlerConfiguration {
       }
     } catch (ClassNotFoundException e) {
       throw new PSExtensionException(
-          IPSExtensionErrors.CLASS_NOT_FOUND, def.getInitParameter("className"));
+          ExtensionErrorCodes.CLASS_NOT_FOUND, def.getInitParameter("className"));
     }
   }
 

--- a/system/src/main/java/com/percussion/extension/PSExtensionParams.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionParams.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.util.PSDataTypeConverter;
@@ -53,7 +54,7 @@ public class PSExtensionParams {
    */
   public PSExtensionParams(Object params[], String paramNames[]) throws PSConversionException {
     if (params == null) {
-      throw new PSConversionException(IPSExtensionErrors.INVALID_NULL_PARAMS);
+      throw new PSConversionException(ExtensionErrorCodes.INVALID_NULL_PARAMS);
     }
     m_params = params;
     m_paramNames = paramNames;
@@ -106,13 +107,13 @@ public class PSExtensionParams {
         return Integer.parseInt((String) value);
       } catch (NumberFormatException e) {
         throw new PSConversionException(
-            IPSExtensionErrors.INVALID_NUMBER_PARAM, getParamIndicator(index));
+            ExtensionErrorCodes.INVALID_NUMBER_PARAM, getParamIndicator(index));
       }
     } else if (value == null) {
       return null;
     } else {
       throw new PSConversionException(
-          IPSExtensionErrors.INVALID_NUMBER_PARAM, getParamIndicator(index));
+          ExtensionErrorCodes.INVALID_NUMBER_PARAM, getParamIndicator(index));
     }
   }
 
@@ -142,7 +143,7 @@ public class PSExtensionParams {
           || bvalue.equalsIgnoreCase("yes");
     } else {
       throw new PSConversionException(
-          IPSExtensionErrors.INVALID_BOOLEAN_PARAM, getParamIndicator(index));
+          ExtensionErrorCodes.INVALID_BOOLEAN_PARAM, getParamIndicator(index));
     }
   }
 
@@ -169,12 +170,12 @@ public class PSExtensionParams {
       Date date = PSDataTypeConverter.parseStringToDate((String) value);
       if (date == null) {
         throw new PSConversionException(
-            IPSExtensionErrors.INVALID_DATE_PARAM, getParamIndicator(index));
+            ExtensionErrorCodes.INVALID_DATE_PARAM, getParamIndicator(index));
       }
       return date;
     } else {
       throw new PSConversionException(
-          IPSExtensionErrors.INVALID_DATE_PARAM, getParamIndicator(index));
+          ExtensionErrorCodes.INVALID_DATE_PARAM, getParamIndicator(index));
     }
   }
 
@@ -202,7 +203,7 @@ public class PSExtensionParams {
   private Object getValue(int index, Object defvalue) throws PSConversionException {
     if (index < 0) {
       throw new PSConversionException(
-          IPSExtensionErrors.INVALID_INDEX_VALUE, getParamIndicator(index));
+          ExtensionErrorCodes.INVALID_INDEX_VALUE, getParamIndicator(index));
     }
     Object rval = isParamMissing(index) ? defvalue : m_params[index];
 
@@ -243,7 +244,7 @@ public class PSExtensionParams {
     if (required && isParamMissing(index)) {
 
       throw new PSConversionException(
-          IPSExtensionErrors.MISSING_REQUIRED_PARAM_NO, getParamIndicator(index));
+          ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO, getParamIndicator(index));
     }
   }
 

--- a/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.utils.exceptions.PSExceptionHelper;
@@ -130,7 +131,7 @@ public class PSExtensionProcessingException extends PSException {
    */
   public PSExtensionProcessingException(String extName, Exception e) {
     this(
-        IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION,
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION,
         PSExceptionHelper.findRootCause(e, false),
         new Object[] {extName, e.toString()});
   }
@@ -196,9 +197,9 @@ public class PSExtensionProcessingException extends PSException {
    * @param e the exception
    */
   public PSExtensionProcessingException(String language, String extName, Exception e) {
-    this(
+    super(
         language,
-        IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION,
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION,
         new Object[] {extName, e.toString()},
         e);
   }

--- a/system/src/main/java/com/percussion/extension/PSJavaExtensionHandler.java
+++ b/system/src/main/java/com/percussion/extension/PSJavaExtensionHandler.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.security.error.PSExceptionUtils;
@@ -151,7 +152,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
             "\"" + className + "\" is not a valid class name."
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
 
     super.install(def, resources);
@@ -191,7 +192,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
             "\"" + className + "\" is not a valid class name."
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
 
     super.update(def, resources);
@@ -259,7 +260,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
 
     IPSExtensionDef def = m_config.getExtensionDef(ref);
     if (def == null) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     String className = def.getInitParameter("className");
@@ -271,7 +272,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
             "\"" + className + "\" is not a valid class name."
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
 
     PSExtensionClassLoader loader = m_loaders.get(ref);
@@ -294,11 +295,11 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
       Object[] args =
           new Object[] {ref.getHandlerName(), ref.getExtensionName(), e.getException().toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     } catch (Throwable t) {
       Object[] args = new Object[] {ref.getHandlerName(), ref.getExtensionName(), t.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
   }
 
@@ -331,7 +332,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
                 u.toString() + " does not use a supported protocol"
               };
 
-          throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+          throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
         }
 
         File f = new File(u.getFile());
@@ -344,7 +345,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
                 u.toString() + " does not specify a relative path"
               };
 
-          throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+          throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
         }
 
         if (f.toString().indexOf("..") != -1) // no escape from coderoot
@@ -356,7 +357,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
                 u.toString() + " does not specify a relative path"
               };
 
-          throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+          throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
         }
 
         // make resource path relative to the extension coderoot
@@ -377,7 +378,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
             def.getRef().getHandlerName(), def.getRef().getExtensionName(), e.toString()
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/extension/PSJavaScriptCallException.java
+++ b/system/src/main/java/com/percussion/extension/PSJavaScriptCallException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -28,11 +29,11 @@ import com.percussion.error.PSException;
 public class PSJavaScriptCallException extends PSException {
   /** Constructs a failure with the specified message. */
   public PSJavaScriptCallException(String function, String message) {
-    super(IPSExtensionErrors.JS_CALL_FAILED, new Object[] {function, message});
+    super(ExtensionErrorCodes.JS_CALL_FAILED, new Object[] {function, message});
   }
 
   /** Constructs a failure with the specified context information. */
   public PSJavaScriptCallException(String function, String message, String source) {
-    super(IPSExtensionErrors.JS_CALL_FAILED_SRC, new Object[] {function, message, source});
+    super(ExtensionErrorCodes.JS_CALL_FAILED_SRC, new Object[] {function, message, source});
   }
 }

--- a/system/src/main/java/com/percussion/extension/PSJavaScriptCompileException.java
+++ b/system/src/main/java/com/percussion/extension/PSJavaScriptCompileException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -29,11 +30,11 @@ import com.percussion.error.PSException;
 public class PSJavaScriptCompileException extends PSException {
   /** Constructs a failure with the specified message. */
   public PSJavaScriptCompileException(String function, String message) {
-    super(IPSExtensionErrors.JS_COMPILE_FAILED, new Object[] {function, message});
+    super(ExtensionErrorCodes.JS_COMPILE_FAILED, new Object[] {function, message});
   }
 
   /** Constructs a failure with the specified context information. */
   public PSJavaScriptCompileException(String function, String message, String source) {
-    super(IPSExtensionErrors.JS_COMPILE_FAILED_SRC, new Object[] {function, message, source});
+    super(ExtensionErrorCodes.JS_COMPILE_FAILED_SRC, new Object[] {function, message, source});
   }
 }

--- a/system/src/main/java/com/percussion/extension/PSJavaScriptUdfExtension.java
+++ b/system/src/main/java/com/percussion/extension/PSJavaScriptUdfExtension.java
@@ -17,7 +17,9 @@
 
 package com.percussion.extension;
 
-import com.percussion.data.IPSDataErrors;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.design.objectstore.PSDateLiteral;
 import com.percussion.design.objectstore.PSNumericLiteral;
@@ -91,9 +93,8 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
               + " parameters required, but "
               + String.valueOf(paramCount)
               + " parameters were specified.";
-      int errCode = com.percussion.server.IPSServerErrors.ARGUMENT_ERROR;
       Object[] args = {arg0, "PSJavaScriptUdfExtension/processUdf"};
-      throw new PSConversionException(errCode, args);
+      throw new PSConversionException(ServerErrorCodes.ARGUMENT_ERROR, args);
     }
 
     Object[] paramValues = new Object[paramCount];
@@ -128,7 +129,7 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
         return getBoolean(o);
       default:
         throw new com.percussion.data.PSConversionException(
-            IPSExtensionErrors.UNKNOWN_PARAMETER_TYPE, "Date, Number, String, Boolean");
+            ExtensionErrorCodes.UNKNOWN_PARAMETER_TYPE, "Date, Number, String, Boolean");
     }
   }
 
@@ -147,7 +148,7 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
       } catch (Exception e) {
         Object args[] = {o.getClass().getName(), "String", dateText};
         throw new com.percussion.data.PSConversionException(
-            IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+            DataErrorCodes.UNSUPPORTED_CONVERSION, args);
       }
     } else if (o instanceof java.util.Date) {
       return /*new java.lang.Long(((java.util.Date)*/ o /*).getTime())*/;
@@ -160,7 +161,7 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
     // Throw conversion exception.  o will contain exception information
     //      for string conversion exceptions...
     Object args[] = {o.getClass().getName(), "Date", o.toString()};
-    throw new com.percussion.data.PSConversionException(IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+    throw new com.percussion.data.PSConversionException(DataErrorCodes.UNSUPPORTED_CONVERSION, args);
   }
 
   private Object getNumber(Object o) throws com.percussion.data.PSConversionException {
@@ -188,12 +189,12 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
     } catch (Exception e) {
       Object args[] = {o.getClass().getName(), "Number", o.toString()};
       throw new com.percussion.data.PSConversionException(
-          IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+          DataErrorCodes.UNSUPPORTED_CONVERSION, args);
     }
 
     // Throw conversion exception.
     Object args[] = {o.getClass().getName(), "Number", o.toString()};
-    throw new com.percussion.data.PSConversionException(IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+    throw new com.percussion.data.PSConversionException(DataErrorCodes.UNSUPPORTED_CONVERSION, args);
   }
 
   private Object getBoolean(Object o) throws com.percussion.data.PSConversionException {
@@ -212,7 +213,7 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
 
     // Throw conversion exception.
     Object args[] = {o.getClass().getName(), "Boolean", o.toString()};
-    throw new com.percussion.data.PSConversionException(IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+    throw new com.percussion.data.PSConversionException(DataErrorCodes.UNSUPPORTED_CONVERSION, args);
   }
 
   private Object getString(Object o) throws com.percussion.data.PSConversionException {

--- a/system/src/main/java/com/percussion/extension/PSParameterMismatchException.java
+++ b/system/src/main/java/com/percussion/extension/PSParameterMismatchException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
@@ -41,7 +42,7 @@ public class PSParameterMismatchException extends PSException {
    */
   public PSParameterMismatchException(int expected, int actual) {
     super(
-        IPSExtensionErrors.EXT_PARAM_VALUE_MISMATCH,
+        ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH,
         new Object[] {Integer.valueOf(expected), Integer.valueOf(actual)});
   }
 
@@ -51,7 +52,7 @@ public class PSParameterMismatchException extends PSException {
    * @param message the complete display message.
    */
   public PSParameterMismatchException(String message) {
-    super(IPSExtensionErrors.EXT_PARAM_VALUE_INVALID, message);
+    super(ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID, message);
   }
 
   /**
@@ -65,7 +66,7 @@ public class PSParameterMismatchException extends PSException {
   public PSParameterMismatchException(String language, int expected, int actual) {
     super(
         language,
-        IPSExtensionErrors.EXT_PARAM_VALUE_MISMATCH,
+        ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH,
         new Object[] {Integer.valueOf(expected), Integer.valueOf(actual)});
   }
 
@@ -77,7 +78,7 @@ public class PSParameterMismatchException extends PSException {
    * @param message the complete display message.
    */
   public PSParameterMismatchException(String language, String message) {
-    super(language, IPSExtensionErrors.EXT_PARAM_VALUE_INVALID, message);
+    super(language, ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID, message);
   }
 
   /** See {@link com.percussion.error.PSException#PSException(int, Object)} for documentation. */

--- a/system/src/test/java/com/percussion/extension/PSExtensionLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/extension/PSExtensionLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.data.IPSDataErrors;
+import com.percussion.data.PSConversionException;
+import com.percussion.design.objectstore.PSExtensionParamDef;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.error.PSException;
+import com.percussion.error.PSNotFoundException;
+import com.percussion.server.IPSServerErrors;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Issue #3970 (parent #2616 leftover): {@code com.percussion.extension} production sites throw
+ * typed {@code *ErrorCodes} via IPSErrorCode-aware constructors — not bare {@code IPS*Errors}
+ * ints. Dual-write skip is {@code isAuditable()==false} on leftover operational catalog codes.
+ */
+@Tag("UnitTest")
+class PSExtensionLeftoverErrorCodesSliceTest {
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWrite() {
+    assertEquals(
+        IPSExtensionErrors.EXT_HANDLER_INIT_FAILED,
+        ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_RESOURCE_DELETE_ERROR,
+        ExtensionErrorCodes.EXT_RESOURCE_DELETE_ERROR.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_NOT_FOUND, ExtensionErrorCodes.EXT_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_ALREADY_EXISTS,
+        ExtensionErrorCodes.EXT_ALREADY_EXISTS.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_INSTALL_UPDATE_ERROR,
+        ExtensionErrorCodes.EXT_INSTALL_UPDATE_ERROR.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR,
+        ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR.numericCode());
+    assertEquals(
+        IPSExtensionErrors.CATALOG_EXT_RESOURCE_ERROR,
+        ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_MANAGER_INIT_FAILED,
+        ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_INIT_FAILED, ExtensionErrorCodes.EXT_INIT_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.CLASS_NOT_FOUND, ExtensionErrorCodes.CLASS_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_NULL_PARAMS,
+        ExtensionErrorCodes.INVALID_NULL_PARAMS.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_NUMBER_PARAM,
+        ExtensionErrorCodes.INVALID_NUMBER_PARAM.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_BOOLEAN_PARAM,
+        ExtensionErrorCodes.INVALID_BOOLEAN_PARAM.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_DATE_PARAM,
+        ExtensionErrorCodes.INVALID_DATE_PARAM.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_INDEX_VALUE,
+        ExtensionErrorCodes.INVALID_INDEX_VALUE.numericCode());
+    assertEquals(
+        IPSExtensionErrors.MISSING_REQUIRED_PARAM_NO,
+        ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION,
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_PARAM_VALUE_MISMATCH,
+        ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_PARAM_VALUE_INVALID,
+        ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID.numericCode());
+    assertEquals(
+        IPSExtensionErrors.JS_CALL_FAILED, ExtensionErrorCodes.JS_CALL_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.JS_CALL_FAILED_SRC,
+        ExtensionErrorCodes.JS_CALL_FAILED_SRC.numericCode());
+    assertEquals(
+        IPSExtensionErrors.JS_COMPILE_FAILED,
+        ExtensionErrorCodes.JS_COMPILE_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.JS_COMPILE_FAILED_SRC,
+        ExtensionErrorCodes.JS_COMPILE_FAILED_SRC.numericCode());
+    assertEquals(
+        IPSExtensionErrors.UNKNOWN_PARAMETER_TYPE,
+        ExtensionErrorCodes.UNKNOWN_PARAMETER_TYPE.numericCode());
+    assertEquals(IPSServerErrors.ARGUMENT_ERROR, ServerErrorCodes.ARGUMENT_ERROR.numericCode());
+    assertEquals(
+        IPSDataErrors.UNSUPPORTED_CONVERSION,
+        DataErrorCodes.UNSUPPORTED_CONVERSION.numericCode());
+
+    leftoverNonAuditable(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED);
+    leftoverNonAuditable(ExtensionErrorCodes.EXT_NOT_FOUND);
+    leftoverNonAuditable(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION);
+    leftoverNonAuditable(ExtensionErrorCodes.JS_COMPILE_FAILED);
+    leftoverNonAuditable(ExtensionErrorCodes.UNKNOWN_PARAMETER_TYPE);
+    leftoverNonAuditable(ServerErrorCodes.ARGUMENT_ERROR);
+    leftoverNonAuditable(DataErrorCodes.UNSUPPORTED_CONVERSION);
+  }
+
+  @Test
+  void productionExceptionTypesRetainTypedCodesAndSkipDualWrite() {
+    leftoverNonAuditable(
+        new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, new Object[] {"h", "dir"}),
+        ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED);
+    leftoverNonAuditable(
+        new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, "JavaScript/global/missing"),
+        ExtensionErrorCodes.EXT_NOT_FOUND);
+    leftoverNonAuditable(
+        new PSExtensionException(ExtensionErrorCodes.EXT_ALREADY_EXISTS, "dup"),
+        ExtensionErrorCodes.EXT_ALREADY_EXISTS);
+    leftoverNonAuditable(
+        new PSExtensionException(
+            ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED, new IllegalStateException("io"), "cfg"),
+        ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED);
+    leftoverNonAuditable(
+        new PSConversionException(ExtensionErrorCodes.INVALID_NULL_PARAMS),
+        ExtensionErrorCodes.INVALID_NULL_PARAMS);
+    leftoverNonAuditable(
+        new PSConversionException(ExtensionErrorCodes.INVALID_NUMBER_PARAM, 3),
+        ExtensionErrorCodes.INVALID_NUMBER_PARAM);
+    leftoverNonAuditable(
+        new PSParameterMismatchException(2, 1), ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH);
+    leftoverNonAuditable(
+        new PSParameterMismatchException("bad value"), ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID);
+    leftoverNonAuditable(
+        new PSParameterMismatchException("en-us", 4, 1),
+        ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH);
+    leftoverNonAuditable(
+        new PSJavaScriptCallException("fn", "boom"), ExtensionErrorCodes.JS_CALL_FAILED);
+    leftoverNonAuditable(
+        new PSJavaScriptCallException("fn", "boom", "src"), ExtensionErrorCodes.JS_CALL_FAILED_SRC);
+    leftoverNonAuditable(
+        new PSJavaScriptCompileException("fn", "syntax"), ExtensionErrorCodes.JS_COMPILE_FAILED);
+    leftoverNonAuditable(
+        new PSJavaScriptCompileException("fn", "syntax", "src"),
+        ExtensionErrorCodes.JS_COMPILE_FAILED_SRC);
+    leftoverNonAuditable(
+        new PSExtensionProcessingException("sys_exit", new IllegalStateException("eval")),
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION);
+    leftoverNonAuditable(
+        new PSExtensionProcessingException(
+            "en-us", "sys_exit", new IllegalStateException("eval")),
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION);
+    leftoverNonAuditable(
+        new PSConversionException(
+            ServerErrorCodes.ARGUMENT_ERROR, new Object[] {"need 1", "processUdf"}),
+        ServerErrorCodes.ARGUMENT_ERROR);
+    leftoverNonAuditable(
+        new PSConversionException(
+            DataErrorCodes.UNSUPPORTED_CONVERSION, new Object[] {"java.lang.Object", "Date", "x"}),
+        DataErrorCodes.UNSUPPORTED_CONVERSION);
+  }
+
+  @Test
+  void extensionParamsProductionThrowsRetainTypedCodes() throws Exception {
+    PSConversionException nullParams =
+        assertThrows(PSConversionException.class, () -> new PSExtensionParams(null));
+    leftoverNonAuditable(nullParams, ExtensionErrorCodes.INVALID_NULL_PARAMS);
+
+    PSExtensionParams ep = new PSExtensionParams(new Object[] {Integer.valueOf(7), "abc"});
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getNumberParam(1, null, true)),
+        ExtensionErrorCodes.INVALID_NUMBER_PARAM);
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getBooleanParam(0, false, true)),
+        ExtensionErrorCodes.INVALID_BOOLEAN_PARAM);
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getDateParam(1, null, true)),
+        ExtensionErrorCodes.INVALID_DATE_PARAM);
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getUncheckedParam(-1)),
+        ExtensionErrorCodes.INVALID_INDEX_VALUE);
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getStringParam(5, null, true)),
+        ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO);
+  }
+
+  @Test
+  void handlerInitWithNonDirectoryThrowsTyped(@TempDir Path tmp) throws Exception {
+    Path notDir = tmp.resolve("not-a-directory.txt");
+    Files.writeString(notDir, "x");
+    PSExtensionException ex =
+        assertThrows(
+            PSExtensionException.class, () -> new TestHandler().init(simpleDef(), notDir.toFile()));
+    leftoverNonAuditable(ex, ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED);
+  }
+
+  @Test
+  void handlerConfigMissingFileThrowsTyped(@TempDir Path tmp) {
+    Path missing = tmp.resolve("no-such-extensions.xml");
+    PSExtensionException ex =
+        assertThrows(
+            PSExtensionException.class,
+            () -> new PSExtensionHandlerConfiguration(missing.toFile(), null, false));
+    leftoverNonAuditable(ex, ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED);
+  }
+
+  @Test
+  void javaScriptUdfParamCountMismatchThrowsTyped() throws Exception {
+    PSJavaScriptUdfExtension ext = newUdf("countMismatch", "return 1;", "Number");
+    PSConversionException ex =
+        assertThrows(PSConversionException.class, () -> ext.processUdf(new Object[0], null));
+    leftoverNonAuditable(ex, ServerErrorCodes.ARGUMENT_ERROR);
+  }
+
+  @Test
+  void javaScriptUdfUnknownParameterTypeThrowsTyped() throws Exception {
+    PSJavaScriptUdfExtension ext = newUdf("unknownType", "return p;", "Widget");
+    PSConversionException ex =
+        assertThrows(PSConversionException.class, () -> ext.processUdf(new Object[] {"x"}, null));
+    leftoverNonAuditable(ex, ExtensionErrorCodes.UNKNOWN_PARAMETER_TYPE);
+  }
+
+  @Test
+  void javaScriptUdfUnsupportedDateConversionThrowsTyped() throws Exception {
+    PSJavaScriptUdfExtension ext = newUdf("badDate", "return p;", "Date");
+    PSConversionException ex =
+        assertThrows(
+            PSConversionException.class, () -> ext.processUdf(new Object[] {new Object()}, null));
+    leftoverNonAuditable(ex, DataErrorCodes.UNSUPPORTED_CONVERSION);
+  }
+
+  @Test
+  void typedLogMessageRejectsNullCode() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new TestHandler().logMessage((IPSErrorCode) null, new Object[] {"x"}));
+  }
+
+  private static PSJavaScriptUdfExtension newUdf(
+      String extensionName, String scriptBody, String paramType) throws PSExtensionException {
+    Properties init = new Properties();
+    init.setProperty("scriptBody", scriptBody);
+    PSExtensionParamDef param = new PSExtensionParamDef("p", paramType);
+    PSExtensionDef def =
+        new PSExtensionDef(
+            new PSExtensionRef("JavaScript", "global/", extensionName),
+            List.of(IPSUdfProcessor.class.getName()).iterator(),
+            null,
+            init,
+            List.of(param).iterator());
+    PSJavaScriptUdfExtension ext = new PSJavaScriptUdfExtension();
+    ext.init(def, null);
+    return ext;
+  }
+
+  private static IPSExtensionDef simpleDef() {
+    Properties init = new Properties();
+    init.setProperty(IPSExtensionHandler.INIT_PARAM_CONFIG_FILENAME, "Extensions.xml");
+    return new PSExtensionDef(
+        new PSExtensionRef("Java", "global/", "testHandler"),
+        List.of(IPSExtensionHandler.class.getName()).iterator(),
+        null,
+        init,
+        null);
+  }
+
+  private static void leftoverNonAuditable(IPSErrorCode expected) {
+    assertFalse(expected.isAuditable(), expected.toString());
+  }
+
+  private static void leftoverNonAuditable(PSException ex, IPSErrorCode expected) {
+    assertSame(expected, ex.getTypedErrorCode(), expected.toString());
+    assertEquals(expected.numericCode(), ex.getErrorCode(), expected.toString());
+    assertFalse(ex.isAuditable(), expected.toString());
+    assertFalse(expected.isAuditable(), expected.toString());
+  }
+
+  /** Package-visible stub so leftover init/log paths can be exercised without a live handler. */
+  static final class TestHandler extends PSExtensionHandler {
+    @Override
+    public String getName() {
+      return "testHandler";
+    }
+
+    @Override
+    protected IPSExtension loadExtension(PSExtensionRef ref) {
+      return null;
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/extension/PSExtensionLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/extension/PSExtensionLeftoverErrorCodesSliceTest.java
@@ -261,6 +261,13 @@ class PSExtensionLeftoverErrorCodesSliceTest {
         () -> new TestHandler().logMessage((IPSErrorCode) null, new Object[] {"x"}));
   }
 
+  @Test
+  void typedLogMessageRejectsNullArgs() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new TestHandler().logMessage(ExtensionErrorCodes.EXT_RESOURCE_DELETE_ERROR, null));
+  }
+
   private static PSJavaScriptUdfExtension newUdf(
       String extensionName, String scriptBody, String paramType) throws PSExtensionException {
     Properties init = new Properties();


### PR DESCRIPTION
## Summary

Parent #2616 leftover slice. Retype remaining `system/src/main/java/com/percussion/extension` production `IPS*Errors` call-sites to typed `*ErrorCodes` (`ExtensionErrorCodes` plus `ServerErrorCodes.ARGUMENT_ERROR` / `DataErrorCodes.UNSUPPORTED_CONVERSION` on `PSJavaScriptUdfExtension`). Additive `logMessage(IPSErrorCode, Object[])` on `PSExtensionHandler`. Residual allow-list shrunk by those nine exact paths. Dual-write skip tests cover leftover non-auditable catalog codes and production throws.

Fixes #3970
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `python scripts/verify-no-bare-ipserrors.py` — PASS (nine converted paths no longer residual).
2. `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 20 passed.
3. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS.
4. Confirm `PSExtensionLeftoverErrorCodesSliceTest` 9/9 (typed codes, dual-write skip, production throws).

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal error-catalog retype; numeric codes and exception contracts unchanged
- [x] **Unit / module tests** — behavioral tests for leftover typed construction and production throws; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install (no skipTests); reverse-deps not required (additive protected overload only)
- [x] **Cross-platform** — new tests use `@TempDir` + `Path` / `Files.writeString`

## C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2587, Failures: 0, Errors: 0, Skipped: 246 (`PSExtensionLeftoverErrorCodesSliceTest` 9/9). `python scripts/verify-no-bare-ipserrors.py` PASS. `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 20 passed.
- **downstream_checked:** C2 additive only (`PSExtensionHandler.logMessage(IPSErrorCode, Object[])`). Grep `extends PSExtensionHandler` → `PSJavaExtensionHandler`, `PSJavaScriptExtensionHandler`, package test stub; no anonymous subclasses. Exception int constructors unchanged. No reverse-dep module install required.

## C5 UI proof

N/A — no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
