### PR TITLE
Fix #3969 leftover system design.catalog IPS*Errors typed ErrorCodes

### DIFF
--- a/docs/ai-generated/code-reviews/3969-design-catalog-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3969-design-catalog-errorcodes-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review — #3969 system design.catalog leftover IPS*Errors typed ErrorCodes
+
+**Scope:** uncommitted branch `fix/issue-3969-design-catalog-typed-errorcodes` vs `origin/main`  
+**Memory patterns hit:** typed `*ErrorCodes` + `IPSErrorCode` constructors; dual-write skip for `isAuditable()==false`; do not delete `IPS*Errors` interfaces; int-only APIs (`PSLogServerWarning`, `PSCatalogRequestError`) use `.numericCode()`; allow-list companion shrink.  
+**Cross-platform path checklist:** N/A (no new filesystem path joins; tests construct exceptions in-memory).
+
+## Summary
+
+Parent #2616 leftover slice: 22 `system/src/main/java/com/percussion/design/catalog/` production `IPS*Errors` sites now construct typed `CatalogErrorCodes` / `ServerErrorCodes`. Residual allow-list shrunk by those exact 22 paths. Dual-write skip tests cover leftover non-auditable catalog protocol codes and `RESPONSE_SEND_ERROR`. Production exception type is `PSIllegalArgumentException` with typed codes retained. `IPSCatalogErrors` interface is not deleted. Out of scope (`design.objectstore`, `design.server`, `com.percussion.error`) left on the allow-list. No product UI/config surface.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None.
+
+## Verification
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2581, Failures: 0, Skipped: 246 (`PSDesignCatalogLeftoverErrorCodesSliceTest` 3/3)
+- `python scripts/verify-no-bare-ipserrors.py` — PASS
+- `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 20 passed
+
+## Notes
+
+- C2: call-site retype only. No `final`/`sealed`, no public/protected signature change. Grep: no `extends PSIllegalArgumentException`; no anonymous `new PSIllegalArgumentException() {`.
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- `IPSCatalogErrors.CATALOG_EXCEPTION` and `IPSServerErrors.RESPONSE_SEND_ERROR` stay int-only at `PSCatalogRequestError` / `PSLogServerWarning` via `.numericCode()`.
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); dual-write skip when non-auditable.

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -18,8 +18,10 @@
 #   #3900 leftover cms.objectstore.server call sites
 #   #3939 leftover system/src/main com.percussion.data (+ macro/vfs)
 #   #3940 leftover system/src/main com.percussion.security call sites
+#   #3969 leftover system/src/main design.catalog call sites
 # Converted (no longer listed): extensions-main #3756/#3938 (allow-list
-# shrink after #3793 re-listed already-typed production paths).
+# shrink after #3793 re-listed already-typed production paths);
+# design.catalog leftover #3969.
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -50,28 +52,6 @@ system/src/main/java/com/percussion/cx/PSOption.java
 system/src/main/java/com/percussion/cx/PSOptions.java
 system/src/main/java/com/percussion/cx/PSUserOptions.java
 system/src/main/java/com/percussion/debug/PSDebugLogHandler.java
-system/src/main/java/com/percussion/design/catalog/PSCatalogRequestHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSColumnCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSDatasourceCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSForeignKeyCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSIndexCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSTableCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSTableTypesCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSUniqueKeyCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionHandlerCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/file/server/PSColumnCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/function/server/PSDatabaseFunctionCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/macro/server/PSMacroCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/mail/server/PSMailProviderCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSAttributesCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSCatalogerCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSObjectCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSObjectTypesCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSProviderCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSServerCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/system/server/PSLocaleCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/system/server/PSMimeTypeCatalogHandler.java
 system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
 system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
 system/src/main/java/com/percussion/design/objectstore/PSObjectStore.java

--- a/scripts/test_verify_no_bare_ipserrors.py
+++ b/scripts/test_verify_no_bare_ipserrors.py
@@ -35,7 +35,7 @@ DEPLOYER_RESIDUAL = (
 # converted in #3882, cms handlers in #3883, cms.objectstore+client in #3884;
 # cms.objectstore.server converted in #3900; extensions-main converted in
 # #3756/#3938; com.percussion.data (+ macro/vfs) in #3939; com.percussion.security
-# in #3940.
+# in #3940; design.catalog leftover call-sites in #3969.
 # Keep an exact residual that is still frozen (system debug leftover).
 SYSTEM_CMS_RESIDUAL = (
     "system/src/main/java/com/percussion/debug/PSDebugLogHandler.java"
@@ -395,6 +395,7 @@ def test_residual_allowlist_is_exact_paths_only() -> None:
         assert entry.endswith(".java"), entry
         assert not entry.startswith("modules/extensions-main/"), entry
         assert not entry.startswith("system/src/main/java/com/percussion/security/"), entry
+        assert not entry.startswith("system/src/main/java/com/percussion/design/catalog/"), entry
 
 
 def test_extensions_main_converted_paths_not_allowlisted() -> None:
@@ -419,6 +420,22 @@ def test_system_security_converted_paths_not_allowlisted() -> None:
     ]
     resurrected = [
         e for e in entries if e.startswith("system/src/main/java/com/percussion/security/")
+    ]
+    assert resurrected == [], resurrected
+
+
+def test_system_design_catalog_converted_paths_not_allowlisted() -> None:
+    """#3969 typed leftover com.percussion.design.catalog production call-sites."""
+    text = ALLOWLIST.read_text(encoding="utf-8")
+    entries = [
+        ln.strip()
+        for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+    resurrected = [
+        e
+        for e in entries
+        if e.startswith("system/src/main/java/com/percussion/design/catalog/")
     ]
     assert resurrected == [], resurrected
 

--- a/system/src/main/java/com/percussion/design/catalog/PSCatalogRequestHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/PSCatalogRequestHandler.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.catalog;
 
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.design.objectstore.PSAclEntry;
 import com.percussion.error.IPSException;
 import com.percussion.error.PSErrorHandler;
@@ -69,14 +71,14 @@ public abstract class PSCatalogRequestHandler implements IPSRequestHandler, IPSV
       Document reqDoc = request.getInputDocument();
       if (reqDoc == null) {
         createErrorResponse(
-            request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING_GENERIC));
+            request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING_GENERIC));
         return;
       }
 
       Element root = reqDoc.getDocumentElement();
       if (root == null) {
         createErrorResponse(
-            request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_ROOT_MISSING_GENERIC));
+            request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC));
         return;
       }
 
@@ -86,7 +88,7 @@ public abstract class PSCatalogRequestHandler implements IPSRequestHandler, IPSV
       if (rh == null) {
         Object[] args = {root.getTagName()};
         createErrorResponse(
-            request, new PSIllegalArgumentException(IPSCatalogErrors.NO_REQ_HANDLER_FOUND, args));
+            request, new PSIllegalArgumentException(CatalogErrorCodes.NO_REQ_HANDLER_FOUND, args));
         return;
       }
 
@@ -146,7 +148,7 @@ public abstract class PSCatalogRequestHandler implements IPSRequestHandler, IPSV
         errorCode = pse.getErrorCode();
         args = pse.getErrorArguments();
       } else {
-        errorCode = IPSCatalogErrors.CATALOG_EXCEPTION;
+        errorCode = CatalogErrorCodes.CATALOG_EXCEPTION.numericCode();
         args = new Object[] {t.toString()};
       }
 
@@ -185,7 +187,7 @@ public abstract class PSCatalogRequestHandler implements IPSRequestHandler, IPSV
       };
       com.percussion.log.PSLogManager.write(
           new com.percussion.log.PSLogServerWarning(
-              com.percussion.server.IPSServerErrors.RESPONSE_SEND_ERROR,
+              ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(),
               args,
               true,
               "CatalogRequestHandler"));

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSColumnCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSColumnCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.server.PSRequest;
@@ -73,7 +73,7 @@ public class PSColumnCatalogHandler extends com.percussion.design.catalog.PSCata
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -81,7 +81,7 @@ public class PSColumnCatalogHandler extends com.percussion.design.catalog.PSCata
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSDatasourceCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSDatasourceCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -71,7 +71,7 @@ public class PSDatasourceCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {REQUEST_CATEGORY, REQUEST_TYPE, REQUEST_DTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
     String tAttrib = root.getAttribute("includeDbPubOnlySources");
@@ -81,7 +81,7 @@ public class PSDatasourceCatalogHandler extends PSCatalogRequestHandler
     if (!REQUEST_DTD.equals(root.getTagName())) {
       Object[] args = {REQUEST_DTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSForeignKeyCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSForeignKeyCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.error.PSSqlException;
@@ -79,7 +79,7 @@ public class PSForeignKeyCatalogHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -87,7 +87,7 @@ public class PSForeignKeyCatalogHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSIndexCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSIndexCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.error.PSSqlException;
@@ -76,7 +76,7 @@ public class PSIndexCatalogHandler extends com.percussion.design.catalog.PSCatal
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -84,7 +84,7 @@ public class PSIndexCatalogHandler extends com.percussion.design.catalog.PSCatal
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSTableCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSTableCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.server.PSRequest;
@@ -80,7 +80,7 @@ public class PSTableCatalogHandler extends com.percussion.design.catalog.PSCatal
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -88,7 +88,7 @@ public class PSTableCatalogHandler extends com.percussion.design.catalog.PSCatal
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSTableTypesCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSTableTypesCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.error.PSSqlException;
@@ -75,7 +75,7 @@ public class PSTableTypesCatalogHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -83,7 +83,7 @@ public class PSTableTypesCatalogHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSUniqueKeyCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSUniqueKeyCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.error.PSSqlException;
@@ -76,7 +76,7 @@ public class PSUniqueKeyCatalogHandler extends com.percussion.design.catalog.PSC
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -84,7 +84,7 @@ public class PSUniqueKeyCatalogHandler extends com.percussion.design.catalog.PSC
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.exit.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -111,7 +111,7 @@ public class PSExtensionCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -119,7 +119,7 @@ public class PSExtensionCatalogHandler extends PSCatalogRequestHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionHandlerCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionHandlerCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.exit.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -94,7 +94,7 @@ public class PSExtensionHandlerCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -102,7 +102,7 @@ public class PSExtensionHandlerCatalogHandler extends PSCatalogRequestHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/file/server/PSColumnCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/file/server/PSColumnCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.file.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.server.PSRequest;
@@ -78,7 +78,7 @@ public class PSColumnCatalogHandler extends com.percussion.design.catalog.PSCata
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -86,7 +86,7 @@ public class PSColumnCatalogHandler extends com.percussion.design.catalog.PSCata
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/function/server/PSDatabaseFunctionCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/function/server/PSDatabaseFunctionCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.function.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -82,7 +82,7 @@ public class PSDatabaseFunctionCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {REQ_CATEGORY_VALUE, REQ_TYPE_VALUE, NODE_NAME};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -90,7 +90,7 @@ public class PSDatabaseFunctionCatalogHandler extends PSCatalogRequestHandler
     if (!NODE_NAME.equals(root.getTagName())) {
       Object[] args = {NODE_NAME, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/macro/server/PSMacroCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/macro/server/PSMacroCatalogHandler.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.design.catalog.macro.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -70,7 +70,7 @@ public class PSMacroCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {REQ_CATEGORY_VALUE, REQ_TYPE_VALUE, CATALOGER_NAME};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -78,7 +78,7 @@ public class PSMacroCatalogHandler extends PSCatalogRequestHandler
     if (!CATALOGER_NAME.equals(root.getTagName())) {
       Object[] args = {CATALOGER_NAME, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/mail/server/PSMailProviderCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/mail/server/PSMailProviderCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.mail.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.server.PSRequest;
@@ -115,7 +115,7 @@ public class PSMailProviderCatalogHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -123,7 +123,7 @@ public class PSMailProviderCatalogHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSAttributesCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSAttributesCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.security.IPSSecurityProviderMetaData;
 import com.percussion.security.PSSecurityProvider;
@@ -113,7 +113,7 @@ public class PSAttributesCatalogHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -121,7 +121,7 @@ public class PSAttributesCatalogHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSCatalogerCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSCatalogerCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -59,7 +59,7 @@ public class PSCatalogerCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -67,7 +67,7 @@ public class PSCatalogerCatalogHandler extends PSCatalogRequestHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSObjectCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSObjectCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -145,7 +145,7 @@ public class PSObjectCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -153,7 +153,7 @@ public class PSObjectCatalogHandler extends PSCatalogRequestHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSObjectTypesCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSObjectTypesCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -67,7 +67,7 @@ public class PSObjectTypesCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -75,7 +75,7 @@ public class PSObjectTypesCatalogHandler extends PSCatalogRequestHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSProviderCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSProviderCatalogHandler.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.security.PSSecurityProvider;
 import com.percussion.server.PSRequest;
@@ -115,7 +115,7 @@ public class PSProviderCatalogHandler extends com.percussion.design.catalog.PSCa
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -123,7 +123,7 @@ public class PSProviderCatalogHandler extends com.percussion.design.catalog.PSCa
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSServerCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSServerCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.security.IPSSecurityProviderMetaData;
 import com.percussion.security.PSSecurityProviderPool;
@@ -97,7 +97,7 @@ public class PSServerCatalogHandler extends com.percussion.design.catalog.PSCata
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -105,7 +105,7 @@ public class PSServerCatalogHandler extends com.percussion.design.catalog.PSCata
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/system/server/PSLocaleCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/system/server/PSLocaleCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.system.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -66,7 +66,7 @@ public class PSLocaleCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -74,7 +74,7 @@ public class PSLocaleCatalogHandler extends PSCatalogRequestHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/system/server/PSMimeTypeCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/system/server/PSMimeTypeCatalogHandler.java
@@ -18,7 +18,7 @@
 package com.percussion.design.catalog.system.server;
 
 import com.percussion.content.PSContentFactory;
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -63,7 +63,7 @@ public class PSMimeTypeCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -71,7 +71,7 @@ public class PSMimeTypeCatalogHandler extends PSCatalogRequestHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/test/java/com/percussion/design/catalog/PSDesignCatalogLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/design/catalog/PSDesignCatalogLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.error.PSIllegalArgumentException;
+import com.percussion.server.IPSServerErrors;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3969 (parent #2616): leftover {@code com.percussion.design.catalog} production sites throw
+ * typed {@code CatalogErrorCodes} / {@code ServerErrorCodes} (not bare {@code IPS*Errors} ints).
+ * Dual-write is skipped: leftover catalog protocol codes and {@code RESPONSE_SEND_ERROR} are
+ * non-auditable.
+ */
+@Tag("UnitTest")
+class PSDesignCatalogLeftoverErrorCodesSliceTest {
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWrite() {
+    assertEquals(
+        IPSCatalogErrors.REQ_DOC_MISSING, CatalogErrorCodes.REQ_DOC_MISSING.numericCode());
+    assertEquals(
+        IPSCatalogErrors.REQ_DOC_MISSING_GENERIC,
+        CatalogErrorCodes.REQ_DOC_MISSING_GENERIC.numericCode());
+    assertEquals(
+        IPSCatalogErrors.REQ_DOC_ROOT_MISSING_GENERIC,
+        CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC.numericCode());
+    assertEquals(
+        IPSCatalogErrors.REQ_DOC_INVALID_TYPE,
+        CatalogErrorCodes.REQ_DOC_INVALID_TYPE.numericCode());
+    assertEquals(
+        IPSCatalogErrors.NO_REQ_HANDLER_FOUND,
+        CatalogErrorCodes.NO_REQ_HANDLER_FOUND.numericCode());
+    assertEquals(
+        IPSCatalogErrors.CATALOG_EXCEPTION, CatalogErrorCodes.CATALOG_EXCEPTION.numericCode());
+    assertEquals(
+        IPSServerErrors.RESPONSE_SEND_ERROR, ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode());
+
+    leftoverNonAuditable(CatalogErrorCodes.REQ_DOC_MISSING);
+    leftoverNonAuditable(CatalogErrorCodes.REQ_DOC_MISSING_GENERIC);
+    leftoverNonAuditable(CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC);
+    leftoverNonAuditable(CatalogErrorCodes.REQ_DOC_INVALID_TYPE);
+    leftoverNonAuditable(CatalogErrorCodes.NO_REQ_HANDLER_FOUND);
+    leftoverNonAuditable(CatalogErrorCodes.CATALOG_EXCEPTION);
+    leftoverNonAuditable(ServerErrorCodes.RESPONSE_SEND_ERROR);
+  }
+
+  @Test
+  void leftoverProductionExceptionTypesRetainTypedCodes() {
+    Object[] missingArgs = {"data", "Column", "PSXColumnCatalog"};
+    PSIllegalArgumentException missingDoc =
+        new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, missingArgs);
+    assertSame(CatalogErrorCodes.REQ_DOC_MISSING, missingDoc.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.REQ_DOC_MISSING, missingDoc.getErrorCode());
+    assertFalse(missingDoc.isAuditable());
+
+    Object[] invalidTypeArgs = {"PSXColumnCatalog", "WrongRoot"};
+    PSIllegalArgumentException invalidType =
+        new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, invalidTypeArgs);
+    assertSame(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, invalidType.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, invalidType.getErrorCode());
+    assertFalse(invalidType.isAuditable());
+
+    PSIllegalArgumentException missingGeneric =
+        new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING_GENERIC);
+    assertSame(CatalogErrorCodes.REQ_DOC_MISSING_GENERIC, missingGeneric.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.REQ_DOC_MISSING_GENERIC, missingGeneric.getErrorCode());
+    assertFalse(missingGeneric.isAuditable());
+
+    PSIllegalArgumentException missingRoot =
+        new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC);
+    assertSame(CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC, missingRoot.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.REQ_DOC_ROOT_MISSING_GENERIC, missingRoot.getErrorCode());
+    assertFalse(missingRoot.isAuditable());
+
+    Object[] noHandlerArgs = {"UnknownCatalogRoot"};
+    PSIllegalArgumentException noHandler =
+        new PSIllegalArgumentException(CatalogErrorCodes.NO_REQ_HANDLER_FOUND, noHandlerArgs);
+    assertSame(CatalogErrorCodes.NO_REQ_HANDLER_FOUND, noHandler.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.NO_REQ_HANDLER_FOUND, noHandler.getErrorCode());
+    assertFalse(noHandler.isAuditable());
+  }
+
+  @Test
+  void typedProductionCtorsRejectNullCode() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSIllegalArgumentException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSIllegalArgumentException((IPSErrorCode) null, "arg"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSIllegalArgumentException((IPSErrorCode) null, new Object[] {"arg"}));
+  }
+
+  private static void leftoverNonAuditable(SystemErrorCode code) {
+    assertFalse(code.isAuditable(), code.toString());
+  }
+}


### PR DESCRIPTION
## Summary

Parent leftover slice of #2616. Converts remaining `system/src/main/java/com/percussion/design/catalog/` production `IPS*Errors` call-sites to typed `CatalogErrorCodes` / `ServerErrorCodes`. Residual allow-list shrunk by those exact 22 paths.

Int-only APIs (`PSLogServerWarning`, `PSCatalogRequestError`) use `.numericCode()`. Dual-write skip: leftover catalog protocol codes and `RESPONSE_SEND_ERROR` are non-auditable. `IPSCatalogErrors` interface is not deleted. `design.objectstore` and `design.server` leftovers stay on the allow-list (out of scope).

Fixes #3969
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2581, Failures: 0, Skipped: 246 (`PSDesignCatalogLeftoverErrorCodesSliceTest` 3/3)
2. `python scripts/verify-no-bare-ipserrors.py` — PASS
3. `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 20 passed
4. Review leftover production exception construction: typed catalog codes retained, null-code ctors rejected

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal error-catalog retype; no operator/API/UX/config change
- [x] **Unit / module tests** — behavioral leftover slice test for exact production exception types + dual-write skip; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` (no skipTests)
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- `modules_built=system`
- `build_evidence=cd system && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2581, Failures: 0, Skipped: 246 (`PSDesignCatalogLeftoverErrorCodesSliceTest` 3/3). `python scripts/verify-no-bare-ipserrors.py` PASS. pytest `scripts/test_verify_no_bare_ipserrors.py` 20 passed.
- `downstream_checked=C2 did not apply: call-site retype only (no final/sealed, no public/protected signature change). Grep: no extends PSIllegalArgumentException; no anonymous new PSIllegalArgumentException() {. No reverse-dep module rebuild required.`

### C5 UI proof

N/A — Java backend leftover retype; no UI surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
