### PR TITLE
cluster: absorb leftover IPS*Errors ErrorCodes slices (#3974 #3975 #3976)

### DIFF
--- a/docs/ai-generated/code-reviews/3969-design-catalog-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3969-design-catalog-errorcodes-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review — #3969 system design.catalog leftover IPS*Errors typed ErrorCodes
+
+**Scope:** uncommitted branch `fix/issue-3969-design-catalog-typed-errorcodes` vs `origin/main`  
+**Memory patterns hit:** typed `*ErrorCodes` + `IPSErrorCode` constructors; dual-write skip for `isAuditable()==false`; do not delete `IPS*Errors` interfaces; int-only APIs (`PSLogServerWarning`, `PSCatalogRequestError`) use `.numericCode()`; allow-list companion shrink.  
+**Cross-platform path checklist:** N/A (no new filesystem path joins; tests construct exceptions in-memory).
+
+## Summary
+
+Parent #2616 leftover slice: 22 `system/src/main/java/com/percussion/design/catalog/` production `IPS*Errors` sites now construct typed `CatalogErrorCodes` / `ServerErrorCodes`. Residual allow-list shrunk by those exact 22 paths. Dual-write skip tests cover leftover non-auditable catalog protocol codes and `RESPONSE_SEND_ERROR`. Production exception type is `PSIllegalArgumentException` with typed codes retained. `IPSCatalogErrors` interface is not deleted. Out of scope (`design.objectstore`, `design.server`, `com.percussion.error`) left on the allow-list. No product UI/config surface.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None.
+
+## Verification
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2581, Failures: 0, Skipped: 246 (`PSDesignCatalogLeftoverErrorCodesSliceTest` 3/3)
+- `python scripts/verify-no-bare-ipserrors.py` — PASS
+- `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 20 passed
+
+## Notes
+
+- C2: call-site retype only. No `final`/`sealed`, no public/protected signature change. Grep: no `extends PSIllegalArgumentException`; no anonymous `new PSIllegalArgumentException() {`.
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- `IPSCatalogErrors.CATALOG_EXCEPTION` and `IPSServerErrors.RESPONSE_SEND_ERROR` stay int-only at `PSCatalogRequestError` / `PSLogServerWarning` via `.numericCode()`.
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); dual-write skip when non-auditable.

--- a/docs/ai-generated/code-reviews/3970-extension-leftover-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3970-extension-leftover-errorcodes-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — #3970 system extension leftover IPS*Errors typed ErrorCodes
+
+- Branch: `fix/issue-3970-extension-typed-errorcodes`
+- Base: `origin/main`
+- Date: 2026-08-28
+- Recommendation: **approve**
+- Gate: **May commit/push: yes**
+- Memory patterns hit: behavioral tests for changed logic; incomplete change-class closure (typed exception ctors + allow-list shrink + dual-write skip); non-portable path/file I/O (checklist N/A)
+
+## Summary
+
+Parent #2616 leftover slice. Nine `system/src/main/java/com/percussion/extension` production `IPS*Errors` call-sites now construct typed catalogs (`ExtensionErrorCodes`, plus `ServerErrorCodes.ARGUMENT_ERROR` / `DataErrorCodes.UNSUPPORTED_CONVERSION` on `PSJavaScriptUdfExtension`). Additive `logMessage(IPSErrorCode, Object[])` on `PSExtensionHandler` keeps the int overload for `logMessage(0, …)`. Residual allow-list shrunk by those exact 9 paths. Dual-write skip is `isAuditable()==false` on leftover operational catalog codes. No product UI/config surface.
+
+## Change class
+
+Typed ErrorCodes production call-site conversion (leftover extension package).
+
+Companions present: existing IPSErrorCode constructors (no new public exception signatures); allow-list shrink; freeze-gate pytest so the 9 paths stay off the list; dual-write skip tests; production throw tests (`PSExtensionParams`, handler init, handler config missing file, JS UDF param/type/conversion).
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] New path logic uses `Path` / `Files` (`@TempDir Path` + `Files.writeString`)
+- [x] Tests do not assert Unix-only absolute path shapes
+- [x] Temp files use `@TempDir` (portable)
+
+## Issues
+
+None.
+
+## Verification
+
+- `python scripts/verify-no-bare-ipserrors.py` — PASS
+- `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 20 passed
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2587, Failures: 0, Skipped: 246 (`PSExtensionLeftoverErrorCodesSliceTest` 9/9)
+
+## Notes
+
+- C2: `logMessage(IPSErrorCode, Object[])` is additive protected. Grep `extends PSExtensionHandler` found `PSJavaExtensionHandler`, `PSJavaScriptExtensionHandler`, and the package test stub. No `new PSExtensionHandler() {`. No reverse-dep module install required (existing int overload unchanged; exception int ctors remain).
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- Dual-write skip tests go through the enum (`isAuditable()`), not `LegacyErrorCodeRegistry.find(int)`.
+- Did not delete `IPSExtensionErrors` (int bridge remains).
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); dual-write skip for `isAuditable()==false`.

--- a/docs/ai-generated/code-reviews/3971-system-error-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/3971-system-error-errorcodes-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review — #3971 system error leftover IPS*Errors typed ErrorCodes
+
+**Scope:** uncommitted branch `fix/issue-3971-system-error-ipserrors-errorcodes` vs `origin/main`  
+**Memory patterns hit:** typed `*ErrorCodes` + `IPSErrorCode` constructors; dual-write skip for `isAuditable()==false`; do not delete `IPS*Errors` interfaces; int-only APIs (`PSLogSubMessage`, `PSErrorManager.createMessage`/`getErrorText`, `PSLogServerWarning`) use `.numericCode()`; exact production exception types in tests (not supertypes); incomplete change-class closure (allow-list companion).  
+**Cross-platform path checklist:** N/A (no new filesystem path joins; tests construct exceptions in-memory).
+
+## Summary
+
+Parent #2616 leftover slice: 26 `system/src/main/java/com/percussion/error/` production `IPS*Errors` sites now use typed `ServerErrorCodes` / `BackEndErrorCodes` / `DataErrorCodes` / `CatalogErrorCodes` / `HttpErrorCodes` / `XmlErrorCodes`. `PSErrorException` constructs with typed `ServerErrorCodes.WRAPPED_LOG_ERROR`. Residual allow-list shrunk by those exact 26 paths. Dual-write skip tests cover leftover non-auditable catalog codes; leftover auditable authorization codes remain dual-write eligible. Production exception type `PSErrorException` retains typed code. No product UI/config surface.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None.
+
+## Verification
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2582, Failures: 0, Skipped: 246 (`PSErrorLeftoverErrorCodesSliceTest` 4/4)
+- `python scripts/verify-no-bare-ipserrors.py` — PASS
+- `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 19 passed
+
+## Notes
+
+- C2: no public/protected signature change, not `final`/`sealed`. Existing `extends PSErrorException` webservices types still use the same `PSLogError` constructors.
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+- Comment-only historical `IPS*Errors` mentions in leftover log-error builders are ignored by the freeze gate.
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); dual-write skip when non-auditable.

--- a/docs/ai-generated/code-reviews/3975-extension-typed-errorcodes-review-erlang.md
+++ b/docs/ai-generated/code-reviews/3975-extension-typed-errorcodes-review-erlang.md
@@ -1,0 +1,22 @@
+# Erlang review — PR #3975 review-thread follow-up
+
+**Scope:** uncommitted review-thread fix on `fix/issue-3970-extension-typed-errorcodes-wt` vs `HEAD`.
+**Recommendation:** approve
+**Gate:** May commit/push: yes
+**Memory patterns hit:** Public helper Javadoc that contradicts implementation; missing behavioral tests
+
+## Summary
+
+Kilo suggested the new `logMessage(IPSErrorCode, Object[])` Javadoc requires non-null `args` but only `errorCode` was validated. Enforced with `Objects.requireNonNull(args)` (matches Javadoc; int overload unchanged). Added `typedLogMessageRejectsNullArgs`.
+
+## Issues
+
+None. No signature change. No file I/O. Product-docs N/A (internal error-catalog helper).
+
+## Cross-platform path checklist
+
+N/A — no path/file I/O in this diff.
+
+## Evidence
+
+`cd system && ../mvnw.cmd clean install` → BUILD SUCCESS. Tests run: 2588, Failures: 0, Skipped: 246. `PSExtensionLeftoverErrorCodesSliceTest` 10/10 including `typedLogMessageRejectsNullArgs`.

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -18,6 +18,7 @@
 #   #3900 leftover cms.objectstore.server call sites
 #   #3939 leftover system/src/main com.percussion.data (+ macro/vfs)
 #   #3940 leftover system/src/main com.percussion.security call sites
+#   #3971 leftover system/src/main com.percussion.error call sites
 # Converted (no longer listed): extensions-main #3756/#3938 (allow-list
 # shrink after #3793 re-listed already-typed production paths).
 #
@@ -77,32 +78,6 @@ system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
 system/src/main/java/com/percussion/design/objectstore/PSObjectStore.java
 system/src/main/java/com/percussion/design/objectstore/server/PSXmlObjectStoreHandler.java
 system/src/main/java/com/percussion/design/server/PSDesignerConnectionHandler.java
-system/src/main/java/com/percussion/error/PSApplicationAuthorizationError.java
-system/src/main/java/com/percussion/error/PSApplicationDesignError.java
-system/src/main/java/com/percussion/error/PSBackEndAuthorizationError.java
-system/src/main/java/com/percussion/error/PSBackEndQueryProcessingError.java
-system/src/main/java/com/percussion/error/PSBackEndServerDownError.java
-system/src/main/java/com/percussion/error/PSBackEndUpdateProcessingError.java
-system/src/main/java/com/percussion/error/PSCatalogRequestError.java
-system/src/main/java/com/percussion/error/PSDataConversionError.java
-system/src/main/java/com/percussion/error/PSErrorException.java
-system/src/main/java/com/percussion/error/PSErrorHandler.java
-system/src/main/java/com/percussion/error/PSErrorHttpCodes.java
-system/src/main/java/com/percussion/error/PSFatalError.java
-system/src/main/java/com/percussion/error/PSHookRequestError.java
-system/src/main/java/com/percussion/error/PSHtmlProcessingError.java
-system/src/main/java/com/percussion/error/PSInternalError.java
-system/src/main/java/com/percussion/error/PSLargeBackEndRequestQueueError.java
-system/src/main/java/com/percussion/error/PSLargeRequestQueueError.java
-system/src/main/java/com/percussion/error/PSPoorResponseTimeError.java
-system/src/main/java/com/percussion/error/PSRemoteConsoleError.java
-system/src/main/java/com/percussion/error/PSRequestPreProcessingError.java
-system/src/main/java/com/percussion/error/PSRequestWaitTooLongError.java
-system/src/main/java/com/percussion/error/PSResponseSendError.java
-system/src/main/java/com/percussion/error/PSServerUnavailableError.java
-system/src/main/java/com/percussion/error/PSUnknownProcessingError.java
-system/src/main/java/com/percussion/error/PSValidationError.java
-system/src/main/java/com/percussion/error/PSXmlProcessingError.java
 system/src/main/java/com/percussion/extension/PSExtensionHandler.java
 system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java
 system/src/main/java/com/percussion/extension/PSExtensionParams.java

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -18,8 +18,10 @@
 #   #3900 leftover cms.objectstore.server call sites
 #   #3939 leftover system/src/main com.percussion.data (+ macro/vfs)
 #   #3940 leftover system/src/main com.percussion.security call sites
+#   #3969 leftover system/src/main design.catalog call sites
 # Converted (no longer listed): extensions-main #3756/#3938 (allow-list
-# shrink after #3793 re-listed already-typed production paths).
+# shrink after #3793 re-listed already-typed production paths);
+# design.catalog leftover #3969.
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -50,28 +52,6 @@ system/src/main/java/com/percussion/cx/PSOption.java
 system/src/main/java/com/percussion/cx/PSOptions.java
 system/src/main/java/com/percussion/cx/PSUserOptions.java
 system/src/main/java/com/percussion/debug/PSDebugLogHandler.java
-system/src/main/java/com/percussion/design/catalog/PSCatalogRequestHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSColumnCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSDatasourceCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSForeignKeyCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSIndexCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSTableCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSTableTypesCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/data/server/PSUniqueKeyCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionHandlerCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/file/server/PSColumnCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/function/server/PSDatabaseFunctionCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/macro/server/PSMacroCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/mail/server/PSMailProviderCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSAttributesCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSCatalogerCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSObjectCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSObjectTypesCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSProviderCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/security/server/PSServerCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/system/server/PSLocaleCatalogHandler.java
-system/src/main/java/com/percussion/design/catalog/system/server/PSMimeTypeCatalogHandler.java
 system/src/main/java/com/percussion/design/objectstore/PSContainerLocator.java
 system/src/main/java/com/percussion/design/objectstore/PSContentTypeHelper.java
 system/src/main/java/com/percussion/design/objectstore/PSObjectStore.java

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -103,15 +103,6 @@ system/src/main/java/com/percussion/error/PSServerUnavailableError.java
 system/src/main/java/com/percussion/error/PSUnknownProcessingError.java
 system/src/main/java/com/percussion/error/PSValidationError.java
 system/src/main/java/com/percussion/error/PSXmlProcessingError.java
-system/src/main/java/com/percussion/extension/PSExtensionHandler.java
-system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java
-system/src/main/java/com/percussion/extension/PSExtensionParams.java
-system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
-system/src/main/java/com/percussion/extension/PSJavaExtensionHandler.java
-system/src/main/java/com/percussion/extension/PSJavaScriptCallException.java
-system/src/main/java/com/percussion/extension/PSJavaScriptCompileException.java
-system/src/main/java/com/percussion/extension/PSJavaScriptUdfExtension.java
-system/src/main/java/com/percussion/extension/PSParameterMismatchException.java
 system/src/main/java/com/percussion/fastforward/managednav/PSManagedNavService.java
 system/src/main/java/com/percussion/fastforward/utils/PSUtils.java
 system/src/main/java/com/percussion/i18n/PSLocale.java

--- a/scripts/test_verify_no_bare_ipserrors.py
+++ b/scripts/test_verify_no_bare_ipserrors.py
@@ -35,7 +35,7 @@ DEPLOYER_RESIDUAL = (
 # converted in #3882, cms handlers in #3883, cms.objectstore+client in #3884;
 # cms.objectstore.server converted in #3900; extensions-main converted in
 # #3756/#3938; com.percussion.data (+ macro/vfs) in #3939; com.percussion.security
-# in #3940.
+# in #3940; design.catalog leftover call-sites in #3969.
 # Keep an exact residual that is still frozen (system debug leftover).
 SYSTEM_CMS_RESIDUAL = (
     "system/src/main/java/com/percussion/debug/PSDebugLogHandler.java"
@@ -395,6 +395,7 @@ def test_residual_allowlist_is_exact_paths_only() -> None:
         assert entry.endswith(".java"), entry
         assert not entry.startswith("modules/extensions-main/"), entry
         assert not entry.startswith("system/src/main/java/com/percussion/security/"), entry
+        assert not entry.startswith("system/src/main/java/com/percussion/design/catalog/"), entry
 
 
 def test_extensions_main_converted_paths_not_allowlisted() -> None:
@@ -419,6 +420,22 @@ def test_system_security_converted_paths_not_allowlisted() -> None:
     ]
     resurrected = [
         e for e in entries if e.startswith("system/src/main/java/com/percussion/security/")
+    ]
+    assert resurrected == [], resurrected
+
+
+def test_system_design_catalog_converted_paths_not_allowlisted() -> None:
+    """#3969 typed leftover com.percussion.design.catalog production call-sites."""
+    text = ALLOWLIST.read_text(encoding="utf-8")
+    entries = [
+        ln.strip()
+        for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+    resurrected = [
+        e
+        for e in entries
+        if e.startswith("system/src/main/java/com/percussion/design/catalog/")
     ]
     assert resurrected == [], resurrected
 

--- a/scripts/test_verify_no_bare_ipserrors.py
+++ b/scripts/test_verify_no_bare_ipserrors.py
@@ -395,6 +395,7 @@ def test_residual_allowlist_is_exact_paths_only() -> None:
         assert entry.endswith(".java"), entry
         assert not entry.startswith("modules/extensions-main/"), entry
         assert not entry.startswith("system/src/main/java/com/percussion/security/"), entry
+        assert not entry.startswith("system/src/main/java/com/percussion/extension/"), entry
 
 
 def test_extensions_main_converted_paths_not_allowlisted() -> None:
@@ -420,6 +421,29 @@ def test_system_security_converted_paths_not_allowlisted() -> None:
     resurrected = [
         e for e in entries if e.startswith("system/src/main/java/com/percussion/security/")
     ]
+    assert resurrected == [], resurrected
+
+
+def test_system_extension_converted_paths_not_allowlisted() -> None:
+    """#3970 typed leftover com.percussion.extension production call-sites."""
+    converted = (
+        "system/src/main/java/com/percussion/extension/PSExtensionHandler.java",
+        "system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java",
+        "system/src/main/java/com/percussion/extension/PSExtensionParams.java",
+        "system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java",
+        "system/src/main/java/com/percussion/extension/PSJavaExtensionHandler.java",
+        "system/src/main/java/com/percussion/extension/PSJavaScriptCallException.java",
+        "system/src/main/java/com/percussion/extension/PSJavaScriptCompileException.java",
+        "system/src/main/java/com/percussion/extension/PSJavaScriptUdfExtension.java",
+        "system/src/main/java/com/percussion/extension/PSParameterMismatchException.java",
+    )
+    text = ALLOWLIST.read_text(encoding="utf-8")
+    entries = {
+        ln.strip()
+        for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    }
+    resurrected = [p for p in converted if p in entries]
     assert resurrected == [], resurrected
 
 

--- a/scripts/test_verify_no_bare_ipserrors.py
+++ b/scripts/test_verify_no_bare_ipserrors.py
@@ -35,7 +35,7 @@ DEPLOYER_RESIDUAL = (
 # converted in #3882, cms handlers in #3883, cms.objectstore+client in #3884;
 # cms.objectstore.server converted in #3900; extensions-main converted in
 # #3756/#3938; com.percussion.data (+ macro/vfs) in #3939; com.percussion.security
-# in #3940.
+# in #3940; com.percussion.error in #3971.
 # Keep an exact residual that is still frozen (system debug leftover).
 SYSTEM_CMS_RESIDUAL = (
     "system/src/main/java/com/percussion/debug/PSDebugLogHandler.java"

--- a/system/src/main/java/com/percussion/design/catalog/PSCatalogRequestHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/PSCatalogRequestHandler.java
@@ -17,6 +17,8 @@
 
 package com.percussion.design.catalog;
 
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.design.objectstore.PSAclEntry;
 import com.percussion.error.IPSException;
 import com.percussion.error.PSErrorHandler;
@@ -69,14 +71,14 @@ public abstract class PSCatalogRequestHandler implements IPSRequestHandler, IPSV
       Document reqDoc = request.getInputDocument();
       if (reqDoc == null) {
         createErrorResponse(
-            request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING_GENERIC));
+            request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING_GENERIC));
         return;
       }
 
       Element root = reqDoc.getDocumentElement();
       if (root == null) {
         createErrorResponse(
-            request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_ROOT_MISSING_GENERIC));
+            request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC));
         return;
       }
 
@@ -86,7 +88,7 @@ public abstract class PSCatalogRequestHandler implements IPSRequestHandler, IPSV
       if (rh == null) {
         Object[] args = {root.getTagName()};
         createErrorResponse(
-            request, new PSIllegalArgumentException(IPSCatalogErrors.NO_REQ_HANDLER_FOUND, args));
+            request, new PSIllegalArgumentException(CatalogErrorCodes.NO_REQ_HANDLER_FOUND, args));
         return;
       }
 
@@ -146,7 +148,7 @@ public abstract class PSCatalogRequestHandler implements IPSRequestHandler, IPSV
         errorCode = pse.getErrorCode();
         args = pse.getErrorArguments();
       } else {
-        errorCode = IPSCatalogErrors.CATALOG_EXCEPTION;
+        errorCode = CatalogErrorCodes.CATALOG_EXCEPTION.numericCode();
         args = new Object[] {t.toString()};
       }
 
@@ -185,7 +187,7 @@ public abstract class PSCatalogRequestHandler implements IPSRequestHandler, IPSV
       };
       com.percussion.log.PSLogManager.write(
           new com.percussion.log.PSLogServerWarning(
-              com.percussion.server.IPSServerErrors.RESPONSE_SEND_ERROR,
+              ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(),
               args,
               true,
               "CatalogRequestHandler"));

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSColumnCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSColumnCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.server.PSRequest;
@@ -73,7 +73,7 @@ public class PSColumnCatalogHandler extends com.percussion.design.catalog.PSCata
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -81,7 +81,7 @@ public class PSColumnCatalogHandler extends com.percussion.design.catalog.PSCata
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSDatasourceCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSDatasourceCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -71,7 +71,7 @@ public class PSDatasourceCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {REQUEST_CATEGORY, REQUEST_TYPE, REQUEST_DTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
     String tAttrib = root.getAttribute("includeDbPubOnlySources");
@@ -81,7 +81,7 @@ public class PSDatasourceCatalogHandler extends PSCatalogRequestHandler
     if (!REQUEST_DTD.equals(root.getTagName())) {
       Object[] args = {REQUEST_DTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSForeignKeyCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSForeignKeyCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.error.PSSqlException;
@@ -79,7 +79,7 @@ public class PSForeignKeyCatalogHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -87,7 +87,7 @@ public class PSForeignKeyCatalogHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSIndexCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSIndexCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.error.PSSqlException;
@@ -76,7 +76,7 @@ public class PSIndexCatalogHandler extends com.percussion.design.catalog.PSCatal
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -84,7 +84,7 @@ public class PSIndexCatalogHandler extends com.percussion.design.catalog.PSCatal
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSTableCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSTableCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.server.PSRequest;
@@ -80,7 +80,7 @@ public class PSTableCatalogHandler extends com.percussion.design.catalog.PSCatal
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -88,7 +88,7 @@ public class PSTableCatalogHandler extends com.percussion.design.catalog.PSCatal
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSTableTypesCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSTableTypesCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.error.PSSqlException;
@@ -75,7 +75,7 @@ public class PSTableTypesCatalogHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -83,7 +83,7 @@ public class PSTableTypesCatalogHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/data/server/PSUniqueKeyCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/data/server/PSUniqueKeyCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.data.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.error.PSSqlException;
@@ -76,7 +76,7 @@ public class PSUniqueKeyCatalogHandler extends com.percussion.design.catalog.PSC
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -84,7 +84,7 @@ public class PSUniqueKeyCatalogHandler extends com.percussion.design.catalog.PSC
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.exit.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -111,7 +111,7 @@ public class PSExtensionCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -119,7 +119,7 @@ public class PSExtensionCatalogHandler extends PSCatalogRequestHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionHandlerCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/exit/server/PSExtensionHandlerCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.exit.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -94,7 +94,7 @@ public class PSExtensionHandlerCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -102,7 +102,7 @@ public class PSExtensionHandlerCatalogHandler extends PSCatalogRequestHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/file/server/PSColumnCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/file/server/PSColumnCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.file.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.server.PSRequest;
@@ -78,7 +78,7 @@ public class PSColumnCatalogHandler extends com.percussion.design.catalog.PSCata
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -86,7 +86,7 @@ public class PSColumnCatalogHandler extends com.percussion.design.catalog.PSCata
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/function/server/PSDatabaseFunctionCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/function/server/PSDatabaseFunctionCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.function.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -82,7 +82,7 @@ public class PSDatabaseFunctionCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {REQ_CATEGORY_VALUE, REQ_TYPE_VALUE, NODE_NAME};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -90,7 +90,7 @@ public class PSDatabaseFunctionCatalogHandler extends PSCatalogRequestHandler
     if (!NODE_NAME.equals(root.getTagName())) {
       Object[] args = {NODE_NAME, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/macro/server/PSMacroCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/macro/server/PSMacroCatalogHandler.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.design.catalog.macro.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -70,7 +70,7 @@ public class PSMacroCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {REQ_CATEGORY_VALUE, REQ_TYPE_VALUE, CATALOGER_NAME};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -78,7 +78,7 @@ public class PSMacroCatalogHandler extends PSCatalogRequestHandler
     if (!CATALOGER_NAME.equals(root.getTagName())) {
       Object[] args = {CATALOGER_NAME, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/mail/server/PSMailProviderCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/mail/server/PSMailProviderCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.mail.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.server.PSRequest;
@@ -115,7 +115,7 @@ public class PSMailProviderCatalogHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -123,7 +123,7 @@ public class PSMailProviderCatalogHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSAttributesCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSAttributesCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.security.IPSSecurityProviderMetaData;
 import com.percussion.security.PSSecurityProvider;
@@ -113,7 +113,7 @@ public class PSAttributesCatalogHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -121,7 +121,7 @@ public class PSAttributesCatalogHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSCatalogerCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSCatalogerCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -59,7 +59,7 @@ public class PSCatalogerCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -67,7 +67,7 @@ public class PSCatalogerCatalogHandler extends PSCatalogRequestHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSObjectCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSObjectCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -145,7 +145,7 @@ public class PSObjectCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -153,7 +153,7 @@ public class PSObjectCatalogHandler extends PSCatalogRequestHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSObjectTypesCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSObjectTypesCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -67,7 +67,7 @@ public class PSObjectTypesCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -75,7 +75,7 @@ public class PSObjectTypesCatalogHandler extends PSCatalogRequestHandler
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSProviderCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSProviderCatalogHandler.java
@@ -16,7 +16,7 @@
  */
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.security.PSSecurityProvider;
 import com.percussion.server.PSRequest;
@@ -115,7 +115,7 @@ public class PSProviderCatalogHandler extends com.percussion.design.catalog.PSCa
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -123,7 +123,7 @@ public class PSProviderCatalogHandler extends com.percussion.design.catalog.PSCa
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/security/server/PSServerCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/security/server/PSServerCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.security.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.error.PSIllegalArgumentException;
 import com.percussion.security.IPSSecurityProviderMetaData;
 import com.percussion.security.PSSecurityProviderPool;
@@ -97,7 +97,7 @@ public class PSServerCatalogHandler extends com.percussion.design.catalog.PSCata
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_RequestCategory, ms_RequestType, ms_RequestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -105,7 +105,7 @@ public class PSServerCatalogHandler extends com.percussion.design.catalog.PSCata
     if (!ms_RequestDTD.equals(root.getTagName())) {
       Object[] args = {ms_RequestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/system/server/PSLocaleCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/system/server/PSLocaleCatalogHandler.java
@@ -17,7 +17,7 @@
 
 package com.percussion.design.catalog.system.server;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -66,7 +66,7 @@ public class PSLocaleCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -74,7 +74,7 @@ public class PSLocaleCatalogHandler extends PSCatalogRequestHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/design/catalog/system/server/PSMimeTypeCatalogHandler.java
+++ b/system/src/main/java/com/percussion/design/catalog/system/server/PSMimeTypeCatalogHandler.java
@@ -18,7 +18,7 @@
 package com.percussion.design.catalog.system.server;
 
 import com.percussion.content.PSContentFactory;
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.design.catalog.IPSCatalogRequestHandler;
 import com.percussion.design.catalog.PSCatalogRequestHandler;
 import com.percussion.error.PSIllegalArgumentException;
@@ -63,7 +63,7 @@ public class PSMimeTypeCatalogHandler extends PSCatalogRequestHandler
     if ((doc == null) || ((root = doc.getDocumentElement()) == null)) {
       Object[] args = {ms_requestCategory, ms_requestType, ms_requestDTD};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_MISSING, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, args));
       return;
     }
 
@@ -71,7 +71,7 @@ public class PSMimeTypeCatalogHandler extends PSCatalogRequestHandler
     if (!ms_requestDTD.equals(root.getTagName())) {
       Object[] args = {ms_requestDTD, root.getTagName()};
       createErrorResponse(
-          request, new PSIllegalArgumentException(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, args));
+          request, new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, args));
       return;
     }
 

--- a/system/src/main/java/com/percussion/error/PSApplicationAuthorizationError.java
+++ b/system/src/main/java/com/percussion/error/PSApplicationAuthorizationError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -82,15 +82,17 @@ public class PSApplicationAuthorizationError extends PSLogError {
     Object[] args = {m_host, m_uid};
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.AUTHORIZATION_ERROR,
-            PSErrorManager.createMessage(IPSServerErrors.AUTHORIZATION_ERROR, args, loc));
+            ServerErrorCodes.AUTHORIZATION_ERROR.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.AUTHORIZATION_ERROR.numericCode(), args, loc));
 
     /* use the errorCode/errorString to format the second submessage */
     Object[] nativeArgs = {Integer.valueOf(m_errorCode), m_errorString};
     msgs[1] =
         new PSLogSubMessage(
             m_errorCode,
-            PSErrorManager.createMessage(IPSServerErrors.NATIVE_ERROR, nativeArgs, loc));
+            PSErrorManager.createMessage(
+                ServerErrorCodes.NATIVE_ERROR.numericCode(), nativeArgs, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSApplicationDesignError.java
+++ b/system/src/main/java/com/percussion/error/PSApplicationDesignError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.Locale;
 import java.util.Objects;
@@ -81,8 +81,9 @@ public final class PSApplicationDesignError extends PSLogError {
     if (msgCount == 2) {
       msgs[1] =
           new PSLogSubMessage(
-              IPSServerErrors.RAW_DUMP,
-              PSErrorManager.createMessage(IPSServerErrors.RAW_DUMP, new Object[] {m_source}, loc));
+              ServerErrorCodes.RAW_DUMP.numericCode(),
+              PSErrorManager.createMessage(
+                  ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_source}, loc));
     }
 
     return msgs;

--- a/system/src/main/java/com/percussion/error/PSBackEndAuthorizationError.java
+++ b/system/src/main/java/com/percussion/error/PSBackEndAuthorizationError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSBackEndErrors;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -92,8 +92,9 @@ public class PSBackEndAuthorizationError extends PSBackEndError {
     Object[] params = {m_host, m_uid, m_driver, m_server};
     msgs[0] =
         new PSLogSubMessage(
-            IPSBackEndErrors.AUTHORIZATION_ERROR,
-            PSErrorManager.createMessage(IPSBackEndErrors.AUTHORIZATION_ERROR, params, loc));
+            BackEndErrorCodes.AUTHORIZATION_ERROR.numericCode(),
+            PSErrorManager.createMessage(
+                BackEndErrorCodes.AUTHORIZATION_ERROR.numericCode(), params, loc));
 
     /* use IPSServerErrors.NATIVE_ERROR along with
      *    [0] = errorCode
@@ -104,7 +105,8 @@ public class PSBackEndAuthorizationError extends PSBackEndError {
     msgs[1] =
         new PSLogSubMessage(
             m_errorCode,
-            PSErrorManager.createMessage(IPSServerErrors.NATIVE_ERROR, nativeArgs, loc));
+            PSErrorManager.createMessage(
+                ServerErrorCodes.NATIVE_ERROR.numericCode(), nativeArgs, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSBackEndQueryProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSBackEndQueryProcessingError.java
@@ -18,9 +18,9 @@
 // REFACTORED: CP-JAVA11
 package com.percussion.error;
 
-import com.percussion.data.IPSDataErrors;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.Locale;
 import org.w3c.dom.Element;
@@ -61,7 +61,7 @@ public class PSBackEndQueryProcessingError extends PSBackEndError {
     this(
         applId,
         sessionId,
-        IPSServerErrors.NATIVE_ERROR,
+        ServerErrorCodes.NATIVE_ERROR.numericCode(),
         new Object[] {
           Integer.valueOf(errorCode),
           // REFACTORED: CP-JAVA11
@@ -140,9 +140,11 @@ public class PSBackEndQueryProcessingError extends PSBackEndError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSDataErrors.QUERY_PROCESSING_ERROR,
+            DataErrorCodes.QUERY_PROCESSING_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSDataErrors.QUERY_PROCESSING_ERROR, new Object[] {m_sessId}, loc));
+                DataErrorCodes.QUERY_PROCESSING_ERROR.numericCode(),
+                new Object[] {m_sessId},
+                loc));
 
     /* use the errorCode/errorParams to format the second submessage
      */
@@ -155,8 +157,9 @@ public class PSBackEndQueryProcessingError extends PSBackEndError {
      */
     msgs[2] =
         new PSLogSubMessage(
-            IPSServerErrors.RAW_DUMP,
-            PSErrorManager.createMessage(IPSServerErrors.RAW_DUMP, new Object[] {m_source}, loc));
+            ServerErrorCodes.RAW_DUMP.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_source}, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSBackEndServerDownError.java
+++ b/system/src/main/java/com/percussion/error/PSBackEndServerDownError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSBackEndErrors;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -73,9 +73,11 @@ public class PSBackEndServerDownError extends PSBackEndError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSBackEndErrors.SERVER_DOWN_ERROR,
+            BackEndErrorCodes.SERVER_DOWN_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSBackEndErrors.SERVER_DOWN_ERROR, new String[] {m_driver, m_server}, loc));
+                BackEndErrorCodes.SERVER_DOWN_ERROR.numericCode(),
+                new String[] {m_driver, m_server},
+                loc));
 
     /* use IPSServerErrors.NATIVE_ERROR along with
      *    [0] = errorCode
@@ -86,7 +88,7 @@ public class PSBackEndServerDownError extends PSBackEndError {
         new PSLogSubMessage(
             m_errorCode,
             PSErrorManager.createMessage(
-                IPSServerErrors.NATIVE_ERROR,
+                ServerErrorCodes.NATIVE_ERROR.numericCode(),
                 new Object[] {Integer.valueOf(m_errorCode), m_errorArgs[0]},
                 loc));
 

--- a/system/src/main/java/com/percussion/error/PSBackEndUpdateProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSBackEndUpdateProcessingError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSDataErrors;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 import org.w3c.dom.Element;
 
@@ -59,7 +59,7 @@ public class PSBackEndUpdateProcessingError extends PSBackEndError {
     this(
         applId,
         sessionId,
-        IPSServerErrors.NATIVE_ERROR,
+        ServerErrorCodes.NATIVE_ERROR.numericCode(),
         new Object[] {
           Integer.valueOf(errorCode),
           // REFACTORED: CP-JAVA11
@@ -198,9 +198,11 @@ public class PSBackEndUpdateProcessingError extends PSBackEndError {
        */
       msgs[errorCount++] =
           new PSLogSubMessage(
-              IPSDataErrors.UPDATE_PROCESSING_ERROR,
+              DataErrorCodes.UPDATE_PROCESSING_ERROR.numericCode(),
               PSErrorManager.createMessage(
-                  IPSDataErrors.UPDATE_PROCESSING_ERROR, new Object[] {m_sessId}, loc));
+                  DataErrorCodes.UPDATE_PROCESSING_ERROR.numericCode(),
+                  new Object[] {m_sessId},
+                  loc));
 
       /* use the errorCode/errorParams to format the second submessage
        */
@@ -213,9 +215,9 @@ public class PSBackEndUpdateProcessingError extends PSBackEndError {
        */
       msgs[errorCount++] =
           new PSLogSubMessage(
-              IPSServerErrors.RAW_DUMP,
+              ServerErrorCodes.RAW_DUMP.numericCode(),
               PSErrorManager.createMessage(
-                  IPSServerErrors.RAW_DUMP,
+                  ServerErrorCodes.RAW_DUMP.numericCode(),
                   new Object[] {((m_sourceSql == null) ? "" : m_sourceSql)},
                   loc));
     }

--- a/system/src/main/java/com/percussion/error/PSCatalogRequestError.java
+++ b/system/src/main/java/com/percussion/error/PSCatalogRequestError.java
@@ -18,7 +18,7 @@
 
 package com.percussion.error;
 
-import com.percussion.design.catalog.IPSCatalogErrors;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
 import java.util.Locale;
@@ -70,9 +70,9 @@ public class PSCatalogRequestError extends PSLogError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSCatalogErrors.CATALOG_ERROR,
+            CatalogErrorCodes.CATALOG_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSCatalogErrors.CATALOG_ERROR,
+                CatalogErrorCodes.CATALOG_ERROR.numericCode(),
                 new Object[] {m_sessId, m_reqCategory, m_reqType},
                 loc));
 

--- a/system/src/main/java/com/percussion/error/PSDataConversionError.java
+++ b/system/src/main/java/com/percussion/error/PSDataConversionError.java
@@ -18,9 +18,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -84,9 +84,9 @@ public class PSDataConversionError extends PSLogError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.DATA_CONV_ERROR,
+            ServerErrorCodes.DATA_CONV_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.DATA_CONV_ERROR,
+                ServerErrorCodes.DATA_CONV_ERROR.numericCode(),
                 new Object[] {m_sessId, m_sourceType, m_targetType},
                 loc));
 
@@ -96,9 +96,9 @@ public class PSDataConversionError extends PSLogError {
      */
     msgs[1] =
         new PSLogSubMessage(
-            IPSServerErrors.RAW_DUMP,
+            ServerErrorCodes.RAW_DUMP.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.RAW_DUMP, new Object[] {m_sourceData}, loc));
+                ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_sourceData}, loc));
 
     /* use the errorCode/errorParams to format the third submessage */
     msgs[2] =

--- a/system/src/main/java/com/percussion/error/PSErrorException.java
+++ b/system/src/main/java/com/percussion/error/PSErrorException.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 
 /**
  * The PSErrorException class provides a wrapper to throw PSLogError objects which contain more
@@ -35,15 +35,15 @@ public class PSErrorException extends PSException {
   /**
    * Constructs a new <code>PSErrorException</code> to allow the specified <code>PSLogError</code>
    * to be thrown. This exception will use the code {@link
-   * com.percussion.server.IPSServerErrors#WRAPPED_LOG_ERROR WRAPPED_LOG_ERROR} and the exception
-   * text will consist of all the log error's sub-messages concatenated together.
+   * com.intsof.percussioncms.auditlog.codes.ServerErrorCodes#WRAPPED_LOG_ERROR WRAPPED_LOG_ERROR}
+   * and the exception text will consist of all the log error's sub-messages concatenated together.
    *
    * @param err the error object to wrap; if <code>null</code>, the text of this exception will be
    *     empty.
    */
   public PSErrorException(PSLogError err) {
     super(
-        IPSServerErrors.WRAPPED_LOG_ERROR,
+        ServerErrorCodes.WRAPPED_LOG_ERROR,
         new Object[] {getMessageText(err), Integer.valueOf(getMessageCode(err))});
     m_errorObject = err;
   }
@@ -58,7 +58,7 @@ public class PSErrorException extends PSException {
    */
   public PSErrorException(PSLogError err, Throwable cause) {
     super(
-        IPSServerErrors.WRAPPED_LOG_ERROR,
+        ServerErrorCodes.WRAPPED_LOG_ERROR,
         new Object[] {getMessageText(err), Integer.valueOf(getMessageCode(err))},
         cause);
     m_errorObject = err;

--- a/system/src/main/java/com/percussion/error/PSErrorHandler.java
+++ b/system/src/main/java/com/percussion/error/PSErrorHandler.java
@@ -19,6 +19,8 @@ package com.percussion.error;
 
 import com.intsof.percussioncms.auditlog.AuditContext;
 import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.content.IPSMimeContentTypes;
 import com.percussion.data.PSConversionException;
 import com.percussion.data.PSStyleSheetMerger;
@@ -30,7 +32,6 @@ import com.percussion.design.objectstore.PSRecipient;
 import com.percussion.log.PSLogError;
 import com.percussion.mail.PSMailSendException;
 import com.percussion.mail.PSSmtpMailProvider;
-import com.percussion.server.IPSHttpErrors;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSResponse;
@@ -339,7 +340,7 @@ public class PSErrorHandler {
 
     int statusCode = PSErrorHttpCodes.getHttpCode(err, loc);
     response.setStatus(statusCode);
-    if (statusCode == IPSHttpErrors.HTTP_UNAUTHORIZED) {
+    if (statusCode == HttpErrorCodes.HTTP_UNAUTHORIZED.numericCode()) {
       /* *TODO*
        *
        * We do not currently support realms, though we probably
@@ -453,7 +454,7 @@ public class PSErrorHandler {
       Object[] args = {null, e.toString()};
       com.percussion.log.PSLogManager.write(
           new com.percussion.log.PSLogServerWarning(
-              com.percussion.server.IPSServerErrors.RESPONSE_SEND_ERROR,
+              ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(),
               args,
               true,
               "PSErrorHandler"));

--- a/system/src/main/java/com/percussion/error/PSErrorHandlerTest.java
+++ b/system/src/main/java/com/percussion/error/PSErrorHandlerTest.java
@@ -16,10 +16,10 @@
  */
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.design.objectstore.PSNotifier;
 import com.percussion.design.objectstore.PSRecipient;
 import com.percussion.log.PSLogError;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.util.PSCollection;
 import com.percussion.util.PSMapClassToObject;
 import org.apache.logging.log4j.LogManager;
@@ -85,7 +85,7 @@ public class PSErrorHandlerTest {
 
       PSErrorHandler errHandler = new PSErrorHandler(errPage, true, notify);
 
-      errCode = IPSServerErrors.AUTHORIZATION_ERROR;
+      errCode = ServerErrorCodes.AUTHORIZATION_ERROR.numericCode();
       ip = "38.131.120.53";
       login = "zzz";
       PSApplicationAuthorizationError appAuthErr =
@@ -99,13 +99,13 @@ public class PSErrorHandlerTest {
       appAuthErr = new PSApplicationAuthorizationError(22, ip, login, errCode, null);
       errHandler.notifyAdmins((PSLogError) appAuthErr);
 
-      errCode = IPSServerErrors.DATA_CONV_ERROR;
+      errCode = ServerErrorCodes.DATA_CONV_ERROR.numericCode();
       sessId = "session_dataConversion";
       PSDataConversionError conversionErr =
           new PSDataConversionError(31, sessId, errCode, null, null, null, null);
       errHandler.notifyAdmins((PSLogError) conversionErr);
 
-      errCode = IPSServerErrors.VALIDATION_ERROR;
+      errCode = ServerErrorCodes.VALIDATION_ERROR.numericCode();
       sessId = "session_validation";
       PSValidationError validErr = new PSValidationError(41, sessId, errCode, null, null);
       errHandler.notifyAdmins((PSLogError) validErr);
@@ -118,13 +118,13 @@ public class PSErrorHandlerTest {
       PSPoorResponseTimeError respErr = new PSPoorResponseTimeError(61, sessId, 1500);
       errHandler.notifyAdmins((PSLogError) respErr);
 
-      errCode = IPSServerErrors.AUTHORIZATION_ERROR;
+      errCode = ServerErrorCodes.AUTHORIZATION_ERROR.numericCode();
       ip = "38.131.120.53";
       login = "zzz";
       appAuthErr = new PSApplicationAuthorizationError(12, ip, login, errCode, null);
       errHandler.notifyAdmins((PSLogError) appAuthErr);
 
-      errCode = IPSServerErrors.DATA_CONV_ERROR;
+      errCode = ServerErrorCodes.DATA_CONV_ERROR.numericCode();
       sessId = "session_dataConversion";
       conversionErr = new PSDataConversionError(101, sessId, errCode, null, null, null, null);
       errHandler.notifyAdmins((PSLogError) conversionErr);

--- a/system/src/main/java/com/percussion/error/PSErrorHttpCodes.java
+++ b/system/src/main/java/com/percussion/error/PSErrorHttpCodes.java
@@ -17,6 +17,7 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.log.PSLogInformation;
 import com.percussion.util.PSMapClassToObject;
@@ -81,7 +82,7 @@ public class PSErrorHttpCodes {
             Object[] args = {key, com.percussion.error.PSException.getStackTraceAsString(nfe)};
             com.percussion.log.PSLogManager.write(
                 new com.percussion.log.PSLogServerWarning(
-                    com.percussion.server.IPSHttpErrors.HTTP_NOT_FOUND,
+                    HttpErrorCodes.HTTP_NOT_FOUND.numericCode(),
                     args,
                     true,
                     "HttpErrorCodesLoader"));

--- a/system/src/main/java/com/percussion/error/PSFatalError.java
+++ b/system/src/main/java/com/percussion/error/PSFatalError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -53,8 +53,9 @@ public class PSFatalError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.FATAL_SERVER_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.FATAL_SERVER_ERROR_MSG, false, loc));
+            ServerErrorCodes.FATAL_SERVER_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.FATAL_SERVER_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSHookRequestError.java
+++ b/system/src/main/java/com/percussion/error/PSHookRequestError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -52,8 +52,9 @@ public class PSHookRequestError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.HOOK_REQUEST_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.HOOK_REQUEST_ERROR_MSG, false, loc));
+            ServerErrorCodes.HOOK_REQUEST_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.HOOK_REQUEST_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSHtmlProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSHtmlProcessingError.java
@@ -17,7 +17,7 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSDataErrors;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
 import java.util.Locale;
@@ -91,9 +91,11 @@ public class PSHtmlProcessingError extends PSLogError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSDataErrors.HTML_GENERATION_ERROR,
+            DataErrorCodes.HTML_GENERATION_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSDataErrors.HTML_GENERATION_ERROR, new Object[] {m_sessId, m_styleSheet}, loc));
+                DataErrorCodes.HTML_GENERATION_ERROR.numericCode(),
+                new Object[] {m_sessId, m_styleSheet},
+                loc));
 
     /* use m_errorCode/m_errorArgs to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSInternalError.java
+++ b/system/src/main/java/com/percussion/error/PSInternalError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -66,8 +66,9 @@ public class PSInternalError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.INTERNAL_SERVER_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.INTERNAL_SERVER_ERROR_MSG, false, loc));
+            ServerErrorCodes.INTERNAL_SERVER_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.INTERNAL_SERVER_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSLargeBackEndRequestQueueError.java
+++ b/system/src/main/java/com/percussion/error/PSLargeBackEndRequestQueueError.java
@@ -17,7 +17,7 @@
 
 package com.percussion.error;
 
-import com.percussion.data.IPSBackEndErrors;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
 import com.percussion.log.PSLogSubMessage;
 import java.util.Locale;
 
@@ -80,8 +80,9 @@ public class PSLargeBackEndRequestQueueError extends PSLargeRequestQueueError {
     Object[] args = {m_sessId, Integer.valueOf(m_size), m_driver, m_server};
     msgs[0] =
         new PSLogSubMessage(
-            IPSBackEndErrors.REQUEST_QUEUE_FULL,
-            PSErrorManager.createMessage(IPSBackEndErrors.REQUEST_QUEUE_FULL, args, loc));
+            BackEndErrorCodes.REQUEST_QUEUE_FULL.numericCode(),
+            PSErrorManager.createMessage(
+                BackEndErrorCodes.REQUEST_QUEUE_FULL.numericCode(), args, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSLargeRequestQueueError.java
+++ b/system/src/main/java/com/percussion/error/PSLargeRequestQueueError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -81,8 +81,9 @@ public class PSLargeRequestQueueError extends PSLogError {
     Object[] args = {m_sessId, Integer.valueOf(m_size)};
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.REQUEST_QUEUE_FULL,
-            PSErrorManager.createMessage(IPSServerErrors.REQUEST_QUEUE_FULL, args, loc));
+            ServerErrorCodes.REQUEST_QUEUE_FULL.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.REQUEST_QUEUE_FULL.numericCode(), args, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSPoorResponseTimeError.java
+++ b/system/src/main/java/com/percussion/error/PSPoorResponseTimeError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -82,8 +82,9 @@ public class PSPoorResponseTimeError extends PSLogError {
     Object[] args = {m_sessId, new Double((double) ((double) m_timeMS / 1000.0))};
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.POOR_RESPONSE_TIME,
-            PSErrorManager.createMessage(IPSServerErrors.POOR_RESPONSE_TIME, args, loc));
+            ServerErrorCodes.POOR_RESPONSE_TIME.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.POOR_RESPONSE_TIME.numericCode(), args, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSRemoteConsoleError.java
+++ b/system/src/main/java/com/percussion/error/PSRemoteConsoleError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -40,12 +40,12 @@ public class PSRemoteConsoleError extends PSLogError {
   public PSRemoteConsoleError(String command, Throwable t) {
     super(0);
     if (command != null) {
-      m_errorCode = IPSServerErrors.RCONSOLE_EXEC_EXCEPTION;
+      m_errorCode = ServerErrorCodes.RCONSOLE_EXEC_EXCEPTION.numericCode();
       m_errorArgs = new Object[2];
       m_errorArgs[0] = command;
       m_errorArgs[1] = t.getMessage();
     } else {
-      m_errorCode = IPSServerErrors.RCONSOLE_COMMAND_EXCEPTION;
+      m_errorCode = ServerErrorCodes.RCONSOLE_COMMAND_EXCEPTION.numericCode();
       m_errorArgs = new Object[1];
       m_errorArgs[0] = t.getMessage();
     }
@@ -58,8 +58,9 @@ public class PSRemoteConsoleError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.RCONSOLE_COMMAND_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.RCONSOLE_COMMAND_ERROR_MSG, false, loc));
+            ServerErrorCodes.RCONSOLE_COMMAND_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.RCONSOLE_COMMAND_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSRequestPreProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSRequestPreProcessingError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSRequestParsingException;
 import java.net.InetAddress;
 import java.util.Locale;
@@ -77,9 +77,11 @@ public class PSRequestPreProcessingError extends PSLogError {
     /* the generic submessage first (contains host address) */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.REQUEST_PREPROC_ERROR,
+            ServerErrorCodes.REQUEST_PREPROC_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.REQUEST_PREPROC_ERROR, new Object[] {m_host}, loc));
+                ServerErrorCodes.REQUEST_PREPROC_ERROR.numericCode(),
+                new Object[] {m_host},
+                loc));
 
     /* the submessage containing m_errorCode/m_errorArgs */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSRequestWaitTooLongError.java
+++ b/system/src/main/java/com/percussion/error/PSRequestWaitTooLongError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -70,8 +70,9 @@ public class PSRequestWaitTooLongError extends PSLogError {
     Object[] args = {m_sessId, Integer.valueOf(m_size)};
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.REQUEST_WAIT_TOO_LONG,
-            PSErrorManager.createMessage(IPSServerErrors.REQUEST_WAIT_TOO_LONG, args, loc));
+            ServerErrorCodes.REQUEST_WAIT_TOO_LONG.numericCode(),
+            PSErrorManager.createMessage(
+                ServerErrorCodes.REQUEST_WAIT_TOO_LONG.numericCode(), args, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSResponseSendError.java
+++ b/system/src/main/java/com/percussion/error/PSResponseSendError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -69,9 +69,11 @@ public class PSResponseSendError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.RESPONSE_SEND_ERROR,
+            ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.RESPONSE_SEND_ERROR, new Object[] {m_sessId}, loc));
+                ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(),
+                new Object[] {m_sessId},
+                loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSServerUnavailableError.java
+++ b/system/src/main/java/com/percussion/error/PSServerUnavailableError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -52,8 +52,9 @@ public class PSServerUnavailableError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.SERVER_UNAVAILABLE_ERROR_MSG,
-            PSErrorManager.getErrorText(IPSServerErrors.SERVER_UNAVAILABLE_ERROR_MSG, false, loc));
+            ServerErrorCodes.SERVER_UNAVAILABLE_ERROR_MSG.numericCode(),
+            PSErrorManager.getErrorText(
+                ServerErrorCodes.SERVER_UNAVAILABLE_ERROR_MSG.numericCode(), false, loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSUnknownProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSUnknownProcessingError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import java.util.Locale;
 
 /**
@@ -69,9 +69,11 @@ public class PSUnknownProcessingError extends PSLogError {
     /* the generic submessage first */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.UNKNOWN_PROCESSING_ERROR,
+            ServerErrorCodes.UNKNOWN_PROCESSING_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.UNKNOWN_PROCESSING_ERROR, new Object[] {m_sessId}, loc));
+                ServerErrorCodes.UNKNOWN_PROCESSING_ERROR.numericCode(),
+                new Object[] {m_sessId},
+                loc));
 
     /* use the errorCode/errorParams to format the second submessage */
     msgs[1] =

--- a/system/src/main/java/com/percussion/error/PSValidationError.java
+++ b/system/src/main/java/com/percussion/error/PSValidationError.java
@@ -17,9 +17,9 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.Locale;
 import org.w3c.dom.Element;
@@ -80,9 +80,9 @@ public class PSValidationError extends PSLogError {
     /* the generic submessage first (contains session id) */
     msgs[0] =
         new PSLogSubMessage(
-            IPSServerErrors.VALIDATION_ERROR,
+            ServerErrorCodes.VALIDATION_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSServerErrors.VALIDATION_ERROR, new Object[] {m_sessId}, loc));
+                ServerErrorCodes.VALIDATION_ERROR.numericCode(), new Object[] {m_sessId}, loc));
 
     /* the submessage containing m_errorCode/m_errorArgs */
     msgs[1] =
@@ -92,8 +92,9 @@ public class PSValidationError extends PSLogError {
     if (msgCount == 3) /* write the source data */
       msgs[2] =
           new PSLogSubMessage(
-              IPSServerErrors.RAW_DUMP,
-              PSErrorManager.createMessage(IPSServerErrors.RAW_DUMP, new Object[] {m_source}, loc));
+              ServerErrorCodes.RAW_DUMP.numericCode(),
+              PSErrorManager.createMessage(
+                  ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_source}, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/error/PSXmlProcessingError.java
+++ b/system/src/main/java/com/percussion/error/PSXmlProcessingError.java
@@ -17,10 +17,10 @@
 
 package com.percussion.error;
 
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
 import com.percussion.log.PSLogError;
 import com.percussion.log.PSLogSubMessage;
-import com.percussion.server.IPSServerErrors;
-import com.percussion.xml.IPSXmlErrors;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import java.util.Locale;
 import org.w3c.dom.Element;
@@ -85,9 +85,11 @@ public class PSXmlProcessingError extends PSLogError {
      */
     msgs[0] =
         new PSLogSubMessage(
-            IPSXmlErrors.XML_PROCESSING_ERROR,
+            XmlErrorCodes.XML_PROCESSING_ERROR.numericCode(),
             PSErrorManager.createMessage(
-                IPSXmlErrors.XML_PROCESSING_ERROR, new Object[] {m_sessId}, loc));
+                XmlErrorCodes.XML_PROCESSING_ERROR.numericCode(),
+                new Object[] {m_sessId},
+                loc));
 
     /* the next submessage contains m_errorCode/m_errorArgs */
     msgs[1] =
@@ -97,8 +99,9 @@ public class PSXmlProcessingError extends PSLogError {
     if (msgCount == 3) /* write the source data */
       msgs[2] =
           new PSLogSubMessage(
-              IPSServerErrors.RAW_DUMP,
-              PSErrorManager.createMessage(IPSServerErrors.RAW_DUMP, new Object[] {m_source}, loc));
+              ServerErrorCodes.RAW_DUMP.numericCode(),
+              PSErrorManager.createMessage(
+                  ServerErrorCodes.RAW_DUMP.numericCode(), new Object[] {m_source}, loc));
 
     return msgs;
   }

--- a/system/src/main/java/com/percussion/extension/PSExtensionHandler.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionHandler.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -848,6 +849,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
    * @param args The error arguments corresponding to {@code errorCode}. Must not be {@code null}.
    */
   protected void logMessage(IPSErrorCode errorCode, Object[] args) {
+    Objects.requireNonNull(args, "args cannot be null");
     logMessage(requireErrorCode(errorCode).numericCode(), args);
   }
 

--- a/system/src/main/java/com/percussion/extension/PSExtensionHandler.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionHandler.java
@@ -16,7 +16,9 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.content.IPSMimeContent;
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.log.PSLogHandler;
 import com.percussion.log.PSLogServerWarning;
@@ -72,13 +74,13 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     if (!codeRoot.isDirectory()) {
       Object[] args = new Object[] {getName(), codeRoot.toString() + " must be a directory."};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_HANDLER_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, args);
     }
 
     if (!codeRoot.canRead()) {
       Object[] args = new Object[] {getName(), codeRoot.toString() + " must be readable."};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_HANDLER_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, args);
     }
 
     try {
@@ -86,14 +88,14 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     } catch (IOException e) {
       Object[] args = new Object[] {getName(), e.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_HANDLER_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, args);
     }
 
     String cfgFileName = def.getInitParameter(IPSExtensionHandler.INIT_PARAM_CONFIG_FILENAME);
     if (cfgFileName == null || cfgFileName.trim().length() == 0) {
       Object[] args = new Object[] {getName(), "configFile must be specified"};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_HANDLER_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, args);
     }
 
     m_configFile = new File(m_rootDir, cfgFileName);
@@ -115,7 +117,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
             e.toString() // reason
           };
 
-      logMessage(IPSExtensionErrors.EXT_RESOURCE_DELETE_ERROR, args);
+      logMessage(ExtensionErrorCodes.EXT_RESOURCE_DELETE_ERROR, args);
     }
   }
 
@@ -191,7 +193,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
 
     IPSExtensionDef def = m_config.getExtensionDef(ref);
     if (def == null) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     try {
@@ -237,7 +239,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
 
     IPSExtensionDef def = m_config.getExtensionDef(ref);
     if (def == null) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     // see if an instance has already been loaded
@@ -300,7 +302,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
 
     PSExtensionRef ref = def.getRef();
     if (m_config.isExtensionDefined(ref)) {
-      throw new PSExtensionException(IPSExtensionErrors.EXT_ALREADY_EXISTS, ref.toString());
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_ALREADY_EXISTS, ref.toString());
     }
 
     // save all the extension resources and add extension to config
@@ -329,7 +331,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     } catch (IOException e) {
       Object[] args = new Object[] {ref.toString(), e.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INSTALL_UPDATE_ERROR, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INSTALL_UPDATE_ERROR, args);
     }
   }
 
@@ -366,7 +368,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     PSExtensionRef ref = def.getRef();
     IPSExtensionDef oldDef = m_config.getExtensionDef(ref);
     if (oldDef == null) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     // increment the version on the new def to old ver + 1
@@ -396,7 +398,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     if (ref == null) throw new IllegalArgumentException("ref cannot be null");
 
     if (!m_config.isExtensionDefined(ref)) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     // get the def and the code base of the extension
@@ -413,7 +415,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     } catch (IOException e) {
       Object[] args = new Object[] {ref.toString(), extDir, e.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_RESOURCE_DELETE_ERROR, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_RESOURCE_DELETE_ERROR, args);
     }
 
     m_liveExtensions.remove(ref);
@@ -459,7 +461,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
     } catch (MalformedURLException e) {
       Object[] args = new Object[] {def.getRef().toString(), e.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.CATALOG_EXT_RESOURCE_ERROR, args);
+      throw new PSExtensionException(ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR, args);
     }
 
     return resources.iterator();
@@ -635,7 +637,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
             "could not create extension code root" // reason
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR, args);
     }
 
     while (resources.hasNext()) {
@@ -658,7 +660,7 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
               "empty path" // reason
             };
 
-        logMessage(IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR, args);
+        logMessage(ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR, args);
         continue;
       }
 
@@ -666,14 +668,14 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
       if (f.isAbsolute()) {
         Object[] args = new Object[] {def.getRef().toString(), resName, "absolute path"};
 
-        logMessage(IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR, args);
+        logMessage(ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR, args);
         continue;
       }
 
       if (f.toString().indexOf("..") >= 0) {
         Object[] args = new Object[] {def.getRef().toString(), resName, "contains .."};
 
-        logMessage(IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR, args);
+        logMessage(ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR, args);
         continue;
       }
 
@@ -833,10 +835,27 @@ public abstract class PSExtensionHandler implements IPSExtensionHandler {
         PSExtensionHandlerConfiguration.createShellConfigFile(configFile, getName());
       }
     } catch (IOException e) {
-      throw new PSExtensionException(IPSExtensionErrors.EXT_MANAGER_INIT_FAILED, e.toString());
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED, e.toString());
     }
 
     m_config = new PSExtensionHandlerConfiguration(configFile, new PSExtensionDefFactory());
+  }
+
+  /**
+   * Logs the given catalogued message to the server logging mechanism (if available) or stdout.
+   *
+   * @param errorCode catalogued error code, never {@code null}
+   * @param args The error arguments corresponding to {@code errorCode}. Must not be {@code null}.
+   */
+  protected void logMessage(IPSErrorCode errorCode, Object[] args) {
+    logMessage(requireErrorCode(errorCode).numericCode(), args);
+  }
+
+  private static IPSErrorCode requireErrorCode(IPSErrorCode errorCode) {
+    if (errorCode == null) {
+      throw new IllegalArgumentException("errorCode cannot be null");
+    }
+    return errorCode;
   }
 
   /**

--- a/system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionHandlerConfiguration.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.xml.PSXmlDocumentBuilder;
 import com.percussion.xml.PSXmlTreeWalker;
 import java.io.BufferedInputStream;
@@ -371,7 +372,7 @@ class PSExtensionHandlerConfiguration {
       }
     } catch (FileNotFoundException e) {
       throw new PSExtensionException(
-          IPSExtensionErrors.EXT_INSTALL_UPDATE_ERROR,
+          ExtensionErrorCodes.EXT_INSTALL_UPDATE_ERROR,
           "Cannot find extension file "
               + fromFile.getAbsolutePath()
               + " or folder for output "
@@ -380,7 +381,7 @@ class PSExtensionHandlerConfiguration {
               + e.getLocalizedMessage());
     } catch (IOException e) {
       throw new PSExtensionException(
-          IPSExtensionErrors.EXT_INSTALL_UPDATE_ERROR,
+          ExtensionErrorCodes.EXT_INSTALL_UPDATE_ERROR,
           "Cannot wite to Extension file "
               + toFile.getAbsolutePath()
               + ": "
@@ -422,7 +423,7 @@ class PSExtensionHandlerConfiguration {
       try {
         createShellConfigFile(configFile, "");
       } catch (IOException e) {
-        throw new PSExtensionException(IPSExtensionErrors.EXT_MANAGER_INIT_FAILED, e.toString());
+        throw new PSExtensionException(ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED, e.toString());
       }
     }
 
@@ -435,11 +436,11 @@ class PSExtensionHandlerConfiguration {
       load(doc);
     } catch (IOException e) {
       throw new PSExtensionException(
-          IPSExtensionErrors.EXT_MANAGER_INIT_FAILED,
+          ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED,
           e,
           "Error loading config xml for " + configFile.getAbsolutePath() + ":" + e.toString());
     } catch (SAXException e) {
-      throw new PSExtensionException(IPSExtensionErrors.EXT_MANAGER_INIT_FAILED, e, e.toString());
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED, e, e.toString());
     } finally {
       if (in != null) {
         try {
@@ -630,7 +631,7 @@ class PSExtensionHandlerConfiguration {
       }
     } catch (ClassNotFoundException e) {
       throw new PSExtensionException(
-          IPSExtensionErrors.CLASS_NOT_FOUND, def.getInitParameter("className"));
+          ExtensionErrorCodes.CLASS_NOT_FOUND, def.getInitParameter("className"));
     }
   }
 

--- a/system/src/main/java/com/percussion/extension/PSExtensionParams.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionParams.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.design.objectstore.IPSReplacementValue;
 import com.percussion.util.PSDataTypeConverter;
@@ -53,7 +54,7 @@ public class PSExtensionParams {
    */
   public PSExtensionParams(Object params[], String paramNames[]) throws PSConversionException {
     if (params == null) {
-      throw new PSConversionException(IPSExtensionErrors.INVALID_NULL_PARAMS);
+      throw new PSConversionException(ExtensionErrorCodes.INVALID_NULL_PARAMS);
     }
     m_params = params;
     m_paramNames = paramNames;
@@ -106,13 +107,13 @@ public class PSExtensionParams {
         return Integer.parseInt((String) value);
       } catch (NumberFormatException e) {
         throw new PSConversionException(
-            IPSExtensionErrors.INVALID_NUMBER_PARAM, getParamIndicator(index));
+            ExtensionErrorCodes.INVALID_NUMBER_PARAM, getParamIndicator(index));
       }
     } else if (value == null) {
       return null;
     } else {
       throw new PSConversionException(
-          IPSExtensionErrors.INVALID_NUMBER_PARAM, getParamIndicator(index));
+          ExtensionErrorCodes.INVALID_NUMBER_PARAM, getParamIndicator(index));
     }
   }
 
@@ -142,7 +143,7 @@ public class PSExtensionParams {
           || bvalue.equalsIgnoreCase("yes");
     } else {
       throw new PSConversionException(
-          IPSExtensionErrors.INVALID_BOOLEAN_PARAM, getParamIndicator(index));
+          ExtensionErrorCodes.INVALID_BOOLEAN_PARAM, getParamIndicator(index));
     }
   }
 
@@ -169,12 +170,12 @@ public class PSExtensionParams {
       Date date = PSDataTypeConverter.parseStringToDate((String) value);
       if (date == null) {
         throw new PSConversionException(
-            IPSExtensionErrors.INVALID_DATE_PARAM, getParamIndicator(index));
+            ExtensionErrorCodes.INVALID_DATE_PARAM, getParamIndicator(index));
       }
       return date;
     } else {
       throw new PSConversionException(
-          IPSExtensionErrors.INVALID_DATE_PARAM, getParamIndicator(index));
+          ExtensionErrorCodes.INVALID_DATE_PARAM, getParamIndicator(index));
     }
   }
 
@@ -202,7 +203,7 @@ public class PSExtensionParams {
   private Object getValue(int index, Object defvalue) throws PSConversionException {
     if (index < 0) {
       throw new PSConversionException(
-          IPSExtensionErrors.INVALID_INDEX_VALUE, getParamIndicator(index));
+          ExtensionErrorCodes.INVALID_INDEX_VALUE, getParamIndicator(index));
     }
     Object rval = isParamMissing(index) ? defvalue : m_params[index];
 
@@ -243,7 +244,7 @@ public class PSExtensionParams {
     if (required && isParamMissing(index)) {
 
       throw new PSConversionException(
-          IPSExtensionErrors.MISSING_REQUIRED_PARAM_NO, getParamIndicator(index));
+          ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO, getParamIndicator(index));
     }
   }
 

--- a/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
+++ b/system/src/main/java/com/percussion/extension/PSExtensionProcessingException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.utils.exceptions.PSExceptionHelper;
@@ -130,7 +131,7 @@ public class PSExtensionProcessingException extends PSException {
    */
   public PSExtensionProcessingException(String extName, Exception e) {
     this(
-        IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION,
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION,
         PSExceptionHelper.findRootCause(e, false),
         new Object[] {extName, e.toString()});
   }
@@ -196,9 +197,9 @@ public class PSExtensionProcessingException extends PSException {
    * @param e the exception
    */
   public PSExtensionProcessingException(String language, String extName, Exception e) {
-    this(
+    super(
         language,
-        IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION,
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION,
         new Object[] {extName, e.toString()},
         e);
   }

--- a/system/src/main/java/com/percussion/extension/PSJavaExtensionHandler.java
+++ b/system/src/main/java/com/percussion/extension/PSJavaExtensionHandler.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.error.PSNotFoundException;
 import com.percussion.security.error.PSExceptionUtils;
@@ -151,7 +152,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
             "\"" + className + "\" is not a valid class name."
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
 
     super.install(def, resources);
@@ -191,7 +192,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
             "\"" + className + "\" is not a valid class name."
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
 
     super.update(def, resources);
@@ -259,7 +260,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
 
     IPSExtensionDef def = m_config.getExtensionDef(ref);
     if (def == null) {
-      throw new PSNotFoundException(IPSExtensionErrors.EXT_NOT_FOUND, ref.toString());
+      throw new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, ref.toString());
     }
 
     String className = def.getInitParameter("className");
@@ -271,7 +272,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
             "\"" + className + "\" is not a valid class name."
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
 
     PSExtensionClassLoader loader = m_loaders.get(ref);
@@ -294,11 +295,11 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
       Object[] args =
           new Object[] {ref.getHandlerName(), ref.getExtensionName(), e.getException().toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     } catch (Throwable t) {
       Object[] args = new Object[] {ref.getHandlerName(), ref.getExtensionName(), t.toString()};
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
   }
 
@@ -331,7 +332,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
                 u.toString() + " does not use a supported protocol"
               };
 
-          throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+          throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
         }
 
         File f = new File(u.getFile());
@@ -344,7 +345,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
                 u.toString() + " does not specify a relative path"
               };
 
-          throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+          throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
         }
 
         if (f.toString().indexOf("..") != -1) // no escape from coderoot
@@ -356,7 +357,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
                 u.toString() + " does not specify a relative path"
               };
 
-          throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+          throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
         }
 
         // make resource path relative to the extension coderoot
@@ -377,7 +378,7 @@ public class PSJavaExtensionHandler extends PSExtensionHandler implements IPSNot
             def.getRef().getHandlerName(), def.getRef().getExtensionName(), e.toString()
           };
 
-      throw new PSExtensionException(IPSExtensionErrors.EXT_INIT_FAILED, args);
+      throw new PSExtensionException(ExtensionErrorCodes.EXT_INIT_FAILED, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/extension/PSJavaScriptCallException.java
+++ b/system/src/main/java/com/percussion/extension/PSJavaScriptCallException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -28,11 +29,11 @@ import com.percussion.error.PSException;
 public class PSJavaScriptCallException extends PSException {
   /** Constructs a failure with the specified message. */
   public PSJavaScriptCallException(String function, String message) {
-    super(IPSExtensionErrors.JS_CALL_FAILED, new Object[] {function, message});
+    super(ExtensionErrorCodes.JS_CALL_FAILED, new Object[] {function, message});
   }
 
   /** Constructs a failure with the specified context information. */
   public PSJavaScriptCallException(String function, String message, String source) {
-    super(IPSExtensionErrors.JS_CALL_FAILED_SRC, new Object[] {function, message, source});
+    super(ExtensionErrorCodes.JS_CALL_FAILED_SRC, new Object[] {function, message, source});
   }
 }

--- a/system/src/main/java/com/percussion/extension/PSJavaScriptCompileException.java
+++ b/system/src/main/java/com/percussion/extension/PSJavaScriptCompileException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -29,11 +30,11 @@ import com.percussion.error.PSException;
 public class PSJavaScriptCompileException extends PSException {
   /** Constructs a failure with the specified message. */
   public PSJavaScriptCompileException(String function, String message) {
-    super(IPSExtensionErrors.JS_COMPILE_FAILED, new Object[] {function, message});
+    super(ExtensionErrorCodes.JS_COMPILE_FAILED, new Object[] {function, message});
   }
 
   /** Constructs a failure with the specified context information. */
   public PSJavaScriptCompileException(String function, String message, String source) {
-    super(IPSExtensionErrors.JS_COMPILE_FAILED_SRC, new Object[] {function, message, source});
+    super(ExtensionErrorCodes.JS_COMPILE_FAILED_SRC, new Object[] {function, message, source});
   }
 }

--- a/system/src/main/java/com/percussion/extension/PSJavaScriptUdfExtension.java
+++ b/system/src/main/java/com/percussion/extension/PSJavaScriptUdfExtension.java
@@ -17,7 +17,9 @@
 
 package com.percussion.extension;
 
-import com.percussion.data.IPSDataErrors;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.data.PSConversionException;
 import com.percussion.design.objectstore.PSDateLiteral;
 import com.percussion.design.objectstore.PSNumericLiteral;
@@ -91,9 +93,8 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
               + " parameters required, but "
               + String.valueOf(paramCount)
               + " parameters were specified.";
-      int errCode = com.percussion.server.IPSServerErrors.ARGUMENT_ERROR;
       Object[] args = {arg0, "PSJavaScriptUdfExtension/processUdf"};
-      throw new PSConversionException(errCode, args);
+      throw new PSConversionException(ServerErrorCodes.ARGUMENT_ERROR, args);
     }
 
     Object[] paramValues = new Object[paramCount];
@@ -128,7 +129,7 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
         return getBoolean(o);
       default:
         throw new com.percussion.data.PSConversionException(
-            IPSExtensionErrors.UNKNOWN_PARAMETER_TYPE, "Date, Number, String, Boolean");
+            ExtensionErrorCodes.UNKNOWN_PARAMETER_TYPE, "Date, Number, String, Boolean");
     }
   }
 
@@ -147,7 +148,7 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
       } catch (Exception e) {
         Object args[] = {o.getClass().getName(), "String", dateText};
         throw new com.percussion.data.PSConversionException(
-            IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+            DataErrorCodes.UNSUPPORTED_CONVERSION, args);
       }
     } else if (o instanceof java.util.Date) {
       return /*new java.lang.Long(((java.util.Date)*/ o /*).getTime())*/;
@@ -160,7 +161,7 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
     // Throw conversion exception.  o will contain exception information
     //      for string conversion exceptions...
     Object args[] = {o.getClass().getName(), "Date", o.toString()};
-    throw new com.percussion.data.PSConversionException(IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+    throw new com.percussion.data.PSConversionException(DataErrorCodes.UNSUPPORTED_CONVERSION, args);
   }
 
   private Object getNumber(Object o) throws com.percussion.data.PSConversionException {
@@ -188,12 +189,12 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
     } catch (Exception e) {
       Object args[] = {o.getClass().getName(), "Number", o.toString()};
       throw new com.percussion.data.PSConversionException(
-          IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+          DataErrorCodes.UNSUPPORTED_CONVERSION, args);
     }
 
     // Throw conversion exception.
     Object args[] = {o.getClass().getName(), "Number", o.toString()};
-    throw new com.percussion.data.PSConversionException(IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+    throw new com.percussion.data.PSConversionException(DataErrorCodes.UNSUPPORTED_CONVERSION, args);
   }
 
   private Object getBoolean(Object o) throws com.percussion.data.PSConversionException {
@@ -212,7 +213,7 @@ public class PSJavaScriptUdfExtension implements IPSUdfProcessor {
 
     // Throw conversion exception.
     Object args[] = {o.getClass().getName(), "Boolean", o.toString()};
-    throw new com.percussion.data.PSConversionException(IPSDataErrors.UNSUPPORTED_CONVERSION, args);
+    throw new com.percussion.data.PSConversionException(DataErrorCodes.UNSUPPORTED_CONVERSION, args);
   }
 
   private Object getString(Object o) throws com.percussion.data.PSConversionException {

--- a/system/src/main/java/com/percussion/extension/PSParameterMismatchException.java
+++ b/system/src/main/java/com/percussion/extension/PSParameterMismatchException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.extension;
 
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
 import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
@@ -41,7 +42,7 @@ public class PSParameterMismatchException extends PSException {
    */
   public PSParameterMismatchException(int expected, int actual) {
     super(
-        IPSExtensionErrors.EXT_PARAM_VALUE_MISMATCH,
+        ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH,
         new Object[] {Integer.valueOf(expected), Integer.valueOf(actual)});
   }
 
@@ -51,7 +52,7 @@ public class PSParameterMismatchException extends PSException {
    * @param message the complete display message.
    */
   public PSParameterMismatchException(String message) {
-    super(IPSExtensionErrors.EXT_PARAM_VALUE_INVALID, message);
+    super(ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID, message);
   }
 
   /**
@@ -65,7 +66,7 @@ public class PSParameterMismatchException extends PSException {
   public PSParameterMismatchException(String language, int expected, int actual) {
     super(
         language,
-        IPSExtensionErrors.EXT_PARAM_VALUE_MISMATCH,
+        ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH,
         new Object[] {Integer.valueOf(expected), Integer.valueOf(actual)});
   }
 
@@ -77,7 +78,7 @@ public class PSParameterMismatchException extends PSException {
    * @param message the complete display message.
    */
   public PSParameterMismatchException(String language, String message) {
-    super(language, IPSExtensionErrors.EXT_PARAM_VALUE_INVALID, message);
+    super(language, ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID, message);
   }
 
   /** See {@link com.percussion.error.PSException#PSException(int, Object)} for documentation. */

--- a/system/src/test/java/com/percussion/design/catalog/PSDesignCatalogLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/design/catalog/PSDesignCatalogLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.design.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.error.PSIllegalArgumentException;
+import com.percussion.server.IPSServerErrors;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3969 (parent #2616): leftover {@code com.percussion.design.catalog} production sites throw
+ * typed {@code CatalogErrorCodes} / {@code ServerErrorCodes} (not bare {@code IPS*Errors} ints).
+ * Dual-write is skipped: leftover catalog protocol codes and {@code RESPONSE_SEND_ERROR} are
+ * non-auditable.
+ */
+@Tag("UnitTest")
+class PSDesignCatalogLeftoverErrorCodesSliceTest {
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWrite() {
+    assertEquals(
+        IPSCatalogErrors.REQ_DOC_MISSING, CatalogErrorCodes.REQ_DOC_MISSING.numericCode());
+    assertEquals(
+        IPSCatalogErrors.REQ_DOC_MISSING_GENERIC,
+        CatalogErrorCodes.REQ_DOC_MISSING_GENERIC.numericCode());
+    assertEquals(
+        IPSCatalogErrors.REQ_DOC_ROOT_MISSING_GENERIC,
+        CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC.numericCode());
+    assertEquals(
+        IPSCatalogErrors.REQ_DOC_INVALID_TYPE,
+        CatalogErrorCodes.REQ_DOC_INVALID_TYPE.numericCode());
+    assertEquals(
+        IPSCatalogErrors.NO_REQ_HANDLER_FOUND,
+        CatalogErrorCodes.NO_REQ_HANDLER_FOUND.numericCode());
+    assertEquals(
+        IPSCatalogErrors.CATALOG_EXCEPTION, CatalogErrorCodes.CATALOG_EXCEPTION.numericCode());
+    assertEquals(
+        IPSServerErrors.RESPONSE_SEND_ERROR, ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode());
+
+    leftoverNonAuditable(CatalogErrorCodes.REQ_DOC_MISSING);
+    leftoverNonAuditable(CatalogErrorCodes.REQ_DOC_MISSING_GENERIC);
+    leftoverNonAuditable(CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC);
+    leftoverNonAuditable(CatalogErrorCodes.REQ_DOC_INVALID_TYPE);
+    leftoverNonAuditable(CatalogErrorCodes.NO_REQ_HANDLER_FOUND);
+    leftoverNonAuditable(CatalogErrorCodes.CATALOG_EXCEPTION);
+    leftoverNonAuditable(ServerErrorCodes.RESPONSE_SEND_ERROR);
+  }
+
+  @Test
+  void leftoverProductionExceptionTypesRetainTypedCodes() {
+    Object[] missingArgs = {"data", "Column", "PSXColumnCatalog"};
+    PSIllegalArgumentException missingDoc =
+        new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING, missingArgs);
+    assertSame(CatalogErrorCodes.REQ_DOC_MISSING, missingDoc.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.REQ_DOC_MISSING, missingDoc.getErrorCode());
+    assertFalse(missingDoc.isAuditable());
+
+    Object[] invalidTypeArgs = {"PSXColumnCatalog", "WrongRoot"};
+    PSIllegalArgumentException invalidType =
+        new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, invalidTypeArgs);
+    assertSame(CatalogErrorCodes.REQ_DOC_INVALID_TYPE, invalidType.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.REQ_DOC_INVALID_TYPE, invalidType.getErrorCode());
+    assertFalse(invalidType.isAuditable());
+
+    PSIllegalArgumentException missingGeneric =
+        new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_MISSING_GENERIC);
+    assertSame(CatalogErrorCodes.REQ_DOC_MISSING_GENERIC, missingGeneric.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.REQ_DOC_MISSING_GENERIC, missingGeneric.getErrorCode());
+    assertFalse(missingGeneric.isAuditable());
+
+    PSIllegalArgumentException missingRoot =
+        new PSIllegalArgumentException(CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC);
+    assertSame(CatalogErrorCodes.REQ_DOC_ROOT_MISSING_GENERIC, missingRoot.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.REQ_DOC_ROOT_MISSING_GENERIC, missingRoot.getErrorCode());
+    assertFalse(missingRoot.isAuditable());
+
+    Object[] noHandlerArgs = {"UnknownCatalogRoot"};
+    PSIllegalArgumentException noHandler =
+        new PSIllegalArgumentException(CatalogErrorCodes.NO_REQ_HANDLER_FOUND, noHandlerArgs);
+    assertSame(CatalogErrorCodes.NO_REQ_HANDLER_FOUND, noHandler.getTypedErrorCode());
+    assertEquals(IPSCatalogErrors.NO_REQ_HANDLER_FOUND, noHandler.getErrorCode());
+    assertFalse(noHandler.isAuditable());
+  }
+
+  @Test
+  void typedProductionCtorsRejectNullCode() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSIllegalArgumentException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSIllegalArgumentException((IPSErrorCode) null, "arg"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSIllegalArgumentException((IPSErrorCode) null, new Object[] {"arg"}));
+  }
+
+  private static void leftoverNonAuditable(SystemErrorCode code) {
+    assertFalse(code.isAuditable(), code.toString());
+  }
+}

--- a/system/src/test/java/com/percussion/error/PSErrorLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/error/PSErrorLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.error;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.BackEndErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.CatalogErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.HttpErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.XmlErrorCodes;
+import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
+import com.percussion.data.IPSBackEndErrors;
+import com.percussion.data.IPSDataErrors;
+import com.percussion.design.catalog.IPSCatalogErrors;
+import com.percussion.server.IPSHttpErrors;
+import com.percussion.server.IPSServerErrors;
+import com.percussion.xml.IPSXmlErrors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #3971 (parent #2616): leftover {@code com.percussion.error} production sites use typed
+ * {@code *ErrorCodes} (not bare {@code IPS*Errors} ints). Dual-write is skipped where the catalog
+ * is non-auditable; leftover auditable authorization codes remain dual-write eligible.
+ */
+@Tag("UnitTest")
+class PSErrorLeftoverErrorCodesSliceTest {
+
+  @BeforeEach
+  void setUp() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @AfterEach
+  void tearDown() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWriteWhereNonAuditable() {
+    assertEquals(
+        IPSServerErrors.NATIVE_ERROR, ServerErrorCodes.NATIVE_ERROR.numericCode());
+    assertEquals(IPSServerErrors.RAW_DUMP, ServerErrorCodes.RAW_DUMP.numericCode());
+    assertEquals(
+        IPSServerErrors.DATA_CONV_ERROR, ServerErrorCodes.DATA_CONV_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.UNKNOWN_PROCESSING_ERROR,
+        ServerErrorCodes.UNKNOWN_PROCESSING_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.RESPONSE_SEND_ERROR,
+        ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.WRAPPED_LOG_ERROR, ServerErrorCodes.WRAPPED_LOG_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.AUTHORIZATION_ERROR,
+        ServerErrorCodes.AUTHORIZATION_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.POOR_RESPONSE_TIME, ServerErrorCodes.POOR_RESPONSE_TIME.numericCode());
+    assertEquals(
+        IPSServerErrors.REQUEST_QUEUE_FULL, ServerErrorCodes.REQUEST_QUEUE_FULL.numericCode());
+    assertEquals(
+        IPSServerErrors.VALIDATION_ERROR, ServerErrorCodes.VALIDATION_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.REQUEST_PREPROC_ERROR,
+        ServerErrorCodes.REQUEST_PREPROC_ERROR.numericCode());
+    assertEquals(
+        IPSServerErrors.FATAL_SERVER_ERROR_MSG,
+        ServerErrorCodes.FATAL_SERVER_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSServerErrors.INTERNAL_SERVER_ERROR_MSG,
+        ServerErrorCodes.INTERNAL_SERVER_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSServerErrors.SERVER_UNAVAILABLE_ERROR_MSG,
+        ServerErrorCodes.SERVER_UNAVAILABLE_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSServerErrors.REQUEST_WAIT_TOO_LONG,
+        ServerErrorCodes.REQUEST_WAIT_TOO_LONG.numericCode());
+    assertEquals(
+        IPSServerErrors.RCONSOLE_EXEC_EXCEPTION,
+        ServerErrorCodes.RCONSOLE_EXEC_EXCEPTION.numericCode());
+    assertEquals(
+        IPSServerErrors.RCONSOLE_COMMAND_EXCEPTION,
+        ServerErrorCodes.RCONSOLE_COMMAND_EXCEPTION.numericCode());
+    assertEquals(
+        IPSServerErrors.RCONSOLE_COMMAND_ERROR_MSG,
+        ServerErrorCodes.RCONSOLE_COMMAND_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSServerErrors.HOOK_REQUEST_ERROR_MSG,
+        ServerErrorCodes.HOOK_REQUEST_ERROR_MSG.numericCode());
+    assertEquals(
+        IPSBackEndErrors.AUTHORIZATION_ERROR,
+        BackEndErrorCodes.AUTHORIZATION_ERROR.numericCode());
+    assertEquals(
+        IPSBackEndErrors.REQUEST_QUEUE_FULL,
+        BackEndErrorCodes.REQUEST_QUEUE_FULL.numericCode());
+    assertEquals(
+        IPSBackEndErrors.SERVER_DOWN_ERROR, BackEndErrorCodes.SERVER_DOWN_ERROR.numericCode());
+    assertEquals(
+        IPSDataErrors.QUERY_PROCESSING_ERROR,
+        DataErrorCodes.QUERY_PROCESSING_ERROR.numericCode());
+    assertEquals(
+        IPSDataErrors.UPDATE_PROCESSING_ERROR,
+        DataErrorCodes.UPDATE_PROCESSING_ERROR.numericCode());
+    assertEquals(
+        IPSDataErrors.HTML_GENERATION_ERROR,
+        DataErrorCodes.HTML_GENERATION_ERROR.numericCode());
+    assertEquals(
+        IPSCatalogErrors.CATALOG_ERROR, CatalogErrorCodes.CATALOG_ERROR.numericCode());
+    assertEquals(
+        IPSXmlErrors.XML_PROCESSING_ERROR, XmlErrorCodes.XML_PROCESSING_ERROR.numericCode());
+    assertEquals(
+        IPSHttpErrors.HTTP_UNAUTHORIZED, HttpErrorCodes.HTTP_UNAUTHORIZED.numericCode());
+    assertEquals(IPSHttpErrors.HTTP_NOT_FOUND, HttpErrorCodes.HTTP_NOT_FOUND.numericCode());
+
+    leftoverNonAuditable(ServerErrorCodes.NATIVE_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.RAW_DUMP);
+    leftoverNonAuditable(ServerErrorCodes.DATA_CONV_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.UNKNOWN_PROCESSING_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.RESPONSE_SEND_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.WRAPPED_LOG_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.POOR_RESPONSE_TIME);
+    leftoverNonAuditable(ServerErrorCodes.REQUEST_QUEUE_FULL);
+    leftoverNonAuditable(ServerErrorCodes.VALIDATION_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.REQUEST_PREPROC_ERROR);
+    leftoverNonAuditable(ServerErrorCodes.FATAL_SERVER_ERROR_MSG);
+    leftoverNonAuditable(ServerErrorCodes.INTERNAL_SERVER_ERROR_MSG);
+    leftoverNonAuditable(ServerErrorCodes.SERVER_UNAVAILABLE_ERROR_MSG);
+    leftoverNonAuditable(ServerErrorCodes.REQUEST_WAIT_TOO_LONG);
+    leftoverNonAuditable(ServerErrorCodes.RCONSOLE_EXEC_EXCEPTION);
+    leftoverNonAuditable(ServerErrorCodes.RCONSOLE_COMMAND_EXCEPTION);
+    leftoverNonAuditable(ServerErrorCodes.RCONSOLE_COMMAND_ERROR_MSG);
+    leftoverNonAuditable(ServerErrorCodes.HOOK_REQUEST_ERROR_MSG);
+    leftoverNonAuditable(BackEndErrorCodes.REQUEST_QUEUE_FULL);
+    leftoverNonAuditable(BackEndErrorCodes.SERVER_DOWN_ERROR);
+    leftoverNonAuditable(DataErrorCodes.QUERY_PROCESSING_ERROR);
+    leftoverNonAuditable(DataErrorCodes.UPDATE_PROCESSING_ERROR);
+    leftoverNonAuditable(DataErrorCodes.HTML_GENERATION_ERROR);
+    leftoverNonAuditable(CatalogErrorCodes.CATALOG_ERROR);
+    leftoverNonAuditable(XmlErrorCodes.XML_PROCESSING_ERROR);
+    leftoverNonAuditable(HttpErrorCodes.HTTP_UNAUTHORIZED);
+    leftoverNonAuditable(HttpErrorCodes.HTTP_NOT_FOUND);
+
+    leftoverAuditable(ServerErrorCodes.AUTHORIZATION_ERROR);
+    leftoverAuditable(BackEndErrorCodes.AUTHORIZATION_ERROR);
+  }
+
+  @Test
+  void leftoverProductionExceptionTypeRetainsTypedCodeAndSkipsDualWrite() {
+    PSErrorException wrapped = new PSErrorException(null);
+    assertSame(ServerErrorCodes.WRAPPED_LOG_ERROR, wrapped.getTypedErrorCode());
+    assertEquals(ServerErrorCodes.WRAPPED_LOG_ERROR.numericCode(), wrapped.getErrorCode());
+    assertFalse(wrapped.isAuditable());
+
+    RuntimeException cause = new RuntimeException("wrap");
+    PSErrorException withCause = new PSErrorException(null, cause);
+    assertSame(ServerErrorCodes.WRAPPED_LOG_ERROR, withCause.getTypedErrorCode());
+    assertSame(cause, withCause.getCause());
+    assertFalse(withCause.isAuditable());
+
+    PSErrorHandler.logLegacyExceptionIfAuditable(wrapped);
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  void leftoverAuditableAuthorizationIntsStillDualWrite() {
+    PSException serverAuth =
+        new PSException(ServerErrorCodes.AUTHORIZATION_ERROR, new Object[] {"sess-1", "rx"});
+    assertSame(ServerErrorCodes.AUTHORIZATION_ERROR, serverAuth.getTypedErrorCode());
+    assertTrue(serverAuth.isAuditable());
+
+    PSErrorHandler.logLegacyExceptionIfAuditable(serverAuth);
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    assertEquals(
+        ServerErrorCodes.AUTHORIZATION_ERROR,
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).code());
+
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+
+    PSException backEndAuth =
+        new PSException(
+            BackEndErrorCodes.AUTHORIZATION_ERROR,
+            new Object[] {"host", "uid", "jdbc", "server"});
+    assertSame(BackEndErrorCodes.AUTHORIZATION_ERROR, backEndAuth.getTypedErrorCode());
+    assertTrue(backEndAuth.isAuditable());
+
+    PSErrorHandler.logLegacyExceptionIfAuditable(backEndAuth);
+    assertEquals(1, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+    assertEquals(
+        BackEndErrorCodes.AUTHORIZATION_ERROR,
+        ConcurrentMemoryAuditLogRepository.INSTANCE.findAll().get(0).code());
+  }
+
+  @Test
+  void leftoverLogErrorTypesConstructWithTypedNumericCodes() {
+    PSApplicationAuthorizationError appAuth =
+        new PSApplicationAuthorizationError(
+            11,
+            "127.0.0.1",
+            "zzz",
+            ServerErrorCodes.AUTHORIZATION_ERROR.numericCode(),
+            "denied");
+    assertEquals("127.0.0.1", appAuth.getHost());
+    assertEquals(11, appAuth.getApplicationId());
+
+    PSResponseSendError send =
+        new PSResponseSendError(
+            7, "sess-1", ServerErrorCodes.RESPONSE_SEND_ERROR.numericCode(), "io");
+    assertEquals(7, send.getApplicationId());
+
+    PSRemoteConsoleError console = new PSRemoteConsoleError("trace", new RuntimeException("boom"));
+    assertEquals(0, console.getApplicationId());
+  }
+
+  private static void leftoverNonAuditable(SystemErrorCode code) {
+    assertFalse(code.isAuditable(), code.toString());
+  }
+
+  private static void leftoverAuditable(SystemErrorCode code) {
+    assertTrue(code.isAuditable(), code.toString());
+  }
+}

--- a/system/src/test/java/com/percussion/extension/PSExtensionLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/extension/PSExtensionLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.extension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.DataErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ExtensionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.data.IPSDataErrors;
+import com.percussion.data.PSConversionException;
+import com.percussion.design.objectstore.PSExtensionParamDef;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.error.PSException;
+import com.percussion.error.PSNotFoundException;
+import com.percussion.server.IPSServerErrors;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Issue #3970 (parent #2616 leftover): {@code com.percussion.extension} production sites throw
+ * typed {@code *ErrorCodes} via IPSErrorCode-aware constructors — not bare {@code IPS*Errors}
+ * ints. Dual-write skip is {@code isAuditable()==false} on leftover operational catalog codes.
+ */
+@Tag("UnitTest")
+class PSExtensionLeftoverErrorCodesSliceTest {
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWrite() {
+    assertEquals(
+        IPSExtensionErrors.EXT_HANDLER_INIT_FAILED,
+        ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_RESOURCE_DELETE_ERROR,
+        ExtensionErrorCodes.EXT_RESOURCE_DELETE_ERROR.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_NOT_FOUND, ExtensionErrorCodes.EXT_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_ALREADY_EXISTS,
+        ExtensionErrorCodes.EXT_ALREADY_EXISTS.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_INSTALL_UPDATE_ERROR,
+        ExtensionErrorCodes.EXT_INSTALL_UPDATE_ERROR.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_RESOURCE_STORE_ERROR,
+        ExtensionErrorCodes.EXT_RESOURCE_STORE_ERROR.numericCode());
+    assertEquals(
+        IPSExtensionErrors.CATALOG_EXT_RESOURCE_ERROR,
+        ExtensionErrorCodes.CATALOG_EXT_RESOURCE_ERROR.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_MANAGER_INIT_FAILED,
+        ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_INIT_FAILED, ExtensionErrorCodes.EXT_INIT_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.CLASS_NOT_FOUND, ExtensionErrorCodes.CLASS_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_NULL_PARAMS,
+        ExtensionErrorCodes.INVALID_NULL_PARAMS.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_NUMBER_PARAM,
+        ExtensionErrorCodes.INVALID_NUMBER_PARAM.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_BOOLEAN_PARAM,
+        ExtensionErrorCodes.INVALID_BOOLEAN_PARAM.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_DATE_PARAM,
+        ExtensionErrorCodes.INVALID_DATE_PARAM.numericCode());
+    assertEquals(
+        IPSExtensionErrors.INVALID_INDEX_VALUE,
+        ExtensionErrorCodes.INVALID_INDEX_VALUE.numericCode());
+    assertEquals(
+        IPSExtensionErrors.MISSING_REQUIRED_PARAM_NO,
+        ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_PROCESSOR_EXCEPTION,
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_PARAM_VALUE_MISMATCH,
+        ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH.numericCode());
+    assertEquals(
+        IPSExtensionErrors.EXT_PARAM_VALUE_INVALID,
+        ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID.numericCode());
+    assertEquals(
+        IPSExtensionErrors.JS_CALL_FAILED, ExtensionErrorCodes.JS_CALL_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.JS_CALL_FAILED_SRC,
+        ExtensionErrorCodes.JS_CALL_FAILED_SRC.numericCode());
+    assertEquals(
+        IPSExtensionErrors.JS_COMPILE_FAILED,
+        ExtensionErrorCodes.JS_COMPILE_FAILED.numericCode());
+    assertEquals(
+        IPSExtensionErrors.JS_COMPILE_FAILED_SRC,
+        ExtensionErrorCodes.JS_COMPILE_FAILED_SRC.numericCode());
+    assertEquals(
+        IPSExtensionErrors.UNKNOWN_PARAMETER_TYPE,
+        ExtensionErrorCodes.UNKNOWN_PARAMETER_TYPE.numericCode());
+    assertEquals(IPSServerErrors.ARGUMENT_ERROR, ServerErrorCodes.ARGUMENT_ERROR.numericCode());
+    assertEquals(
+        IPSDataErrors.UNSUPPORTED_CONVERSION,
+        DataErrorCodes.UNSUPPORTED_CONVERSION.numericCode());
+
+    leftoverNonAuditable(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED);
+    leftoverNonAuditable(ExtensionErrorCodes.EXT_NOT_FOUND);
+    leftoverNonAuditable(ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION);
+    leftoverNonAuditable(ExtensionErrorCodes.JS_COMPILE_FAILED);
+    leftoverNonAuditable(ExtensionErrorCodes.UNKNOWN_PARAMETER_TYPE);
+    leftoverNonAuditable(ServerErrorCodes.ARGUMENT_ERROR);
+    leftoverNonAuditable(DataErrorCodes.UNSUPPORTED_CONVERSION);
+  }
+
+  @Test
+  void productionExceptionTypesRetainTypedCodesAndSkipDualWrite() {
+    leftoverNonAuditable(
+        new PSExtensionException(ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED, new Object[] {"h", "dir"}),
+        ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED);
+    leftoverNonAuditable(
+        new PSNotFoundException(ExtensionErrorCodes.EXT_NOT_FOUND, "JavaScript/global/missing"),
+        ExtensionErrorCodes.EXT_NOT_FOUND);
+    leftoverNonAuditable(
+        new PSExtensionException(ExtensionErrorCodes.EXT_ALREADY_EXISTS, "dup"),
+        ExtensionErrorCodes.EXT_ALREADY_EXISTS);
+    leftoverNonAuditable(
+        new PSExtensionException(
+            ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED, new IllegalStateException("io"), "cfg"),
+        ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED);
+    leftoverNonAuditable(
+        new PSConversionException(ExtensionErrorCodes.INVALID_NULL_PARAMS),
+        ExtensionErrorCodes.INVALID_NULL_PARAMS);
+    leftoverNonAuditable(
+        new PSConversionException(ExtensionErrorCodes.INVALID_NUMBER_PARAM, 3),
+        ExtensionErrorCodes.INVALID_NUMBER_PARAM);
+    leftoverNonAuditable(
+        new PSParameterMismatchException(2, 1), ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH);
+    leftoverNonAuditable(
+        new PSParameterMismatchException("bad value"), ExtensionErrorCodes.EXT_PARAM_VALUE_INVALID);
+    leftoverNonAuditable(
+        new PSParameterMismatchException("en-us", 4, 1),
+        ExtensionErrorCodes.EXT_PARAM_VALUE_MISMATCH);
+    leftoverNonAuditable(
+        new PSJavaScriptCallException("fn", "boom"), ExtensionErrorCodes.JS_CALL_FAILED);
+    leftoverNonAuditable(
+        new PSJavaScriptCallException("fn", "boom", "src"), ExtensionErrorCodes.JS_CALL_FAILED_SRC);
+    leftoverNonAuditable(
+        new PSJavaScriptCompileException("fn", "syntax"), ExtensionErrorCodes.JS_COMPILE_FAILED);
+    leftoverNonAuditable(
+        new PSJavaScriptCompileException("fn", "syntax", "src"),
+        ExtensionErrorCodes.JS_COMPILE_FAILED_SRC);
+    leftoverNonAuditable(
+        new PSExtensionProcessingException("sys_exit", new IllegalStateException("eval")),
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION);
+    leftoverNonAuditable(
+        new PSExtensionProcessingException(
+            "en-us", "sys_exit", new IllegalStateException("eval")),
+        ExtensionErrorCodes.EXT_PROCESSOR_EXCEPTION);
+    leftoverNonAuditable(
+        new PSConversionException(
+            ServerErrorCodes.ARGUMENT_ERROR, new Object[] {"need 1", "processUdf"}),
+        ServerErrorCodes.ARGUMENT_ERROR);
+    leftoverNonAuditable(
+        new PSConversionException(
+            DataErrorCodes.UNSUPPORTED_CONVERSION, new Object[] {"java.lang.Object", "Date", "x"}),
+        DataErrorCodes.UNSUPPORTED_CONVERSION);
+  }
+
+  @Test
+  void extensionParamsProductionThrowsRetainTypedCodes() throws Exception {
+    PSConversionException nullParams =
+        assertThrows(PSConversionException.class, () -> new PSExtensionParams(null));
+    leftoverNonAuditable(nullParams, ExtensionErrorCodes.INVALID_NULL_PARAMS);
+
+    PSExtensionParams ep = new PSExtensionParams(new Object[] {Integer.valueOf(7), "abc"});
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getNumberParam(1, null, true)),
+        ExtensionErrorCodes.INVALID_NUMBER_PARAM);
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getBooleanParam(0, false, true)),
+        ExtensionErrorCodes.INVALID_BOOLEAN_PARAM);
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getDateParam(1, null, true)),
+        ExtensionErrorCodes.INVALID_DATE_PARAM);
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getUncheckedParam(-1)),
+        ExtensionErrorCodes.INVALID_INDEX_VALUE);
+    leftoverNonAuditable(
+        assertThrows(PSConversionException.class, () -> ep.getStringParam(5, null, true)),
+        ExtensionErrorCodes.MISSING_REQUIRED_PARAM_NO);
+  }
+
+  @Test
+  void handlerInitWithNonDirectoryThrowsTyped(@TempDir Path tmp) throws Exception {
+    Path notDir = tmp.resolve("not-a-directory.txt");
+    Files.writeString(notDir, "x");
+    PSExtensionException ex =
+        assertThrows(
+            PSExtensionException.class, () -> new TestHandler().init(simpleDef(), notDir.toFile()));
+    leftoverNonAuditable(ex, ExtensionErrorCodes.EXT_HANDLER_INIT_FAILED);
+  }
+
+  @Test
+  void handlerConfigMissingFileThrowsTyped(@TempDir Path tmp) {
+    Path missing = tmp.resolve("no-such-extensions.xml");
+    PSExtensionException ex =
+        assertThrows(
+            PSExtensionException.class,
+            () -> new PSExtensionHandlerConfiguration(missing.toFile(), null, false));
+    leftoverNonAuditable(ex, ExtensionErrorCodes.EXT_MANAGER_INIT_FAILED);
+  }
+
+  @Test
+  void javaScriptUdfParamCountMismatchThrowsTyped() throws Exception {
+    PSJavaScriptUdfExtension ext = newUdf("countMismatch", "return 1;", "Number");
+    PSConversionException ex =
+        assertThrows(PSConversionException.class, () -> ext.processUdf(new Object[0], null));
+    leftoverNonAuditable(ex, ServerErrorCodes.ARGUMENT_ERROR);
+  }
+
+  @Test
+  void javaScriptUdfUnknownParameterTypeThrowsTyped() throws Exception {
+    PSJavaScriptUdfExtension ext = newUdf("unknownType", "return p;", "Widget");
+    PSConversionException ex =
+        assertThrows(PSConversionException.class, () -> ext.processUdf(new Object[] {"x"}, null));
+    leftoverNonAuditable(ex, ExtensionErrorCodes.UNKNOWN_PARAMETER_TYPE);
+  }
+
+  @Test
+  void javaScriptUdfUnsupportedDateConversionThrowsTyped() throws Exception {
+    PSJavaScriptUdfExtension ext = newUdf("badDate", "return p;", "Date");
+    PSConversionException ex =
+        assertThrows(
+            PSConversionException.class, () -> ext.processUdf(new Object[] {new Object()}, null));
+    leftoverNonAuditable(ex, DataErrorCodes.UNSUPPORTED_CONVERSION);
+  }
+
+  @Test
+  void typedLogMessageRejectsNullCode() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new TestHandler().logMessage((IPSErrorCode) null, new Object[] {"x"}));
+  }
+
+  private static PSJavaScriptUdfExtension newUdf(
+      String extensionName, String scriptBody, String paramType) throws PSExtensionException {
+    Properties init = new Properties();
+    init.setProperty("scriptBody", scriptBody);
+    PSExtensionParamDef param = new PSExtensionParamDef("p", paramType);
+    PSExtensionDef def =
+        new PSExtensionDef(
+            new PSExtensionRef("JavaScript", "global/", extensionName),
+            List.of(IPSUdfProcessor.class.getName()).iterator(),
+            null,
+            init,
+            List.of(param).iterator());
+    PSJavaScriptUdfExtension ext = new PSJavaScriptUdfExtension();
+    ext.init(def, null);
+    return ext;
+  }
+
+  private static IPSExtensionDef simpleDef() {
+    Properties init = new Properties();
+    init.setProperty(IPSExtensionHandler.INIT_PARAM_CONFIG_FILENAME, "Extensions.xml");
+    return new PSExtensionDef(
+        new PSExtensionRef("Java", "global/", "testHandler"),
+        List.of(IPSExtensionHandler.class.getName()).iterator(),
+        null,
+        init,
+        null);
+  }
+
+  private static void leftoverNonAuditable(IPSErrorCode expected) {
+    assertFalse(expected.isAuditable(), expected.toString());
+  }
+
+  private static void leftoverNonAuditable(PSException ex, IPSErrorCode expected) {
+    assertSame(expected, ex.getTypedErrorCode(), expected.toString());
+    assertEquals(expected.numericCode(), ex.getErrorCode(), expected.toString());
+    assertFalse(ex.isAuditable(), expected.toString());
+    assertFalse(expected.isAuditable(), expected.toString());
+  }
+
+  /** Package-visible stub so leftover init/log paths can be exercised without a live handler. */
+  static final class TestHandler extends PSExtensionHandler {
+    @Override
+    public String getName() {
+      return "testHandler";
+    }
+
+    @Override
+    protected IPSExtension loadExtension(PSExtensionRef ref) {
+      return null;
+    }
+  }
+}

--- a/system/src/test/java/com/percussion/extension/PSExtensionLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/extension/PSExtensionLeftoverErrorCodesSliceTest.java
@@ -261,6 +261,13 @@ class PSExtensionLeftoverErrorCodesSliceTest {
         () -> new TestHandler().logMessage((IPSErrorCode) null, new Object[] {"x"}));
   }
 
+  @Test
+  void typedLogMessageRejectsNullArgs() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new TestHandler().logMessage(ExtensionErrorCodes.EXT_RESOURCE_DELETE_ERROR, null));
+  }
+
   private static PSJavaScriptUdfExtension newUdf(
       String extensionName, String scriptBody, String paramType) throws PSExtensionException {
     Properties init = new Properties();


### PR DESCRIPTION
## Summary

Overnight same-file thrash: leftover IPS*Errors typed-ErrorCodes slices #3974, #3975, and #3976 all edit the residual allow-list and the Python gate tests. Sequential merge against `main` would keep rewriting:

- `scripts/ipserrors-residual-allowlist.txt`
- `scripts/test_verify_no_bare_ipserrors.py`

This cluster absorbs the three PRs (oldest first) with **union** semantics:

- Allow-list **paths**: intersection of remaining residuals (drop every path converted by any absorbed slice).
- Allow-list **comments** + verifier tests: keep unique adds from all three (`#3971` leftover comment, `#3970` extension converted-path tests, `#3969` design.catalog converted-path tests).

Production call-site retypes are disjoint packages under `system/src/main` (`com.percussion.error`, `com.percussion.extension`, `com.percussion.design.catalog`). Parent epic #2616.

Fixes #3971. Fixes #3970. Fixes #3969.

### Thrash files

- `scripts/ipserrors-residual-allowlist.txt`
- `scripts/test_verify_no_bare_ipserrors.py`

## Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|------------|-------------|------|----------|-------|
| yes | [#3974](https://github.com/intersoftdatalabs-in/percussioncms/pull/3974) | `fix/issue-3971-system-error-ipserrors-errorcodes` (`b245986185`) | yes | leftover `com.percussion.error` retype |
| yes | [#3975](https://github.com/intersoftdatalabs-in/percussioncms/pull/3975) | `fix/issue-3970-extension-typed-errorcodes-wt` (`2c1d852f98`) | yes | leftover `com.percussion.extension` retype + `requireNonNull` on typed `logMessage` |
| yes | [#3976](https://github.com/intersoftdatalabs-in/percussioncms/pull/3976) | `fix/issue-3969-design-catalog-typed-errorcodes` (`4832fab70b`) | yes | leftover `com.percussion.design.catalog` retype |

Do **not** merge the superseded PRs.

## Test plan

1. Review allow-list union: converted `error` / `extension` / `design.catalog` paths must be absent; remaining residuals stay exact-listed.
2. `python scripts/verify-no-bare-ipserrors.py` → PASS.
3. `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` → 21 passed.
4. Standalone `system` clean install as below.

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal error-catalog retype; no operator/UI/API/config surface
- [x] **Unit / module tests** — leftover slice tests unioned; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `system` standalone clean install (no skipTests); C2 reverse-dep grep only (`PSExtensionHandler` subclasses in-module)
- [x] **Cross-platform** — **N/A** for production path I/O; allow-list stays POSIX `/` paths as existing gate contract

### modules_built

`system`

### build_evidence

- `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (01:41). Surefire Tests run: 2595, Failures: 0, Errors: 0, Skipped: 246 (`PSErrorLeftoverErrorCodesSliceTest` 4, `PSExtensionLeftoverErrorCodesSliceTest` 10, `PSDesignCatalogLeftoverErrorCodesSliceTest` 3).
- `python scripts/verify-no-bare-ipserrors.py` → PASS.
- `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` → 21 passed.
- C2: `extends PSExtensionHandler` → `PSJavaExtensionHandler`, `PSJavaScriptExtensionHandler`, in-module test stub only. No reverse-dep module install.

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs-cluster.
