### PR TITLE
feat(rest): CD-04 include system/shared fields (#3985)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3985-rest-cd04-include-fields-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3985-rest-cd04-include-fields-erlang.md
@@ -1,0 +1,48 @@
+# Erlang review — issue #3985 REST CD-04 include system/shared fields
+
+**Branch:** `feat/issue-3985-rest-cd04-include-fields`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (rest resource + adaptor interface + sitemanage impl + Spring stub + Mockito resource tests + adaptor tests); C2 interface implementors; product-docs REST companion
+
+## Summary
+
+Admin REST adds `POST /contenttypes/{idOrName}/fields/include` to include an existing system or shared field under a held design-session lock. Persist is `IPSContentDesignWs.loadContentTypes` / `saveContentTypes` only (catalog read of system/shared defs is unlocked). Origin stays `system`/`shared` (excludes + display mapping; typed field is not copied as local). Status mapping matches content-type write peers (400/403/404/409). No SPA. No new SOAP.
+
+## Scope
+
+Uncommitted vs `HEAD` on this branch (rest, sitemanage, product-docs/8.2, gap map). C5 Playwright N/A (no WebUI). Cross-platform path I/O: identifier sanitization only (`/`, `\\`, `..` rejected on field names).
+
+## Issues
+
+None that block.
+
+## Companions
+
+| Companion | Status |
+|-----------|--------|
+| rest resource + OpenAPI | yes |
+| `IContentTypesAdaptor` | yes |
+| sitemanage `ContentTypeAdaptor` | yes |
+| rest Spring stub `TestContentTypeAdaptor` | yes |
+| `ContentTypesTestAdaptor` | yes |
+| Mockito resource tests | yes |
+| adaptor success/403/404/409/lock | yes |
+| product-docs 8.2 REST + admin CT | yes |
+| gap map CD-04 | yes |
+| designGaps `CT_SHARED_FIELD_INCLUSION` | yes |
+
+## C2
+
+Grep `implements IContentTypesAdaptor`: 3 types (`ContentTypeAdaptor` + two rest test stubs), all updated. No anonymous subclasses. sitemanage standalone `mvnw clean install` green after rest install.
+
+## Build
+
+- `rest`: standalone `mvnw.cmd clean install` BUILD SUCCESS; ContentTypesResourceDetailTest 98/0; module Tests run: 763, Failures: 0
+- `projects/sitemanage`: standalone `mvnw.cmd clean install` BUILD SUCCESS; ContentTypeAdaptorIncludeFieldTest 15/0; module Tests run: 1799, Failures: 0, Skipped: 125
+
+## Cross-platform path checklist
+
+- No new filesystem path joins
+- Field-name sanitizer rejects `/`, `\\`, `..` (same class as CD-03)
+- N/A for installers/packaging

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -2,7 +2,7 @@
 
 |  Field   |                                  Value                                   |
 |----------|--------------------------------------------------------------------------|
-| **Date** | 2026-08-28                                                               |
+| **Date** | 2026-08-29                                                               |
 | **FR**   | CD-01–CD-19 in `docs/developer-module/workbench-functional-inventory.md` |
 
 ## Surfaces available today
@@ -18,6 +18,7 @@
 | Public REST shared-field detail   | CD-15 group fields (Admin only)     | `GET /services/sharedfields/{idOrName}`        |
 | Public REST shared-field write    | CD-15 create/save/delete (Admin)    | `POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}` |
 | Public REST shared-field fields   | CD-15 field create/delete (Admin)   | `POST …/{idOrName}/fields`, `DELETE …/{idOrName}/fields/{fieldName}` |
+| Public REST include field         | CD-04 include system/shared (Admin) | `POST /services/contenttypes/{idOrName}/fields/include` |
 | Public REST system-def catalog    | CD-16 GET (Admin only)              | `GET /services/systemdef`                      |
 | Public REST system-def write      | CD-16 field-property save (Admin)   | `PUT /services/systemdef` (request lock, release on save) |
 | Design SOAP (Workbench)           | Full load/save/lock/create/delete   | `IPSContentDesignWs` / `ContentDesignSOAPImpl` |
@@ -83,6 +84,7 @@ slices.
 | ACL                                                  | CD-19, §5.4  | Existing ACL REST may help later                  |
 | ~~Keyword write~~                                    | CD-17        | **Done** — REST + SPA + design WS (#1612/#1701)   |
 | Locale **write** (create/update/delete)              | CD-18        | **REST write shipped** (#3959, design WS + Admin 403 / lock 409). Auto-translation editor + SPA remain open |
+| Include system/shared fields                         | CD-04        | **REST `POST /contenttypes/{id}/fields/include` shipped** (#3985, held design lock, origin stays system/shared). SPA field picker still Workbench |
 
 ## Recommended next API work
 
@@ -93,8 +95,9 @@ slices.
 5. ~~Control property value/choice catalogs~~ **Done CD-07 REST** (#3786). Field-rule write/save still open
 6. ~~Shared field catalog read~~ **Done CD-15 read** (`GET /services/sharedfields`, Admin 403). ~~Write~~ **Done CD-15 group create/save/delete** (`POST`/`PUT`/`DELETE`, #3944). ~~Field create/delete~~ **Done** (`POST …/fields`, `DELETE …/fields/{fieldName}`, #3954). Control/choice write + SPA editor still open
 7. ~~System def field-property write~~ **Done CD-16 PUT** (`PUT /services/systemdef`, Admin 403, request lock + release on save, #3958). Field create/delete + SPA still open
-8. Templates/slots design editors
-9. CD-18 remainder: auto-translation set editor + SPA locale editor (REST locale CRUD shipped #3959)
+8. ~~Include system/shared fields~~ **Done CD-04 REST** (`POST /contenttypes/{id}/fields/include`, Admin 403, held lock 409, origin stays system/shared, #3985). SPA field picker still open
+9. Templates/slots design editors
+10. CD-18 remainder: auto-translation set editor + SPA locale editor (REST locale CRUD shipped #3959)
 
 ## Client behavior
 

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, enable or disable, rename via REST, add or delete local fields via REST, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
+description: Lock, enable or disable, rename via REST, add or delete local fields via REST, include system or shared fields via REST, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -20,12 +20,17 @@ That call persists the type (Workbench Finish). A successful create is then
 `GET /services/contenttypes/{name}` **200**. Duplicate or reserved system names
 (for example **Folder**) are **409**. Invalid names (blank, spaces, wildcard)
 are **400**. Non-Admin callers are **403**. This chrome does **not** include a
-create wizard; rename, delete, and **local field create/delete** are REST-only
-(no SPA field editor). After a held lock, integrators add a local field with
+create wizard; rename, delete, **local field create/delete**, and **include
+system/shared fields** are REST-only (no SPA field editor or field picker).
+After a held lock, integrators add a local field with
 `POST /services/contenttypes/{idOrName}/fields` (JSON `name` required) and
 remove one with `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}`.
 Duplicate field names are **409**. System and shared fields cannot be removed
-here (**400**). Optional `fieldSet` targets or creates a named child field set.
+here (**400**). Include an existing system or shared field with
+`POST /services/contenttypes/{idOrName}/fields/include` (JSON `name` and
+`fieldType` `system` or `shared`; origin is not copied as local). Duplicate
+include is **409**; unknown catalog field is **404**. Optional `fieldSet` on
+local create targets or creates a named child field set.
 Shared field
 **files** are a separate design object: Admin-only `GET /services/sharedfields` and
 `GET /services/sharedfields/{idOrName}` (catalog), plus

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -264,7 +264,8 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` | **Admin** (CD-08 design action). Requires a held design-session lock (`POST .../lock` first). Does **not** acquire or release the lock. Full replace of `allowedWorkflows` (empty list clears). Optional `defaultWorkflow`. Workflow name/guid must exist. `200` + `ContentTypeDetail` with the new `allowedWorkflows` / `defaultWorkflow` (lock still held). |
 | Enable/disable | `PUT /services/contenttypes/{idOrName}/enabled` | **Admin** (CD-13 design action). Requires a held design-session lock — `POST .../lock` first, then `PUT .../enabled`, then `POST .../unlock` when done. Does **not** acquire or release the lock. `200` + `ContentTypeDetail` with the new `enabled` value (lock still held). |
 | Rename | `PUT /services/contenttypes/{idOrName}/name` | **Admin** (CD-01). Requires a **held** design-session lock. Sets the internal name. Unique (case-insensitive); **no spaces** or wildcards. Bulk `PUT .../{idOrName}` does **not** change name. After success, `GET` by the previous name is **404**; `GET` by id returns the new name. Does not acquire or release the lock. |
-| Add local field | `POST /services/contenttypes/{idOrName}/fields` | **Admin** (CD-03). Requires a **held** design-session lock. Adds a persistable **local** field (backend column + display mapping) via `IPSContentDesignWs.saveContentTypes`. Body `name` is required (letter, then letters/digits/underscore; unique case-insensitive on the type). Optional `dataType` defaults to `text`. Optional `searchable` and `occurrence`/`required` use the same rules as PUT field patches. Optional `fieldSet` names an existing child field set, or **creates** a named complex child when missing. Duplicate field is **409**. System/shared inclusion is out of scope (CD-04). Does not acquire or release the lock. |
+| Add local field | `POST /services/contenttypes/{idOrName}/fields` | **Admin** (CD-03). Requires a **held** design-session lock. Adds a persistable **local** field (backend column + display mapping) via `IPSContentDesignWs.saveContentTypes`. Body `name` is required (letter, then letters/digits/underscore; unique case-insensitive on the type). Optional `dataType` defaults to `text`. Optional `searchable` and `occurrence`/`required` use the same rules as PUT field patches. Optional `fieldSet` names an existing child field set, or **creates** a named complex child when missing. Duplicate field is **409**. Include an existing system or shared field with `POST .../fields/include` (CD-04). Does not acquire or release the lock. |
+| Include system/shared field | `POST /services/contenttypes/{idOrName}/fields/include` | **Admin** (CD-04). Requires a **held** design-session lock (`POST .../lock` first; the lock is not stolen). Includes an existing **system** or **shared** field by `name` and `fieldType` (`system` or `shared`). Origin stays system/shared (not copied as local). Persist via `IPSContentDesignWs.loadContentTypes` / `saveContentTypes`. Duplicate include is **409**. Unknown catalog field is **404**. Invalid `fieldType` (including `local`) is **400**. Does not acquire or release the lock. |
 | Delete local field | `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}` | **Admin** (CD-03). Requires a **held** design-session lock. Removes a **local** field and its display mapping. System/shared fields are **400**. Missing type or field is **404**. Does not acquire or release the lock. `204` on success (lock still held). |
 | Field control properties | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | Control parameter **name/value** pairs and the choice catalog for one field (CD-07). No lock required. Empty `properties` means none. `choices` omitted when none. |
 | Replace field control properties | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | **Admin** (CD-07). Requires a **held** design-session lock. Full replace of `properties` (empty clears). `choices` omitted leaves the catalog unchanged; `type: none` clears. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
@@ -273,18 +274,18 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 | Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). Include system/shared is REST-only: **lock → POST .../fields/include → unlock** (no SPA field picker). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
 
 Lock / save / unlock / create / rename / delete status codes:
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / rename succeeded (lock still held), POST create succeeded (`ContentTypeDetail`), or POST local field succeeded |
+| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / rename succeeded (lock still held), POST create succeeded (`ContentTypeDetail`), POST local field succeeded, or POST include field succeeded |
 | `204` | Unlock success, content type deleted, or local field deleted |
-| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid or colliding rename), invalid create name (blank, spaces, wildcard), invalid local-field name/`dataType`/origin, DELETE field of a system/shared field, or DELETE type rejected because the type has dependents |
+| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid or colliding rename), invalid create name (blank, spaces, wildcard), invalid local-field name/`dataType`/origin, invalid include `fieldType`/`name`, DELETE field of a system/shared field, or DELETE type rejected because the type has dependents |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
-| `404` | Content type not found |
-| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time), including reserved system types such as Folder; POST local field when the field name already exists on the type |
+| `404` | Content type not found, or include of an unknown system/shared catalog field |
+| `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time), including reserved system types such as Folder; POST local field when the field name already exists on the type; POST include when the field is already on the type |
 | `500` | Design service or server failure |
 
 ### Rename (CD-01)
@@ -323,7 +324,7 @@ Jackson root wrap:
 existing content type. `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}`
 removes one. Both require a **held** design-session lock (`POST .../lock` first).
 The lock is **not** released. Including system or shared fields into a type
-(CD-04) is a different surface.
+uses `POST .../fields/include` (CD-04).
 
 Typical flow: `POST .../lock` → `POST .../fields` (or `DELETE .../fields/{name}`)
 → (optional further design writes) → `POST .../unlock`.
@@ -344,6 +345,44 @@ Optional `fieldSet` names an existing child field set, or creates a named
 complex child when missing. Duplicate field names on the type are **409**.
 Unknown field on DELETE is **404**. Deleting a system or shared field is
 **400**. Field **order** in the editor remains Workbench-only.
+
+### Include system or shared fields (CD-04)
+
+`POST /services/contenttypes/{idOrName}/fields/include` includes an existing
+**system** or **shared** field into a content type (Workbench “include field”).
+It does **not** create a local copy. After success, `GET` detail shows
+`fieldType` `system` or `shared` for that field.
+
+Requires a **held** design-session lock (`POST .../lock` first). The lock is
+**not** released and is **not** stolen from another user. Catalog lookup uses
+the design web service system def / shared def (read, unlocked). Persist is
+`IPSContentDesignWs.saveContentTypes` only.
+
+Typical flow: `POST .../lock` → `POST .../fields/include` → (optional further
+design writes) → `POST .../unlock`.
+
+Include body is a `ContentTypeField`:
+
+```json
+{
+  "name": "sys_title",
+  "fieldType": "system"
+}
+```
+
+Shared fields may use a simple name or `group.field`:
+
+```json
+{
+  "name": "displaytitle",
+  "fieldType": "shared"
+}
+```
+
+`fieldType` is required and must be `system` or `shared`. `local` is **400**
+(use `POST .../fields`). Duplicate include is **409**. Unknown catalog field is
+**404**. Non-Admin is **403**. Unlocked or locked by another user is **409**.
+There is no SPA field-picker chrome for this surface.
 
 ### Enable or disable (CD-13)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -28,7 +28,10 @@ import com.percussion.design.objectstore.PSChoices;
 import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSConditionalExit;
 import com.percussion.design.objectstore.PSContentEditor;
+import com.percussion.design.objectstore.PSContentEditorMapper;
 import com.percussion.design.objectstore.PSContentEditorPipe;
+import com.percussion.design.objectstore.PSContentEditorSharedDef;
+import com.percussion.design.objectstore.PSContentEditorSystemDef;
 import com.percussion.design.objectstore.PSContentTypeHelper;
 import com.percussion.design.objectstore.PSControlRef;
 import com.percussion.design.objectstore.PSDisplayMapper;
@@ -49,8 +52,10 @@ import com.percussion.design.objectstore.PSParam;
 import com.percussion.design.objectstore.PSPipe;
 import com.percussion.design.objectstore.PSRule;
 import com.percussion.design.objectstore.PSSearchProperties;
+import com.percussion.design.objectstore.PSSharedFieldGroup;
 import com.percussion.design.objectstore.PSSystemValidationException;
 import com.percussion.design.objectstore.PSTextLiteral;
+import com.percussion.design.objectstore.PSUIDefinition;
 import com.percussion.design.objectstore.PSUISet;
 import com.percussion.design.objectstore.PSUrlRequest;
 import com.percussion.design.objectstore.PSValidationRules;
@@ -457,11 +462,14 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
             "CT_FIELD_CREATE_DELETE",
             "Local field create/delete: POST/DELETE /contenttypes/{idOrName}/fields"
                 + " (held lock). Optional fieldSet names an existing child or creates a named"
-                + " complex child. System/shared inclusion is CD-04. Field order remains"
-                + " Workbench"));
+                + " complex child. Include system/shared: POST .../fields/include (CD-04)."
+                + " Field order remains Workbench"));
     gaps.add(
         DesignGap.of(
-            "CT_SHARED_FIELD_INCLUSION", "Shared/system field inclusion editing not supported"));
+            "CT_SHARED_FIELD_INCLUSION",
+            "Include system/shared fields: POST /contenttypes/{idOrName}/fields/include"
+                + " (held lock, Admin). Origin stays system/shared. SPA field picker remains"
+                + " Workbench"));
     gaps.add(
         DesignGap.of(
             "CT_WF_TEMPLATE_ASSOC_SEMANTICS",
@@ -1307,6 +1315,82 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (Exception e) {
       log.error("Failed to delete local field for {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to delete local field", e);
+    }
+  }
+
+  @Override
+  public ContentTypeDetail includeField(URI baseUri, String idOrName, ContentTypeField body) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String origin = requireIncludeOrigin(body.getFieldType());
+    String requestedName = validateIncludeFieldName(body.getName());
+    String simpleName = simpleIncludeFieldName(requestedName);
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    requireSessionUserForLock();
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      IPSGuid ctGuid = resolveExistingContentTypeGuid(trimmed);
+      if (ctGuid == null) {
+        return null;
+      }
+      requireHeldLock(ctGuid, "Could not include content type field");
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not include content type field");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      if (findField(def, simpleName) != null
+          || findDisplayMapping(displayMapperOfStatic(def), simpleName) != null) {
+        throw new WebApplicationException("Field already included: " + simpleName, 409);
+      }
+      if ("system".equals(origin)) {
+        PSDisplayMapping mapping = loadSystemFieldMapping(simpleName, session, user);
+        if (mapping == null) {
+          throw new WebApplicationException("Unknown system field: " + simpleName, 404);
+        }
+        includeSystemOrSharedField(def, simpleName, PSField.TYPE_SYSTEM, mapping, null, body);
+      } else {
+        PSSharedFieldGroup group = loadSharedGroupForInclude(requestedName, session, user);
+        if (group == null) {
+          throw new WebApplicationException("Unknown shared field: " + requestedName, 404);
+        }
+        PSDisplayMapping mapping = mappingFromSharedGroup(group, simpleName);
+        includeSystemOrSharedField(def, simpleName, PSField.TYPE_SHARED, mapping, group, body);
+      }
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not include content type field");
+        }
+        log.error("Failed to save included field for {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save included field", e);
+      }
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
+      return reloaded != null ? toDetail(reloaded) : toDetail(def);
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to include field for {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to include field", e);
     }
   }
 
@@ -2809,6 +2893,260 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     }
     String name = StringUtils.defaultIfBlank(def.getName(), "CONTENTTYPE");
     return new PSBackEndTable(columnNameForField(name));
+  }
+
+  static String requireIncludeOrigin(String fieldType) {
+    if (StringUtils.isBlank(fieldType)) {
+      throw new IllegalArgumentException("fieldType is required (system or shared)");
+    }
+    String origin = fieldType.trim().toLowerCase();
+    if ("local".equals(origin)) {
+      throw new IllegalArgumentException("Use POST .../fields to create a local field");
+    }
+    if (!"system".equals(origin) && !"shared".equals(origin)) {
+      throw new IllegalArgumentException("fieldType must be system or shared");
+    }
+    return origin;
+  }
+
+  static String validateIncludeFieldName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String trimmed = name.trim();
+    if (containsWhitespace(trimmed)) {
+      throw new IllegalArgumentException("name cannot contain spaces");
+    }
+    if (trimmed.contains("..")
+        || trimmed.indexOf('/') >= 0
+        || trimmed.indexOf('\\') >= 0
+        || trimmed.indexOf('\0') >= 0) {
+      throw new IllegalArgumentException("name contains invalid path characters");
+    }
+    String[] parts;
+    try {
+      parts = PSContentTypeHelper.getSharedFieldName(trimmed);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("name must be a field or group.field", e);
+    }
+    for (String part : parts) {
+      validateFieldName(part);
+    }
+    return trimmed;
+  }
+
+  static String simpleIncludeFieldName(String name) {
+    return PSContentTypeHelper.getSharedFieldName(name)[0];
+  }
+
+  /**
+   * Workbench include: drop the field from system/shared excludes, include the shared group when
+   * needed, append a display mapping, and keep a typed (non-local) field on the parent set so GET
+   * detail reports origin system/shared.
+   */
+  static PSField includeSystemOrSharedField(
+      PSItemDefinition def,
+      String fieldName,
+      int type,
+      PSDisplayMapping sourceMapping,
+      PSSharedFieldGroup sharedGroup,
+      ContentTypeField body) {
+    if (def == null) {
+      throw new IllegalArgumentException("content type is required");
+    }
+    if (type != PSField.TYPE_SYSTEM && type != PSField.TYPE_SHARED) {
+      throw new IllegalArgumentException("include type must be system or shared");
+    }
+    PSContentEditorMapper mapper = contentEditorMapperOf(def);
+    if (type == PSField.TYPE_SHARED) {
+      if (sharedGroup == null) {
+        throw new IllegalArgumentException("shared field group is required");
+      }
+      ensureSharedGroupIncluded(mapper, sharedGroup);
+    }
+    removeFieldFromExcludes(mapper, fieldName, type);
+    appendIncludeDisplayMapping(displayMapperOfStatic(def), fieldName, sourceMapping, body);
+    return ensureTypedIncludedField(def, fieldName, type);
+  }
+
+  static PSContentEditorMapper contentEditorMapperOf(PSItemDefinition def) {
+    if (def == null) {
+      throw new IllegalArgumentException("content type is required");
+    }
+    try {
+      PSContentEditorMapper mapper = def.getContentEditorMapper();
+      if (mapper == null) {
+        throw new IllegalArgumentException("Content type has no editor mapper");
+      }
+      return mapper;
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("Content type has no editor mapper", e);
+    }
+  }
+
+  static void ensureSharedGroupIncluded(
+      PSContentEditorMapper mapper, PSSharedFieldGroup group) {
+    ArrayList<String> includes = copyStringList(mapper.getSharedFieldIncludes());
+    boolean already =
+        includes.stream().anyMatch(n -> n.equalsIgnoreCase(group.getName()));
+    if (already) {
+      return;
+    }
+    includes.add(group.getName());
+    mapper.setSharedFieldIncludes(includes);
+    ArrayList<String> excludes = copyStringList(mapper.getSharedFieldExcludes());
+    if (group.getFieldSet() != null) {
+      for (PSField f : group.getFieldSet().getAllFields()) {
+        if (f == null || StringUtils.isBlank(f.getSubmitName())) {
+          continue;
+        }
+        boolean present =
+            excludes.stream().anyMatch(n -> n.equalsIgnoreCase(f.getSubmitName()));
+        if (!present) {
+          excludes.add(f.getSubmitName());
+        }
+      }
+    }
+    mapper.setSharedFieldExcludes(excludes);
+  }
+
+  static void removeFieldFromExcludes(
+      PSContentEditorMapper mapper, String fieldName, int type) {
+    ArrayList<String> names =
+        type == PSField.TYPE_SYSTEM
+            ? copyStringList(mapper.getSystemFieldExcludes())
+            : copyStringList(mapper.getSharedFieldExcludes());
+    names.removeIf(n -> n != null && n.equalsIgnoreCase(fieldName));
+    if (type == PSField.TYPE_SYSTEM) {
+      mapper.setSystemFieldExcludes(names);
+    } else {
+      mapper.setSharedFieldExcludes(names);
+    }
+  }
+
+  static ArrayList<String> copyStringList(Iterator<?> it) {
+    ArrayList<String> names = new ArrayList<>();
+    if (it == null) {
+      return names;
+    }
+    while (it.hasNext()) {
+      Object o = it.next();
+      if (o != null) {
+        names.add(o.toString());
+      }
+    }
+    return names;
+  }
+
+  static void appendIncludeDisplayMapping(
+      PSDisplayMapper mapper,
+      String fieldName,
+      PSDisplayMapping source,
+      ContentTypeField body) {
+    if (mapper == null) {
+      throw new IllegalArgumentException("Content type has no display mapper");
+    }
+    ContentTypeField labelBody = new ContentTypeField();
+    labelBody.setName(fieldName);
+    if (body != null && StringUtils.isNotBlank(body.getLabel())) {
+      labelBody.setLabel(body.getLabel().trim());
+    } else if (source != null
+        && source.getUISet() != null
+        && source.getUISet().getLabel() != null
+        && StringUtils.isNotBlank(source.getUISet().getLabel().getText())) {
+      labelBody.setLabel(source.getUISet().getLabel().getText());
+    }
+    if (body != null && StringUtils.isNotBlank(body.getControl())) {
+      labelBody.setControl(body.getControl().trim());
+    } else if (source != null
+        && source.getUISet() != null
+        && source.getUISet().getControl() != null
+        && StringUtils.isNotBlank(source.getUISet().getControl().getName())) {
+      labelBody.setControl(source.getUISet().getControl().getName());
+    }
+    appendDefaultDisplayMapping(mapper, fieldName, labelBody);
+  }
+
+  static PSField ensureTypedIncludedField(PSItemDefinition def, String fieldName, int type) {
+    PSField existing = findField(def, fieldName);
+    if (existing != null) {
+      return existing;
+    }
+    PSFieldSet parent = def.getFieldSet();
+    if (parent == null) {
+      throw new IllegalArgumentException("Content type has no field set");
+    }
+    PSField field = new PSField(type, fieldName, null);
+    parent.add(field);
+    return field;
+  }
+
+  static PSDisplayMapping findSystemFieldMapping(
+      PSContentEditorSystemDef sysDef, String fieldName) {
+    if (sysDef == null || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    PSUIDefinition ui = sysDef.getUIDefinition();
+    if (ui == null) {
+      return null;
+    }
+    PSDisplayMapping exact = ui.getMapping(fieldName);
+    if (exact != null) {
+      return exact;
+    }
+    return findDisplayMapping(ui.getDisplayMapper(), fieldName);
+  }
+
+  static PSSharedFieldGroup findSharedGroup(
+      PSContentEditorSharedDef sharedDef, String fieldName) {
+    if (sharedDef == null || StringUtils.isBlank(fieldName)) {
+      return null;
+    }
+    String[] parts = PSContentTypeHelper.getSharedFieldName(fieldName);
+    String simple = parts[0];
+    String grpName = parts.length == 2 ? parts[1] : null;
+    Iterator<?> groups = sharedDef.getFieldGroups();
+    if (groups == null) {
+      return null;
+    }
+    while (groups.hasNext()) {
+      Object o = groups.next();
+      if (!(o instanceof PSSharedFieldGroup group)) {
+        continue;
+      }
+      if (grpName != null && !group.getName().equalsIgnoreCase(grpName)) {
+        continue;
+      }
+      if (group.getFieldSet() != null && group.getFieldSet().findFieldByName(simple) != null) {
+        return group;
+      }
+    }
+    return null;
+  }
+
+  static PSDisplayMapping mappingFromSharedGroup(PSSharedFieldGroup group, String fieldName) {
+    if (group == null || group.getUIDefinition() == null) {
+      return null;
+    }
+    PSDisplayMapping exact = group.getUIDefinition().getMapping(fieldName);
+    if (exact != null) {
+      return exact;
+    }
+    return findDisplayMapping(group.getUIDefinition().getDisplayMapper(), fieldName);
+  }
+
+  private PSDisplayMapping loadSystemFieldMapping(String fieldName, String session, String user)
+      throws Exception {
+    PSContentEditorSystemDef sysDef =
+        designSvc.loadContentEditorSystemDef(false, false, session, user);
+    return findSystemFieldMapping(sysDef, fieldName);
+  }
+
+  private PSSharedFieldGroup loadSharedGroupForInclude(
+      String fieldName, String session, String user) throws Exception {
+    PSContentEditorSharedDef sharedDef =
+        designSvc.loadContentEditorSharedDef(false, false, session, user);
+    return findSharedGroup(sharedDef, fieldName);
   }
 
   static String validateFieldName(String name) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorIncludeFieldTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorIncludeFieldTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSBackEndTable;
+import com.percussion.design.objectstore.PSContentEditorMapper;
+import com.percussion.design.objectstore.PSContentEditorSharedDef;
+import com.percussion.design.objectstore.PSContentEditorSystemDef;
+import com.percussion.design.objectstore.PSDisplayMapper;
+import com.percussion.design.objectstore.PSDisplayMapping;
+import com.percussion.design.objectstore.PSDisplayText;
+import com.percussion.design.objectstore.PSField;
+import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.design.objectstore.PSSharedFieldGroup;
+import com.percussion.design.objectstore.PSUIDefinition;
+import com.percussion.design.objectstore.PSUISet;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeField;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.util.PSCollection;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CD-04 include system/shared fields: POST .../fields/include persists via {@code
+ * saveContentTypes} under a held design-session lock. Origin stays system/shared.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorIncludeFieldTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void includeSystemOrSharedField_systemRemovesExcludeAndKeepsOrigin() {
+    StubType stub = stubType(List.of("sys_title"), List.of(), List.of());
+    PSDisplayMapping source = mapping("sys_title", "Title:");
+    PSField field =
+        ContentTypeAdaptor.includeSystemOrSharedField(
+            stub.def, "sys_title", PSField.TYPE_SYSTEM, source, null, null);
+    assertEquals(PSField.TYPE_SYSTEM, field.getType());
+    assertEquals("sys_title", field.getSubmitName());
+    assertFalse(containsIgnoreCase(stub.mapper.getSystemFieldExcludes(), "sys_title"));
+    assertNotNull(ContentTypeAdaptor.findDisplayMapping(stub.display, "sys_title"));
+    assertEquals(PSField.TYPE_SYSTEM, stub.parent.findFieldByName("sys_title", false).getType());
+  }
+
+  @Test
+  void includeSystemOrSharedField_sharedIncludesGroupAndKeepsOrigin() {
+    StubType stub = stubType(List.of(), List.of(), List.of());
+    PSSharedFieldGroup group = sharedGroup("shared", "displaytitle", "body");
+    PSDisplayMapping source = mapping("displaytitle", "Display title:");
+    PSField field =
+        ContentTypeAdaptor.includeSystemOrSharedField(
+            stub.def, "displaytitle", PSField.TYPE_SHARED, source, group, null);
+    assertEquals(PSField.TYPE_SHARED, field.getType());
+    assertTrue(containsIgnoreCase(stub.mapper.getSharedFieldIncludes(), "shared"));
+    assertFalse(containsIgnoreCase(stub.mapper.getSharedFieldExcludes(), "displaytitle"));
+    assertTrue(containsIgnoreCase(stub.mapper.getSharedFieldExcludes(), "body"));
+    assertNotNull(ContentTypeAdaptor.findDisplayMapping(stub.display, "displaytitle"));
+  }
+
+  @Test
+  void includeField_savesSystemWhenLockHeld() throws Exception {
+    stubHeldLock();
+    StubType stub = stubType(List.of("sys_title"), List.of(), List.of());
+    stubLockedLoad(stub.def);
+    stubSystemDef("sys_title");
+    ContentTypeField body = new ContentTypeField();
+    body.setName("sys_title");
+    body.setFieldType("system");
+    adaptor.includeField(null, "311", body);
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(
+        PSField.TYPE_SYSTEM, stub.parent.findFieldByName("sys_title", false).getType());
+    verify(designWs)
+        .loadContentEditorSystemDef(false, false, "test-session", "Admin");
+    verify(designWs, never()).loadContentEditorSharedDef(anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void includeField_savesSharedWhenLockHeld() throws Exception {
+    stubHeldLock();
+    StubType stub = stubType(List.of(), List.of(), List.of());
+    stubLockedLoad(stub.def);
+    stubSharedDef("shared", "displaytitle", "body");
+    ContentTypeField body = new ContentTypeField();
+    body.setName("displaytitle");
+    body.setFieldType("shared");
+    adaptor.includeField(null, "311", body);
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(
+        PSField.TYPE_SHARED, stub.parent.findFieldByName("displaytitle", false).getType());
+    assertTrue(containsIgnoreCase(stub.mapper.getSharedFieldIncludes(), "shared"));
+  }
+
+  @Test
+  void includeField_duplicateIs409() throws Exception {
+    stubHeldLock();
+    StubType stub = stubType(List.of(), List.of(), List.of());
+    ContentTypeAdaptor.includeSystemOrSharedField(
+        stub.def,
+        "sys_title",
+        PSField.TYPE_SYSTEM,
+        mapping("sys_title", "Title:"),
+        null,
+        null);
+    stubLockedLoad(stub.def);
+    ContentTypeField body = new ContentTypeField();
+    body.setName("sys_title");
+    body.setFieldType("system");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.includeField(null, "311", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void includeField_unknownSystemFieldIs404() throws Exception {
+    stubHeldLock();
+    stubLockedLoad(stubType(List.of(), List.of(), List.of()).def);
+    stubSystemDef("sys_title");
+    ContentTypeField body = new ContentTypeField();
+    body.setName("sys_missing");
+    body.setFieldType("system");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.includeField(null, "311", body));
+    assertEquals(404, ex.getResponse().getStatus());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void includeField_unknownSharedFieldIs404() throws Exception {
+    stubHeldLock();
+    stubLockedLoad(stubType(List.of(), List.of(), List.of()).def);
+    stubSharedDef("shared", "displaytitle");
+    ContentTypeField body = new ContentTypeField();
+    body.setName("nope");
+    body.setFieldType("shared");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.includeField(null, "311", body));
+    assertEquals(404, ex.getResponse().getStatus());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void includeField_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    ContentTypeField body = new ContentTypeField();
+    body.setName("sys_title");
+    body.setFieldType("system");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.includeField(null, "311", body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void includeField_unknownTypeReturnsNull() throws Exception {
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of());
+    ContentTypeField body = new ContentTypeField();
+    body.setName("sys_title");
+    body.setFieldType("system");
+    assertNull(adaptor.includeField(null, "999", body));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void includeField_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of());
+    stubLockedLoad(stubType(List.of(), List.of(), List.of()).def);
+    ContentTypeField body = new ContentTypeField();
+    body.setName("sys_title");
+    body.setFieldType("system");
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class, () -> adaptor.includeField(null, "311", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void includeField_localOriginIs400() {
+    ContentTypeField body = new ContentTypeField();
+    body.setName("rx_note");
+    body.setFieldType("local");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.includeField(null, "311", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("local"));
+  }
+
+  @Test
+  void includeField_missingOriginIs400() {
+    ContentTypeField body = new ContentTypeField();
+    body.setName("sys_title");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.includeField(null, "311", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("fieldtype"));
+  }
+
+  @Test
+  void validateIncludeFieldName_allowsGroupDotField() {
+    assertEquals(
+        "shared.displaytitle", ContentTypeAdaptor.validateIncludeFieldName(" shared.displaytitle "));
+    assertEquals("displaytitle", ContentTypeAdaptor.simpleIncludeFieldName("shared.displaytitle"));
+  }
+
+  @Test
+  void validateIncludeFieldName_rejectsPath() {
+    assertThrows(
+        IllegalArgumentException.class, () -> ContentTypeAdaptor.validateIncludeFieldName("../x"));
+    assertThrows(
+        IllegalArgumentException.class, () -> ContentTypeAdaptor.validateIncludeFieldName("a/b"));
+  }
+
+  @Test
+  void requireIncludeOrigin_rejectsUnknown() {
+    assertEquals("system", ContentTypeAdaptor.requireIncludeOrigin("SYSTEM"));
+    assertEquals("shared", ContentTypeAdaptor.requireIncludeOrigin(" shared "));
+    assertThrows(IllegalArgumentException.class, () -> ContentTypeAdaptor.requireIncludeOrigin(""));
+    assertThrows(
+        IllegalArgumentException.class, () -> ContentTypeAdaptor.requireIncludeOrigin("other"));
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private void stubLockedLoad(PSItemDefinition def) throws Exception {
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(def));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void stubSystemDef(String fieldName) throws Exception {
+    PSContentEditorSystemDef sysDef = mock(PSContentEditorSystemDef.class);
+    PSDisplayMapper sysDisplay = new PSDisplayMapper("sys");
+    sysDisplay.add(mapping(fieldName, fieldName + ":"));
+    when(sysDef.getUIDefinition()).thenReturn(new PSUIDefinition(sysDisplay));
+    when(designWs.loadContentEditorSystemDef(false, false, "test-session", "Admin"))
+        .thenReturn(sysDef);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void stubSharedDef(String groupName, String... fieldNames) throws Exception {
+    PSSharedFieldGroup group = sharedGroup(groupName, fieldNames);
+    PSContentEditorSharedDef sharedDef = mock(PSContentEditorSharedDef.class);
+    PSCollection<PSSharedFieldGroup> coll = new PSCollection<>(PSSharedFieldGroup.class);
+    coll.add(group);
+    when(sharedDef.getFieldGroups()).thenAnswer(inv -> coll.iterator());
+    when(designWs.loadContentEditorSharedDef(false, false, "test-session", "Admin"))
+        .thenReturn(sharedDef);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static PSSharedFieldGroup sharedGroup(String groupName, String... fieldNames) {
+    PSFieldSet set = new PSFieldSet(groupName);
+    PSDisplayMapper display = new PSDisplayMapper(groupName);
+    for (String name : fieldNames) {
+      set.add(new PSField(PSField.TYPE_SHARED, name, null));
+      display.add(mapping(name, name + ":"));
+    }
+    PSSharedFieldGroup group = new PSSharedFieldGroup(groupName, groupName + ".xml");
+    group.setFieldSet(set);
+    group.setUIDefinition(new PSUIDefinition(display));
+    return group;
+  }
+
+  private static PSDisplayMapping mapping(String fieldName, String label) {
+    PSUISet ui = new PSUISet();
+    ui.setLabel(new PSDisplayText(label));
+    return new PSDisplayMapping(fieldName, ui);
+  }
+
+  private static boolean containsIgnoreCase(Iterator<?> it, String name) {
+    while (it != null && it.hasNext()) {
+      Object o = it.next();
+      if (o != null && o.toString().equalsIgnoreCase(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private StubType stubType(
+      List<String> systemExcludes, List<String> sharedIncludes, List<String> sharedExcludes) {
+    PSFieldSet parent = new PSFieldSet("percPage");
+    PSDisplayMapper display = new PSDisplayMapper("percPage");
+    PSContentEditorMapper mapper =
+        new PSContentEditorMapper(
+            new ArrayList<>(systemExcludes),
+            new ArrayList<>(sharedIncludes),
+            parent,
+            new PSUIDefinition(display));
+    mapper.setSharedFieldExcludes(new ArrayList<>(sharedExcludes));
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn("percPage");
+    when(def.getLabel()).thenReturn("Page");
+    when(def.getDescription()).thenReturn("");
+    when(def.isEnabled()).thenReturn(true);
+    when(def.isHidden()).thenReturn(false);
+    when(def.getAppName()).thenReturn("rx_cePage");
+    when(def.getEditorUrl()).thenReturn("/Rhythmyx/rx_cePage/percPage.html");
+    when(def.getTypeId()).thenReturn(311);
+    when(def.getFieldSet()).thenReturn(parent);
+    when(def.getComplexChildren()).thenReturn(List.of());
+    when(def.getDisplayMapper("percPage")).thenReturn(display);
+    when(def.getTypeTables()).thenReturn(List.of(new PSBackEndTable("PERCPAGE")));
+    when(def.getContentEditor()).thenReturn(null);
+    when(def.getContentEditorMapper()).thenReturn(mapper);
+    return new StubType(def, parent, display, mapper);
+  }
+
+  private record StubType(
+      PSItemDefinition def,
+      PSFieldSet parent,
+      PSDisplayMapper display,
+      PSContentEditorMapper mapper) {}
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -62,6 +62,14 @@ class DesignGapsStructuredTest {
                         && g.getMessage().contains("/fields")
                         && g.getMessage().toLowerCase().contains("held")),
         () -> gaps.toString());
+    assertTrue(
+        gaps.stream()
+            .anyMatch(
+                g ->
+                    "CT_SHARED_FIELD_INCLUSION".equals(g.getCode())
+                        && g.getMessage().contains("fields/include")
+                        && g.getMessage().toLowerCase().contains("held")),
+        () -> gaps.toString());
     assertFalse(codes.contains("CT_CONTROL_RESOLUTION"));
     for (DesignGap g : gaps) {
       assertNotNull(g.getCode());

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeField.java
@@ -25,12 +25,15 @@ import java.util.List;
 /**
  * Field summary for a content type (Developer module design view). GET catalog rows are read-only
  * except searchable/occurrence on PUT detail. Create uses POST {@code
- * /contenttypes/{idOrName}/fields} (held design lock); delete uses DELETE {@code
- * .../fields/{fieldName}}.
+ * /contenttypes/{idOrName}/fields} (held design lock); include system/shared uses POST {@code
+ * .../fields/include}; delete uses DELETE {@code .../fields/{fieldName}}.
  */
 @XmlRootElement(name = "ContentTypeField")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(description = "Content type field summary; POST .../fields creates a local field")
+@Schema(
+    description =
+        "Content type field summary; POST .../fields creates a local field;"
+            + " POST .../fields/include includes an existing system or shared field")
 public class ContentTypeField {
 
   @Schema(description = "Field submit name (system name)")
@@ -42,7 +45,7 @@ public class ContentTypeField {
   @Schema(
       description =
           "Field origin: local | system | shared | unknown. POST .../fields always creates"
-              + " local; other origins are rejected")
+              + " local. POST .../fields/include requires system or shared")
   private String fieldType;
 
   @Schema(description = "Storage / data type (text, integer, date, binary, …)")

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -1424,7 +1424,8 @@ public class ContentTypesResource {
               + " Optional searchable and occurrence/required use the same rules as PUT field"
               + " patches. Optional fieldSet names an existing child field set, or creates a named"
               + " complex child when missing. Duplicate field is 409. Missing type is 404."
-              + " Including system/shared fields is out of scope (CD-04).",
+              + " Include an existing system or shared field with POST .../fields/include"
+              + " (CD-04).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -1483,6 +1484,52 @@ public class ContentTypesResource {
         throw new WebApplicationException("Content type not found: " + idOrName, 404);
       }
       return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapMutationFailure(e);
+    } catch (Exception e) {
+      throw mapWriteFailure(e);
+    }
+  }
+
+  @POST
+  @Path("/{idOrName}/fields/include")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Include a system or shared field into a content type",
+      description =
+          "CD-04. Admin. Includes an existing system or shared field by name and origin"
+              + " (fieldType) via IPSContentDesignWs.loadContentTypes / saveContentTypes."
+              + " Requires a held design-session lock (POST .../lock). Does not acquire or"
+              + " release the lock. Does not steal another user's lock. Origin stays system or"
+              + " shared (the field is not copied as local). Body name is required. fieldType"
+              + " must be system or shared. Duplicate include is 409. Unknown catalog field is"
+              + " 404. Missing type is 404. Local field create remains POST .../fields (CD-03).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Field included (lock is still held)",
+            content = @Content(schema = @Schema(implementation = ContentTypeDetail.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid name or fieldType"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "Content type or system/shared field not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "Field already included, or design lock not held by the current user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeDetail includeField(
+      @PathParam("idOrName") String idOrName, ContentTypeField body) {
+    try {
+      ContentTypeDetail detail =
+          requireAdaptor().includeField(uriInfo.getBaseUri(), idOrName, body);
+      if (detail == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return detail;
     } catch (RuntimeException e) {
       throw mapMutationFailure(e);
     } catch (Exception e) {

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -288,4 +288,19 @@ public interface IContentTypesAdaptor {
    * @throws jakarta.ws.rs.WebApplicationException {@code 404} when the field name is unknown
    */
   Boolean deleteLocalField(URI baseUri, String idOrName, String fieldName);
+
+  /**
+   * Include an existing system or shared field into a content type (CD-04). Requires a
+   * design-session lock already held by the current user. Does not acquire or release the lock.
+   * Origin stays system/shared (the field is not copied as local). Duplicate include is {@code
+   * 409}. Unknown catalog field is {@code 404}.
+   *
+   * @param body {@code name} required; {@code fieldType} must be {@code system} or {@code shared}
+   * @return updated detail, or {@code null} when the content type is not found
+   * @throws ContentTypeDesignLockException when no lock is held or another user owns the lock
+   * @throws IllegalArgumentException when input is invalid
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin; {@code
+   *     409} when the field is already on the type; {@code 404} when the catalog field is unknown
+   */
+  ContentTypeDetail includeField(URI baseUri, String idOrName, ContentTypeField body);
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -1176,4 +1176,89 @@ public class ContentTypesResourceDetailTest {
             WebApplicationException.class, () -> resource.deleteLocalField("percPage", "rx_note"));
     assertEquals(403, ex.getResponse().getStatus());
   }
+
+  @Test
+  public void includeFieldSuccess() {
+    ContentTypeField body = new ContentTypeField();
+    body.setName("sys_title");
+    body.setFieldType("system");
+    ContentTypeDetail updated = new ContentTypeDetail();
+    updated.setName("percPage");
+    ContentTypeField included = new ContentTypeField();
+    included.setName("sys_title");
+    included.setFieldType("system");
+    updated.setFields(List.of(included));
+    when(adaptor.includeField(any(), eq("percPage"), any())).thenReturn(updated);
+    ContentTypeDetail out = resource.includeField("percPage", body);
+    assertEquals("percPage", out.getName());
+    assertEquals("system", out.getFields().get(0).getFieldType());
+    verify(adaptor).includeField(any(), eq("percPage"), eq(body));
+  }
+
+  @Test
+  public void includeFieldNotFound() {
+    when(adaptor.includeField(any(), eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.includeField("missing", new ContentTypeField()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void includeFieldUnknownCatalogField404() {
+    when(adaptor.includeField(any(), eq("percPage"), any()))
+        .thenThrow(new WebApplicationException("Unknown system field: nope", 404));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.includeField("percPage", new ContentTypeField()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void includeFieldInvalidOrigin400() {
+    when(adaptor.includeField(any(), eq("percPage"), any()))
+        .thenThrow(new IllegalArgumentException("fieldType must be system or shared"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.includeField("percPage", new ContentTypeField()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void includeFieldDuplicate409() {
+    when(adaptor.includeField(any(), eq("percPage"), any()))
+        .thenThrow(new WebApplicationException("Field already included: sys_title", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.includeField("percPage", new ContentTypeField()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void includeFieldRequiresLock() {
+    when(adaptor.includeField(any(), eq("percPage"), any()))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not include content type field; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.includeField("percPage", new ContentTypeField()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void includeFieldForbiddenWhenNotAdmin() {
+    when(adaptor.includeField(any(), eq("percPage"), any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.includeField("percPage", new ContentTypeField()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -184,4 +184,9 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
   public Boolean deleteLocalField(URI baseUri, String idOrName, String fieldName) {
     return Boolean.TRUE;
   }
+
+  @Override
+  public ContentTypeDetail includeField(URI baseUri, String idOrName, ContentTypeField body) {
+    return getContentType(baseUri, idOrName);
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -204,4 +204,9 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   public Boolean deleteLocalField(URI baseUri, String idOrName, String fieldName) {
     return Boolean.TRUE;
   }
+
+  @Override
+  public ContentTypeDetail includeField(URI baseUri, String idOrName, ContentTypeField body) {
+    return getContentType(baseUri, idOrName);
+  }
 }


### PR DESCRIPTION
## Summary

Admin REST **include** of an existing **system** or **shared** field into a content type (Workbench “include field”), parent **#1690** slice **CD-04** (#3985).

`POST /services/contenttypes/{idOrName}/fields/include` requires a **held** design-session lock (`POST .../lock` first; do not steal). Persist is `IPSContentDesignWs.loadContentTypes` / `saveContentTypes` only — no new SOAP. Origin stays `system`/`shared` (not copied as local). Duplicate include is **409**. Unknown catalog field is **404**. Invalid `fieldType` (including `local`) is **400**. Non-Admin is **403**. Unlocked or other-user lock is **409**.

No SPA chrome. Local field create/delete remains `POST/DELETE .../fields` (CD-03).

Fixes #3985. Parent #1690.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS.
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS.
3. Mockito: `ContentTypesResourceDetailTest` include success/404/400/409/403/lock.
4. Adaptor: `ContentTypeAdaptorIncludeFieldTest` system/shared persist, origin, duplicate 409, unknown 404, Admin 403, lock 409.
5. Spring test stub `TestContentTypeAdaptor.includeField` so rest `MainTest` stays green.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` and `product-docs/8.2/admin/developer-content-types.md`; gap map CD-04
- [x] **Unit / module tests** — rest + sitemanage standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — standalone clean install; C2: `IContentTypesAdaptor` implementors grepped (3 types updated); sitemanage built as reverse-dep
- [x] **Cross-platform** — N/A (no filesystem path I/O; field names reject `/` `\\` `..`)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 763, Failures: 0 (ContentTypesResourceDetailTest 98/0)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1799, Failures: 0, Skipped: 125 (ContentTypeAdaptorIncludeFieldTest 15/0)
- **downstream_checked:** grep `implements IContentTypesAdaptor` (3 types, all updated); sitemanage standalone clean install (implements rest adaptor interface)

### C5 UI proof

N/A — REST-only; no SPA / Playwright.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
