### PR TITLE
feat(rest): CD-07 write choice filter, null-entry, default-selected (#3995)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3995-choice-catalog-write-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3995-choice-catalog-write-erlang.md
@@ -1,0 +1,60 @@
+# Erlang review — issue #3995 REST CD-07 remaining choice catalog write
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-08-29 |
+| **Branch** | `fix/issue-3995-choice-catalog-write` |
+| **Base** | `origin/main` |
+| **Recommendation** | approve |
+| **Gate** | pass |
+| **May commit/push** | yes |
+
+## Summary
+
+Parent #1690 / CD-07 remainder after #3786. Existing GET/PUT
+`/services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` already
+replaces property name/value and the choice catalog. This slice writes **choice
+filter**, **null-entry**, and **default-selected** on that same catalog object.
+
+Persist path is unchanged: held design-session lock + `IPSContentDesignWs`
+`loadContentTypes` / `saveContentTypes`. Omitted `choices` still leaves the
+catalog untouched; `type: none` still clears. No SPA Choices tab. Shared-field
+control properties remain #3984.
+
+**Memory patterns hit:** change-class closure (rest DTO + resource + Mockito +
+Spring stub + sitemanage adaptor tests + product-docs); no new adaptor methods
+so existing `TestContentTypeAdaptor` still satisfies the interface.
+
+## Change-class companions
+
+| Companion | Status |
+|-----------|--------|
+| rest DTOs / OpenAPI | New `filter` / `nullEntry` / `defaultSelected` on `ContentTypeChoiceCatalog` |
+| Adaptor mapping | `toChoiceCatalog` / `fromChoiceCatalog` round-trip; validation → 400 |
+| Mockito resource | GET extras, PUT extras, invalid filter 400 |
+| Spring test stub | Same interface; stub GET now returns extras |
+| sitemanage adaptor tests | Persist, omit, type none, 403/409/404 unchanged |
+| product-docs 8.2 | `developer/rest.md` + admin content-types note (SPA still omits `choices`) |
+| Gap map | CD-07 remaining write marked shipped |
+
+## Cross-platform path checklist
+
+N/A — no filesystem path/file I/O.
+
+## Issues
+
+None blocking.
+
+### Suggestion (not a gate)
+
+`PSChoiceFilter` lookup is mapped as `lookupHref` / `lookupName` only, matching
+existing catalog lookup mapping. Converter UDFs and query parameters on the
+filter URL are not round-tripped. Out of scope for this slice.
+
+## Tests / builds
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 759, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1717, Failures: 0, Skipped: 125
+- Downstream: `projects/sitemanage` (implements `IContentTypesAdaptor`). Additive DTO fields; no `final`/signature break.
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -28,7 +28,7 @@
 - name, label, description, enabled, hideFromMenu, appName, editorUrl, guid
 - fields: name, label (display), origin (local/system/shared), dataType, control, searchable, fieldSet, required
 - fields **P0.2c rule flags**: readOnly, occurrence, hasValidation, hasVisibilityRules, hasInputTranslation, hasOutputTranslation
-- fields **CD-05–07 read-only expressions** (issue #2920): `validationExpression`, `visibilityExpression`, `inputTranslationExpression`, `outputTranslationExpression`, `controlPropertyNames[]` plus `controlProperties[]` name/value (CD-07 GET/PUT #3786)
+- fields **CD-05–07 read-only expressions** (issue #2920): `validationExpression`, `visibilityExpression`, `inputTranslationExpression`, `outputTranslationExpression`, `controlPropertyNames[]` plus `controlProperties[]` name/value (CD-07 GET/PUT #3786; choice filter / null-entry / default-selected write #3995)
 - child field set names
 - **allowedWorkflows[]** + **defaultWorkflow** (P0.2b)
 - **allowedTemplates[]** (P0.2b)
@@ -71,7 +71,7 @@ slices.
 |                         Gap                          |    FR IDs    |                       Notes                       |
 |------------------------------------------------------|--------------|---------------------------------------------------|
 | Full field rule **expressions** / control properties | CD-05–CD-07  | **Read-only expressions** shipped (#2920); **control property values + choice catalogs** GET/PUT (#3786). Rule write/save still open |
-| Control property + choice configuration              | CD-07        | **REST GET/PUT** `.../fields/{fieldName}/controlProperties` (#3786, held design lock for PUT). Choice filter / null-entry / default-selected not written |
+| Control property + choice configuration              | CD-07        | **REST GET/PUT** `.../fields/{fieldName}/controlProperties` (#3786, held design lock for PUT). Choice filter / null-entry / default-selected **written** when `choices` is sent (#3995). SPA still omits `choices`. Shared-field control properties are #3984 |
 | Item-level pre/post exits & validations              | CD-09        | Properties tab                                    |
 | Edit workflow/template associations                  | CD-08, CD-12 | **CD-08 REST PUT .../allowedWorkflows** (#3763, held design lock); **CD-12 REST PUT .../allowedTemplates** (#3775, held design lock; full replace, empty list clears) |
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
@@ -90,7 +90,7 @@ slices.
 2. ~~Read-only field rule expressions + control property names~~ **Done CD-05-07 read path (#2920)**
 3. ~~Design-session lock + `PUT` save via thin REST over `IPSContentDesignWs`~~ **Lock** (#3742) + **PUT save requires held lock** (#3743)
 4. ~~Keyword create/update/delete~~ **Done CD-17** (REST write + design WS + SPA editor)
-5. ~~Control property value/choice catalogs~~ **Done CD-07 REST** (#3786). Field-rule write/save still open
+5. ~~Control property value/choice catalogs~~ **Done CD-07 REST** (#3786). ~~Choice filter / null-entry / default-selected write~~ **Done** (#3995). Field-rule write/save still open. SPA Choices tab still later. Shared-field control properties are #3984
 6. ~~Shared field catalog read~~ **Done CD-15 read** (`GET /services/sharedfields`, Admin 403). ~~Write~~ **Done CD-15 group create/save/delete** (`POST`/`PUT`/`DELETE`, #3944). ~~Field create/delete~~ **Done** (`POST …/fields`, `DELETE …/fields/{fieldName}`, #3954). Control/choice write + SPA editor still open
 7. ~~System def field-property write~~ **Done CD-16 PUT** (`PUT /services/systemdef`, Admin 403, request lock + release on save, #3958). Field create/delete + SPA still open
 8. Templates/slots design editors

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -166,8 +166,10 @@ After **Lock**:
    edit does not persist.
 
 This is not the full Workbench Properties tab. Choice catalogs show as
-read-only (type only). Choice filter, null-entry, and default-selected are
-not written.
+read-only (type only) in this chrome; Save omits `choices`. Integrators write
+choice filter, null-entry, and default-selected on
+`PUT .../fields/{fieldName}/controlProperties` by sending `choices` — see
+[REST API — Content types](id:developer-rest).
 
 ### Field rule expressions (after lock)
 

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -266,14 +266,14 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Rename | `PUT /services/contenttypes/{idOrName}/name` | **Admin** (CD-01). Requires a **held** design-session lock. Sets the internal name. Unique (case-insensitive); **no spaces** or wildcards. Bulk `PUT .../{idOrName}` does **not** change name. After success, `GET` by the previous name is **404**; `GET` by id returns the new name. Does not acquire or release the lock. |
 | Add local field | `POST /services/contenttypes/{idOrName}/fields` | **Admin** (CD-03). Requires a **held** design-session lock. Adds a persistable **local** field (backend column + display mapping) via `IPSContentDesignWs.saveContentTypes`. Body `name` is required (letter, then letters/digits/underscore; unique case-insensitive on the type). Optional `dataType` defaults to `text`. Optional `searchable` and `occurrence`/`required` use the same rules as PUT field patches. Optional `fieldSet` names an existing child field set, or **creates** a named complex child when missing. Duplicate field is **409**. System/shared inclusion is out of scope (CD-04). Does not acquire or release the lock. |
 | Delete local field | `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}` | **Admin** (CD-03). Requires a **held** design-session lock. Removes a **local** field and its display mapping. System/shared fields are **400**. Missing type or field is **404**. Does not acquire or release the lock. `204` on success (lock still held). |
-| Field control properties | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | Control parameter **name/value** pairs and the choice catalog for one field (CD-07). No lock required. Empty `properties` means none. `choices` omitted when none. |
-| Replace field control properties | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | **Admin** (CD-07). Requires a **held** design-session lock. Full replace of `properties` (empty clears). `choices` omitted leaves the catalog unchanged; `type: none` clears. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
+| Field control properties | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | Control parameter **name/value** pairs and the choice catalog for one field (CD-07). No lock required. Empty `properties` means none. `choices` omitted when none. GET round-trips `filter`, `nullEntry`, and `defaultSelected` when present. |
+| Replace field control properties | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` | **Admin** (CD-07). Requires a **held** design-session lock. Full replace of `properties` (empty clears). `choices` omitted leaves the catalog unchanged; present replaces including choice filter, null-entry, and default-selected; `type: none` clears. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Field rule expressions | `GET /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | Field-level validation, visibility, and input/output translation expressions (CD-05–07). No lock required. Empty lists mean none. Unknown field is **404**. Jackson root wrap is `ContentTypeFieldRuleExpressions`. |
 | Replace field rule expressions | `PUT /services/contenttypes/{idOrName}/fields/{fieldName}/ruleExpressions` | **Admin** (CD-05–07). Requires a **held** design-session lock. Full replace of `validation`, `visibility`, `inputTranslation`, and `outputTranslation` (empty lists clear). Unknown field names are **400**. **409** if unlocked or locked by another user. Does not acquire or release the lock. |
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 | Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07). That chrome still omits `choices` on save (catalogs stay unchanged from the SPA). Integrators write choice filter, null-entry, and default-selected on the same PUT by sending `choices`. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
 
 Lock / save / unlock / create / rename / delete status codes:
 
@@ -585,9 +585,9 @@ the lock is held; the product does not steal another user's lock. This is not
 the Workbench visual rule builder. See [Developer Content Types](id:admin-developer-content-types).
 
 Control property **values** use the dedicated CD-07 path below and the
-Developer Content Types **Control property values** chrome after a held lock. Choice
-catalogs are read-only in that chrome (filter / null-entry / default-selected are
-not written).
+Developer Content Types **Control property values** chrome after a held lock. That
+chrome omits `choices` on save so catalogs stay unchanged from the SPA. Integrators
+write choice filter, null-entry, and default-selected on the same REST PUT.
 
 ### Control property values (CD-07)
 
@@ -616,7 +616,24 @@ Jackson root wrap:
       "sortOrder": "ascending",
       "entries": [
         { "value": "open", "label": "Open" }
-      ]
+      ],
+      "nullEntry": {
+        "value": "",
+        "label": "None",
+        "includeWhen": "always",
+        "sortOrder": "first"
+      },
+      "defaultSelected": [
+        { "type": "nullEntry" },
+        { "type": "text", "text": "open" }
+      ],
+      "filter": {
+        "dependentFields": [
+          { "fieldRef": "sys_communityid", "dependencyType": "optional" }
+        ],
+        "lookupHref": "../sys_lookup/filter.xml",
+        "lookupName": "choiceFilter"
+      }
     }
   }
 }
@@ -626,7 +643,12 @@ Jackson root wrap:
 the catalog unchanged. Choice `type` is `global` (keyword table id in `globalId`),
 `local` (inline `entries`), `lookup` / `internalLookup` (`lookupHref`), or `tableinfo`
 (`table` with `tableName` / `labelColumn` / `valueColumn`). `type: none` clears the
-catalog. Choice filters, null-entry, and default-selected are not written.
+catalog. When `choices` is present, `filter`, `nullEntry`, and `defaultSelected` are
+written as part of that replace (omit/null/empty clears those extras). `filter.dependentFields`
+need `fieldRef` plus `dependencyType` `optional` or `required`, and `lookupHref`.
+`nullEntry.includeWhen` is `always` or `onlyIfNull`; `nullEntry.sortOrder` is `first`,
+`last`, or `sorted`. `defaultSelected[].type` is `nullEntry`, `sequence` (needs
+`sequence` ≥ 0), or `text` (needs `text`).
 
 | Status | Typical meaning |
 |--------|-----------------|

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -23,8 +23,10 @@ import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.design.objectstore.PSApplyWhen;
 import com.percussion.design.objectstore.PSBackEndColumn;
 import com.percussion.design.objectstore.PSBackEndTable;
+import com.percussion.design.objectstore.PSChoiceFilter;
 import com.percussion.design.objectstore.PSChoiceTableInfo;
 import com.percussion.design.objectstore.PSChoices;
+import com.percussion.design.objectstore.PSDefaultSelected;
 import com.percussion.design.objectstore.PSConditional;
 import com.percussion.design.objectstore.PSConditionalExit;
 import com.percussion.design.objectstore.PSContentEditor;
@@ -40,6 +42,7 @@ import com.percussion.design.objectstore.PSExtensionCallSet;
 import com.percussion.design.objectstore.PSExtensionParamValue;
 import com.percussion.design.objectstore.PSField;
 import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.design.objectstore.PSNullEntry;
 import com.percussion.design.objectstore.PSFieldTranslation;
 import com.percussion.design.objectstore.PSFieldValidationRules;
 import com.percussion.design.objectstore.IPSReplacementValue;
@@ -62,7 +65,11 @@ import com.percussion.rest.Guid;
 import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.contenttypes.ContentType;
 import com.percussion.rest.contenttypes.ContentTypeChoiceCatalog;
+import com.percussion.rest.contenttypes.ContentTypeChoiceDefaultSelected;
 import com.percussion.rest.contenttypes.ContentTypeChoiceEntry;
+import com.percussion.rest.contenttypes.ContentTypeChoiceFilter;
+import com.percussion.rest.contenttypes.ContentTypeChoiceFilterField;
+import com.percussion.rest.contenttypes.ContentTypeChoiceNullEntry;
 import com.percussion.rest.contenttypes.ContentTypeChoiceTable;
 import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
@@ -2250,10 +2257,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   static List<DesignGap> controlPropertyDesignGaps() {
-    return List.of(
-        DesignGap.of(
-            "CT_CHOICE_FILTER",
-            "Choice filters, null-entry, and default-selected are not writable"));
+    return List.of();
   }
 
   static String choiceTypeName(int type) {
@@ -2327,6 +2331,9 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         cat.setTable(table);
       }
     }
+    cat.setNullEntry(toNullEntry(choices.getNullEntry()));
+    cat.setDefaultSelected(toDefaultSelected(choices));
+    cat.setFilter(toChoiceFilter(choices.getChoiceFilter()));
     return cat;
   }
 
@@ -2395,7 +2402,201 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     if (StringUtils.isNotBlank(catalog.getSortOrder())) {
       choices.setSortOrder(parseSortOrder(catalog.getSortOrder()));
     }
+    choices.setNullEntry(fromNullEntry(catalog.getNullEntry()));
+    choices.setDefaultSelected(fromDefaultSelected(catalog.getDefaultSelected()));
+    choices.setChoiceFilter(fromChoiceFilter(catalog.getFilter()));
     return choices;
+  }
+
+  static ContentTypeChoiceNullEntry toNullEntry(PSNullEntry entry) {
+    if (entry == null) {
+      return null;
+    }
+    ContentTypeChoiceNullEntry out = new ContentTypeChoiceNullEntry();
+    out.setValue(entry.getValue());
+    if (entry.getLabel() != null) {
+      out.setLabel(entry.getLabel().getText());
+    }
+    out.setIncludeWhen(
+        entry.getIncludeWhen() == PSNullEntry.INCLUDE_WHEN_ALWAYS ? "always" : "onlyIfNull");
+    out.setSortOrder(
+        switch (entry.getSortOrder()) {
+          case PSNullEntry.SORT_ORDER_LAST -> "last";
+          case PSNullEntry.SORT_ORDER_SORTED -> "sorted";
+          default -> "first";
+        });
+    return out;
+  }
+
+  static PSNullEntry fromNullEntry(ContentTypeChoiceNullEntry body) {
+    if (body == null) {
+      return null;
+    }
+    String value = body.getValue() != null ? body.getValue() : "";
+    String label = StringUtils.isNotBlank(body.getLabel()) ? body.getLabel() : value;
+    PSNullEntry entry = new PSNullEntry(value, new PSDisplayText(label));
+    if (StringUtils.isNotBlank(body.getIncludeWhen())) {
+      entry.setIncludeWhen(parseNullEntryIncludeWhen(body.getIncludeWhen()));
+    }
+    if (StringUtils.isNotBlank(body.getSortOrder())) {
+      entry.setSortOrder(parseNullEntrySortOrder(body.getSortOrder()));
+    }
+    return entry;
+  }
+
+  static int parseNullEntryIncludeWhen(String includeWhen) {
+    if ("always".equalsIgnoreCase(includeWhen)) {
+      return PSNullEntry.INCLUDE_WHEN_ALWAYS;
+    }
+    if ("onlyIfNull".equalsIgnoreCase(includeWhen)) {
+      return PSNullEntry.INCLUDE_WHEN_ONLY_IF_NULL;
+    }
+    throw new IllegalArgumentException("choices.nullEntry.includeWhen must be always or onlyIfNull");
+  }
+
+  static int parseNullEntrySortOrder(String sortOrder) {
+    if ("first".equalsIgnoreCase(sortOrder)) {
+      return PSNullEntry.SORT_ORDER_FIRST;
+    }
+    if ("last".equalsIgnoreCase(sortOrder)) {
+      return PSNullEntry.SORT_ORDER_LAST;
+    }
+    if ("sorted".equalsIgnoreCase(sortOrder)) {
+      return PSNullEntry.SORT_ORDER_SORTED;
+    }
+    throw new IllegalArgumentException("choices.nullEntry.sortOrder must be first, last, or sorted");
+  }
+
+  static List<ContentTypeChoiceDefaultSelected> toDefaultSelected(PSChoices choices) {
+    if (choices == null) {
+      return null;
+    }
+    List<ContentTypeChoiceDefaultSelected> out = new ArrayList<>();
+    for (Iterator<?> it = choices.getDefaultSelected(); it.hasNext(); ) {
+      Object o = it.next();
+      if (o instanceof PSDefaultSelected selected) {
+        ContentTypeChoiceDefaultSelected item = new ContentTypeChoiceDefaultSelected();
+        switch (selected.getType()) {
+          case PSDefaultSelected.TYPE_SEQUENCE -> {
+            item.setType("sequence");
+            item.setSequence(selected.getSequence());
+          }
+          case PSDefaultSelected.TYPE_TEXT -> {
+            item.setType("text");
+            item.setText(selected.getText());
+          }
+          default -> item.setType("nullEntry");
+        }
+        out.add(item);
+      }
+    }
+    return out.isEmpty() ? null : out;
+  }
+
+  static PSCollection<PSDefaultSelected> fromDefaultSelected(
+      List<ContentTypeChoiceDefaultSelected> items) {
+    if (items == null || items.isEmpty()) {
+      return null;
+    }
+    PSCollection<PSDefaultSelected> col = new PSCollection<>(PSDefaultSelected.class);
+    for (int i = 0; i < items.size(); i++) {
+      col.add(fromDefaultSelectedItem(items.get(i), i));
+    }
+    return col;
+  }
+
+  static PSDefaultSelected fromDefaultSelectedItem(
+      ContentTypeChoiceDefaultSelected item, int index) {
+    if (item == null) {
+      throw new IllegalArgumentException("choices.defaultSelected[" + index + "] is required");
+    }
+    String type = item.getType() == null ? "" : item.getType().trim();
+    if (type.isEmpty() || "nullEntry".equalsIgnoreCase(type)) {
+      return new PSDefaultSelected();
+    }
+    if ("sequence".equalsIgnoreCase(type)) {
+      if (item.getSequence() == null || item.getSequence() < 0) {
+        throw new IllegalArgumentException(
+            "choices.defaultSelected[" + index + "].sequence is required for type sequence");
+      }
+      return new PSDefaultSelected(item.getSequence());
+    }
+    if ("text".equalsIgnoreCase(type)) {
+      if (StringUtils.isBlank(item.getText())) {
+        throw new IllegalArgumentException(
+            "choices.defaultSelected[" + index + "].text is required for type text");
+      }
+      return new PSDefaultSelected(item.getText().trim());
+    }
+    throw new IllegalArgumentException(
+        "choices.defaultSelected[" + index + "].type must be nullEntry, sequence, or text");
+  }
+
+  static ContentTypeChoiceFilter toChoiceFilter(PSChoiceFilter filter) {
+    if (filter == null) {
+      return null;
+    }
+    ContentTypeChoiceFilter out = new ContentTypeChoiceFilter();
+    List<ContentTypeChoiceFilterField> deps = new ArrayList<>();
+    if (filter.getDependentFields() != null) {
+      for (Iterator<?> it = filter.getDependentFields().iterator(); it.hasNext(); ) {
+        Object o = it.next();
+        if (o instanceof PSChoiceFilter.DependentField field) {
+          deps.add(new ContentTypeChoiceFilterField(field.getFieldRef(), field.getDependencyType()));
+        }
+      }
+    }
+    out.setDependentFields(deps);
+    if (filter.getLookup() != null) {
+      out.setLookupHref(filter.getLookup().getHref());
+      out.setLookupName(filter.getLookup().getName());
+    }
+    return out;
+  }
+
+  static PSChoiceFilter fromChoiceFilter(ContentTypeChoiceFilter filter) {
+    if (filter == null) {
+      return null;
+    }
+    List<ContentTypeChoiceFilterField> deps = filter.getDependentFields();
+    if (deps == null || deps.isEmpty()) {
+      throw new IllegalArgumentException("choices.filter.dependentFields is required");
+    }
+    if (StringUtils.isBlank(filter.getLookupHref())) {
+      throw new IllegalArgumentException("choices.filter.lookupHref is required");
+    }
+    PSCollection<PSChoiceFilter.DependentField> fields =
+        new PSCollection<>(PSChoiceFilter.DependentField.class);
+    for (int i = 0; i < deps.size(); i++) {
+      ContentTypeChoiceFilterField dep = deps.get(i);
+      if (dep == null || StringUtils.isBlank(dep.getFieldRef())) {
+        throw new IllegalArgumentException(
+            "choices.filter.dependentFields[" + i + "].fieldRef is required");
+      }
+      if (StringUtils.isBlank(dep.getDependencyType())) {
+        throw new IllegalArgumentException(
+            "choices.filter.dependentFields[" + i + "].dependencyType is required");
+      }
+      String depType = dep.getDependencyType().trim();
+      if (!PSChoiceFilter.DependentField.TYPE_OPTIONAL.equalsIgnoreCase(depType)
+          && !PSChoiceFilter.DependentField.TYPE_REQUIRED.equalsIgnoreCase(depType)) {
+        throw new IllegalArgumentException(
+            "choices.filter.dependentFields["
+                + i
+                + "].dependencyType must be optional or required");
+      }
+      String canonical =
+          PSChoiceFilter.DependentField.TYPE_REQUIRED.equalsIgnoreCase(depType)
+              ? PSChoiceFilter.DependentField.TYPE_REQUIRED
+              : PSChoiceFilter.DependentField.TYPE_OPTIONAL;
+      fields.add(new PSChoiceFilter.DependentField(dep.getFieldRef().trim(), canonical));
+    }
+    String lookupName =
+        StringUtils.isBlank(filter.getLookupName()) ? null : filter.getLookupName().trim();
+    return new PSChoiceFilter(
+        fields,
+        new PSUrlRequest(
+            lookupName, filter.getLookupHref().trim(), new PSCollection<>(PSParam.class)));
   }
 
   static PSCollection<PSParam> toParamCollection(List<ContentTypeControlProperty> properties) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorControlPropertiesTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorControlPropertiesTest.java
@@ -35,8 +35,10 @@ import static org.mockito.Mockito.when;
 import com.percussion.cms.objectstore.PSInvalidContentTypeException;
 import com.percussion.cms.objectstore.PSItemDefinition;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSChoiceFilter;
 import com.percussion.design.objectstore.PSChoiceTableInfo;
 import com.percussion.design.objectstore.PSChoices;
+import com.percussion.design.objectstore.PSDefaultSelected;
 import com.percussion.design.objectstore.PSContentEditor;
 import com.percussion.design.objectstore.PSContentEditorMapper;
 import com.percussion.design.objectstore.PSContentEditorPipe;
@@ -45,12 +47,18 @@ import com.percussion.design.objectstore.PSDisplayMapper;
 import com.percussion.design.objectstore.PSDisplayMapping;
 import com.percussion.design.objectstore.PSDisplayText;
 import com.percussion.design.objectstore.PSEntry;
+import com.percussion.design.objectstore.PSNullEntry;
 import com.percussion.design.objectstore.PSParam;
 import com.percussion.design.objectstore.PSTextLiteral;
 import com.percussion.design.objectstore.PSUIDefinition;
 import com.percussion.design.objectstore.PSUISet;
+import com.percussion.design.objectstore.PSUrlRequest;
 import com.percussion.rest.contenttypes.ContentTypeChoiceCatalog;
+import com.percussion.rest.contenttypes.ContentTypeChoiceDefaultSelected;
 import com.percussion.rest.contenttypes.ContentTypeChoiceEntry;
+import com.percussion.rest.contenttypes.ContentTypeChoiceFilter;
+import com.percussion.rest.contenttypes.ContentTypeChoiceFilterField;
+import com.percussion.rest.contenttypes.ContentTypeChoiceNullEntry;
 import com.percussion.rest.contenttypes.ContentTypeChoiceTable;
 import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
@@ -73,8 +81,9 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
- * CD-07 control property values and choice catalogs: GET returns name+value; PUT requires a held
- * design-session lock and persists via {@code saveContentTypes}.
+ * CD-07 control property values and choice catalogs: GET returns name+value plus choice filter,
+ * null-entry, and default-selected; PUT requires a held design-session lock and persists via
+ * {@code saveContentTypes}.
  */
 @Tag("UnitTest")
 class ContentTypeAdaptorControlPropertiesTest {
@@ -140,6 +149,11 @@ class ContentTypeAdaptorControlPropertiesTest {
   }
 
   @Test
+  void controlPropertyDesignGaps_emptyWhenChoiceExtrasWritable() {
+    assertTrue(ContentTypeAdaptor.controlPropertyDesignGaps().isEmpty());
+  }
+
+  @Test
   void fromChoiceCatalog_roundTripLocalAndNone() {
     ContentTypeChoiceCatalog body = new ContentTypeChoiceCatalog();
     body.setType("local");
@@ -195,6 +209,70 @@ class ContentTypeAdaptorControlPropertiesTest {
   }
 
   @Test
+  void fromChoiceCatalog_roundTripFilterNullEntryDefaultSelected() {
+    ContentTypeChoiceCatalog body = sampleCatalogWithExtras("closed", "Closed");
+    PSChoices choices = ContentTypeAdaptor.fromChoiceCatalog(body);
+    ContentTypeChoiceCatalog round = ContentTypeAdaptor.toChoiceCatalog(choices);
+    assertEquals("local", round.getType());
+    assertEquals("", round.getNullEntry().getValue());
+    assertEquals("None", round.getNullEntry().getLabel());
+    assertEquals("always", round.getNullEntry().getIncludeWhen());
+    assertEquals("first", round.getNullEntry().getSortOrder());
+    assertEquals(2, round.getDefaultSelected().size());
+    assertEquals("nullEntry", round.getDefaultSelected().get(0).getType());
+    assertEquals("text", round.getDefaultSelected().get(1).getType());
+    assertEquals("closed", round.getDefaultSelected().get(1).getText());
+    assertEquals("sys_communityid", round.getFilter().getDependentFields().get(0).getFieldRef());
+    assertEquals("optional", round.getFilter().getDependentFields().get(0).getDependencyType());
+    assertEquals("../sys_lookup/filter.xml", round.getFilter().getLookupHref());
+    assertEquals("choiceFilter", round.getFilter().getLookupName());
+  }
+
+  @Test
+  void fromChoiceCatalog_rejectsInvalidFilterAndDefaultSelected() {
+    ContentTypeChoiceCatalog missingHref = sampleCatalogWithExtras("open", "Open");
+    missingHref.getFilter().setLookupHref(null);
+    IllegalArgumentException href =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ContentTypeAdaptor.fromChoiceCatalog(missingHref));
+    assertTrue(href.getMessage().contains("lookupHref"), href.getMessage());
+
+    ContentTypeChoiceCatalog missingDeps = sampleCatalogWithExtras("open", "Open");
+    missingDeps.getFilter().setDependentFields(List.of());
+    IllegalArgumentException deps =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ContentTypeAdaptor.fromChoiceCatalog(missingDeps));
+    assertTrue(deps.getMessage().contains("dependentFields"), deps.getMessage());
+
+    ContentTypeChoiceCatalog badDepType = sampleCatalogWithExtras("open", "Open");
+    badDepType.getFilter().getDependentFields().get(0).setDependencyType("maybe");
+    IllegalArgumentException depType =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ContentTypeAdaptor.fromChoiceCatalog(badDepType));
+    assertTrue(depType.getMessage().contains("dependencyType"), depType.getMessage());
+
+    ContentTypeChoiceCatalog badDefault = sampleCatalogWithExtras("open", "Open");
+    ContentTypeChoiceDefaultSelected seq = new ContentTypeChoiceDefaultSelected("sequence");
+    badDefault.setDefaultSelected(List.of(seq));
+    IllegalArgumentException sequence =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ContentTypeAdaptor.fromChoiceCatalog(badDefault));
+    assertTrue(sequence.getMessage().contains("sequence"), sequence.getMessage());
+
+    ContentTypeChoiceCatalog badInclude = sampleCatalogWithExtras("open", "Open");
+    badInclude.getNullEntry().setIncludeWhen("sometimes");
+    IllegalArgumentException includeWhen =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ContentTypeAdaptor.fromChoiceCatalog(badInclude));
+    assertTrue(includeWhen.getMessage().contains("includeWhen"), includeWhen.getMessage());
+  }
+
+  @Test
   void get_returnsPropertyValuesAndChoices() throws Exception {
     stubDefinition();
     ContentTypeFieldControlProperties out =
@@ -206,6 +284,12 @@ class ContentTypeAdaptorControlPropertiesTest {
     assertEquals("200", out.getProperties().get(0).getValue());
     assertEquals("local", out.getChoices().getType());
     assertEquals("open", out.getChoices().getEntries().get(0).getValue());
+    assertEquals("None", out.getChoices().getNullEntry().getLabel());
+    assertEquals("always", out.getChoices().getNullEntry().getIncludeWhen());
+    assertEquals("nullEntry", out.getChoices().getDefaultSelected().get(0).getType());
+    assertEquals(
+        "sys_communityid", out.getChoices().getFilter().getDependentFields().get(0).getFieldRef());
+    assertTrue(out.getDesignGaps().isEmpty());
   }
 
   @Test
@@ -302,6 +386,56 @@ class ContentTypeAdaptorControlPropertiesTest {
         adaptor.replaceFieldControlProperties(null, "311", "sys_title", body);
     assertEquals("local", out.getChoices().getType());
     assertEquals("open", out.getChoices().getEntries().get(0).getValue());
+    assertEquals("None", out.getChoices().getNullEntry().getLabel());
+    assertEquals("sys_communityid", out.getChoices().getFilter().getDependentFields().get(0).getFieldRef());
+  }
+
+  @Test
+  void put_persistsChoiceFilterNullEntryDefaultSelected() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of(new ContentTypeControlProperty("width", "640")));
+    body.setChoices(sampleCatalogWithExtras("closed", "Closed"));
+
+    ContentTypeFieldControlProperties out =
+        adaptor.replaceFieldControlProperties(null, "311", "sys_title", body);
+
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals("closed", out.getChoices().getEntries().get(0).getValue());
+    assertEquals("None", out.getChoices().getNullEntry().getLabel());
+    assertEquals("always", out.getChoices().getNullEntry().getIncludeWhen());
+    assertEquals("text", out.getChoices().getDefaultSelected().get(1).getType());
+    assertEquals("closed", out.getChoices().getDefaultSelected().get(1).getText());
+    assertEquals("../sys_lookup/filter.xml", out.getChoices().getFilter().getLookupHref());
+    PSChoices persisted = uiSet.getChoices();
+    assertEquals("", persisted.getNullEntry().getValue());
+    assertEquals("None", persisted.getNullEntry().getLabel().getText());
+    assertEquals(PSNullEntry.INCLUDE_WHEN_ALWAYS, persisted.getNullEntry().getIncludeWhen());
+    PSDefaultSelected firstDefault = (PSDefaultSelected) persisted.getDefaultSelected().next();
+    assertEquals(PSDefaultSelected.TYPE_NULL_ENTRY, firstDefault.getType());
+    PSChoiceFilter.DependentField dep =
+        (PSChoiceFilter.DependentField) persisted.getChoiceFilter().getDependentFields().get(0);
+    assertEquals("sys_communityid", dep.getFieldRef());
+  }
+
+  @Test
+  void put_typeNoneClearsCatalogIncludingExtras() throws Exception {
+    stubHeldLock();
+    stubDefinition();
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    ContentTypeChoiceCatalog none = new ContentTypeChoiceCatalog();
+    none.setType("none");
+    body.setChoices(none);
+
+    ContentTypeFieldControlProperties out =
+        adaptor.replaceFieldControlProperties(null, "311", "sys_title", body);
+
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertNull(out.getChoices());
+    assertNull(uiSet.getChoices());
   }
 
   @Test
@@ -383,6 +517,7 @@ class ContentTypeAdaptorControlPropertiesTest {
     PSCollection local = new PSCollection(PSEntry.class);
     local.add(new PSEntry("open", new PSDisplayText("Open")));
     uiSet.setChoices(new PSChoices(local));
+    applySampleChoiceExtras(uiSet.getChoices());
 
     PSDisplayMapper dmapper = new PSDisplayMapper("fs");
     dmapper.add(new PSDisplayMapping("sys_title", uiSet));
@@ -404,5 +539,46 @@ class ContentTypeAdaptorControlPropertiesTest {
     when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(def));
     return def;
+  }
+
+  private static ContentTypeChoiceCatalog sampleCatalogWithExtras(String value, String label) {
+    ContentTypeChoiceCatalog catalog = new ContentTypeChoiceCatalog();
+    catalog.setType("local");
+    catalog.setEntries(List.of(new ContentTypeChoiceEntry(value, label)));
+    ContentTypeChoiceNullEntry nullEntry = new ContentTypeChoiceNullEntry();
+    nullEntry.setValue("");
+    nullEntry.setLabel("None");
+    nullEntry.setIncludeWhen("always");
+    nullEntry.setSortOrder("first");
+    catalog.setNullEntry(nullEntry);
+    ContentTypeChoiceDefaultSelected nullDefault = new ContentTypeChoiceDefaultSelected("nullEntry");
+    ContentTypeChoiceDefaultSelected textDefault = new ContentTypeChoiceDefaultSelected("text");
+    textDefault.setText(value);
+    catalog.setDefaultSelected(List.of(nullDefault, textDefault));
+    ContentTypeChoiceFilter filter = new ContentTypeChoiceFilter();
+    filter.setDependentFields(List.of(new ContentTypeChoiceFilterField("sys_communityid", "optional")));
+    filter.setLookupHref("../sys_lookup/filter.xml");
+    filter.setLookupName("choiceFilter");
+    catalog.setFilter(filter);
+    return catalog;
+  }
+
+  private static void applySampleChoiceExtras(PSChoices choices) {
+    PSNullEntry nullEntry = new PSNullEntry("", new PSDisplayText("None"));
+    nullEntry.setIncludeWhen(PSNullEntry.INCLUDE_WHEN_ALWAYS);
+    choices.setNullEntry(nullEntry);
+    PSCollection<PSDefaultSelected> defaults = new PSCollection<>(PSDefaultSelected.class);
+    defaults.add(new PSDefaultSelected());
+    choices.setDefaultSelected(defaults);
+    PSCollection<PSChoiceFilter.DependentField> deps =
+        new PSCollection<>(PSChoiceFilter.DependentField.class);
+    deps.add(new PSChoiceFilter.DependentField("sys_communityid", "optional"));
+    choices.setChoiceFilter(
+        new PSChoiceFilter(
+            deps,
+            new PSUrlRequest(
+                "choiceFilter",
+                "../sys_lookup/filter.xml",
+                new PSCollection<>(PSParam.class))));
   }
 }

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceCatalog.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceCatalog.java
@@ -20,17 +20,27 @@ package com.percussion.rest.contenttypes;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
 import java.util.List;
 
 /**
  * Choice catalog for a field control (CD-07).
  *
  * <p>{@code type} is {@code global}, {@code local}, {@code lookup}, {@code internalLookup}, or
- * {@code tableinfo}. PUT {@code type=none} (or empty) clears the catalog. Choice filters, null
- * entry, and default-selected are not written.
+ * {@code tableinfo}. PUT {@code type=none} (or empty) clears the catalog. When this object is
+ * present on PUT, {@code filter}, {@code nullEntry}, and {@code defaultSelected} are written as
+ * part of the catalog replace (omit/null clears those extras).
  */
 @XmlRootElement(name = "ContentTypeChoiceCatalog")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@XmlSeeAlso({
+  ContentTypeChoiceEntry.class,
+  ContentTypeChoiceTable.class,
+  ContentTypeChoiceFilter.class,
+  ContentTypeChoiceFilterField.class,
+  ContentTypeChoiceNullEntry.class,
+  ContentTypeChoiceDefaultSelected.class
+})
 @Schema(description = "Choice catalog for a content type field control")
 public class ContentTypeChoiceCatalog {
 
@@ -56,6 +66,21 @@ public class ContentTypeChoiceCatalog {
 
   @Schema(description = "Table info when type is tableinfo")
   private ContentTypeChoiceTable table;
+
+  @Schema(
+      description =
+          "Choice filter. GET: omitted when none. PUT: omit/null clears; present replaces.")
+  private ContentTypeChoiceFilter filter;
+
+  @Schema(
+      description =
+          "Null entry added to the catalog. GET: omitted when none. PUT: omit/null clears.")
+  private ContentTypeChoiceNullEntry nullEntry;
+
+  @Schema(
+      description =
+          "Default-selected entries. GET: omitted when none. PUT: omit/null/empty clears.")
+  private List<ContentTypeChoiceDefaultSelected> defaultSelected;
 
   public ContentTypeChoiceCatalog() {}
 
@@ -113,5 +138,29 @@ public class ContentTypeChoiceCatalog {
 
   public void setTable(ContentTypeChoiceTable table) {
     this.table = table;
+  }
+
+  public ContentTypeChoiceFilter getFilter() {
+    return filter;
+  }
+
+  public void setFilter(ContentTypeChoiceFilter filter) {
+    this.filter = filter;
+  }
+
+  public ContentTypeChoiceNullEntry getNullEntry() {
+    return nullEntry;
+  }
+
+  public void setNullEntry(ContentTypeChoiceNullEntry nullEntry) {
+    this.nullEntry = nullEntry;
+  }
+
+  public List<ContentTypeChoiceDefaultSelected> getDefaultSelected() {
+    return defaultSelected;
+  }
+
+  public void setDefaultSelected(List<ContentTypeChoiceDefaultSelected> defaultSelected) {
+    this.defaultSelected = defaultSelected;
   }
 }

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceDefaultSelected.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceDefaultSelected.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Default-selected choice on a field catalog (CD-07). */
+@XmlRootElement(name = "ContentTypeChoiceDefaultSelected")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Default-selected entry for a content type field choice catalog")
+public class ContentTypeChoiceDefaultSelected {
+
+  @Schema(
+      required = true,
+      description = "nullEntry | sequence | text. nullEntry uses the catalog null-entry.")
+  private String type;
+
+  @Schema(description = "Zero-based sequence when type is sequence")
+  private Integer sequence;
+
+  @Schema(description = "Matching entry value when type is text")
+  private String text;
+
+  public ContentTypeChoiceDefaultSelected() {}
+
+  public ContentTypeChoiceDefaultSelected(String type) {
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public Integer getSequence() {
+    return sequence;
+  }
+
+  public void setSequence(Integer sequence) {
+    this.sequence = sequence;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceFilter.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceFilter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+/**
+ * Choice filter that replaces the unfiltered catalog with a lookup driven by dependent fields
+ * (CD-07).
+ */
+@XmlRootElement(name = "ContentTypeChoiceFilter")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Choice filter for a content type field control")
+public class ContentTypeChoiceFilter {
+
+  @Schema(required = true, description = "Dependent fields; at least one is required on PUT")
+  private List<ContentTypeChoiceFilterField> dependentFields;
+
+  @Schema(required = true, description = "Lookup href used to generate the filtered catalog")
+  private String lookupHref;
+
+  @Schema(description = "Optional lookup request name")
+  private String lookupName;
+
+  public ContentTypeChoiceFilter() {}
+
+  public List<ContentTypeChoiceFilterField> getDependentFields() {
+    return dependentFields;
+  }
+
+  public void setDependentFields(List<ContentTypeChoiceFilterField> dependentFields) {
+    this.dependentFields = dependentFields;
+  }
+
+  public String getLookupHref() {
+    return lookupHref;
+  }
+
+  public void setLookupHref(String lookupHref) {
+    this.lookupHref = lookupHref;
+  }
+
+  public String getLookupName() {
+    return lookupName;
+  }
+
+  public void setLookupName(String lookupName) {
+    this.lookupName = lookupName;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceFilterField.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceFilterField.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Dependent field used to filter a dynamic choice catalog (CD-07). */
+@XmlRootElement(name = "ContentTypeChoiceFilterField")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Dependent field for a content type field choice filter")
+public class ContentTypeChoiceFilterField {
+
+  @Schema(required = true, description = "Field submit name used as a filter input")
+  private String fieldRef;
+
+  @Schema(required = true, description = "optional | required")
+  private String dependencyType;
+
+  public ContentTypeChoiceFilterField() {}
+
+  public ContentTypeChoiceFilterField(String fieldRef, String dependencyType) {
+    this.fieldRef = fieldRef;
+    this.dependencyType = dependencyType;
+  }
+
+  public String getFieldRef() {
+    return fieldRef;
+  }
+
+  public void setFieldRef(String fieldRef) {
+    this.fieldRef = fieldRef;
+  }
+
+  public String getDependencyType() {
+    return dependencyType;
+  }
+
+  public void setDependencyType(String dependencyType) {
+    this.dependencyType = dependencyType;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceNullEntry.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeChoiceNullEntry.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/** Optional null entry on a field choice catalog (CD-07). */
+@XmlRootElement(name = "ContentTypeChoiceNullEntry")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Null entry added to a content type field choice catalog")
+public class ContentTypeChoiceNullEntry {
+
+  @Schema(description = "Stored value; empty string is allowed")
+  private String value;
+
+  @Schema(description = "Display label; defaults to value when omitted on PUT")
+  private String label;
+
+  @Schema(description = "always | onlyIfNull. PUT default onlyIfNull")
+  private String includeWhen;
+
+  @Schema(description = "first | last | sorted. PUT default first")
+  private String sortOrder;
+
+  public ContentTypeChoiceNullEntry() {}
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public void setLabel(String label) {
+    this.label = label;
+  }
+
+  public String getIncludeWhen() {
+    return includeWhen;
+  }
+
+  public void setIncludeWhen(String includeWhen) {
+    this.includeWhen = includeWhen;
+  }
+
+  public String getSortOrder() {
+    return sortOrder;
+  }
+
+  public void setSortOrder(String sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldControlProperties.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeFieldControlProperties.java
@@ -30,7 +30,7 @@ import java.util.List;
  * <p>Jackson root wrap is {@code ContentTypeFieldControlProperties}. GET always returns {@code
  * properties} (may be empty). PUT is a full replace of {@code properties} (empty clears). {@code
  * choices} omitted on PUT leaves the catalog unchanged; present replaces (type {@code none}
- * clears).
+ * clears), including choice filter, null-entry, and default-selected.
  */
 @XmlRootElement(name = "ContentTypeFieldControlProperties")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -53,7 +53,8 @@ public class ContentTypeFieldControlProperties {
   @Schema(
       description =
           "Choice catalog. GET: omitted when none. PUT: omit/null leave unchanged; present"
-              + " replaces; type none/empty clears.")
+              + " replaces (filter, nullEntry, defaultSelected included); type none/empty"
+              + " clears.")
   private ContentTypeChoiceCatalog choices;
 
   @Schema(description = "Structured capability notes vs full Workbench. GET always present.")

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -1498,7 +1498,8 @@ public class ContentTypesResource {
       description =
           "CD-07 GET: control parameter name/value pairs and the choice catalog for one field."
               + " No design lock is required. Empty properties means none. choices is omitted when"
-              + " none. Jackson root wrap is ContentTypeFieldControlProperties.",
+              + " none. Choice filter, null-entry, and default-selected round-trip when present."
+              + " Jackson root wrap is ContentTypeFieldControlProperties.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -1536,7 +1537,8 @@ public class ContentTypesResource {
           "CD-07 PUT: full replace of control parameter values via IPSContentDesignWs"
               + " .saveContentTypes. Requires a held design-session lock (POST .../lock). Does not"
               + " acquire or release the lock. Empty properties clears parameters. choices omitted"
-              + " leaves the catalog unchanged; type none clears. Jackson root wrap is"
+              + " leaves the catalog unchanged; present replaces including filter, null-entry, and"
+              + " default-selected; type none clears. Jackson root wrap is"
               + " ContentTypeFieldControlProperties.",
       responses = {
         @ApiResponse(

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -217,6 +217,7 @@ public interface IContentTypesAdaptor {
   /**
    * Load control property values and the choice catalog for one field (CD-07). No design lock is
    * required. Empty {@code properties} means none configured. {@code choices} is null when none.
+   * Choice filter, null-entry, and default-selected round-trip on {@code choices} when present.
    *
    * @return envelope, or {@code null} when the content type is not found
    */
@@ -227,7 +228,8 @@ public interface IContentTypesAdaptor {
    * Replace control property values (and optionally the choice catalog) for one field. Requires a
    * design-session lock already held by the current user. Does not acquire or release the lock.
    * {@code properties} is a full replace (empty clears). {@code choices} null leaves the catalog
-   * unchanged.
+   * unchanged. When {@code choices} is present, filter, null-entry, and default-selected are
+   * written as part of the catalog replace ({@code type} none/empty still clears).
    *
    * @return persisted envelope, or {@code null} when the content type is not found
    * @throws ContentTypeDesignLockException when no lock is held or another user owns the lock

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -810,6 +810,67 @@ public class ContentTypesResourceDetailTest {
   }
 
   @Test
+  public void getFieldControlPropertiesReturnsChoiceExtras() {
+    ContentTypeFieldControlProperties envelope = new ContentTypeFieldControlProperties();
+    envelope.setFieldName("sys_title");
+    ContentTypeChoiceCatalog choices = new ContentTypeChoiceCatalog();
+    choices.setType("local");
+    choices.setEntries(List.of(new ContentTypeChoiceEntry("open", "Open")));
+    ContentTypeChoiceNullEntry nullEntry = new ContentTypeChoiceNullEntry();
+    nullEntry.setValue("");
+    nullEntry.setLabel("None");
+    nullEntry.setIncludeWhen("always");
+    choices.setNullEntry(nullEntry);
+    choices.setDefaultSelected(List.of(new ContentTypeChoiceDefaultSelected("nullEntry")));
+    ContentTypeChoiceFilter filter = new ContentTypeChoiceFilter();
+    filter.setDependentFields(
+        List.of(new ContentTypeChoiceFilterField("sys_communityid", "optional")));
+    filter.setLookupHref("../sys_lookup/filter.xml");
+    choices.setFilter(filter);
+    envelope.setChoices(choices);
+    when(adaptor.getFieldControlProperties(any(), eq("percPage"), eq("sys_title")))
+        .thenReturn(envelope);
+    ContentTypeFieldControlProperties out =
+        resource.getFieldControlProperties("percPage", "sys_title");
+    assertEquals("None", out.getChoices().getNullEntry().getLabel());
+    assertEquals("nullEntry", out.getChoices().getDefaultSelected().get(0).getType());
+    assertEquals(
+        "sys_communityid", out.getChoices().getFilter().getDependentFields().get(0).getFieldRef());
+  }
+
+  @Test
+  public void replaceFieldControlPropertiesWritesChoiceExtras() {
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    ContentTypeChoiceCatalog choices = new ContentTypeChoiceCatalog();
+    choices.setType("local");
+    choices.setEntries(List.of(new ContentTypeChoiceEntry("closed", "Closed")));
+    ContentTypeChoiceNullEntry nullEntry = new ContentTypeChoiceNullEntry();
+    nullEntry.setLabel("None");
+    choices.setNullEntry(nullEntry);
+    body.setChoices(choices);
+    when(adaptor.replaceFieldControlProperties(any(), eq("percPage"), eq("sys_title"), any()))
+        .thenReturn(body);
+    ContentTypeFieldControlProperties out =
+        resource.replaceFieldControlProperties("percPage", "sys_title", body);
+    assertEquals("None", out.getChoices().getNullEntry().getLabel());
+    assertEquals("closed", out.getChoices().getEntries().get(0).getValue());
+  }
+
+  @Test
+  public void replaceFieldControlPropertiesInvalidFilter() {
+    ContentTypeFieldControlProperties body = new ContentTypeFieldControlProperties();
+    body.setProperties(List.of());
+    when(adaptor.replaceFieldControlProperties(any(), eq("percPage"), eq("sys_title"), any()))
+        .thenThrow(new IllegalArgumentException("choices.filter.lookupHref is required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceFieldControlProperties("percPage", "sys_title", body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void getFieldRuleExpressionsReturnsEnvelope() {
     ContentTypeFieldRuleExpressions envelope = new ContentTypeFieldRuleExpressions();
     envelope.setFieldName("sys_title");

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -148,6 +148,15 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
     out.setFieldName(fieldName);
     out.setControl("sys_EditBox");
     out.setProperties(List.of());
+    ContentTypeChoiceCatalog choices = new ContentTypeChoiceCatalog();
+    choices.setType("local");
+    choices.setEntries(List.of(new ContentTypeChoiceEntry("open", "Open")));
+    ContentTypeChoiceNullEntry nullEntry = new ContentTypeChoiceNullEntry();
+    nullEntry.setValue("");
+    nullEntry.setLabel("None");
+    choices.setNullEntry(nullEntry);
+    choices.setDefaultSelected(List.of(new ContentTypeChoiceDefaultSelected("nullEntry")));
+    out.setChoices(choices);
     return out;
   }
 

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -22,6 +22,10 @@ package com.percussion.rest.test.apibridge;
 import com.percussion.rest.Guid;
 import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.contenttypes.ContentType;
+import com.percussion.rest.contenttypes.ContentTypeChoiceCatalog;
+import com.percussion.rest.contenttypes.ContentTypeChoiceDefaultSelected;
+import com.percussion.rest.contenttypes.ContentTypeChoiceEntry;
+import com.percussion.rest.contenttypes.ContentTypeChoiceNullEntry;
 import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeField;
@@ -168,6 +172,16 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
     out.setFieldName(fieldName);
     out.setControl("sys_EditBox");
     out.setProperties(List.of(new ContentTypeControlProperty("height", "200")));
+    ContentTypeChoiceCatalog choices = new ContentTypeChoiceCatalog();
+    choices.setType("local");
+    choices.setEntries(List.of(new ContentTypeChoiceEntry("open", "Open")));
+    ContentTypeChoiceNullEntry nullEntry = new ContentTypeChoiceNullEntry();
+    nullEntry.setValue("");
+    nullEntry.setLabel("None");
+    nullEntry.setIncludeWhen("always");
+    choices.setNullEntry(nullEntry);
+    choices.setDefaultSelected(List.of(new ContentTypeChoiceDefaultSelected("nullEntry")));
+    out.setChoices(choices);
     return out;
   }
 


### PR DESCRIPTION
## Summary

Parent: #1690. **Fixes #3995.**

Extends existing CD-07 `GET/PUT /services/contenttypes/{idOrName}/fields/{fieldName}/controlProperties` so PUT writes **choice filter**, **null-entry**, and **default-selected** when `choices` is present. GET round-trips those fields. Omitted `choices` still leaves the catalog unchanged; `type: none` still clears. Held design-session lock on PUT (does not steal). Persist via existing `IPSContentDesignWs.loadContentTypes` / `saveContentTypes`. Property name/value PUT is unchanged (#3786). No SPA Choices tab. Shared-field control properties remain #3984.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Mockito: `ContentTypesResourceDetailTest` GET extras, PUT extras, invalid filter 400, existing 409/400 lock/properties.
2. Adaptor: `ContentTypeAdaptorControlPropertiesTest` round-trip mapping, persist extras, omitted `choices` keeps extras, `type: none` clears, 403/404/409.
3. Spring stub `TestContentTypeAdaptor` still implements `IContentTypesAdaptor` (MainTest / shared rest context).
4. Standalone Maven (below).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (CD-07 filter / null-entry / default-selected) and `product-docs/8.2/admin/developer-content-types.md` (SPA still omits `choices`; REST PUT writes extras). Gap map `docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md`.
- [x] **Unit / module tests** — behavioral tests for mapping + persist; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST only)
- [x] **Build gates** — each changed Maven module standalone clean install; reverse-dep `projects/sitemanage` built after `rest`
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**, Tests run: 759, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**, Tests run: 1717, Failures: 0, Skipped: 125
- **downstream_checked:** `projects/sitemanage` (implements `IContentTypesAdaptor`). Additive DTO fields only; no `final` or method-signature break. Grep not required for subclass-of-final.

## C5 UI proof

N/A — no WebUI / Playwright surface.

Erlang review: `docs/ai-generated/code-reviews/issue-3995-choice-catalog-write-erlang.md` (approve).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
