### PR TITLE
feat(rest): CD-10 type-level content type search indexing (#3996)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3996-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3996-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — issue #3996 REST CD-10 content type search indexing
+
+**Change class:** New public REST adaptor surface (GET/PUT type-level search indexing).
+
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class completeness (rest resource + DTO + IXxxAdaptor + Spring stub + sitemanage impl + Mockito + adaptor tests + product-docs); rest MainTest Spring stub; held design-session lock without steal.
+
+## Summary
+
+Dedicated Admin PUT (and unauthenticated-for-lock GET) at `/services/contenttypes/{idOrName}/searchIndexing` persists the Workbench Properties “Enable searching for this Content Type” flag as the root mapper field-set `isUserSearchable` via existing `IPSContentDesignWs`. Peer is CD-13 PUT `.../enabled`. Distinct from per-field `searchable`. No SPA chrome.
+
+## Issues
+
+None that block.
+
+## Companions
+
+| Artifact | Present |
+|----------|---------|
+| rest resource + OpenAPI | yes |
+| wire DTO `ContentTypeSearchIndexing` | yes |
+| `IContentTypesAdaptor` methods | yes |
+| Spring `TestContentTypeAdaptor` + `ContentTypesTestAdaptor` | yes |
+| sitemanage `ContentTypeAdaptor` | yes |
+| Mockito resource tests | yes |
+| adaptor success/403/404/409 tests | yes |
+| product-docs 8.2 + gap map CD-10 | yes |
+| Playwright / SPA | N/A (explicitly out of scope) |
+
+## Cross-platform path checklist
+
+N/A — no filesystem path/file I/O.
+
+## Tests / build
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 767, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1798, Failures: 0, Skipped: 125
+- Downstream: sitemanage implements `IContentTypesAdaptor`; grep found three implementors (production + two rest test stubs), all updated.
+
+## Notes
+
+- GET does not require Admin (same as GET itemExits / GET detail). PUT is Admin-only (403). Issue text said “Admin GET/PUT”; 403 is specified with the PUT error set.
+- PUT does not acquire or steal the design lock; 409 when unlocked or locked by another user.
+- Default-on when the mapper field-set is null (Workbench default).

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -2,7 +2,7 @@
 
 |  Field   |                                  Value                                   |
 |----------|--------------------------------------------------------------------------|
-| **Date** | 2026-08-28                                                               |
+| **Date** | 2026-08-29                                                               |
 | **FR**   | CD-01–CD-19 in `docs/developer-module/workbench-functional-inventory.md` |
 
 ## Surfaces available today
@@ -74,6 +74,7 @@ slices.
 | Control property + choice configuration              | CD-07        | **REST GET/PUT** `.../fields/{fieldName}/controlProperties` (#3786, held design lock for PUT). Choice filter / null-entry / default-selected not written |
 | Item-level pre/post exits & validations              | CD-09        | Properties tab                                    |
 | Edit workflow/template associations                  | CD-08, CD-12 | **CD-08 REST PUT .../allowedWorkflows** (#3763, held design lock); **CD-12 REST PUT .../allowedTemplates** (#3775, held design lock; full replace, empty list clears) |
+| Enable/disable search indexing at type level         | CD-10        | **REST `GET`/`PUT /contenttypes/{id}/searchIndexing`** (#3996, root field-set `isUserSearchable`; held design lock on PUT; 409 without). Default on. Distinct from per-field `searchable`. SPA Properties checkbox still open |
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
 | Shared field file **write**                          | CD-15        | **Group create/save/delete shipped** (`POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}`, #3944). **Field create/delete shipped** (`POST …/fields`, `DELETE …/fields/{fieldName}`, persistable `PSField` + display mapping, Admin 403, lock 409, #3954). Control/choice write and SPA editor still open |
 | System def **write** (existing field properties)     | CD-16        | **PUT `/services/systemdef` shipped** (#3958, Admin 403, lock 409). Field create/delete, control/stylesheet/flow, and SPA editor still SOAP |

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -251,6 +251,7 @@ The chrome calls:
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
 | Save (label, description, fields) | `PUT /services/contenttypes/{idOrName}` (requires a held lock; does not send `enabled`, `allowedWorkflows`, or `allowedTemplates`) |
 | Enable / disable | `PUT /services/contenttypes/{idOrName}/enabled` (CD-13; requires a held lock; does not acquire or release it) |
+| Type-level search indexing | `GET` / `PUT /services/contenttypes/{idOrName}/searchIndexing` (CD-10; REST-only; PUT requires a held lock; default on; not the per-field searchable flag; no SPA Properties checkbox) |
 | Rename | `PUT /services/contenttypes/{idOrName}/name` (CD-01; Admin; held lock; unique name, no spaces; bulk PUT does not rename) |
 | Save allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (requires a held lock; does not unlock) |
 | Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` (held lock; full replace) |

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -263,6 +263,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** change name (use `PUT .../name`). Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions use the dedicated path below (not this PUT). |
 | Allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` | **Admin** (CD-08 design action). Requires a held design-session lock (`POST .../lock` first). Does **not** acquire or release the lock. Full replace of `allowedWorkflows` (empty list clears). Optional `defaultWorkflow`. Workflow name/guid must exist. `200` + `ContentTypeDetail` with the new `allowedWorkflows` / `defaultWorkflow` (lock still held). |
 | Enable/disable | `PUT /services/contenttypes/{idOrName}/enabled` | **Admin** (CD-13 design action). Requires a held design-session lock — `POST .../lock` first, then `PUT .../enabled`, then `POST .../unlock` when done. Does **not** acquire or release the lock. `200` + `ContentTypeDetail` with the new `enabled` value (lock still held). |
+| Search indexing | `GET` / `PUT /services/contenttypes/{idOrName}/searchIndexing` | **Admin** PUT (CD-10). Type-level search indexing — Workbench Properties **Enable searching for this Content Type** (root field-set `isUserSearchable`). **Default is on.** Distinct from per-field `searchable` on PUT detail. GET does not require a lock. PUT requires a **held** design-session lock and does **not** acquire or release it. Missing `searchIndexing` boolean is **400**. Jackson root wrap is `ContentTypeSearchIndexing`. No SPA Properties checkbox in this release. |
 | Rename | `PUT /services/contenttypes/{idOrName}/name` | **Admin** (CD-01). Requires a **held** design-session lock. Sets the internal name. Unique (case-insensitive); **no spaces** or wildcards. Bulk `PUT .../{idOrName}` does **not** change name. After success, `GET` by the previous name is **404**; `GET` by id returns the new name. Does not acquire or release the lock. |
 | Add local field | `POST /services/contenttypes/{idOrName}/fields` | **Admin** (CD-03). Requires a **held** design-session lock. Adds a persistable **local** field (backend column + display mapping) via `IPSContentDesignWs.saveContentTypes`. Body `name` is required (letter, then letters/digits/underscore; unique case-insensitive on the type). Optional `dataType` defaults to `text`. Optional `searchable` and `occurrence`/`required` use the same rules as PUT field patches. Optional `fieldSet` names an existing child field set, or **creates** a named complex child when missing. Duplicate field is **409**. System/shared inclusion is out of scope (CD-04). Does not acquire or release the lock. |
 | Delete local field | `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}` | **Admin** (CD-03). Requires a **held** design-session lock. Removes a **local** field and its display mapping. System/shared fields are **400**. Missing type or field is **404**. Does not acquire or release the lock. `204` on success (lock still held). |
@@ -273,7 +274,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 | Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Type-level search indexing is REST-only (`GET`/`PUT .../searchIndexing`, CD-10; no SPA Properties checkbox). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
 
 Lock / save / unlock / create / rename / delete status codes:
 
@@ -281,7 +282,7 @@ Lock / save / unlock / create / rename / delete status codes:
 |--------|-----------------|
 | `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / rename succeeded (lock still held), POST create succeeded (`ContentTypeDetail`), or POST local field succeeded |
 | `204` | Unlock success, content type deleted, or local field deleted |
-| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid or colliding rename), invalid create name (blank, spaces, wildcard), invalid local-field name/`dataType`/origin, DELETE field of a system/shared field, or DELETE type rejected because the type has dependents |
+| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` or `searchIndexing` flag, invalid or colliding rename), invalid create name (blank, spaces, wildcard), invalid local-field name/`dataType`/origin, DELETE field of a system/shared field, or DELETE type rejected because the type has dependents |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found |
 | `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time), including reserved system types such as Folder; POST local field when the field name already exists on the type |
@@ -364,6 +365,39 @@ Jackson root wrap:
   }
 }
 ```
+
+### Type-level search indexing (CD-10)
+
+`GET /services/contenttypes/{idOrName}/searchIndexing` and `PUT
+.../searchIndexing` read and write whether items of this content type may be
+indexed for search. This is the Workbench Content Type editor Properties
+checkbox **Enable searching for this Content Type**. It maps the **root**
+mapper field-set `isUserSearchable` flag. It is **not** the per-field
+`searchable` flag already available on PUT content-type detail and local-field
+create.
+
+The flag **defaults to on** when a content type has no mapper field-set (same
+as Workbench). PUT is **Admin** only and requires a **held** design-session
+lock (`POST .../lock` first). The lock is **not** acquired or released by this
+call. GET does not require a lock.
+
+Typical flow: `POST .../lock` → `PUT .../searchIndexing` → (optional further
+design writes) → `POST .../unlock`. Then `GET .../searchIndexing` round-trips
+the saved value.
+
+Jackson root wrap:
+
+```json
+{
+  "ContentTypeSearchIndexing": {
+    "searchIndexing": false
+  }
+}
+```
+
+Missing `searchIndexing` on PUT is **400**. Unlocked or another user's lock is
+**409**. Unknown type is **404**. Non-Admin PUT is **403**. The Developer SPA
+does **not** expose a Properties-tab search checkbox in this release; use REST.
 
 `GET /services/contenttypes` (the catalog list) may be a JSON array or a Jackson
 root envelope (`ContentTypeList` and/or `ContentType`). The Developer **Content

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -76,6 +76,7 @@ import com.percussion.rest.contenttypes.ContentTypeFilter;
 import com.percussion.rest.contenttypes.ContentTypeItemExit;
 import com.percussion.rest.contenttypes.ContentTypeItemExitParam;
 import com.percussion.rest.contenttypes.ContentTypeItemExits;
+import com.percussion.rest.contenttypes.ContentTypeSearchIndexing;
 import com.percussion.rest.contenttypes.IContentTypesAdaptor;
 import com.percussion.rest.contenttypes.NamedObjectRef;
 import com.percussion.services.assembly.IPSAssemblyService;
@@ -324,8 +325,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    *
    * @param includeDisabledFromStore when {@code true}, a cache miss falls back to the
    *     object store so disabled types (unregistered from the editor cache) still load.
-   *     GET detail, enable/disable (CD-13), and DELETE pass {@code true}; other callers keep
-   *     the pre-CD-13 cache-only 404 for disabled types.
+   *     GET detail, enable/disable (CD-13), search indexing (CD-10), and DELETE pass {@code
+   *     true}; other callers keep the pre-CD-13 cache-only 404 for disabled types.
    */
   private PSItemDefinition resolveItemDef(String idOrName, boolean includeDisabledFromStore)
       throws PSInvalidContentTypeException {
@@ -428,6 +429,25 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
   }
 
   /**
+   * Root mapper field-set {@code isUserSearchable} (CD-10). Workbench default is on when the
+   * field-set is absent.
+   */
+  private static ContentTypeSearchIndexing toSearchIndexing(PSItemDefinition def) {
+    PSFieldSet fs = def.getFieldSet();
+    boolean searchable = fs == null || fs.isUserSearchable();
+    return new ContentTypeSearchIndexing(searchable);
+  }
+
+  /** Persist Workbench type-level search indexing on the mapper root field-set. */
+  private static void applyRootFieldSetSearchable(PSItemDefinition def, boolean searchable) {
+    PSFieldSet fs = def.getFieldSet();
+    if (fs == null) {
+      throw new IllegalStateException("Content type has no mapper field-set");
+    }
+    fs.setUserSearchable(searchable);
+  }
+
+  /**
    * Structured designGaps for content-type detail (REST-GAPS-01). Package-visible for unit tests.
    */
   static List<DesignGap> contentTypeDesignGaps(boolean controlsResolved) {
@@ -476,6 +496,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         DesignGap.of(
             "CT_FIELD_LABELS_WRITE",
             "Field display labels are not writable via PUT content type detail"));
+    gaps.add(
+        DesignGap.of(
+            "CT_SEARCH_INDEXING",
+            "Type-level search indexing: GET/PUT /contenttypes/{idOrName}/searchIndexing"
+                + " (held lock for write). Default is on. Per-field searchable is a separate PUT"
+                + " detail flag. SPA Properties checkbox is not exposed"));
     if (!controlsResolved) {
       gaps.add(
           DesignGap.of(
@@ -722,6 +748,97 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (Exception e) {
       log.error("Failed to enable/disable content type {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to enable/disable content type", e);
+    }
+  }
+
+  @Override
+  public ContentTypeSearchIndexing getContentTypeSearchIndexing(URI baseUri, String idOrName) {
+    if (StringUtils.isBlank(idOrName)) {
+      return null;
+    }
+    try {
+      PSItemDefinition def = resolveItemDef(idOrName.trim(), true);
+      if (def == null) {
+        return null;
+      }
+      return toSearchIndexing(def);
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for search indexing: {}", idOrName);
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to load content type search indexing {}: {}", idOrName, e.getMessage(), e);
+      throw new RuntimeException(
+          "Failed to load content type search indexing ("
+              + e.getClass().getName()
+              + "): "
+              + e.getMessage(),
+          e);
+    }
+  }
+
+  @Override
+  public ContentTypeSearchIndexing setContentTypeSearchIndexing(
+      URI baseUri, String idOrName, boolean searchIndexing) {
+    requireAdmin();
+    requireSessionUserForLock();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      PSItemDefinition current = resolveItemDef(trimmed, true);
+      if (current == null) {
+        return null;
+      }
+      IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
+      requireHeldLock(ctGuid);
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not update content type search indexing");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      applyRootFieldSetSearchable(def, searchIndexing);
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not update content type search indexing");
+        }
+        log.error(
+            "Failed to save content type search indexing {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save content type search indexing", e);
+      }
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
+      if (reloaded != null && reloaded != def) {
+        applyRootFieldSetSearchable(reloaded, searchIndexing);
+        return toSearchIndexing(reloaded);
+      }
+      return toSearchIndexing(def);
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for search indexing: {}", idOrName);
+      return null;
+    } catch (IllegalStateException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Failed to update content type search indexing {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to update content type search indexing", e);
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorSearchIndexingTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorSearchIndexingTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSInvalidContentTypeException;
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSFieldSet;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeSearchIndexing;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * CD-10 type-level search indexing requires a held design-session lock on PUT and persists root
+ * field-set {@code isUserSearchable} without releasing the lock.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorSearchIndexingTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void disable_persistsRootFieldSetWhenLockHeld() throws Exception {
+    stubHeldLock();
+    PSFieldSet fieldSet = stubDefinition(true);
+
+    ContentTypeSearchIndexing out = adaptor.setContentTypeSearchIndexing(null, "311", false);
+
+    assertEquals(Boolean.FALSE, out.getSearchIndexing());
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSItemDefinition>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveContentTypes(saved.capture(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    verify(fieldSet).setUserSearchable(false);
+    verify(systemDesign).isLocked(anyList(), eq("Admin"));
+  }
+
+  @Test
+  void enable_persistsRootFieldSetWhenLockHeld() throws Exception {
+    stubHeldLock();
+    PSFieldSet fieldSet = stubDefinition(false);
+
+    ContentTypeSearchIndexing out = adaptor.setContentTypeSearchIndexing(null, "311", true);
+
+    assertEquals(Boolean.TRUE, out.getSearchIndexing());
+    verify(fieldSet).setUserSearchable(true);
+    verify(designWs).saveContentTypes(anyList(), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void get_roundTripsAfterDisable() throws Exception {
+    stubHeldLock();
+    stubDefinition(true);
+
+    ContentTypeSearchIndexing disabled = adaptor.setContentTypeSearchIndexing(null, "311", false);
+    assertEquals(Boolean.FALSE, disabled.getSearchIndexing());
+
+    ContentTypeSearchIndexing get = adaptor.getContentTypeSearchIndexing(null, "311");
+    assertEquals(Boolean.FALSE, get.getSearchIndexing());
+  }
+
+  @Test
+  void get_defaultsOnWhenFieldSetNull() throws Exception {
+    PSItemDefinition def = stubStoreDefinition(true);
+    when(def.getFieldSet()).thenReturn(null);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+
+    ContentTypeSearchIndexing get = adaptor.getContentTypeSearchIndexing(null, "311");
+
+    assertEquals(Boolean.TRUE, get.getSearchIndexing());
+    verify(systemDesign, never()).isLocked(anyList(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void disable_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(Collections.singletonList(null));
+    stubDefinition(true);
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.setContentTypeSearchIndexing(null, "311", false));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(true), anyBoolean(), any(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void disable_conflictWhenLockedByOtherUser() throws Exception {
+    PSObjectSummary other = new PSObjectSummary(guid, "percPage");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+    stubDefinition(true);
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.setContentTypeSearchIndexing(null, "311", false));
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void disable_conflictWhenLockedInAnotherSession() throws Exception {
+    stubHeldLock();
+    stubDefinition(true);
+    PSErrorResultsException errors = new PSErrorResultsException();
+    errors.addError(
+        guid, new PSLockErrorException(1, "LOCK_EXTENSION_INVALID_SESSION", "stack", "Admin", 12));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenThrow(errors);
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () -> adaptor.setContentTypeSearchIndexing(null, "311", false));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void disable_unknownName_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.setContentTypeSearchIndexing(null, "missing", false));
+    verify(systemDesign, never()).isLocked(anyList(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void get_unknownName_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.getContentTypeSearchIndexing(null, "missing"));
+  }
+
+  @Test
+  void disable_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> denied.setContentTypeSearchIndexing(null, "311", false));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void disable_missingFieldSet_isServerError() throws Exception {
+    stubHeldLock();
+    PSItemDefinition def = stubStoreDefinition(true);
+    when(def.getFieldSet()).thenReturn(null);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class,
+            () -> adaptor.setContentTypeSearchIndexing(null, "311", false));
+    assertTrue(ex.getMessage().toLowerCase().contains("field-set"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void disable_wildcardName_isBadRequest() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.setContentTypeSearchIndexing(null, "perc*", false));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void get_cacheMiss_usesObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    PSItemDefinition storeDef = stubStoreDefinition(false);
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(storeDef).when(spy).loadItemDefFromObjectStore("311");
+
+    ContentTypeSearchIndexing get = spy.getContentTypeSearchIndexing(null, "311");
+
+    assertEquals(Boolean.FALSE, get.getSearchIndexing());
+    verify(spy).loadItemDefFromObjectStore("311");
+  }
+
+  @Test
+  void enable_cacheMiss_usesObjectStoreFallback() throws Exception {
+    stubHeldLock();
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    PSItemDefinition storeDef = stubStoreDefinition(false);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(storeDef));
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(storeDef).when(spy).loadItemDefFromObjectStore("311");
+
+    ContentTypeSearchIndexing out = spy.setContentTypeSearchIndexing(null, "311", true);
+
+    assertEquals(Boolean.TRUE, out.getSearchIndexing());
+    verify(spy).loadItemDefFromObjectStore("311");
+    verify(storeDef.getFieldSet()).setUserSearchable(true);
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private PSFieldSet stubDefinition(boolean initiallySearchable) throws Exception {
+    PSItemDefinition def = stubStoreDefinition(initiallySearchable);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    return def.getFieldSet();
+  }
+
+  private PSItemDefinition stubStoreDefinition(boolean initiallySearchable) {
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn("percPage");
+    when(def.getLabel()).thenReturn("Page");
+    when(def.getDescription()).thenReturn("desc");
+    when(def.isEnabled()).thenReturn(true);
+    when(def.isHidden()).thenReturn(false);
+    when(def.getAppName()).thenReturn("rx_cePage");
+    when(def.getEditorUrl()).thenReturn("/Rhythmyx/rx_cePage/percPage.html");
+    when(def.getTypeId()).thenReturn(311);
+    when(def.getContentEditor()).thenReturn(null);
+    PSFieldSet fieldSet = mock(PSFieldSet.class);
+    when(fieldSet.isUserSearchable()).thenReturn(initiallySearchable);
+    doAnswer(
+            inv -> {
+              when(fieldSet.isUserSearchable()).thenReturn(inv.getArgument(0));
+              return null;
+            })
+        .when(fieldSet)
+        .setUserSearchable(anyBoolean());
+    when(def.getFieldSet()).thenReturn(fieldSet);
+    return def;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -42,6 +42,16 @@ class DesignGapsStructuredTest {
     assertTrue(codes.contains("CT_ITEM_EXITS"));
     assertTrue(codes.contains("CT_CREATE_DELETE"));
     assertTrue(codes.contains("CT_FIELD_CREATE_DELETE"));
+    assertTrue(codes.contains("CT_SEARCH_INDEXING"));
+    assertTrue(
+        gaps.stream()
+            .anyMatch(
+                g ->
+                    "CT_SEARCH_INDEXING".equals(g.getCode())
+                        && g.getMessage().contains("searchIndexing")
+                        && g.getMessage().toLowerCase().contains("held")
+                        && g.getMessage().toLowerCase().contains("default")),
+        () -> gaps.toString());
     assertTrue(
         gaps.stream()
             .anyMatch(

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeSearchIndexing.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeSearchIndexing.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Type-level search indexing flag for a Content Type (CD-10).
+ *
+ * <p>Maps Workbench Properties {@code Enable searching for this Content Type} (root mapper
+ * field-set {@code isUserSearchable}). Default is on. Distinct from per-field {@code searchable}
+ * on PUT detail / local-field create.
+ *
+ * <p>Jackson root wrap is {@code ContentTypeSearchIndexing} ({@code WRAP_ROOT_VALUE} /
+ * {@code UNWRAP_ROOT_VALUE}).
+ */
+@XmlRootElement(name = "ContentTypeSearchIndexing")
+@JsonRootName("ContentTypeSearchIndexing")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Content type type-level search indexing flag")
+public class ContentTypeSearchIndexing {
+
+  @Schema(
+      required = true,
+      description =
+          "When true, items of this content type may be indexed for search. Default is true"
+              + " (Workbench default-on). Does not change per-field searchable.")
+  private Boolean searchIndexing;
+
+  public ContentTypeSearchIndexing() {}
+
+  public ContentTypeSearchIndexing(boolean searchIndexing) {
+    this.searchIndexing = searchIndexing;
+  }
+
+  public Boolean getSearchIndexing() {
+    return searchIndexing;
+  }
+
+  public void setSearchIndexing(Boolean searchIndexing) {
+    this.searchIndexing = searchIndexing;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -1115,6 +1115,90 @@ public class ContentTypesResource {
     }
   }
 
+  @GET
+  @Path("/{idOrName}/searchIndexing")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Get content type search indexing flag",
+      description =
+          "CD-10: returns the type-level search indexing flag (Workbench Properties"
+              + " \"Enable searching for this Content Type\"). Maps the root mapper field-set"
+              + " isUserSearchable. Default is on. Distinct from per-field searchable on PUT"
+              + " detail. No design lock is required. Jackson root wrap is"
+              + " ContentTypeSearchIndexing.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content =
+                @Content(schema = @Schema(implementation = ContentTypeSearchIndexing.class))),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeSearchIndexing getContentTypeSearchIndexing(
+      @PathParam("idOrName") String idOrName) {
+    try {
+      ContentTypeSearchIndexing out =
+          requireAdaptor().getContentTypeSearchIndexing(uriInfo.getBaseUri(), idOrName);
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}/searchIndexing")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Enable or disable type-level search indexing",
+      description =
+          "CD-10 design action: sets the content type root field-set isUserSearchable flag"
+              + " (Workbench Properties \"Enable searching for this Content Type\"). Admin only."
+              + " Requires a design-session lock already held by the current user (POST"
+              + " .../lock). Does not acquire or release the lock. Distinct from per-field"
+              + " searchable on PUT detail. Default is on. Jackson root wrap is"
+              + " ContentTypeSearchIndexing.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated (lock is still held)",
+            content =
+                @Content(schema = @Schema(implementation = ContentTypeSearchIndexing.class))),
+        @ApiResponse(responseCode = "400", description = "searchIndexing is required"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock required, or locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeSearchIndexing setContentTypeSearchIndexing(
+      @PathParam("idOrName") String idOrName, ContentTypeSearchIndexing body) {
+    if (body == null || body.getSearchIndexing() == null) {
+      throw new WebApplicationException("searchIndexing is required", 400);
+    }
+    try {
+      ContentTypeSearchIndexing out =
+          requireAdaptor()
+              .setContentTypeSearchIndexing(
+                  uriInfo.getBaseUri(), idOrName, body.getSearchIndexing());
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (RuntimeException e) {
+      throw mapEnabledFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
   @PUT
   @Path("/{idOrName}/name")
   @Consumes({MediaType.APPLICATION_JSON})

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -141,6 +141,35 @@ public interface IContentTypesAdaptor {
   ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled);
 
   /**
+   * Load type-level search indexing for a content type (CD-10). No design lock is required.
+   * Reflects the root mapper field-set {@code isUserSearchable} (Workbench Properties {@code
+   * Enable searching for this Content Type}). Default is on when the field-set is missing.
+   * Distinct from per-field {@code searchable}.
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or internal name
+   * @return envelope, or {@code null} when the content type is not found
+   */
+  ContentTypeSearchIndexing getContentTypeSearchIndexing(URI baseUri, String idOrName);
+
+  /**
+   * Enable or disable type-level search indexing (CD-10). Requires a design-session lock already
+   * held by the current user (peer lock REST). Does not acquire or release the lock. Persists
+   * root mapper field-set {@code setUserSearchable} via {@code IPSContentDesignWs}. Distinct from
+   * per-field {@code searchable}.
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or internal name
+   * @param searchIndexing {@code true} to allow indexing, {@code false} to disable type-level
+   *     search
+   * @return updated envelope, or {@code null} when not found
+   * @throws ContentTypeDesignLockException when no lock is held or the lock is owned by another
+   *     user
+   */
+  ContentTypeSearchIndexing setContentTypeSearchIndexing(
+      URI baseUri, String idOrName, boolean searchIndexing);
+
+  /**
    * Rename a content type (CD-01). Requires a design-session lock already held by the current
    * user. Does not acquire or release the lock. Bulk {@link #updateContentType} does not change
    * name. After a successful rename, GET by the previous name is not found; GET by id returns the

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypeSearchIndexingSerialDeserialTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypeSearchIndexingSerialDeserialTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.rest.JacksonContextResolver;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Wire contract for {@link ContentTypeSearchIndexing} under WRAP_ROOT_VALUE / UNWRAP_ROOT_VALUE.
+ *
+ * <p>Peer: {@link ContentTypeNameSerialDeserialTest}.
+ */
+@Tag("UnitTest")
+public class ContentTypeSearchIndexingSerialDeserialTest {
+
+  @Test
+  public void productionMapperSerializesContentTypeSearchIndexingEnvelope() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ContentTypeSearchIndexing.class);
+    String json = mapper.writeValueAsString(new ContentTypeSearchIndexing(false));
+    assertTrue(json.contains("\"ContentTypeSearchIndexing\""), "expected WRAP_ROOT_VALUE: " + json);
+    assertTrue(json.contains("\"searchIndexing\""), json);
+    assertTrue(json.contains("false"), json);
+
+    ContentTypeSearchIndexing roundTrip = mapper.readValue(json, ContentTypeSearchIndexing.class);
+    assertEquals(Boolean.FALSE, roundTrip.getSearchIndexing());
+  }
+
+  @Test
+  public void productionMapperRoundTripsDefaultOn() {
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ContentTypeSearchIndexing.class);
+    String json = mapper.writeValueAsString(new ContentTypeSearchIndexing(true));
+    ContentTypeSearchIndexing roundTrip = mapper.readValue(json, ContentTypeSearchIndexing.class);
+    assertTrue(roundTrip.getSearchIndexing());
+    assertFalse(json.contains("\"enabled\""), "must not collide with CD-13 enabled: " + json);
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -1176,4 +1176,104 @@ public class ContentTypesResourceDetailTest {
             WebApplicationException.class, () -> resource.deleteLocalField("percPage", "rx_note"));
     assertEquals(403, ex.getResponse().getStatus());
   }
+
+  @Test
+  public void getSearchIndexingReturnsFlag() {
+    when(adaptor.getContentTypeSearchIndexing(any(), eq("percPage")))
+        .thenReturn(new ContentTypeSearchIndexing(true));
+    ContentTypeSearchIndexing out = resource.getContentTypeSearchIndexing("percPage");
+    assertEquals(Boolean.TRUE, out.getSearchIndexing());
+  }
+
+  @Test
+  public void getSearchIndexingNotFound() {
+    when(adaptor.getContentTypeSearchIndexing(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.getContentTypeSearchIndexing("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setSearchIndexingSuccess() {
+    when(adaptor.setContentTypeSearchIndexing(any(), eq("percPage"), eq(false)))
+        .thenReturn(new ContentTypeSearchIndexing(false));
+    ContentTypeSearchIndexing out =
+        resource.setContentTypeSearchIndexing("percPage", new ContentTypeSearchIndexing(false));
+    assertEquals(Boolean.FALSE, out.getSearchIndexing());
+  }
+
+  @Test
+  public void setSearchIndexingRequiresBoolean() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.setContentTypeSearchIndexing("percPage", new ContentTypeSearchIndexing()));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("searchIndexing"), ex.getMessage());
+  }
+
+  @Test
+  public void setSearchIndexingNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.setContentTypeSearchIndexing("percPage", null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setSearchIndexingNotFound() {
+    when(adaptor.setContentTypeSearchIndexing(any(), eq("missing"), eq(false))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeSearchIndexing(
+                    "missing", new ContentTypeSearchIndexing(false)));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setSearchIndexingRequiresLock() {
+    when(adaptor.setContentTypeSearchIndexing(any(), eq("percPage"), eq(false)))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not update content type search indexing; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeSearchIndexing(
+                    "percPage", new ContentTypeSearchIndexing(false)));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setSearchIndexingLockedByOtherUser() {
+    when(adaptor.setContentTypeSearchIndexing(any(), eq("percPage"), eq(false)))
+        .thenThrow(
+            new ContentTypeDesignLockException(
+                "Could not update content type search indexing; locked by editor2"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeSearchIndexing(
+                    "percPage", new ContentTypeSearchIndexing(false)));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setSearchIndexingForbiddenWhenNotAdmin() {
+    when(adaptor.setContentTypeSearchIndexing(any(), eq("percPage"), eq(false)))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeSearchIndexing(
+                    "percPage", new ContentTypeSearchIndexing(false)));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -106,6 +106,17 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public ContentTypeSearchIndexing getContentTypeSearchIndexing(URI baseUri, String idOrName) {
+    return new ContentTypeSearchIndexing(true);
+  }
+
+  @Override
+  public ContentTypeSearchIndexing setContentTypeSearchIndexing(
+      URI baseUri, String idOrName, boolean searchIndexing) {
+    return new ContentTypeSearchIndexing(searchIndexing);
+  }
+
+  @Override
   public ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName) {
     return null;
   }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -29,6 +29,7 @@ import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
 import com.percussion.rest.contenttypes.ContentTypeFieldRuleExpressions;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
 import com.percussion.rest.contenttypes.ContentTypeItemExits;
+import com.percussion.rest.contenttypes.ContentTypeSearchIndexing;
 import com.percussion.rest.contenttypes.IContentTypesAdaptor;
 import com.percussion.rest.contenttypes.NamedObjectRef;
 import java.net.URI;
@@ -123,6 +124,17 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   @Override
   public ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled) {
     return null;
+  }
+
+  @Override
+  public ContentTypeSearchIndexing getContentTypeSearchIndexing(URI baseUri, String idOrName) {
+    return new ContentTypeSearchIndexing(true);
+  }
+
+  @Override
+  public ContentTypeSearchIndexing setContentTypeSearchIndexing(
+      URI baseUri, String idOrName, boolean searchIndexing) {
+    return new ContentTypeSearchIndexing(searchIndexing);
   }
 
   @Override


### PR DESCRIPTION
## Summary

Parent: #1690. Implements **REST CD-10** type-level search indexing for content types.

Admin **GET/PUT** `/services/contenttypes/{idOrName}/searchIndexing` reads and writes Workbench Properties **Enable searching for this Content Type** (root mapper field-set `isUserSearchable`) through existing `IPSContentDesignWs` load/save. PUT requires a **held** design-session lock and does **not** acquire, release, or steal it (same lock pattern as CD-13 `PUT .../enabled`). Distinct from per-field `searchable` already on PUT detail / local-field create. Default is **on**. No SPA Properties checkbox (out of scope; sibling CD-11 icon #3997 is backlog).

Fixes #3996

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install`
2. `cd projects/sitemanage && ../../mvnw.cmd clean install`
3. Unit coverage: GET round-trip, PUT persist `setUserSearchable`, missing boolean **400**, non-Admin **403**, unknown type **404**, lock not held / other user **409**.
4. Integrator: `POST .../lock` → `PUT .../searchIndexing` with `{ "ContentTypeSearchIndexing": { "searchIndexing": false } }` → `GET .../searchIndexing` returns false → `POST .../unlock`.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/developer/rest.md` (CD-10 GET/PUT) and REST table row on `product-docs/8.2/admin/developer-content-types.md`; gap map CD-10
- [x] **Unit / module tests** — Mockito resource, Jackson wrap, Spring `TestContentTypeAdaptor` + `ContentTypesTestAdaptor`, `ContentTypeAdaptorSearchIndexingTest`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST-only)
- [x] **Build gates** — standalone clean install on `rest` then `projects/sitemanage`; no skipTests
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **767**, Failures: 0 (`ContentTypesResourceDetailTest` 100; `ContentTypeSearchIndexingSerialDeserialTest` 2)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: **1798**, Failures: 0, Skipped: 125 (`ContentTypeAdaptorSearchIndexingTest` 14)
- **downstream_checked:** `IContentTypesAdaptor` public methods added; grep `implements IContentTypesAdaptor` → production `ContentTypeAdaptor` + rest test stubs `TestContentTypeAdaptor` / `ContentTypesTestAdaptor` (all updated). Standalone sitemanage clean install green.

### C5 UI proof

N/A — no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
