### PR TITLE
feat(rest): CD-11 content type icon strategy GET/PUT (#3997)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-3997-rest-cd11-icon-strategy-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3997-rest-cd11-icon-strategy-erlang.md
@@ -1,0 +1,49 @@
+# Erlang review — issue #3997 REST CD-11 content type icon strategy
+
+| Field | Value |
+|-------|-------|
+| **Date** | 2026-08-29 |
+| **Branch** | `fix/issue-3997-content-type-icon-strategy` |
+| **Issue** | #3997 (parent #1690, FR CD-11) |
+| **Recommendation** | approve |
+| **Gate** | May commit/push: yes |
+| **Memory patterns hit** | Incomplete change-class closure (rest↔sitemanage + Spring stub); behavioral tests for validation/403/409/404; C2 interface implementors |
+
+## Summary
+
+Admin REST GET/PUT `/services/contenttypes/{idOrName}/icon` for Workbench Properties icon strategy (`none` / `specified` / `fromFileField`). PUT requires a held design-session lock (does not steal). `none` clears value; non-none blank value is 400. Persist via existing `IPSContentDesignWs.saveContentTypes` + `PSContentEditor.setContentTypeIcon`. No new SOAP, no SPA, no binary upload.
+
+Change-class companions from CD-13 / CD-09 peers are present: wire DTO, resource, adaptor interface, Mockito resource tests, Spring `TestContentTypeAdaptor` stub + `ContentTypesTestAdaptor`, sitemanage apibridge impl + unit tests, product-docs 8.2 Developer REST + admin REST table, gap map CD-11.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: **yes**
+
+## Issues
+
+None that block.
+
+## Cross-platform path checklist
+
+N/A for filesystem I/O. Icon `value` is a persisted object-store string (file path/name or field name). Tests assert those strings; they do not join OS paths.
+
+## C2 / change-class
+
+- `IContentTypesAdaptor` gained methods (public API). Grep `implements IContentTypesAdaptor`: 3 types (`ContentTypeAdaptor`, `TestContentTypeAdaptor`, `ContentTypesTestAdaptor`); all updated. No anonymous subclasses.
+- Downstream: standalone `projects/sitemanage` clean install after `rest` install.
+- Rest `MainTest` Spring stub implemented.
+
+## Tests / builds
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 769, Failures: 0 (`ContentTypesResourceDetailTest` 104)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1799, Failures: 0, Skipped: 125 (`ContentTypeAdaptorIconTest` 15)
+
+## Product documentation
+
+Updated `product-docs/8.2/developer/rest.md` (table + CD-11 section) and `product-docs/8.2/admin/developer-content-types.md` REST table. Gap map `docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md` marks CD-11 REST shipped.
+
+C5 Playwright N/A (no WebUI / SPA).

--- a/docs/ai-generated/code-reviews/issue-3997-rest-cd11-icon-strategy-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-3997-rest-cd11-icon-strategy-erlang.md
@@ -47,3 +47,7 @@ N/A for filesystem I/O. Icon `value` is a persisted object-store string (file pa
 Updated `product-docs/8.2/developer/rest.md` (table + CD-11 section) and `product-docs/8.2/admin/developer-content-types.md` REST table. Gap map `docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md` marks CD-11 REST shipped.
 
 C5 Playwright N/A (no WebUI / SPA).
+
+## Re-review (PR #4007 Kilo lock-prefix)
+
+Kilo thread: no-arg `requireHeldLock(ctGuid)` used generic `"Could not save content type"` for CD-11 PUT. Fix passes `"Could not set content type icon"` so 409 text matches other `lockConflict` calls. Tests assert the prefix on lock-not-held and locked-by-other. Standalone `projects/sitemanage` clean install after this-branch rest SNAPSHOT: BUILD SUCCESS, Tests run: 1799, Failures: 0, Skipped: 125 (`ContentTypeAdaptorIconTest` 15). Recommendation: approve. May commit/push: **yes**.

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -13,6 +13,7 @@
 | Public REST detail (**new P0.2**) | Read-only field catalog + meta      | `GET /services/contenttypes/{idOrName}`        |
 | Public REST lock/unlock           | Self-only design-session lock       | `POST /services/contenttypes/{idOrName}/lock` / `.../unlock` |
 | Public REST PUT save              | Held-lock save (label/description/…) | `PUT /services/contenttypes/{idOrName}`        |
+| Public REST icon strategy (CD-11) | GET/PUT none\|specified\|fromFileField | `GET/PUT /services/contenttypes/{idOrName}/icon` |
 | Public REST POST create           | Persist new type (Workbench Finish) | `POST /services/contenttypes`                  |
 | Public REST shared-field list     | CD-15 catalog (Admin only)          | `GET /services/sharedfields`                   |
 | Public REST shared-field detail   | CD-15 group fields (Admin only)     | `GET /services/sharedfields/{idOrName}`        |
@@ -75,6 +76,7 @@ slices.
 | Item-level pre/post exits & validations              | CD-09        | Properties tab                                    |
 | Edit workflow/template associations                  | CD-08, CD-12 | **CD-08 REST PUT .../allowedWorkflows** (#3763, held design lock); **CD-12 REST PUT .../allowedTemplates** (#3775, held design lock; full replace, empty list clears) |
 | Enable/disable as design action                      | CD-13        | **REST `PUT /contenttypes/{id}/enabled`** (#3773, held design lock; 409 without) |
+| Content type **icon strategy**                       | CD-11        | **REST `GET/PUT /contenttypes/{id}/icon`** (#3997, held design lock for PUT; `none` clears value; blank non-none value 400; no binary upload; SPA picker still Workbench) |
 | Shared field file **write**                          | CD-15        | **Group create/save/delete shipped** (`POST /services/sharedfields`, `PUT …/{idOrName}`, `DELETE …/{idOrName}`, #3944). **Field create/delete shipped** (`POST …/fields`, `DELETE …/fields/{fieldName}`, persistable `PSField` + display mapping, Admin 403, lock 409, #3954). Control/choice write and SPA editor still open |
 | System def **write** (existing field properties)     | CD-16        | **PUT `/services/systemdef` shipped** (#3958, Admin 403, lock 409). Field create/delete, control/stylesheet/flow, and SPA editor still SOAP |
 | Create / delete                                      | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Delete still SOAP design only; lock + PUT save via REST |

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -251,6 +251,8 @@ The chrome calls:
 | Lock | `POST /services/contenttypes/{idOrName}/lock` |
 | Save (label, description, fields) | `PUT /services/contenttypes/{idOrName}` (requires a held lock; does not send `enabled`, `allowedWorkflows`, or `allowedTemplates`) |
 | Enable / disable | `PUT /services/contenttypes/{idOrName}/enabled` (CD-13; requires a held lock; does not acquire or release it) |
+| Load icon strategy | `GET /services/contenttypes/{idOrName}/icon` (CD-11; no lock; `none` / `specified` / `fromFileField`) |
+| Set icon strategy | `PUT /services/contenttypes/{idOrName}/icon` (CD-11; Admin; held lock; `none` clears value; no binary upload; no SPA picker) |
 | Rename | `PUT /services/contenttypes/{idOrName}/name` (CD-01; Admin; held lock; unique name, no spaces; bulk PUT does not rename) |
 | Save allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` (requires a held lock; does not unlock) |
 | Replace allowed templates | `PUT /services/contenttypes/{idOrName}/allowedTemplates` (held lock; full replace) |

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -263,6 +263,8 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Save | `PUT /services/contenttypes/{idOrName}` | **Admin.** Requires a lock already held by the current user. Saves label, description, enabled, per-field searchable/occurrence, workflows, and templates. Does **not** change name (use `PUT .../name`). Does **not** release the lock. POST `/lock` and PUT share the packed NODEDEF design-object id so a lock you hold is found on save. The save load (`lock=true`) **extends** a still-valid lock; a PUT after expiry returns `409` and the client must re-lock. Field rule expressions use the dedicated path below (not this PUT). |
 | Allowed workflows | `PUT /services/contenttypes/{idOrName}/allowedWorkflows` | **Admin** (CD-08 design action). Requires a held design-session lock (`POST .../lock` first). Does **not** acquire or release the lock. Full replace of `allowedWorkflows` (empty list clears). Optional `defaultWorkflow`. Workflow name/guid must exist. `200` + `ContentTypeDetail` with the new `allowedWorkflows` / `defaultWorkflow` (lock still held). |
 | Enable/disable | `PUT /services/contenttypes/{idOrName}/enabled` | **Admin** (CD-13 design action). Requires a held design-session lock — `POST .../lock` first, then `PUT .../enabled`, then `POST .../unlock` when done. Does **not** acquire or release the lock. `200` + `ContentTypeDetail` with the new `enabled` value (lock still held). |
+| Icon strategy | `GET /services/contenttypes/{idOrName}/icon` | Content type icon source and value (CD-11). No lock required. `source` is `none`, `specified` (file path/name), or `fromFileField` (file field name). `none` has no value. Does **not** return icon binaries. Jackson root wrap is `ContentTypeIcon`. |
+| Set icon strategy | `PUT /services/contenttypes/{idOrName}/icon` | **Admin** (CD-11 design action). Requires a held design-session lock — `POST .../lock` first, then `PUT .../icon`, then `POST .../unlock` when done. Does **not** acquire or release the lock. `none` clears value. Non-`none` with a blank value is **400**. Invalid `source` is **400**. Does **not** upload icon binaries. `200` + `ContentTypeIcon` (lock still held). |
 | Rename | `PUT /services/contenttypes/{idOrName}/name` | **Admin** (CD-01). Requires a **held** design-session lock. Sets the internal name. Unique (case-insensitive); **no spaces** or wildcards. Bulk `PUT .../{idOrName}` does **not** change name. After success, `GET` by the previous name is **404**; `GET` by id returns the new name. Does not acquire or release the lock. |
 | Add local field | `POST /services/contenttypes/{idOrName}/fields` | **Admin** (CD-03). Requires a **held** design-session lock. Adds a persistable **local** field (backend column + display mapping) via `IPSContentDesignWs.saveContentTypes`. Body `name` is required (letter, then letters/digits/underscore; unique case-insensitive on the type). Optional `dataType` defaults to `text`. Optional `searchable` and `occurrence`/`required` use the same rules as PUT field patches. Optional `fieldSet` names an existing child field set, or **creates** a named complex child when missing. Duplicate field is **409**. System/shared inclusion is out of scope (CD-04). Does not acquire or release the lock. |
 | Delete local field | `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}` | **Admin** (CD-03). Requires a **held** design-session lock. Removes a **local** field and its display mapping. System/shared fields are **400**. Missing type or field is **404**. Does not acquire or release the lock. `204` on success (lock still held). |
@@ -273,15 +275,15 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 | Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Icon strategy is REST-only: **lock → PUT .../icon → unlock** (no SPA picker; no binary upload). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07); choice catalogs stay read-only in that chrome. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
 
 Lock / save / unlock / create / rename / delete status codes:
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / rename succeeded (lock still held), POST create succeeded (`ContentTypeDetail`), or POST local field succeeded |
+| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / icon / rename succeeded (lock still held), POST create succeeded (`ContentTypeDetail`), or POST local field succeeded |
 | `204` | Unlock success, content type deleted, or local field deleted |
-| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid or colliding rename), invalid create name (blank, spaces, wildcard), invalid local-field name/`dataType`/origin, DELETE field of a system/shared field, or DELETE type rejected because the type has dependents |
+| `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` flag, invalid icon `source` or blank non-none icon `value`, invalid or colliding rename), invalid create name (blank, spaces, wildcard), invalid local-field name/`dataType`/origin, DELETE field of a system/shared field, or DELETE type rejected because the type has dependents |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found |
 | `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time), including reserved system types such as Folder; POST local field when the field name already exists on the type |
@@ -361,6 +363,44 @@ Jackson root wrap:
 {
   "ContentTypeEnabled": {
     "enabled": false
+  }
+}
+```
+
+### Icon strategy (CD-11)
+
+`GET /services/contenttypes/{idOrName}/icon` reads the content type **icon
+strategy**. `PUT /services/contenttypes/{idOrName}/icon` sets it. This is a
+dedicated design action (Workbench Properties tab: None / Specified file /
+From File Field). Bulk `PUT /services/contenttypes/{idOrName}` does **not**
+change the icon. There is no SPA icon picker and no binary upload on this
+path — `value` is a file path/name or a file field name only.
+
+Hold the design-session lock first for PUT; save keeps the lock so you can
+continue editing, then unlock.
+
+Typical flow: `POST .../lock` → `PUT .../icon` → (optional further design
+writes) → `POST .../unlock`. `GET .../icon` does not require a lock.
+
+`source` values:
+
+| `source` | `value` | Meaning |
+|----------|---------|---------|
+| `none` | omitted / empty (cleared) | No content-type icon |
+| `specified` | required file path or name | Use that icon file |
+| `fromFileField` | required file field name | Derive the icon from that file field's extension |
+
+A blank `value` when `source` is not `none` is **400**. An unknown `source` is
+**400**. An unlocked type (or a lock held by another user) is **409** — the
+lock is not stolen. Missing types are **404**. Non-Admin PUT is **403**.
+
+Jackson root wrap:
+
+```json
+{
+  "ContentTypeIcon": {
+    "source": "specified",
+    "value": "rx_resources/images/ContentTypeIcons/page.gif"
   }
 }
 ```

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -778,7 +778,7 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
         return null;
       }
       IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
-      requireHeldLock(ctGuid);
+      requireHeldLock(ctGuid, "Could not set content type icon");
       List<PSItemDefinition> locked;
       try {
         locked =

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -73,6 +73,7 @@ import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
 import com.percussion.rest.contenttypes.ContentTypeFieldRule;
 import com.percussion.rest.contenttypes.ContentTypeFieldRuleExpressions;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
+import com.percussion.rest.contenttypes.ContentTypeIcon;
 import com.percussion.rest.contenttypes.ContentTypeItemExit;
 import com.percussion.rest.contenttypes.ContentTypeItemExitParam;
 import com.percussion.rest.contenttypes.ContentTypeItemExits;
@@ -324,8 +325,8 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
    *
    * @param includeDisabledFromStore when {@code true}, a cache miss falls back to the
    *     object store so disabled types (unregistered from the editor cache) still load.
-   *     GET detail, enable/disable (CD-13), and DELETE pass {@code true}; other callers keep
-   *     the pre-CD-13 cache-only 404 for disabled types.
+   *     GET detail, enable/disable (CD-13), GET/PUT icon (CD-11), and DELETE pass {@code true};
+   *     other callers keep the pre-CD-13 cache-only 404 for disabled types.
    */
   private PSItemDefinition resolveItemDef(String idOrName, boolean includeDisabledFromStore)
       throws PSInvalidContentTypeException {
@@ -472,6 +473,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
             "CT_TEMPLATE_ASSOC_SAVE_ORDER",
             "Template association save is a separate design write after content-type save; if it"
                 + " fails, meta/field/workflow changes may already be committed"));
+    gaps.add(
+        DesignGap.of(
+            "CT_ICON_STRATEGY",
+            "Icon strategy: GET/PUT /contenttypes/{idOrName}/icon (held lock for write)."
+                + " source none|specified|fromFileField. none clears value. Binary upload and"
+                + " SPA picker remain Workbench"));
     gaps.add(
         DesignGap.of(
             "CT_FIELD_LABELS_WRITE",
@@ -723,6 +730,142 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       log.error("Failed to enable/disable content type {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to enable/disable content type", e);
     }
+  }
+
+  @Override
+  public ContentTypeIcon getContentTypeIcon(URI baseUri, String idOrName) {
+    if (StringUtils.isBlank(idOrName)) {
+      return null;
+    }
+    try {
+      PSItemDefinition def = resolveItemDef(idOrName.trim(), true);
+      if (def == null) {
+        return null;
+      }
+      return toIcon(def.getContentEditor());
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for icon: {}", idOrName);
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to load content type icon {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to load content type icon", e);
+    }
+  }
+
+  @Override
+  public ContentTypeIcon setContentTypeIcon(
+      URI baseUri, String idOrName, String source, String value) {
+    requireAdmin();
+    requireSessionUserForLock();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String soapSource = toSoapIconSource(source);
+    String persistValue =
+        PSContentEditor.ICON_SOURCE_NONE.equals(soapSource) ? "" : StringUtils.trimToEmpty(value);
+    if (!PSContentEditor.ICON_SOURCE_NONE.equals(soapSource) && StringUtils.isBlank(persistValue)) {
+      throw new IllegalArgumentException("value is required when source is not none");
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      PSItemDefinition current = resolveItemDef(trimmed, true);
+      if (current == null) {
+        return null;
+      }
+      IPSGuid ctGuid = new PSGuid(PSTypeEnum.NODEDEF, current.getTypeId());
+      requireHeldLock(ctGuid);
+      List<PSItemDefinition> locked;
+      try {
+        locked =
+            designSvc.loadContentTypes(
+                Collections.singletonList(ctGuid), true, false, session, user);
+      } catch (PSErrorResultsException e) {
+        throw lockConflict(e, "Could not set content type icon");
+      }
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = locked.get(0);
+      PSContentEditor editor = def.getContentEditor();
+      if (editor == null) {
+        throw new IllegalArgumentException("content type has no content editor");
+      }
+      editor.setContentTypeIcon(soapSource, persistValue);
+      try {
+        designSvc.saveContentTypes(Collections.singletonList(def), false, session, user);
+      } catch (PSErrorsException e) {
+        if (hasLockError(e.getErrors())) {
+          throw lockConflict(e, "Could not set content type icon");
+        }
+        log.error("Failed to save content type icon {}: {}", idOrName, e.getMessage(), e);
+        throw new IllegalStateException("Failed to save content type icon", e);
+      }
+      PSItemDefinition reloaded = reloadItemDef(trimmed);
+      if (reloaded != null && reloaded.getContentEditor() != null) {
+        return toIcon(reloaded.getContentEditor());
+      }
+      return toIcon(editor);
+    } catch (ContentTypeDesignLockException
+        | IllegalArgumentException
+        | WebApplicationException e) {
+      throw e;
+    } catch (PSInvalidContentTypeException e) {
+      log.debug("Content type not found for icon: {}", idOrName);
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to set content type icon {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to set content type icon", e);
+    }
+  }
+
+  /**
+   * Maps a REST icon source to the object-store {@link PSContentEditor} codes.
+   *
+   * @param source {@code none}, {@code specified}, or {@code fromFileField}
+   * @return SOAP {@code ICON_SOURCE_*} value
+   */
+  static String toSoapIconSource(String source) {
+    if (StringUtils.isBlank(source)) {
+      throw new IllegalArgumentException("source is required");
+    }
+    String trimmed = source.trim();
+    if (ContentTypeIcon.SOURCE_NONE.equalsIgnoreCase(trimmed)) {
+      return PSContentEditor.ICON_SOURCE_NONE;
+    }
+    if (ContentTypeIcon.SOURCE_SPECIFIED.equalsIgnoreCase(trimmed)) {
+      return PSContentEditor.ICON_SOURCE_SPECIFIED;
+    }
+    if (ContentTypeIcon.SOURCE_FROM_FILE_FIELD.equalsIgnoreCase(trimmed)) {
+      return PSContentEditor.ICON_SOURCE_FROMFILEEXT;
+    }
+    throw new IllegalArgumentException("source must be none, specified, or fromFileField");
+  }
+
+  /**
+   * Maps a content editor icon to the REST envelope. Missing editor is {@code none}.
+   *
+   * @param editor may be {@code null}
+   * @return envelope, never {@code null}
+   */
+  static ContentTypeIcon toIcon(PSContentEditor editor) {
+    if (editor == null) {
+      return new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, null);
+    }
+    String soap = editor.getIconSource();
+    if (PSContentEditor.ICON_SOURCE_SPECIFIED.equals(soap)) {
+      return new ContentTypeIcon(
+          ContentTypeIcon.SOURCE_SPECIFIED, StringUtils.trimToNull(editor.getIconValue()));
+    }
+    if (PSContentEditor.ICON_SOURCE_FROMFILEEXT.equals(soap)) {
+      return new ContentTypeIcon(
+          ContentTypeIcon.SOURCE_FROM_FILE_FIELD, StringUtils.trimToNull(editor.getIconValue()));
+    }
+    return new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, null);
   }
 
   @Override

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorIconTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorIconTest.java
@@ -163,6 +163,8 @@ class ContentTypeAdaptorIconTest {
             () ->
                 adaptor.setContentTypeIcon(
                     null, "311", ContentTypeIcon.SOURCE_SPECIFIED, "page.gif"));
+    assertTrue(
+        ex.getMessage().startsWith("Could not set content type icon"), ex.getMessage());
     assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
     verify(designWs, never()).loadContentTypes(anyList(), eq(true), anyBoolean(), any(), any());
     verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
@@ -181,6 +183,8 @@ class ContentTypeAdaptorIconTest {
             () ->
                 adaptor.setContentTypeIcon(
                     null, "311", ContentTypeIcon.SOURCE_SPECIFIED, "page.gif"));
+    assertTrue(
+        ex.getMessage().startsWith("Could not set content type icon"), ex.getMessage());
     assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
     verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
   }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorIconTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorIconTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSInvalidContentTypeException;
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.design.objectstore.PSContentEditor;
+import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeIcon;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * CD-11 icon strategy requires a held design-session lock on PUT and persists via {@code
+ * PSContentEditor.setContentTypeIcon}.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorIconTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+  private ContentTypeAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+    adaptor = new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+    guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  @Test
+  void specified_persistsFileWhenLockHeld() throws Exception {
+    stubHeldLock();
+    PSContentEditor editor = stubDefinition(PSContentEditor.ICON_SOURCE_NONE, null);
+
+    ContentTypeIcon out =
+        adaptor.setContentTypeIcon(
+            null, "311", ContentTypeIcon.SOURCE_SPECIFIED, "rx_resources/images/page.gif");
+
+    assertEquals(ContentTypeIcon.SOURCE_SPECIFIED, out.getSource());
+    assertEquals("rx_resources/images/page.gif", out.getValue());
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSItemDefinition>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveContentTypes(saved.capture(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    verify(editor)
+        .setContentTypeIcon(
+            PSContentEditor.ICON_SOURCE_SPECIFIED, "rx_resources/images/page.gif");
+  }
+
+  @Test
+  void fromFileField_persistsFieldNameWhenLockHeld() throws Exception {
+    stubHeldLock();
+    PSContentEditor editor = stubDefinition(PSContentEditor.ICON_SOURCE_NONE, null);
+
+    ContentTypeIcon out =
+        adaptor.setContentTypeIcon(
+            null, "311", ContentTypeIcon.SOURCE_FROM_FILE_FIELD, "item_file_attachment");
+
+    assertEquals(ContentTypeIcon.SOURCE_FROM_FILE_FIELD, out.getSource());
+    assertEquals("item_file_attachment", out.getValue());
+    verify(editor)
+        .setContentTypeIcon(PSContentEditor.ICON_SOURCE_FROMFILEEXT, "item_file_attachment");
+  }
+
+  @Test
+  void none_clearsValueWhenLockHeld() throws Exception {
+    stubHeldLock();
+    PSContentEditor editor =
+        stubDefinition(PSContentEditor.ICON_SOURCE_SPECIFIED, "rx_resources/images/page.gif");
+
+    ContentTypeIcon out =
+        adaptor.setContentTypeIcon(null, "311", ContentTypeIcon.SOURCE_NONE, "ignored.gif");
+
+    assertEquals(ContentTypeIcon.SOURCE_NONE, out.getSource());
+    assertNull(out.getValue());
+    verify(editor).setContentTypeIcon(PSContentEditor.ICON_SOURCE_NONE, "");
+  }
+
+  @Test
+  void get_reflectsIconAfterSpecifiedPut() throws Exception {
+    stubHeldLock();
+    stubDefinition(PSContentEditor.ICON_SOURCE_NONE, null);
+
+    ContentTypeIcon saved =
+        adaptor.setContentTypeIcon(
+            null, "311", ContentTypeIcon.SOURCE_SPECIFIED, "rx_resources/images/page.gif");
+    assertEquals(ContentTypeIcon.SOURCE_SPECIFIED, saved.getSource());
+
+    ContentTypeIcon get = adaptor.getContentTypeIcon(null, "311");
+    assertEquals(ContentTypeIcon.SOURCE_SPECIFIED, get.getSource());
+    assertEquals("rx_resources/images/page.gif", get.getValue());
+  }
+
+  @Test
+  void put_conflictWhenLockNotHeld() throws Exception {
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(Collections.singletonList(null));
+    stubDefinition(PSContentEditor.ICON_SOURCE_NONE, null);
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () ->
+                adaptor.setContentTypeIcon(
+                    null, "311", ContentTypeIcon.SOURCE_SPECIFIED, "page.gif"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(true), anyBoolean(), any(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_conflictWhenLockedByOtherUser() throws Exception {
+    PSObjectSummary other = new PSObjectSummary(guid, "percPage");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+    stubDefinition(PSContentEditor.ICON_SOURCE_NONE, null);
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () ->
+                adaptor.setContentTypeIcon(
+                    null, "311", ContentTypeIcon.SOURCE_SPECIFIED, "page.gif"));
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_conflictWhenLockedInAnotherSession() throws Exception {
+    stubHeldLock();
+    stubDefinition(PSContentEditor.ICON_SOURCE_NONE, null);
+    PSErrorResultsException errors = new PSErrorResultsException();
+    errors.addError(
+        guid, new PSLockErrorException(1, "LOCK_EXTENSION_INVALID_SESSION", "stack", "Admin", 12));
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenThrow(errors);
+
+    ContentTypeDesignLockException ex =
+        assertThrows(
+            ContentTypeDesignLockException.class,
+            () ->
+                adaptor.setContentTypeIcon(
+                    null, "311", ContentTypeIcon.SOURCE_SPECIFIED, "page.gif"));
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_unknownName_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.setContentTypeIcon(null, "missing", ContentTypeIcon.SOURCE_NONE, null));
+    verify(systemDesign, never()).isLocked(anyList(), any());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void get_unknownName_returnsNull() throws Exception {
+    when(itemDefManager.getItemDef("missing", PSItemDefManager.COMMUNITY_ANY))
+        .thenThrow(new PSInvalidContentTypeException("missing"));
+    assertNull(adaptor.getContentTypeIcon(null, "missing"));
+  }
+
+  @Test
+  void put_forbiddenWhenNotAdmin() {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                denied.setContentTypeIcon(
+                    null, "311", ContentTypeIcon.SOURCE_SPECIFIED, "page.gif"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void put_invalidSource_isBadRequest() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.setContentTypeIcon(null, "311", "unknown", "page.gif"));
+    assertTrue(ex.getMessage().toLowerCase().contains("source"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_blankValueForSpecified_isBadRequest() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                adaptor.setContentTypeIcon(
+                    null, "311", ContentTypeIcon.SOURCE_SPECIFIED, "  "));
+    assertTrue(ex.getMessage().toLowerCase().contains("value"), ex.getMessage());
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_wildcardName_isBadRequest() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> adaptor.setContentTypeIcon(null, "perc*", ContentTypeIcon.SOURCE_NONE, null));
+    verify(designWs, never()).saveContentTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void get_missingEditor_isNone() throws Exception {
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getContentEditor()).thenReturn(null);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+
+    ContentTypeIcon out = adaptor.getContentTypeIcon(null, "311");
+    assertEquals(ContentTypeIcon.SOURCE_NONE, out.getSource());
+    assertNull(out.getValue());
+  }
+
+  @Test
+  void get_cacheMiss_usesObjectStoreFallback() throws Exception {
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY)))
+        .thenThrow(new PSInvalidContentTypeException("311"));
+    PSItemDefinition storeDef = stubStoreDefinition(PSContentEditor.ICON_SOURCE_NONE, null);
+    ContentTypeAdaptor spy = spy(adaptor);
+    doReturn(storeDef).when(spy).loadItemDefFromObjectStore("311");
+
+    ContentTypeIcon get = spy.getContentTypeIcon(null, "311");
+
+    assertEquals(ContentTypeIcon.SOURCE_NONE, get.getSource());
+    verify(spy).loadItemDefFromObjectStore("311");
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "percPage");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+
+  private PSContentEditor stubDefinition(String soapSource, String soapValue) throws Exception {
+    PSItemDefinition def = stubStoreDefinition(soapSource, soapValue);
+    when(itemDefManager.getItemDef(eq(311L), eq(PSItemDefManager.COMMUNITY_ANY))).thenReturn(def);
+    when(designWs.loadContentTypes(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(def));
+    return def.getContentEditor();
+  }
+
+  private PSItemDefinition stubStoreDefinition(String soapSource, String soapValue) {
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn("percPage");
+    when(def.getLabel()).thenReturn("Page");
+    when(def.getDescription()).thenReturn("desc");
+    when(def.isEnabled()).thenReturn(true);
+    when(def.isHidden()).thenReturn(false);
+    when(def.getAppName()).thenReturn("rx_cePage");
+    when(def.getEditorUrl()).thenReturn("/Rhythmyx/rx_cePage/percPage.html");
+    when(def.getTypeId()).thenReturn(311);
+    when(def.getFieldSet()).thenReturn(null);
+    PSContentEditor editor = mock(PSContentEditor.class);
+    when(editor.getIconSource()).thenReturn(soapSource);
+    when(editor.getIconValue()).thenReturn(soapValue);
+    doAnswer(
+            inv -> {
+              when(editor.getIconSource()).thenReturn(inv.getArgument(0));
+              String persisted = inv.getArgument(1);
+              when(editor.getIconValue())
+                  .thenReturn(
+                      PSContentEditor.ICON_SOURCE_NONE.equals(inv.getArgument(0))
+                          ? null
+                          : persisted);
+              return null;
+            })
+        .when(editor)
+        .setContentTypeIcon(any(), any());
+    when(def.getContentEditor()).thenReturn(editor);
+    return def;
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -42,6 +42,15 @@ class DesignGapsStructuredTest {
     assertTrue(codes.contains("CT_ITEM_EXITS"));
     assertTrue(codes.contains("CT_CREATE_DELETE"));
     assertTrue(codes.contains("CT_FIELD_CREATE_DELETE"));
+    assertTrue(codes.contains("CT_ICON_STRATEGY"));
+    assertTrue(
+        gaps.stream()
+            .anyMatch(
+                g ->
+                    "CT_ICON_STRATEGY".equals(g.getCode())
+                        && g.getMessage().contains("/icon")
+                        && g.getMessage().toLowerCase().contains("held")),
+        () -> gaps.toString());
     assertTrue(
         gaps.stream()
             .anyMatch(

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeIcon.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeIcon.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Content type icon strategy (CD-11).
+ *
+ * <p>{@code source} is {@code none}, {@code specified} (file path/name), or {@code fromFileField}
+ * (file field name). {@code none} clears {@code value}. Non-{@code none} requires a non-blank
+ * value. This envelope is path/name only — it does not upload icon binaries.
+ *
+ * <p>Jackson root wrap is {@code ContentTypeIcon} ({@code WRAP_ROOT_VALUE} / {@code
+ * UNWRAP_ROOT_VALUE}).
+ */
+@XmlRootElement(name = "ContentTypeIcon")
+@JsonRootName("ContentTypeIcon")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Content type icon strategy (none, specified file, or from file field)")
+public class ContentTypeIcon {
+
+  /** No icon. Value is cleared. */
+  public static final String SOURCE_NONE = "none";
+
+  /** Icon is a specified file path or name. */
+  public static final String SOURCE_SPECIFIED = "specified";
+
+  /** Icon is derived from a file field (extension). */
+  public static final String SOURCE_FROM_FILE_FIELD = "fromFileField";
+
+  @Schema(
+      required = true,
+      description = "Icon source: none, specified, or fromFileField",
+      allowableValues = {SOURCE_NONE, SOURCE_SPECIFIED, SOURCE_FROM_FILE_FIELD})
+  private String source;
+
+  @Schema(
+      description =
+          "Specified file path/name, or file field name. Omitted/empty when source is none.")
+  private String value;
+
+  public ContentTypeIcon() {}
+
+  public ContentTypeIcon(String source, String value) {
+    this.source = source;
+    this.value = value;
+  }
+
+  /**
+   * Returns whether {@code source} is one of the REST icon sources (case-insensitive).
+   *
+   * @param source candidate source, may be {@code null}
+   * @return {@code true} when {@code none}, {@code specified}, or {@code fromFileField}
+   */
+  public static boolean isKnownSource(String source) {
+    if (source == null) {
+      return false;
+    }
+    String trimmed = source.trim();
+    return SOURCE_NONE.equalsIgnoreCase(trimmed)
+        || SOURCE_SPECIFIED.equalsIgnoreCase(trimmed)
+        || SOURCE_FROM_FILE_FIELD.equalsIgnoreCase(trimmed);
+  }
+
+  /**
+   * Returns whether {@code source} is {@code none} (case-insensitive).
+   *
+   * @param source candidate source, may be {@code null}
+   * @return {@code true} when source is none
+   */
+  public static boolean isNone(String source) {
+    return source != null && SOURCE_NONE.equalsIgnoreCase(source.trim());
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  public void setSource(String source) {
+    this.source = source;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -1115,6 +1115,94 @@ public class ContentTypesResource {
     }
   }
 
+  @GET
+  @Path("/{idOrName}/icon")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Get content type icon strategy",
+      description =
+          "CD-11 GET: icon source (none, specified, fromFileField) and value (file path/name or"
+              + " field name). No design lock is required. none has no value. Does not return"
+              + " icon binaries. Jackson root wrap is ContentTypeIcon.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK",
+            content = @Content(schema = @Schema(implementation = ContentTypeIcon.class))),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeIcon getContentTypeIcon(@PathParam("idOrName") String idOrName) {
+    try {
+      ContentTypeIcon out = requireAdaptor().getContentTypeIcon(uriInfo.getBaseUri(), idOrName);
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}/icon")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Set content type icon strategy",
+      description =
+          "CD-11 design action: sets icon source (none, specified, fromFileField) and value."
+              + " Admin only. Requires a design-session lock already held by the current user"
+              + " (POST .../lock). Does not acquire or release the lock. none clears value."
+              + " Non-none with a blank value is 400. Does not upload icon binaries. GET"
+              + " .../icon reflects the strategy after a successful PUT. Jackson root wrap is"
+              + " ContentTypeIcon.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated (lock is still held)",
+            content = @Content(schema = @Schema(implementation = ContentTypeIcon.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "source is required, invalid, or non-none value is blank"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Design lock required, or locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ContentTypeIcon setContentTypeIcon(
+      @PathParam("idOrName") String idOrName, ContentTypeIcon body) {
+    if (body == null || body.getSource() == null || body.getSource().trim().isEmpty()) {
+      throw new WebApplicationException("source is required", 400);
+    }
+    String source = body.getSource().trim();
+    if (!ContentTypeIcon.isKnownSource(source)) {
+      throw new WebApplicationException(
+          "source must be none, specified, or fromFileField", 400);
+    }
+    if (!ContentTypeIcon.isNone(source)
+        && (body.getValue() == null || body.getValue().trim().isEmpty())) {
+      throw new WebApplicationException("value is required when source is not none", 400);
+    }
+    try {
+      ContentTypeIcon out =
+          requireAdaptor()
+              .setContentTypeIcon(uriInfo.getBaseUri(), idOrName, source, body.getValue());
+      if (out == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (RuntimeException e) {
+      throw mapEnabledFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
   @PUT
   @Path("/{idOrName}/name")
   @Consumes({MediaType.APPLICATION_JSON})

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -141,6 +141,32 @@ public interface IContentTypesAdaptor {
   ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled);
 
   /**
+   * Load the content type icon strategy (CD-11). No design lock is required. {@code none} has no
+   * value. {@code specified} is a file path/name. {@code fromFileField} is a file field name.
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or internal name
+   * @return icon envelope, or {@code null} when not found
+   */
+  ContentTypeIcon getContentTypeIcon(URI baseUri, String idOrName);
+
+  /**
+   * Set the content type icon strategy (CD-11). Requires a design-session lock already held by the
+   * current user. Does not acquire or release the lock. {@code none} clears value. Non-{@code
+   * none} with a blank value is invalid. Does not upload icon binaries.
+   *
+   * @param baseUri requesting URI
+   * @param idOrName content type uuid (numeric) or internal name
+   * @param source {@code none}, {@code specified}, or {@code fromFileField}
+   * @param value file path/name or field name; ignored when source is {@code none}
+   * @return persisted icon envelope, or {@code null} when not found
+   * @throws ContentTypeDesignLockException when no lock is held or the lock is owned by another
+   *     user
+   * @throws IllegalArgumentException when source is invalid or a non-none value is blank
+   */
+  ContentTypeIcon setContentTypeIcon(URI baseUri, String idOrName, String source, String value);
+
+  /**
    * Rename a content type (CD-01). Requires a design-session lock already held by the current
    * user. Does not acquire or release the lock. Bulk {@link #updateContentType} does not change
    * name. After a successful rename, GET by the previous name is not found; GET by id returns the

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
@@ -1042,6 +1043,162 @@ public class ContentTypesResourceDetailTest {
             WebApplicationException.class,
             () -> resource.renameContentType("percPage", new ContentTypeName("percRenamed")));
     assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getContentTypeIconReturnsEnvelope() {
+    ContentTypeIcon icon =
+        new ContentTypeIcon(ContentTypeIcon.SOURCE_SPECIFIED, "rx_resources/images/page.gif");
+    when(adaptor.getContentTypeIcon(any(), eq("percPage"))).thenReturn(icon);
+    ContentTypeIcon out = resource.getContentTypeIcon("percPage");
+    assertEquals(ContentTypeIcon.SOURCE_SPECIFIED, out.getSource());
+    assertEquals("rx_resources/images/page.gif", out.getValue());
+  }
+
+  @Test
+  public void getContentTypeIconNotFound() {
+    when(adaptor.getContentTypeIcon(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getContentTypeIcon("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setContentTypeIconSuccess() {
+    ContentTypeIcon body =
+        new ContentTypeIcon(ContentTypeIcon.SOURCE_SPECIFIED, "rx_resources/images/page.gif");
+    when(adaptor.setContentTypeIcon(
+            any(), eq("percPage"), eq(ContentTypeIcon.SOURCE_SPECIFIED), eq(body.getValue())))
+        .thenReturn(body);
+    ContentTypeIcon out = resource.setContentTypeIcon("percPage", body);
+    assertEquals(ContentTypeIcon.SOURCE_SPECIFIED, out.getSource());
+    assertEquals("rx_resources/images/page.gif", out.getValue());
+  }
+
+  @Test
+  public void setContentTypeIconFromFileFieldSuccess() {
+    ContentTypeIcon body =
+        new ContentTypeIcon(ContentTypeIcon.SOURCE_FROM_FILE_FIELD, "item_file_attachment");
+    when(adaptor.setContentTypeIcon(
+            any(),
+            eq("percPage"),
+            eq(ContentTypeIcon.SOURCE_FROM_FILE_FIELD),
+            eq("item_file_attachment")))
+        .thenReturn(body);
+    ContentTypeIcon out = resource.setContentTypeIcon("percPage", body);
+    assertEquals(ContentTypeIcon.SOURCE_FROM_FILE_FIELD, out.getSource());
+    assertEquals("item_file_attachment", out.getValue());
+  }
+
+  @Test
+  public void setContentTypeIconNoneClearsValue() {
+    ContentTypeIcon body = new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, "ignored.gif");
+    ContentTypeIcon saved = new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, null);
+    when(adaptor.setContentTypeIcon(
+            any(), eq("percPage"), eq(ContentTypeIcon.SOURCE_NONE), eq("ignored.gif")))
+        .thenReturn(saved);
+    ContentTypeIcon out = resource.setContentTypeIcon("percPage", body);
+    assertEquals(ContentTypeIcon.SOURCE_NONE, out.getSource());
+    assertEquals(null, out.getValue());
+  }
+
+  @Test
+  public void setContentTypeIconRequiresSource() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.setContentTypeIcon("percPage", new ContentTypeIcon()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setContentTypeIconInvalidSource400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeIcon(
+                    "percPage", new ContentTypeIcon("unknown", "page.gif")));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setContentTypeIconBlankValue400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeIcon(
+                    "percPage", new ContentTypeIcon(ContentTypeIcon.SOURCE_SPECIFIED, "  ")));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setContentTypeIconNotFound() {
+    when(adaptor.setContentTypeIcon(
+            any(), eq("missing"), eq(ContentTypeIcon.SOURCE_NONE), nullable(String.class)))
+        .thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeIcon(
+                    "missing", new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, null)));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setContentTypeIconRequiresLock() {
+    when(adaptor.setContentTypeIcon(
+            any(), eq("percPage"), eq(ContentTypeIcon.SOURCE_NONE), nullable(String.class)))
+        .thenThrow(
+            new ContentTypeDesignLockException("Could not set content type icon; design lock required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeIcon(
+                    "percPage", new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, null)));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setContentTypeIconLockedByOtherUser() {
+    when(adaptor.setContentTypeIcon(
+            any(), eq("percPage"), eq(ContentTypeIcon.SOURCE_NONE), nullable(String.class)))
+        .thenThrow(
+            new ContentTypeDesignLockException("Could not set content type icon; locked by editor2"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeIcon(
+                    "percPage", new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, null)));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void setContentTypeIconForbiddenWhenNotAdmin() {
+    when(adaptor.setContentTypeIcon(
+            any(), eq("percPage"), eq(ContentTypeIcon.SOURCE_NONE), nullable(String.class)))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () ->
+                resource.setContentTypeIcon(
+                    "percPage", new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, null)));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void contentTypeIconJsonSerializesSourceAndValue() throws Exception {
+    ContentTypeIcon icon =
+        new ContentTypeIcon(ContentTypeIcon.SOURCE_FROM_FILE_FIELD, "item_file_attachment");
+    ObjectMapper mapper = new JacksonContextResolver().getContext(ContentTypeIcon.class);
+    String json = mapper.writeValueAsString(icon);
+    assertTrue(json.contains("fromFileField"), json);
+    assertTrue(json.contains("item_file_attachment"), json);
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -106,6 +106,17 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
   }
 
   @Override
+  public ContentTypeIcon getContentTypeIcon(URI baseUri, String idOrName) {
+    return new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, null);
+  }
+
+  @Override
+  public ContentTypeIcon setContentTypeIcon(
+      URI baseUri, String idOrName, String source, String value) {
+    return new ContentTypeIcon(source, ContentTypeIcon.isNone(source) ? null : value);
+  }
+
+  @Override
   public ContentTypeDetail renameContentType(URI baseUri, String idOrName, String newName) {
     return null;
   }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -28,6 +28,7 @@ import com.percussion.rest.contenttypes.ContentTypeField;
 import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
 import com.percussion.rest.contenttypes.ContentTypeFieldRuleExpressions;
 import com.percussion.rest.contenttypes.ContentTypeFilter;
+import com.percussion.rest.contenttypes.ContentTypeIcon;
 import com.percussion.rest.contenttypes.ContentTypeItemExits;
 import com.percussion.rest.contenttypes.IContentTypesAdaptor;
 import com.percussion.rest.contenttypes.NamedObjectRef;
@@ -123,6 +124,17 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   @Override
   public ContentTypeDetail setContentTypeEnabled(URI baseUri, String idOrName, boolean enabled) {
     return null;
+  }
+
+  @Override
+  public ContentTypeIcon getContentTypeIcon(URI baseUri, String idOrName) {
+    return new ContentTypeIcon(ContentTypeIcon.SOURCE_NONE, null);
+  }
+
+  @Override
+  public ContentTypeIcon setContentTypeIcon(
+      URI baseUri, String idOrName, String source, String value) {
+    return new ContentTypeIcon(source, ContentTypeIcon.isNone(source) ? null : value);
   }
 
   @Override


### PR DESCRIPTION
## Summary

Parent: #1690 (FR CD-11). Slice: #3997.

Adds Admin REST **GET/PUT** `/services/contenttypes/{idOrName}/icon` for the Workbench Properties **icon strategy**:

| `source` | `value` |
|----------|---------|
| `none` | cleared |
| `specified` | file path/name |
| `fromFileField` | file field name |

PUT requires a **held** design-session lock (`POST .../lock`) and does **not** steal. `none` clears value. Non-`none` with a blank value is **400**. Invalid source is **400**. Non-Admin PUT is **403**. Unknown type is **404**. Lock conflict is **409**.

Persist via existing `IPSContentDesignWs` + `PSContentEditor.setContentTypeIcon`. No new SOAP methods. No SPA chrome. No binary upload.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #3997
Parent tracker: #1690

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 769, Failures: 0)
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 1799, Failures: 0, Skipped: 125)
3. Mockito: `ContentTypesResourceDetailTest` GET/PUT success, none clears, invalid source 400, blank value 400, 403/404/409
4. Adaptor: `ContentTypeAdaptorIconTest` specified / fromFileField / none, GET round-trip, 403, lock 409, unknown 404, invalid source 400
5. Spring `TestContentTypeAdaptor` stub on rest test classpath (MainTest companions)
6. Integrator: `POST .../lock` → `PUT .../icon` with `ContentTypeIcon` → `GET .../icon` → `POST .../unlock`

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/` (`product-docs/8.2/developer/rest.md` CD-11 GET/PUT; `product-docs/8.2/admin/developer-content-types.md` REST table). Gap map CD-11 in `docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md`.
- [x] **Unit / module tests** — behavioral tests for resource + adaptor; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST-only, no SPA picker)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-dep `projects/sitemanage` after public `IContentTypesAdaptor` methods added
- [x] **Cross-platform** — N/A (no path/file I/O; icon value is an object-store string)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 769, Failures: 0 (`ContentTypesResourceDetailTest` 104)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1799, Failures: 0, Skipped: 125 (`ContentTypeAdaptorIconTest` 15)
- **downstream_checked:** grep `implements IContentTypesAdaptor` — 3 types (ContentTypeAdaptor + two rest test stubs), all updated; no anonymous subclasses; sitemanage standalone clean install after rest install

### C5 UI proof

N/A — no WebUI / Playwright surface. Icon strategy is REST-only (no SPA).

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
