### PR TITLE
feat(rest): AS-01 Admin POST/DELETE slots (#4006)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-4006-slot-create-delete-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4006-slot-create-delete-erlang.md
@@ -1,0 +1,28 @@
+# Erlang review — issue #4006 REST AS-01 slot create/delete
+
+**Branch:** `feat/issue-4006-slot-create-delete`  
+**Base:** `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class completeness (rest resource + adaptor interface + Spring test stub + sitemanage impl + adaptor tests + product-docs); Admin 403 / duplicate 409 peers from content-type POST/DELETE
+
+## Summary
+
+Admin REST `POST /services/slots` and `DELETE /services/slots/{idOrName}` via existing `IPSAssemblyDesignWs.createSlots` / `saveSlots` / `deleteSlots`. No new SOAP. `SLOT_CREATE_DELETE` retired; remainder gap `SLOT_FINDER_RELATIONSHIP_WRITE`. No SPA; no finder/relationship write.
+
+## Gate
+
+- Bugs: none found
+- Behavioral tests: rest Mockito resource (32) + Spring `TestSlotsAdaptor` stub + sitemanage adaptor create/delete (17)
+- Cross-platform paths: N/A (no filesystem I/O)
+- Change-class companions: complete
+
+## Issues
+
+None.
+
+## Build
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 769, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1729, Failures: 0
+- Downstream: `ISlotsAdaptor` added methods; only implementers are `SlotsAdaptor` and `TestSlotsAdaptor` (both updated); sitemanage clean install green

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -232,7 +232,25 @@ Assembly **slots** used by **Developer → Slots** are exposed under `/services/
 |--------|------|---------|
 | `GET` | `/services/slots` | List slot summaries (label, name, description) |
 | `GET` | `/services/slots/{idOrName}` | Design detail (finder, associations, `designGaps`) |
-| `PUT` | `/services/slots/{idOrName}` | Update label, description, and/or content-type/template associations |
+| `PUT` | `/services/slots/{idOrName}` | Update label, description, layout/styles, and/or content-type/template associations |
+| `POST` | `/services/slots` | **Admin.** Create a slot (`IPSAssemblyDesignWs.createSlots` then `saveSlots`) |
+| `DELETE` | `/services/slots/{idOrName}` | **Admin.** Delete a slot (`IPSAssemblyDesignWs.deleteSlots`) |
+
+Create (`POST /services/slots`) persists immediately (Workbench Finish, not an unsaved stub).
+JSON body requires `name` (unique, case-insensitive; **no spaces**). Optional `label`,
+`description`, and `slotType` (`REGULAR` or `INLINE`) are applied before save. Omitted
+`slotType` defaults to `REGULAR`. Duplicate name is **409**. Blank / whitespace / wildcard
+names and invalid `slotType` are **400**. Missing request session/user is **403**. Non-Admin
+is **403**. The new slot is then `GET /services/slots/{name}` **200**.
+
+Delete (`DELETE /services/slots/{idOrName}`) returns **204** when removed; a following
+`GET` is **404**. Unknown id/name is **404**. System slots cannot be deleted (**409**).
+Locked-by-another-user is **409** (the lock is not stolen). Non-Admin is **403**.
+
+**AS-01 remainder:** finder, relationship, and `finderArguments` stay **read-only** on this
+REST surface. Content-finder / relationship write and SPA slot-editor chrome are later
+slices. Detail `designGaps` code `SLOT_FINDER_RELATIONSHIP_WRITE` records that remainder
+(`SLOT_CREATE_DELETE` is retired now that POST/DELETE ship).
 
 JSON may wrap a single item as `SlotDetail`. `associations` and `designGaps` are arrays
 (`SlotAssociationSummary[]` and structured `{code,message}` gaps). Some Jackson/JAXB

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -237,7 +237,7 @@ Assembly **slots** used by **Developer → Slots** are exposed under `/services/
 | `DELETE` | `/services/slots/{idOrName}` | **Admin.** Delete a slot (`IPSAssemblyDesignWs.deleteSlots`) |
 
 Create (`POST /services/slots`) persists immediately (Workbench Finish, not an unsaved stub).
-JSON body requires `name` (unique, case-insensitive; **no spaces**). Optional `label`,
+JSON body requires `name` (unique, case-insensitive; **no whitespace**). Optional `label`,
 `description`, and `slotType` (`REGULAR` or `INLINE`) are applied before save. Omitted
 `slotType` defaults to `REGULAR`. Duplicate name is **409**. Blank / whitespace / wildcard
 names and invalid `slotType` are **400**. Missing request session/user is **403**. Non-Admin

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
@@ -22,17 +22,24 @@ import com.percussion.rest.slots.SlotAssociationSummary;
 import com.percussion.rest.slots.SlotDetail;
 import com.percussion.rest.slots.SlotSummary;
 import com.percussion.services.assembly.IPSTemplateSlot;
+import com.percussion.services.assembly.IPSTemplateSlot.SlotType;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.utils.types.PSPair;
+import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
 import com.percussion.webservices.assembly.IPSAssemblyDesignWs;
 import com.percussion.webservices.assembly.PSAssemblyWsLocator;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,41 +47,56 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Assembly slots catalog for Developer REST.
  *
  * <p>Workbench parity: routes through {@link IPSAssemblyDesignWs} (same design web service assembly
- * SOAP design uses) for find / load / save — not a parallel path via raw {@code IPSAssemblyService}
- * alone.
+ * SOAP design uses) for find / load / save / create / delete — not a parallel path via raw {@code
+ * IPSAssemblyService} alone.
  */
 @PSSiteManageBean
 public class SlotsAdaptor implements ISlotsAdaptor {
 
   private static final Logger log = LogManager.getLogger(SlotsAdaptor.class);
 
+  static final String ADMIN_REQUIRED = "Admin role required to create or delete slots";
+
   public static final List<DesignGap> SLOT_DESIGN_GAPS =
       List.of(
           DesignGap.of(
-              "SLOT_CREATE_DELETE",
-              "Create / delete not supported via this REST API (use design WS"
-                  + " createSlots/deleteSlots)"),
+              "SLOT_FINDER_RELATIONSHIP_WRITE",
+              "Finder, relationship, and finderArguments are read-only on this REST API"
+                  + " (AS-01 remainder)"),
           DesignGap.of(
               "SLOT_ASSOC_GUIDS_ONLY",
               "Content-type and template names not resolved (GUIDs only)"));
 
   private final IPSAssemblyDesignWs designWs;
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   public SlotsAdaptor() {
-    this(PSAssemblyWsLocator.getAssemblyDesignWebservice());
+    this(PSAssemblyWsLocator.getAssemblyDesignWebservice(), null);
   }
 
-  /** Package-visible for unit tests. */
+  /** Package-visible for unit tests. Admin is allowed so existing PUT tests stay focused. */
   SlotsAdaptor(IPSAssemblyDesignWs designWs) {
+    this(designWs, () -> true);
+  }
+
+  /** Package-visible for unit tests that inject a fake Admin gate. */
+  SlotsAdaptor(IPSAssemblyDesignWs designWs, BooleanSupplier adminChecker) {
     this.designWs = designWs;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   @Override
@@ -175,6 +197,116 @@ public class SlotsAdaptor implements ISlotsAdaptor {
     } catch (Exception e) {
       log.error("Failed to update slot {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to update slot", e);
+    }
+  }
+
+  @Override
+  public SlotDetail createSlot(URI baseUri, SlotDetail body) {
+    requireAdmin();
+    if (body == null || StringUtils.isBlank(body.getName())) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String name = body.getName().trim();
+    if (containsWhitespace(name)) {
+      throw new IllegalArgumentException("name cannot contain spaces");
+    }
+    if (name.contains("*")) {
+      throw new IllegalArgumentException("name must not contain wildcards");
+    }
+    SlotType slotType = parseSlotType(body.getSlotType());
+    requireSessionUserForDesignWrite();
+    String session = currentSession();
+    String user = currentUser();
+    assertNameUnique(name);
+    try {
+      List<IPSTemplateSlot> created = designWs.createSlots(List.of(name), session, user);
+      if (created == null || created.isEmpty() || created.get(0) == null) {
+        throw new IllegalStateException("Design WS createSlots returned empty");
+      }
+      IPSTemplateSlot slot = created.get(0);
+      String label = StringUtils.isNotBlank(body.getLabel()) ? body.getLabel().trim() : name;
+      slot.setLabel(label);
+      if (body.getDescription() != null) {
+        slot.setDescription(body.getDescription());
+      }
+      if (slotType != null) {
+        slot.setSlottype(slotType);
+      }
+      designWs.saveSlots(Collections.singletonList(slot), true, session, user);
+      IPSTemplateSlot reloaded = resolveSlot(name, false);
+      return reloaded != null ? toDetail(reloaded) : toDetail(slot);
+    } catch (WebApplicationException | IllegalStateException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw mapCreateNameCollision(name, e);
+    } catch (PSErrorsException e) {
+      throw mapCreatePersistFailure(name, e, "Failed to save new slot");
+    } catch (Exception e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("Slot already exists: " + name, 409);
+      }
+      log.error("Failed to create slot {}: {}", name, e.getMessage(), e);
+      throw new IllegalStateException("Failed to create slot", e);
+    }
+  }
+
+  @Override
+  public boolean deleteSlot(URI baseUri, String idOrName) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    requireSessionUserForDesignWrite();
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      IPSTemplateSlot current = resolveSlot(trimmed, false);
+      if (current == null) {
+        return false;
+      }
+      if (current.isSystemSlot()) {
+        throw new WebApplicationException(
+            "System slots cannot be deleted: " + StringUtils.defaultString(current.getName()),
+            409);
+      }
+      if (current.getGUID() == null) {
+        throw new IllegalStateException(
+            "Slot '" + trimmed + "' has no GUID (corrupt identifier); cannot delete");
+      }
+      IPSTemplateSlot locked;
+      try {
+        locked = resolveSlot(trimmed, true);
+      } catch (PSErrorResultsException e) {
+        throw new WebApplicationException(
+            "Could not delete slot; design lock required or held by another user", 409);
+      }
+      if (locked == null || locked.getGUID() == null) {
+        throw new WebApplicationException(
+            "Could not delete slot; design lock required or held by another user", 409);
+      }
+      try {
+        designWs.deleteSlots(Collections.singletonList(locked.getGUID()), false, session, user);
+      } catch (PSErrorsException e) {
+        if (isLockFailure(e)) {
+          throw new WebApplicationException(
+              "Could not delete slot; design lock required or held by another user", 409);
+        }
+        String details = formatDeleteErrors(e);
+        throw new IllegalArgumentException("Could not delete slot: " + details, e);
+      }
+      return true;
+    } catch (IllegalArgumentException | IllegalStateException | WebApplicationException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      log.debug("Slot not found for delete {}: {}", idOrName, e.getMessage());
+      return false;
+    } catch (Exception e) {
+      log.error("Failed to delete slot {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to delete slot", e);
     }
   }
 
@@ -384,5 +516,146 @@ public class SlotsAdaptor implements ISlotsAdaptor {
       throw new IllegalStateException(
           "session and user are required for slot design update (IPSAssemblyDesignWs)");
     }
+  }
+
+  private static void requireSessionUserForDesignWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for slot design session", Response.Status.FORBIDDEN);
+    }
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private void assertNameUnique(String name) {
+    List<IPSCatalogSummary> existing = designWs.findSlots(null, null);
+    if (existing == null) {
+      return;
+    }
+    for (IPSCatalogSummary summary : existing) {
+      if (summary != null && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+        throw new WebApplicationException("Slot already exists: " + name, 409);
+      }
+    }
+  }
+
+  private static SlotType parseSlotType(String slotType) {
+    if (StringUtils.isBlank(slotType)) {
+      return null;
+    }
+    String trimmed = slotType.trim();
+    if ("REGULAR".equalsIgnoreCase(trimmed)) {
+      return SlotType.REGULAR;
+    }
+    if ("INLINE".equalsIgnoreCase(trimmed)) {
+      return SlotType.INLINE;
+    }
+    throw new IllegalArgumentException("slotType must be REGULAR or INLINE");
+  }
+
+  private static RuntimeException mapCreateNameCollision(String name, IllegalArgumentException e) {
+    if (isAlreadyExistsFailure(e)) {
+      return new WebApplicationException("Slot already exists: " + name, 409);
+    }
+    return e;
+  }
+
+  private RuntimeException mapCreatePersistFailure(String name, Exception e, String fallback) {
+    if (isAlreadyExistsFailure(e)) {
+      return new WebApplicationException("Slot already exists: " + name, 409);
+    }
+    log.error("{} {}: {}", fallback, name, e.getMessage(), e);
+    return new IllegalStateException(fallback, e);
+  }
+
+  static boolean isAlreadyExistsFailure(Throwable t) {
+    for (Throwable cur = t; cur != null && cur != cur.getCause(); cur = cur.getCause()) {
+      String msg = cur.getMessage();
+      if (cur instanceof PSErrorException pe && StringUtils.isNotBlank(pe.getErrorMessage())) {
+        msg = pe.getErrorMessage();
+      }
+      if (msg != null && msg.toLowerCase().contains("already exists")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isLockFailure(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (err == null) {
+        continue;
+      }
+      String msg = err.toString();
+      if (err instanceof PSErrorException pe && StringUtils.isNotBlank(pe.getErrorMessage())) {
+        msg = pe.getErrorMessage();
+      }
+      if (msg != null) {
+        String lower = msg.toLowerCase();
+        if (lower.contains("lock") || lower.contains("locked")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static String formatDeleteErrors(PSErrorsException e) {
+    if (e == null || e.getErrors() == null || e.getErrors().isEmpty()) {
+      return e != null && e.getMessage() != null ? e.getMessage() : "unknown error";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Object err : e.getErrors().values()) {
+      if (sb.length() > 0) {
+        sb.append("; ");
+      }
+      if (err instanceof PSErrorException pe && StringUtils.isNotBlank(pe.getErrorMessage())) {
+        sb.append(pe.getErrorMessage());
+      } else if (err != null) {
+        sb.append(err);
+      }
+    }
+    return sb.length() > 0 ? sb.toString() : "unknown error";
+  }
+
+  private static boolean containsWhitespace(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isWhitespace(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
@@ -208,7 +208,7 @@ public class SlotsAdaptor implements ISlotsAdaptor {
     }
     String name = body.getName().trim();
     if (containsWhitespace(name)) {
-      throw new IllegalArgumentException("name cannot contain spaces");
+      throw new IllegalArgumentException("name cannot contain whitespace");
     }
     if (name.contains("*")) {
       throw new IllegalArgumentException("name must not contain wildcards");
@@ -557,7 +557,7 @@ public class SlotsAdaptor implements ISlotsAdaptor {
   }
 
   private void assertNameUnique(String name) {
-    List<IPSCatalogSummary> existing = designWs.findSlots(null, null);
+    List<IPSCatalogSummary> existing = designWs.findSlots(name, null);
     if (existing == null) {
       return;
     }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -91,8 +91,8 @@ class DesignGapsStructuredTest {
   void slotDesignGaps_areStructured() {
     assertEquals(2, SlotsAdaptor.SLOT_DESIGN_GAPS.size());
     DesignGap first = SlotsAdaptor.SLOT_DESIGN_GAPS.get(0);
-    assertEquals("SLOT_CREATE_DELETE", first.getCode());
-    assertTrue(first.getMessage().contains("Create"));
+    assertEquals("SLOT_FINDER_RELATIONSHIP_WRITE", first.getCode());
+    assertTrue(first.getMessage().contains("read-only"));
     assertEquals("SLOT_ASSOC_GUIDS_ONLY", SlotsAdaptor.SLOT_DESIGN_GAPS.get(1).getCode());
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SlotsAdaptorCreateDeleteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SlotsAdaptorCreateDeleteTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.slots.SlotDetail;
+import com.percussion.services.assembly.IPSTemplateSlot;
+import com.percussion.services.assembly.IPSTemplateSlot.SlotType;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.assembly.IPSAssemblyDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * AS-01 POST create / DELETE persist via {@code createSlots}/{@code saveSlots}/{@code deleteSlots}.
+ * Admin only; unique name; no spaces; system-slot delete rejected.
+ */
+@Tag("UnitTest")
+class SlotsAdaptorCreateDeleteTest {
+
+  private IPSAssemblyDesignWs designWs;
+  private SlotsAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    designWs = mock(IPSAssemblyDesignWs.class);
+    adaptor = new SlotsAdaptor(designWs, () -> true);
+    guid = new PSGuid(PSTypeEnum.SLOT, 42L);
+    when(designWs.findSlots(isNull(), isNull())).thenReturn(Collections.emptyList());
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void create_usesCreateThenSaveAndReleasesLock() throws Exception {
+    IPSTemplateSlot slot = stubSlot("mySlot", false);
+    when(slot.getLabel()).thenReturn("My Slot");
+    when(designWs.createSlots(eq(List.of("mySlot")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(slot));
+    stubReloadByName("mySlot", slot);
+
+    SlotDetail body = new SlotDetail();
+    body.setName("mySlot");
+    body.setLabel("My Slot");
+    body.setDescription("created via REST");
+
+    SlotDetail out = adaptor.createSlot(null, body);
+
+    assertEquals("mySlot", out.getName());
+    assertEquals("My Slot", out.getLabel());
+    assertEquals("created via REST", out.getDescription());
+    verify(designWs).createSlots(eq(List.of("mySlot")), eq("test-session"), eq("Admin"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSTemplateSlot>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveSlots(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    verify(slot).setLabel("My Slot");
+    verify(slot).setDescription("created via REST");
+  }
+
+  @Test
+  void create_setsInlineSlotType() throws Exception {
+    IPSTemplateSlot slot = stubSlot("inlineSlot", false);
+    when(designWs.createSlots(eq(List.of("inlineSlot")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(slot));
+    stubReloadByName("inlineSlot", slot);
+
+    SlotDetail body = new SlotDetail();
+    body.setName("inlineSlot");
+    body.setSlotType("inline");
+
+    adaptor.createSlot(null, body);
+
+    verify(slot).setSlottype(SlotType.INLINE);
+  }
+
+  @Test
+  void create_invalidSlotType_is400() throws Exception {
+    SlotDetail body = new SlotDetail();
+    body.setName("mySlot");
+    body.setSlotType("WEIRD");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createSlot(null, body));
+    assertTrue(ex.getMessage().contains("slotType"));
+    verify(designWs, never()).createSlots(anyList(), any(), any());
+  }
+
+  @Test
+  void create_duplicateName_is409BeforeCreate() throws Exception {
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("rffList");
+    when(designWs.findSlots(isNull(), isNull())).thenReturn(List.of(existing));
+
+    SlotDetail body = new SlotDetail();
+    body.setName("rfflist");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSlot(null, body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createSlots(anyList(), any(), any());
+    verify(designWs, never()).saveSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_persistTimeDuplicate_is409() throws Exception {
+    when(designWs.createSlots(eq(List.of("mySlot")), eq("test-session"), eq("Admin")))
+        .thenThrow(
+            new IllegalArgumentException("The name 'mySlot' for type 'SLOT' already exists."));
+    SlotDetail body = new SlotDetail();
+    body.setName("mySlot");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSlot(null, body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_blankName_throwsBeforeDesignWs() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createSlot(null, null));
+    SlotDetail blank = new SlotDetail();
+    blank.setName("  ");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createSlot(null, blank));
+    assertTrue(ex.getMessage().contains("name is required"));
+    verify(designWs, never()).createSlots(anyList(), any(), any());
+  }
+
+  @Test
+  void create_nameWithSpaces_throwsBeforeDesignWs() {
+    SlotDetail body = new SlotDetail();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createSlot(null, body));
+    assertTrue(ex.getMessage().contains("spaces"));
+    verify(designWs, never()).createSlots(anyList(), any(), any());
+  }
+
+  @Test
+  void create_nonAdmin_is403() {
+    adaptor = new SlotsAdaptor(designWs, () -> false);
+    SlotDetail body = new SlotDetail();
+    body.setName("mySlot");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSlot(null, body));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).createSlots(anyList(), any(), any());
+  }
+
+  @Test
+  void create_missingSession_is403() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    SlotDetail body = new SlotDetail();
+    body.setName("mySlot");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSlot(null, body));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("session"), ex.getMessage());
+  }
+
+  @Test
+  void create_thenGetByName_returnsDetail() throws Exception {
+    IPSTemplateSlot slot = stubSlot("mySlot", false);
+    when(slot.getLabel()).thenReturn("My Slot");
+    when(designWs.createSlots(eq(List.of("mySlot")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(slot));
+    stubReloadByName("mySlot", slot);
+
+    SlotDetail body = new SlotDetail();
+    body.setName("mySlot");
+    body.setLabel("My Slot");
+
+    adaptor.createSlot(null, body);
+    SlotDetail got = adaptor.getSlot(null, "mySlot");
+
+    assertEquals("mySlot", got.getName());
+    assertEquals("My Slot", got.getLabel());
+  }
+
+  @Test
+  void delete_thenGetByName_isNotFound() throws Exception {
+    IPSTemplateSlot slot = stubSlot("mySlot", false);
+    stubReloadByName("mySlot", slot);
+    when(designWs.loadSlots(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+
+    assertTrue(adaptor.deleteSlot(null, "mySlot"));
+    when(designWs.findSlots(eq("mySlot"), isNull())).thenReturn(Collections.emptyList());
+    org.junit.jupiter.api.Assertions.assertNull(adaptor.getSlot(null, "mySlot"));
+  }
+
+  @Test
+  void delete_callsDesignWsWithoutIgnoringDependents() throws Exception {
+    IPSTemplateSlot slot = stubSlot("mySlot", false);
+    stubReloadByName("mySlot", slot);
+    when(designWs.loadSlots(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+
+    assertTrue(adaptor.deleteSlot(null, "mySlot"));
+
+    verify(designWs)
+        .deleteSlots(eq(List.of(guid)), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void delete_unknown_returnsFalse() throws Exception {
+    when(designWs.findSlots(eq("missing"), isNull())).thenReturn(Collections.emptyList());
+    assertFalse(adaptor.deleteSlot(null, "missing"));
+    verify(designWs, never()).deleteSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_systemSlot_is409() throws Exception {
+    IPSTemplateSlot slot = stubSlot("sys_inline_link", true);
+    stubReloadByName("sys_inline_link", slot);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.deleteSlot(null, "sys_inline_link"));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("system"), ex.getMessage());
+    verify(designWs, never()).deleteSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_lockConflict_is409() throws Exception {
+    IPSTemplateSlot slot = stubSlot("mySlot", false);
+    stubReloadByName("mySlot", slot);
+    when(designWs.loadSlots(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteSlot(null, "mySlot"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_nonAdmin_is403() throws Exception {
+    adaptor = new SlotsAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteSlot(null, "mySlot"));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_blankId_throwsBeforeDesignWs() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.deleteSlot(null, "  "));
+    assertThrows(IllegalArgumentException.class, () -> adaptor.deleteSlot(null, null));
+    verify(designWs, never()).deleteSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  private IPSTemplateSlot stubSlot(String name, boolean system) {
+    IPSTemplateSlot slot = mock(IPSTemplateSlot.class);
+    when(slot.getName()).thenReturn(name);
+    when(slot.getLabel()).thenReturn(name);
+    when(slot.getDescription()).thenReturn("created via REST");
+    when(slot.getGUID()).thenReturn(guid);
+    when(slot.isSystemSlot()).thenReturn(system);
+    when(slot.getSlottypeEnum()).thenReturn(SlotType.REGULAR);
+    return slot;
+  }
+
+  private void stubReloadByName(String name, IPSTemplateSlot slot) throws Exception {
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(sum.getName()).thenReturn(name);
+    when(sum.getLabel()).thenReturn(name);
+    when(designWs.findSlots(eq(name), isNull())).thenReturn(List.of(sum));
+    when(designWs.loadSlots(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SlotsAdaptorCreateDeleteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SlotsAdaptorCreateDeleteTest.java
@@ -53,7 +53,7 @@ import org.mockito.ArgumentCaptor;
 
 /**
  * AS-01 POST create / DELETE persist via {@code createSlots}/{@code saveSlots}/{@code deleteSlots}.
- * Admin only; unique name; no spaces; system-slot delete rejected.
+ * Admin only; unique name; no whitespace; system-slot delete rejected.
  */
 @Tag("UnitTest")
 class SlotsAdaptorCreateDeleteTest {
@@ -71,7 +71,7 @@ class SlotsAdaptorCreateDeleteTest {
     designWs = mock(IPSAssemblyDesignWs.class);
     adaptor = new SlotsAdaptor(designWs, () -> true);
     guid = new PSGuid(PSTypeEnum.SLOT, 42L);
-    when(designWs.findSlots(isNull(), isNull())).thenReturn(Collections.emptyList());
+    when(designWs.findSlots(any(), isNull())).thenReturn(Collections.emptyList());
   }
 
   @AfterEach
@@ -85,7 +85,7 @@ class SlotsAdaptorCreateDeleteTest {
     when(slot.getLabel()).thenReturn("My Slot");
     when(designWs.createSlots(eq(List.of("mySlot")), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(slot));
-    stubReloadByName("mySlot", slot);
+    stubCreateThenReload("mySlot", slot);
 
     SlotDetail body = new SlotDetail();
     body.setName("mySlot");
@@ -111,7 +111,7 @@ class SlotsAdaptorCreateDeleteTest {
     IPSTemplateSlot slot = stubSlot("inlineSlot", false);
     when(designWs.createSlots(eq(List.of("inlineSlot")), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(slot));
-    stubReloadByName("inlineSlot", slot);
+    stubCreateThenReload("inlineSlot", slot);
 
     SlotDetail body = new SlotDetail();
     body.setName("inlineSlot");
@@ -137,7 +137,7 @@ class SlotsAdaptorCreateDeleteTest {
   void create_duplicateName_is409BeforeCreate() throws Exception {
     IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
     when(existing.getName()).thenReturn("rffList");
-    when(designWs.findSlots(isNull(), isNull())).thenReturn(List.of(existing));
+    when(designWs.findSlots(eq("rfflist"), isNull())).thenReturn(List.of(existing));
 
     SlotDetail body = new SlotDetail();
     body.setName("rfflist");
@@ -180,7 +180,17 @@ class SlotsAdaptorCreateDeleteTest {
     body.setName("has space");
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> adaptor.createSlot(null, body));
-    assertTrue(ex.getMessage().contains("spaces"));
+    assertEquals("name cannot contain whitespace", ex.getMessage());
+    verify(designWs, never()).createSlots(anyList(), any(), any());
+  }
+
+  @Test
+  void create_nameWithTab_throwsBeforeDesignWs() {
+    SlotDetail body = new SlotDetail();
+    body.setName("has\ttab");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createSlot(null, body));
+    assertEquals("name cannot contain whitespace", ex.getMessage());
     verify(designWs, never()).createSlots(anyList(), any(), any());
   }
 
@@ -213,7 +223,7 @@ class SlotsAdaptorCreateDeleteTest {
     when(slot.getLabel()).thenReturn("My Slot");
     when(designWs.createSlots(eq(List.of("mySlot")), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(slot));
-    stubReloadByName("mySlot", slot);
+    stubCreateThenReload("mySlot", slot);
 
     SlotDetail body = new SlotDetail();
     body.setName("mySlot");
@@ -317,6 +327,19 @@ class SlotsAdaptorCreateDeleteTest {
     when(sum.getName()).thenReturn(name);
     when(sum.getLabel()).thenReturn(name);
     when(designWs.findSlots(eq(name), isNull())).thenReturn(List.of(sum));
+    when(designWs.loadSlots(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+  }
+
+  /** First {@code findSlots} is the uniqueness check (empty); later calls reload the saved slot. */
+  private void stubCreateThenReload(String name, IPSTemplateSlot slot) throws Exception {
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(sum.getName()).thenReturn(name);
+    when(sum.getLabel()).thenReturn(name);
+    when(designWs.findSlots(eq(name), isNull()))
+        .thenReturn(Collections.emptyList())
+        .thenReturn(List.of(sum));
     when(designWs.loadSlots(anyList(), eq(false), eq(false), any(), any()))
         .thenReturn(List.of(slot));
   }

--- a/rest/src/main/java/com/percussion/rest/slots/ISlotsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/slots/ISlotsAdaptor.java
@@ -45,4 +45,34 @@ public interface ISlotsAdaptor {
    */
   @Nullable
   SlotDetail updateSlot(URI baseUri, String idOrName, SlotDetail body);
+
+  /**
+   * Create and persist a slot (Workbench Finish: {@code IPSAssemblyDesignWs.createSlots} then
+   * {@code saveSlots}). Admin only. Name must be unique (case-insensitive) and must not contain
+   * spaces.
+   *
+   * @param baseUri requesting URI
+   * @param body request body; {@code name} is required. Optional label, description, and {@code
+   *     slotType} ({@code REGULAR} or {@code INLINE}) are applied before save.
+   * @return persisted detail
+   * @throws IllegalArgumentException when the name is blank, contains whitespace, or contains
+   *     wildcards, or when {@code slotType} is not {@code REGULAR}/{@code INLINE}
+   * @throws jakarta.ws.rs.WebApplicationException {@code 409} when a slot with that name already
+   *     exists; {@code 403} when the caller is not Admin or the request has no session/user
+   */
+  SlotDetail createSlot(URI baseUri, SlotDetail body);
+
+  /**
+   * Delete a slot via {@code IPSAssemblyDesignWs.deleteSlots}. Admin only. Acquires a design lock
+   * for this request ({@code loadSlots(lock=true)}, {@code overrideLock=false}) and does not steal
+   * another user's lock. System slots are rejected.
+   *
+   * @param baseUri requesting URI
+   * @param idOrName slot uuid (numeric) or unique name
+   * @return {@code true} when deleted; {@code false} when not found
+   * @throws IllegalArgumentException when {@code idOrName} is blank
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin; {@code
+   *     409} when the slot is a system slot or locked by another user
+   */
+  boolean deleteSlot(URI baseUri, String idOrName);
 }

--- a/rest/src/main/java/com/percussion/rest/slots/ISlotsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/slots/ISlotsAdaptor.java
@@ -49,7 +49,7 @@ public interface ISlotsAdaptor {
   /**
    * Create and persist a slot (Workbench Finish: {@code IPSAssemblyDesignWs.createSlots} then
    * {@code saveSlots}). Admin only. Name must be unique (case-insensitive) and must not contain
-   * spaces.
+   * whitespace.
    *
    * @param baseUri requesting URI
    * @param body request body; {@code name} is required. Optional label, description, and {@code

--- a/rest/src/main/java/com/percussion/rest/slots/SlotDetail.java
+++ b/rest/src/main/java/com/percussion/rest/slots/SlotDetail.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Assembly slot design detail for the Developer module (read + partial write).
+ * Assembly slot design detail for the Developer module (read, PUT, POST create, DELETE).
  *
  * <p>Wire root {@code SlotDetail} matches {@code WRAP_ROOT_VALUE}/{@code
  * UNWRAP_ROOT_VALUE} (see TemplateDetail / issue #3039 companion).

--- a/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
+++ b/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
@@ -25,7 +25,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -103,8 +105,8 @@ public class SlotsResource {
       summary = "Get slot design detail",
       description =
           "Slot detail including finder metadata, content-type/template associations, and"
-              + " ADR-003 slot_layout / slot_styles maps. Create/delete not supported (see"
-              + " designGaps).",
+              + " ADR-003 slot_layout / slot_styles maps. Finder/relationship write remain"
+              + " unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -143,7 +145,7 @@ public class SlotsResource {
               + " associations is present (including empty), replaces the full content-type/template"
               + " association set. Non-null slotLayout/slotStyles replace definition maps (empty or"
               + " schema-only clears to defaults); omit to leave unchanged. Name/id is immutable."
-              + " Create/delete/lock remain unsupported (see designGaps).",
+              + " Finder/relationship write remain unsupported (see designGaps).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -167,6 +169,96 @@ public class SlotsResource {
     } catch (Exception e) {
       log.error(
           "Failed to update slot {} ({}): {}", idOrName, e.getClass().getName(), e.getMessage(), e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Creates an assembly slot (design catalog).
+   *
+   * @param body SlotDetail; {@code name} required
+   * @return created SlotDetail
+   */
+  @POST
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Create assembly slot",
+      description =
+          "Admin. Creates and persists a slot via IPSAssemblyDesignWs.createSlots then saveSlots"
+              + " (Workbench Finish, not an unsaved stub). Name is required, must be unique"
+              + " (case-insensitive), and must not contain spaces. Optional label, description,"
+              + " and slotType (REGULAR or INLINE) are applied before save. Duplicate name is"
+              + " 409. Finder, relationship, and finderArguments are not written on create.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = SlotDetail.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid name (blank, whitespace, or wildcard) or invalid slotType"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "409", description = "A slot with that name already exists"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public SlotDetail createSlot(SlotDetail body) {
+    try {
+      SlotDetail detail = requireAdaptor().createSlot(uriInfo.getBaseUri(), body);
+      if (detail == null) {
+        throw new WebApplicationException("Failed to create slot", 500);
+      }
+      return detail;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), 400);
+    } catch (Exception e) {
+      log.error("Failed to create slot ({}): {}", e.getClass().getName(), e.getMessage(), e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Deletes an assembly slot (design catalog).
+   *
+   * @param idOrName slot uuid or unique name
+   * @return 204 when deleted
+   */
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete assembly slot",
+      description =
+          "Admin. Deletes a slot via IPSAssemblyDesignWs.deleteSlots. Acquires a design lock for"
+              + " this request (does not steal another user's lock). System slots cannot be"
+              + " deleted. Following GET .../{idOrName} is 404 after a successful delete.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid id/name, or design WS rejected"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Slot not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "System slot, or locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteSlot(@PathParam("idOrName") String idOrName) {
+    try {
+      boolean deleted = requireAdaptor().deleteSlot(uriInfo.getBaseUri(), idOrName);
+      if (!deleted) {
+        throw new WebApplicationException("Slot not found: " + idOrName, 404);
+      }
+      return Response.noContent().build();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), 400);
+    } catch (Exception e) {
+      log.error(
+          "Failed to delete slot {} ({}): {}", idOrName, e.getClass().getName(), e.getMessage(), e);
       throw new WebApplicationException(e, 500);
     }
   }

--- a/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
+++ b/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
@@ -187,7 +187,7 @@ public class SlotsResource {
       description =
           "Admin. Creates and persists a slot via IPSAssemblyDesignWs.createSlots then saveSlots"
               + " (Workbench Finish, not an unsaved stub). Name is required, must be unique"
-              + " (case-insensitive), and must not contain spaces. Optional label, description,"
+              + " (case-insensitive), and must not contain whitespace. Optional label, description,"
               + " and slotType (REGULAR or INLINE) are applied before save. Duplicate name is"
               + " 409. Finder, relationship, and finderArguments are not written on create.",
       responses = {

--- a/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
@@ -26,10 +26,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.rest.DesignGap;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
@@ -129,16 +131,16 @@ public class SlotsResourceDetailTest {
     d.setDesignGaps(
         List.of(
             DesignGap.of(
-                "SLOT_CREATE_DELETE",
-                "Create / delete not supported via this REST API (use design WS"
-                    + " createSlots/deleteSlots)")));
+                "SLOT_FINDER_RELATIONSHIP_WRITE",
+                "Finder, relationship, and finderArguments are read-only on this REST API"
+                    + " (AS-01 remainder)")));
     when(adaptor.getSlot(any(), eq("target"))).thenReturn(d);
 
     SlotDetail out = resource.getSlot("target");
     assertNotNull(out.getDesignGaps());
     assertEquals(1, out.getDesignGaps().size());
-    assertEquals("SLOT_CREATE_DELETE", out.getDesignGaps().get(0).getCode());
-    assertTrue(out.getDesignGaps().get(0).getMessage().contains("Create / delete"));
+    assertEquals("SLOT_FINDER_RELATIONSHIP_WRITE", out.getDesignGaps().get(0).getCode());
+    assertTrue(out.getDesignGaps().get(0).getMessage().contains("read-only"));
   }
 
   @Test
@@ -261,5 +263,128 @@ public class SlotsResourceDetailTest {
     SlotDetail result = resource.updateSlot("target", body);
     assertEquals("vertical", result.getSlotLayout().get("orientation"));
     assertEquals("updated-root", result.getSlotStyles().get("rootclass"));
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnCreate() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> newSlotsResourceWithoutAdaptor().createSlot(new SlotDetail()));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnDelete() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> newSlotsResourceWithoutAdaptor().deleteSlot("any"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createSlotSuccess() {
+    SlotDetail body = new SlotDetail();
+    body.setName("mySlot");
+    SlotDetail created = new SlotDetail();
+    created.setName("mySlot");
+    created.setLabel("My Slot");
+    created.setSlotType("REGULAR");
+    when(adaptor.createSlot(any(), any())).thenReturn(created);
+    SlotDetail out = resource.createSlot(body);
+    assertEquals("mySlot", out.getName());
+    assertEquals("My Slot", out.getLabel());
+    assertEquals("REGULAR", out.getSlotType());
+  }
+
+  @Test
+  public void createSlotBadRequest() {
+    when(adaptor.createSlot(any(), any()))
+        .thenThrow(new IllegalArgumentException("name is required"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createSlot(null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createSlotDuplicateIs409() {
+    SlotDetail body = new SlotDetail();
+    body.setName("rffList");
+    when(adaptor.createSlot(any(), any()))
+        .thenThrow(new WebApplicationException("Slot already exists: rffList", 409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createSlot(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createSlotForbiddenWhenNotAdmin() {
+    SlotDetail body = new SlotDetail();
+    body.setName("mySlot");
+    when(adaptor.createSlot(any(), any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createSlot(body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createSlotWrapsFailures() {
+    when(adaptor.createSlot(any(), any())).thenThrow(new IllegalStateException("fail"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.createSlot(new SlotDetail()));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteSlotSuccess() {
+    when(adaptor.deleteSlot(any(), eq("mySlot"))).thenReturn(true);
+    Response out = resource.deleteSlot("mySlot");
+    assertEquals(204, out.getStatus());
+    verify(adaptor).deleteSlot(any(), eq("mySlot"));
+  }
+
+  @Test
+  public void deleteSlotNotFound() {
+    when(adaptor.deleteSlot(any(), eq("missing"))).thenReturn(false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteSlot("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteSlotSystemSlotIs409() {
+    when(adaptor.deleteSlot(any(), eq("sys_inline_link")))
+        .thenThrow(new WebApplicationException("System slots cannot be deleted", 409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteSlot("sys_inline_link"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteSlotForbiddenWhenNotAdmin() {
+    when(adaptor.deleteSlot(any(), eq("mySlot")))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteSlot("mySlot"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteSlotBadRequest() {
+    when(adaptor.deleteSlot(any(), eq("  ")))
+        .thenThrow(new IllegalArgumentException("idOrName is required"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteSlot("  "));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteSlotWrapsFailures() {
+    when(adaptor.deleteSlot(any(), eq("boom"))).thenThrow(new IllegalStateException("fail"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteSlot("boom"));
+    assertEquals(500, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSlotsAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSlotsAdaptor.java
@@ -47,4 +47,14 @@ public class TestSlotsAdaptor implements ISlotsAdaptor {
   public SlotDetail updateSlot(URI baseUri, String idOrName, SlotDetail body) {
     return null;
   }
+
+  @Override
+  public SlotDetail createSlot(URI baseUri, SlotDetail body) {
+    return null;
+  }
+
+  @Override
+  public boolean deleteSlot(URI baseUri, String idOrName) {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary

Admin REST **POST `/services/slots`** and **DELETE `/services/slots/{idOrName}`** for Workbench AS-01 slot create/delete (parent **#1690**, slice **#4006**).

Create takes a unique name (no spaces) plus optional label, description, and `slotType` (`REGULAR` | `INLINE`). Persist uses existing `IPSAssemblyDesignWs.createSlots` then `saveSlots` (Workbench Finish). Delete uses `deleteSlots` after a request-scoped design lock (`overrideLock=false`; does not steal). System slots are rejected. No new SOAP methods. No SPA. Finder / relationship / finderArguments stay read-only (`designGaps` code `SLOT_FINDER_RELATIONSHIP_WRITE`; `SLOT_CREATE_DELETE` retired).

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4006
Partial #1690

## Test plan

1. Mockito: `SlotsResourceDetailTest` — POST 200/400/403/409/500, DELETE 204/400/403/404/409/500, Spring stub still loads.
2. Adaptor: `SlotsAdaptorCreateDeleteTest` — create then GET; delete then GET 404; duplicate 409; spaces 400; non-Admin 403; system-slot delete 409; lock conflict 409.
3. Standalone module clean install (below).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` slots catalog (POST/DELETE, AS-01 remainder)
- [x] **Unit / module tests** — resource + Spring stub + adaptor tests; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `rest` then `projects/sitemanage` standalone clean install (no skipTests); reverse-dep sitemanage built after rest interface add
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS**, Tests run: **769**, Failures: 0 (`SlotsResourceDetailTest` Tests run: 32)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**, Tests run: **1729**, Failures: 0 (`SlotsAdaptorCreateDeleteTest` Tests run: 17)
- **downstream_checked:** added methods on `ISlotsAdaptor`; `git grep implements ISlotsAdaptor` → `SlotsAdaptor` + `TestSlotsAdaptor` only; sitemanage standalone clean install green
- **C5 UI proof:** N/A (REST/adaptor only)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
