### PR TITLE
feat(rest): AS-08 Admin template design XML import (#4010)

### DIFF
--- a/docs/ai-generated/code-reviews/4010-template-import-erlang.md
+++ b/docs/ai-generated/code-reviews/4010-template-import-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review — issue #4010 REST AS-08 template import
+
+**Branch:** `feat/issue-4010-template-import`  
+**Scope:** uncommitted vs HEAD (rest + sitemanage + product-docs 8.2)  
+**Date:** 2026-08-29  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class completeness (rest resource + adaptor interface + Spring stub + sitemanage impl + tests); Admin `IPSUserService.isAdminUser` 403; design-WS create/save/release; no stolen locks
+
+## Summary
+
+Admin POST `/services/templates/import` accepts Workbench-equivalent `<assembly-template>` XML (same document as Workbench export / peer GET export). sitemanage `TemplateAdaptor` parses via `PSAssemblyTemplate.fromXML`, creates through `IPSAssemblyDesignWs.createAssemblyTemplates`, applies XML while keeping the new GUID, and saves with `release=true`. Duplicate name is 409 (no replace). Non-Admin is 403. Invalid XML is 400. Reload uses `lock=false`, `overrideLock=false`.
+
+Change-class companions are present: OpenAPI resource, `ITemplatesAdaptor.importTemplate`, `TestTemplatesAdaptor` stub, Mockito resource tests, adaptor success/403/400/409 tests with name round-trip, product-docs 8.2 developer REST + admin design-templates.
+
+## Issues
+
+None that block.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction. XML is an HTTP body string; `toXML`/`fromXML` in tests is in-memory.
+
+## Tests / evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 822, Failures: 0 (`TemplatesResourceDetailTest` 22/0; `MainTest` ApplicationContext)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1874, Failures: 0 (`TemplateAdaptorImportTest` 8/0)

--- a/product-docs/8.2/admin/design-templates.md
+++ b/product-docs/8.2/admin/design-templates.md
@@ -118,10 +118,23 @@ Workbench-equivalent design XML with:
 
 The response is `application/xml` with `Content-Disposition` named from the template
 (for example `perc.page.xml`). Unknown names return **404**. Non-Admin sessions return
-**403**. Export is read-only and does **not** steal a design lock. **Import** of that XML
-is not available on this REST path yet.
+**403**. Export is read-only and does **not** steal a design lock.
 
 See [REST API](id:developer-rest) (Templates / AS-08 export).
+
+## Import design XML (REST, no SPA wizard)
+
+Administrators can import **one** Workbench-equivalent assembly-template design XML
+document through public REST (AS-08):
+
+`POST /services/templates/import` with `Content-Type: application/xml`.
+
+The document is the same `<assembly-template>` XML Workbench exports (and that
+`GET /services/templates/{idOrName}/export` returns). The imported **name** must be unique
+— a collision is **409** (the existing template is not replaced, and no design lock is
+stolen). Non-Admin callers receive **403**. Invalid XML is **400**.
+
+There is no Design SPA import wizard on this slice. See [REST API](id:developer-rest).
 
 ## Edit assembler, slots, source, and bindings
 
@@ -142,7 +155,7 @@ related upgrade-only JSPs) until those flows are signed off on the SPA. Bookmark
 
 ## Related
 
-- [REST API](id:developer-rest) — `GET`/`POST`/`PUT`/`DELETE /services/templates` and Admin `GET .../export`
+- [REST API](id:developer-rest) — `GET`/`POST`/`PUT`/`DELETE /services/templates`, Admin `GET .../export`, and `POST /services/templates/import`
 - [Extensions & packages](id:developer-extensions)
 - [Product page packages](id:developer-page-packages)
 - [Navigation & site structure](id:admin-architecture-navigation)

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -240,6 +240,7 @@ Assembly templates used by the [Design SPA](id:admin-design-templates) are expos
 | `PUT` | `/services/templates/{idOrName}` | Update label, description, templateSource, assembler, bindings, and/or slots |
 | `POST` | `/services/templates` | Create a modern assembly template (**when installed**) — no Widget XML |
 | `DELETE` | `/services/templates/{idOrName}` | Delete a modern assembly template — no Widget XML |
+| `POST` | `/services/templates/import` | **Admin.** Import one Workbench-equivalent `assembly-template` design XML (AS-08) |
 | `POST` | `/services/templates/summaries-by-filter` | List summaries matching a `TemplateFilter` |
 
 `PUT` omits unchanged fields. Name/id remain unsupported. Delete returns **204** when
@@ -250,8 +251,55 @@ slice is on the server; otherwise create stays on residual classic hosts.
 
 **AS-08 export:** `GET /services/templates/{idOrName}/export` downloads Workbench-equivalent
 design XML (Admin only). Unknown templates are `404`; non-Admin callers are `403`. The
-server does not steal design locks. **Import is not implemented** on this path (later
-AS-08 slice). Details are in the Templates (assembly catalog) section below.
+server does not steal design locks. Import uses a separate path
+(`POST /services/templates/import`). Details are in the Templates (assembly catalog)
+section below.
+
+### AS-08 template design XML import
+
+`POST /services/templates/import` is the Admin REST equivalent of the Workbench **import
+template** wizard for **one** assembly-template design document. The body is
+`application/xml` (or `text/xml`) — the same `<assembly-template>` document that Workbench
+exports and that `GET /services/templates/{idOrName}/export` returns when that export
+slice is installed. Load and save go through existing `IPSAssemblyDesignWs`
+(`createAssemblyTemplates` then `saveAssemblyTemplates` with `release=true`). No new SOAP
+surface.
+
+**Admin (Design) only.** There is no global JAX-RS Admin filter on this path — the
+sitemanage adaptor checks `IPSUserService.isAdminUser` and maps a non-Admin caller to
+**403**.
+
+**Create only — name collision is 409.** Import does **not** replace an existing template
+and does **not** steal a design lock held by another session. The new object is locked
+only for the importing user long enough to persist, then released. There is no overwrite
+query parameter on this path.
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Imported. JSON `TemplateDetail`; `name` round-trips from the XML |
+| `400` | Missing body, not `assembly-template` XML, or invalid name in the document |
+| `403` | Caller is not Admin, or request session/user is missing |
+| `409` | A template with that name already exists (no replace) |
+| `500` | Unexpected server failure |
+
+Example:
+
+```http
+POST /Rhythmyx/rest/templates/import
+Content-Type: application/xml
+Authorization: …
+
+<assembly-template>
+  <name>imported.one</name>
+  <label>Imported One</label>
+  <assembler>Java/global/percussion/assembly/htmlAssembler</assembler>
+  <template>#set($x=1)$x</template>
+  …
+</assembly-template>
+```
+
+Widget definition XML / package compile is out of scope. There is no Design SPA import
+wizard on this slice — operators and integrators call the REST path (or Workbench).
 
 ## Slots (design catalog)
 
@@ -1029,6 +1077,7 @@ Create uses the modern package/manifest model — **no Widget definition XML**.
 | `POST` | `/services/templates/summaries-by-filter` | Filter summaries (for example by content id) |
 | `GET` | `/services/templates/{idOrName}` | Load design detail (source, bindings, slots, assembler) |
 | `GET` | `/services/templates/{idOrName}/export` | **Admin.** AS-08 export of Workbench-equivalent design XML |
+| `POST` | `/services/templates/import` | **Admin.** AS-08 import of one Workbench-equivalent `assembly-template` XML |
 | `PUT` | `/services/templates/{idOrName}` | Update label, description, source, assembler, bindings, slots |
 | `POST` | `/services/templates` | Create a modern assembly template (`name` required, unique, no spaces) |
 | `DELETE` | `/services/templates/{idOrName}` | Delete a modern assembly template (204; no Widget XML) |
@@ -1069,9 +1118,9 @@ derived from the **template name** (for example `perc.page.xml`).
 | `404` | Unknown id or name |
 
 The load is **read-only**. The server does **not** acquire or steal a design lock
-(`lock=false`, `overrideLock=false`). **Import** (POST of the same XML) is **not**
-implemented on this path — that remains a later AS-08 slice. There is no Design SPA
-export wizard; operators and integrators call this REST path directly.
+(`lock=false`, `overrideLock=false`). **Import** of the same XML is
+`POST /services/templates/import` (create only; name collision is **409**). There is no
+Design SPA export wizard; operators and integrators call this REST path directly.
 
 See also [Design templates](id:admin-design-templates).
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/TemplateAdaptor.java
@@ -33,6 +33,7 @@ import com.percussion.services.assembly.IPSAssemblyTemplate;
 import com.percussion.services.assembly.IPSTemplateSlot;
 import com.percussion.services.assembly.PSAssemblyException;
 import com.percussion.services.assembly.PSAssemblyServiceLocator;
+import com.percussion.services.assembly.data.PSAssemblyTemplate;
 import com.percussion.services.assembly.data.PSTemplateBinding;
 import com.percussion.services.catalog.IPSCatalogItem;
 import com.percussion.services.catalog.IPSCatalogSummary;
@@ -48,7 +49,10 @@ import com.percussion.user.data.PSCurrentUser;
 import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.utils.xml.PSInvalidXmlException;
+import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
 import com.percussion.webservices.assembly.IPSAssemblyDesignWs;
 import com.percussion.webservices.assembly.PSAssemblyWsLocator;
 import com.percussion.webservices.assembly.data.PSAssemblyTemplateWs;
@@ -88,7 +92,8 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
           DesignGap.of(
               "TPL_CONTENT_TYPE_ASSOC", "Content-type associations not listed on this payload"));
 
-  static final String ADMIN_REQUIRED = "Admin role required to export assembly templates";
+  static final String ADMIN_REQUIRED =
+      "Admin role required to export or import assembly templates";
 
   private final IPSAssemblyService asmSvc;
   private final IPSContentWs contentwsService;
@@ -116,8 +121,8 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
   }
 
   /**
-   * Package-visible for export tests that inject assembly design WS and an Admin gate. {@code null}
-   * adminChecker uses {@link #isCurrentUserAdmin()}.
+   * Package-visible for export and import tests that inject assembly design WS and an Admin gate.
+   * {@code null} adminChecker uses {@link #isCurrentUserAdmin()}.
    */
   TemplateAdaptor(
       IPSAssemblyService asmSvc,
@@ -367,6 +372,59 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
     }
   }
 
+  @Override
+  public TemplateDetail importTemplate(URI baseUri, String xml) {
+    requireAdmin();
+    requireSessionUserForDesignWrite();
+    if (designWs == null) {
+      throw new IllegalStateException("assembly design WS is not configured");
+    }
+    PSAssemblyTemplate parsed = parseDesignXml(xml);
+    String name = validateCreateName(parsed.getName());
+    assertImportNameUnique(name);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSAssemblyTemplateWs> created =
+          designWs.createAssemblyTemplates(List.of(name), session, user);
+      if (created == null || created.isEmpty() || created.get(0) == null) {
+        throw new IllegalStateException("Design WS createAssemblyTemplates returned empty");
+      }
+      PSAssemblyTemplateWs createdWs = created.get(0);
+      IPSAssemblyTemplate dest = createdWs.getTemplate();
+      if (dest == null || dest.getGUID() == null) {
+        throw new IllegalStateException("Design WS createAssemblyTemplates returned no GUID");
+      }
+      IPSGuid keepGuid = dest.getGUID();
+      applyDesignXml(dest, xml, keepGuid);
+      dest.setName(name);
+      // New object lock is ours; release=true so import does not leave a held lock.
+      designWs.saveAssemblyTemplates(List.of(createdWs), true, session, user);
+      IPSAssemblyTemplate reloaded = loadImportedReadOnly(name, keepGuid, session, user);
+      return reloaded != null ? toDetail(reloaded) : toDetail(dest);
+    } catch (WebApplicationException | IllegalStateException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("Template already exists: " + name, 409);
+      }
+      throw e;
+    } catch (PSErrorsException e) {
+      throw mapImportPersistFailure(name, e);
+    } catch (Exception e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("Template already exists: " + name, 409);
+      }
+      log.error(
+          "Failed to import template {} ({}): {}",
+          name,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new IllegalStateException("Failed to import template", e);
+    }
+  }
+
   /**
    * Load one template through {@link IPSAssemblyDesignWs} without locking ({@code lock=false},
    * {@code overrideLock=false}) so export never steals a Workbench lock.
@@ -481,6 +539,143 @@ public class TemplateAdaptor implements ITemplatesAdaptor {
       log.debug("Not a template GUID: {}", idOrName);
     }
     return null;
+  }
+
+  /**
+   * Parse Workbench / REST-export {@code assembly-template} design XML. Invalid or non-template XML
+   * is 400 via {@link IllegalArgumentException}.
+   */
+  static PSAssemblyTemplate parseDesignXml(String xml) {
+    if (StringUtils.isBlank(xml)) {
+      throw new IllegalArgumentException("assembly-template XML is required");
+    }
+    String trimmed = xml.trim();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      throw new IllegalArgumentException("expected assembly-template XML");
+    }
+    PSAssemblyTemplate parsed = new PSAssemblyTemplate();
+    try {
+      parsed.fromXML(trimmed);
+    } catch (IOException | SAXException | PSInvalidXmlException | RuntimeException e) {
+      throw new IllegalArgumentException("invalid assembly-template XML", e);
+    }
+    if (StringUtils.isBlank(parsed.getName())) {
+      throw new IllegalArgumentException("assembly-template XML is missing name");
+    }
+    return parsed;
+  }
+
+  /**
+   * Apply exported design XML onto the newly created template, keeping the GUID assigned by {@code
+   * createAssemblyTemplates} so we never steal an existing object's identity or lock.
+   */
+  private static void applyDesignXml(IPSAssemblyTemplate dest, String xml, IPSGuid keepGuid)
+      throws IOException, SAXException, PSInvalidXmlException {
+    if (!(dest instanceof IPSCatalogItem item)) {
+      throw new IllegalStateException("created template is not a catalog item");
+    }
+    item.fromXML(xml);
+    dest.setGUID(keepGuid);
+  }
+
+  private void assertImportNameUnique(String name) {
+    List<IPSCatalogSummary> existing =
+        designWs.findAssemblyTemplates(name, null, null, null, null, null, null);
+    if (existing == null) {
+      return;
+    }
+    for (IPSCatalogSummary summary : existing) {
+      if (summary != null && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+        throw new WebApplicationException("Template already exists: " + name, 409);
+      }
+    }
+  }
+
+  /**
+   * Reload the imported template without locking ({@code lock=false}, {@code overrideLock=false}).
+   */
+  private IPSAssemblyTemplate loadImportedReadOnly(
+      String name, IPSGuid guid, String session, String user) {
+    try {
+      if (guid != null) {
+        List<PSAssemblyTemplateWs> loaded =
+            designWs.loadAssemblyTemplates(List.of(guid), false, false, session, user);
+        if (loaded != null && !loaded.isEmpty() && loaded.get(0) != null) {
+          return loaded.get(0).getTemplate();
+        }
+      }
+      List<IPSCatalogSummary> found =
+          designWs.findAssemblyTemplates(name, null, null, null, null, null, null);
+      if (found == null) {
+        return null;
+      }
+      for (IPSCatalogSummary sum : found) {
+        if (sum == null || sum.getGUID() == null) {
+          continue;
+        }
+        if (name.equalsIgnoreCase(sum.getName())) {
+          List<PSAssemblyTemplateWs> loaded =
+              designWs.loadAssemblyTemplates(List.of(sum.getGUID()), false, false, session, user);
+          if (loaded != null && !loaded.isEmpty() && loaded.get(0) != null) {
+            return loaded.get(0).getTemplate();
+          }
+        }
+      }
+    } catch (PSErrorResultsException e) {
+      log.debug("Imported template reload skipped for {}: {}", name, e.getMessage());
+    }
+    return null;
+  }
+
+  private RuntimeException mapImportPersistFailure(String name, PSErrorsException e) {
+    if (isAlreadyExistsFailure(e)) {
+      return new WebApplicationException("Template already exists: " + name, 409);
+    }
+    if (isLockFailure(e)) {
+      return new WebApplicationException(
+          "Could not import template; design lock required or held by another user", 409);
+    }
+    log.error("Failed to save imported template {}: {}", name, e.getMessage(), e);
+    return new IllegalStateException("Failed to import template", e);
+  }
+
+  static boolean isAlreadyExistsFailure(Throwable t) {
+    for (Throwable cur = t; cur != null && cur != cur.getCause(); cur = cur.getCause()) {
+      String msg = cur.getMessage();
+      if (cur instanceof PSErrorException pe && StringUtils.isNotBlank(pe.getErrorMessage())) {
+        msg = pe.getErrorMessage();
+      }
+      if (msg != null && msg.toLowerCase().contains("already exists")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isLockFailure(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (err == null) {
+        continue;
+      }
+      String msg = err instanceof PSErrorException pe ? pe.getErrorMessage() : String.valueOf(err);
+      if (msg != null) {
+        String lower = msg.toLowerCase();
+        if (lower.contains("lock") || lower.contains("locked")) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private static void requireSessionUserForDesignWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for template design import", Response.Status.FORBIDDEN);
+    }
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorImportTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/TemplateAdaptorImportTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.templates.TemplateDetail;
+import com.percussion.services.assembly.IPSAssemblyService;
+import com.percussion.services.assembly.IPSAssemblyTemplate;
+import com.percussion.services.assembly.data.PSAssemblyTemplate;
+import com.percussion.services.assembly.data.PSTemplateBinding;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.assembly.IPSAssemblyDesignWs;
+import com.percussion.webservices.assembly.data.PSAssemblyTemplateWs;
+import com.percussion.webservices.content.IPSContentWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * AS-08 POST import of Workbench-equivalent {@code assembly-template} design XML via {@code
+ * IPSAssemblyDesignWs}. Admin only; 409 on name collision; does not steal locks.
+ */
+@Tag("UnitTest")
+class TemplateAdaptorImportTest {
+
+  private IPSAssemblyService asm;
+  private IPSContentWs contentWs;
+  private IPSAssemblyDesignWs designWs;
+  private TemplateAdaptor adaptor;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    asm = mock(IPSAssemblyService.class);
+    contentWs = mock(IPSContentWs.class);
+    designWs = mock(IPSAssemblyDesignWs.class);
+    adaptor = new TemplateAdaptor(asm, contentWs, designWs, () -> true);
+    when(designWs.findAssemblyTemplates(any(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull()))
+        .thenReturn(List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void import_createsViaDesignWsAndRoundTripsName() throws Exception {
+    String xml = sampleImportXml("imported.one", "Imported One");
+    PSAssemblyTemplate created = newCreatedTemplate(2001L, "imported.one");
+    PSAssemblyTemplateWs createdWs = new PSAssemblyTemplateWs(created, Map.of());
+    when(designWs.createAssemblyTemplates(eq(List.of("imported.one")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(createdWs));
+    stubReload("imported.one", created.getGUID(), createdWs);
+
+    TemplateDetail out = adaptor.importTemplate(null, xml);
+
+    assertEquals("imported.one", out.getName());
+    assertEquals("Imported One", out.getLabel());
+    assertEquals("Java/global/percussion/assembly/htmlAssembler", out.getAssembler());
+    assertEquals("#set($x=1)$x", out.getTemplateSource());
+    verify(designWs)
+        .createAssemblyTemplates(eq(List.of("imported.one")), eq("test-session"), eq("Admin"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSAssemblyTemplateWs>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveAssemblyTemplates(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    IPSAssemblyTemplate persisted = saved.getValue().get(0).getTemplate();
+    assertEquals("imported.one", persisted.getName());
+    assertEquals(2001L, persisted.getGUID().getUUID());
+    verify(designWs)
+        .loadAssemblyTemplates(eq(List.of(created.getGUID())), eq(false), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void import_nonAdmin_is403() throws Exception {
+    adaptor = new TemplateAdaptor(asm, contentWs, designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.importTemplate(null, sampleImportXml("imported.one", "Imported One")));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).createAssemblyTemplates(anyList(), any(), any());
+    verify(designWs, never()).saveAssemblyTemplates(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void import_invalidXml_is400() {
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.importTemplate(null, "<not-a-template"));
+    assertTrue(ex.getMessage().contains("invalid assembly-template XML"));
+    verify(designWs, never()).createAssemblyTemplates(anyList(), any(), any());
+  }
+
+  @Test
+  void import_blankXml_is400() {
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.importTemplate(null, "  "));
+    assertEquals("assembly-template XML is required", ex.getMessage());
+  }
+
+  @Test
+  void import_jsonBody_is400() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.importTemplate(null, "{\"name\":\"x\"}"));
+    assertEquals("expected assembly-template XML", ex.getMessage());
+  }
+
+  @Test
+  void parseDesignXml_roundTripsNameFromWorkbenchXml() throws Exception {
+    String xml = sampleImportXml("imported.one", "Imported One");
+    PSAssemblyTemplate parsed = TemplateAdaptor.parseDesignXml(xml);
+    assertEquals("imported.one", parsed.getName());
+    assertEquals("Imported One", parsed.getLabel());
+  }
+
+  @Test
+  void import_duplicateName_is409BeforeCreate() throws Exception {
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("imported.one");
+    when(designWs.findAssemblyTemplates(
+            eq("imported.one"), isNull(), isNull(), isNull(), isNull(), isNull(), isNull()))
+        .thenReturn(List.of(existing));
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.importTemplate(null, sampleImportXml("imported.one", "Imported One")));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createAssemblyTemplates(anyList(), any(), any());
+    verify(designWs, never()).saveAssemblyTemplates(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void import_persistTimeDuplicate_is409() throws Exception {
+    when(designWs.createAssemblyTemplates(eq(List.of("imported.one")), eq("test-session"), eq("Admin")))
+        .thenThrow(
+            new IllegalArgumentException(
+                "The name 'imported.one' for type 'TEMPLATE' already exists."));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.importTemplate(null, sampleImportXml("imported.one", "Imported One")));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveAssemblyTemplates(anyList(), anyBoolean(), any(), any());
+  }
+
+  private void stubReload(String name, IPSGuid guid, PSAssemblyTemplateWs ws)
+      throws Exception {
+    IPSCatalogSummary summary = mock(IPSCatalogSummary.class);
+    when(summary.getName()).thenReturn(name);
+    when(summary.getGUID()).thenReturn(guid);
+    when(designWs.findAssemblyTemplates(
+            eq(name), isNull(), isNull(), isNull(), isNull(), isNull(), isNull()))
+        .thenReturn(List.of())
+        .thenReturn(List.of(summary));
+    when(designWs.loadAssemblyTemplates(eq(List.of(guid)), eq(false), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(ws));
+  }
+
+  private static PSAssemblyTemplate newCreatedTemplate(long uuid, String name) {
+    PSAssemblyTemplate t = new PSAssemblyTemplate();
+    t.setGUID(new PSGuid(PSTypeEnum.TEMPLATE, uuid));
+    t.setName(name);
+    t.setLabel(name);
+    return t;
+  }
+
+  private static String sampleImportXml(String name, String label) throws Exception {
+    PSAssemblyTemplate t = new PSAssemblyTemplate();
+    t.setGUID(new PSGuid(PSTypeEnum.TEMPLATE, 557L));
+    t.setName(name);
+    t.setLabel(label);
+    t.setAssembler("Java/global/percussion/assembly/htmlAssembler");
+    t.setAssemblyUrl("../assembler/render");
+    t.setCharset("UTF-8");
+    t.setDescription("");
+    t.setMimeType("text/html");
+    t.setActiveAssemblyType(IPSAssemblyTemplate.AAType.Normal);
+    t.setOutputFormat(IPSAssemblyTemplate.OutputFormat.Snippet);
+    t.setPublishWhen(IPSAssemblyTemplate.PublishWhen.Default);
+    t.setTemplateType(IPSAssemblyTemplate.TemplateType.Shared);
+    t.setGlobalTemplateUsage(IPSAssemblyTemplate.GlobalTemplateUsage.None);
+    t.setTemplate("#set($x=1)$x");
+    t.setLocationPrefix("");
+    t.setLocationSuffix("");
+    t.setStyleSheetPath("");
+    t.setBindings(List.of(new PSTemplateBinding(1, "$sys.item", "$sys.item")));
+    return t.toXML();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/templates/ITemplatesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/templates/ITemplatesAdaptor.java
@@ -96,4 +96,21 @@ public interface ITemplatesAdaptor {
    * @return export payload, or {@code null} if not found
    */
   TemplateExport exportTemplate(URI baseUri, String idOrName);
+
+  /**
+   * Import one Workbench-equivalent assembly-template design XML (AS-08).
+   *
+   * <p>Creates a new template via {@code IPSAssemblyDesignWs} ({@code createAssemblyTemplates} then
+   * {@code saveAssemblyTemplates} with {@code release=true}). Does not steal design locks. Name
+   * collision is a conflict (HTTP 409) — this surface does not replace an existing template. Admin
+   * only.
+   *
+   * @param baseUri the base URI (reserved for HATEOAS)
+   * @param xml Workbench / REST export {@code assembly-template} XML
+   * @return created detail (never {@code null}); {@link TemplateDetail#getName()} round-trips the
+   *     imported name
+   * @throws IllegalArgumentException when XML is blank, not assembly-template design XML, or the
+   *     name is invalid
+   */
+  TemplateDetail importTemplate(URI baseUri, String xml);
 }

--- a/rest/src/main/java/com/percussion/rest/templates/TemplatesResource.java
+++ b/rest/src/main/java/com/percussion/rest/templates/TemplatesResource.java
@@ -178,6 +178,58 @@ public class TemplatesResource {
     }
   }
 
+  /**
+   * Imports one Workbench-equivalent assembly-template design XML (AS-08). Create-only: a name that
+   * already exists is 409. Does not steal design locks. Admin only.
+   *
+   * @param xml {@code assembly-template} design XML (same document as GET export / Workbench)
+   * @return created TemplateDetail; name round-trips from the XML
+   */
+  @POST
+  @Path("/import")
+  @Consumes({MediaType.APPLICATION_XML, MediaType.TEXT_XML})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Import assembly template design XML",
+      description =
+          "Admin-only AS-08 import of one assembly template from Workbench-equivalent design XML"
+              + " (same document as GET /templates/{idOrName}/export when that export is installed,"
+              + " otherwise the Workbench assembly-template export). Creates via"
+              + " IPSAssemblyDesignWs. Duplicate name is 409 (no replace). Does not acquire locks"
+              + " on existing templates or steal locks. Save releases the new object's lock.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Imported",
+            content = @Content(schema = @Schema(implementation = TemplateDetail.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid or missing assembly-template XML"),
+        @ApiResponse(responseCode = "403", description = "Caller is not Admin"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Template name already exists (no replace policy)"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public TemplateDetail importTemplate(
+      @RequestBody(
+              required = true,
+              description = "Workbench-equivalent assembly-template design XML",
+              content = @Content(mediaType = MediaType.APPLICATION_XML))
+          String xml) {
+    try {
+      TemplateDetail detail = adaptor.importTemplate(uriInfo.getBaseUri(), xml);
+      if (detail == null) {
+        throw new WebApplicationException("Failed to import template", 500);
+      }
+      return detail;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), 400);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
   @GET
   @Path("/{idOrName}")
   @Produces({MediaType.APPLICATION_JSON})

--- a/rest/src/test/java/com/percussion/rest/templates/TemplatesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/templates/TemplatesResourceDetailTest.java
@@ -286,4 +286,58 @@ public class TemplatesResourceDetailTest {
     assertEquals("a.xml", TemplatesResource.exportFilename("a.xml"));
     assertEquals("Foo.XML", TemplatesResource.exportFilename("Foo.XML"));
   }
+
+  @Test
+  public void importTemplateSuccessRoundTripsName() {
+    TemplateDetail created = new TemplateDetail();
+    created.setName("imported.one");
+    created.setLabel("Imported One");
+    when(adaptor.importTemplate(any(), eq(SAMPLE_IMPORT_XML))).thenReturn(created);
+
+    TemplateDetail out = resource.importTemplate(SAMPLE_IMPORT_XML);
+    assertEquals("imported.one", out.getName());
+    assertEquals("Imported One", out.getLabel());
+    verify(adaptor).importTemplate(any(), eq(SAMPLE_IMPORT_XML));
+  }
+
+  @Test
+  public void importTemplateInvalidXmlIs400() {
+    when(adaptor.importTemplate(any(), any()))
+        .thenThrow(new IllegalArgumentException("invalid assembly-template XML"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.importTemplate("<not-xml"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void importTemplateNonAdminIs403() {
+    when(adaptor.importTemplate(any(), any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.importTemplate(SAMPLE_IMPORT_XML));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void importTemplateNameCollisionIs409() {
+    when(adaptor.importTemplate(any(), any()))
+        .thenThrow(new WebApplicationException("Template already exists: imported.one", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.importTemplate(SAMPLE_IMPORT_XML));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void importTemplateWrapsFailures() {
+    when(adaptor.importTemplate(any(), any())).thenThrow(new IllegalStateException("fail"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.importTemplate(SAMPLE_IMPORT_XML));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
+
+  private static final String SAMPLE_IMPORT_XML =
+      "<assembly-template><name>imported.one</name></assembly-template>";
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestTemplatesAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestTemplatesAdaptor.java
@@ -68,4 +68,9 @@ public class TestTemplatesAdaptor implements ITemplatesAdaptor {
   public TemplateExport exportTemplate(URI baseUri, String idOrName) {
     return null;
   }
+
+  @Override
+  public TemplateDetail importTemplate(URI baseUri, String xml) {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

Parent [#1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690). Slice [#4010](https://github.com/intersoftdatalabs-in/percussioncms/issues/4010): Admin **POST** `/services/templates/import` accepts Workbench-equivalent assembly-template **design XML** (same `<assembly-template>` document as Workbench export and as peer GET `/services/templates/{idOrName}/export` on PR #4009 when that contract is installed). Parse and persist through existing `IPSAssemblyDesignWs` (`createAssemblyTemplates` then `saveAssemblyTemplates` with `release=true`). Duplicate name is **409** (no replace). Does **not** steal design locks. Non-Admin **403**; invalid XML **400**. Imported `name` round-trips on the JSON `TemplateDetail` response.

**Out of scope (this PR):** SPA import wizard, widget definition XML / package compile, human QA.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4010
Partial #1690 (AS-08 import; export is PR #4009)

## Test plan

1. Mockito `TemplatesResourceDetailTest`: import 200 name round-trip, 400 invalid XML, 403, 409, 500 wrap.
2. Spring `TestTemplatesAdaptor.importTemplate` stub so `MainTest` / rest suite load ApplicationContext.
3. `TemplateAdaptorImportTest`: success via design WS (XML name/label/source round-trip, new GUID kept, save `release=true`, reload `lock=false`/`overrideLock=false`), 403 non-Admin, 400 invalid/blank/JSON, 409 name collision before create and persist-time duplicate.
4. Review product-docs: `product-docs/8.2/developer/rest.md` (AS-08 import) and `product-docs/8.2/admin/design-templates.md`.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/rest.md`, `admin/design-templates.md`)
- [x] **Unit / module tests** — behavioral tests for import; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when `final`/API shape changes
- [x] **Cross-platform** — XML is an HTTP body string; tests do not write files or join filesystem paths

### Product-docs pointers

- Gate: root `AGENTS.md` → **Product documentation (HARD GATE)**
- Tree: `product-docs/README.md` (layout, frontmatter `id` stability, build smoke)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: 822, Failures: 0 (`TemplatesResourceDetailTest` 22/0)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: 1874, Failures: 0, Skipped: 125 (`TemplateAdaptorImportTest` 8/0)
- **downstream_checked:** `ITemplatesAdaptor` gained `importTemplate` (not `final`). Grep `implements ITemplatesAdaptor` → `TemplateAdaptor` (updated) + `TestTemplatesAdaptor` (stub). Standalone sitemanage clean install after rest install.
- **C5 UI proof:** N/A — REST/docs only, no SPA/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
