### PR TITLE
feat(rest): CD-14 Admin content-type design XML export (#4018)

### DIFF
--- a/docs/ai-generated/code-reviews/4018-content-type-export-erlang.md
+++ b/docs/ai-generated/code-reviews/4018-content-type-export-erlang.md
@@ -1,0 +1,40 @@
+# Erlang review — #4018 CD-14 content-type design XML export
+
+| Field | Value |
+|-------|--------|
+| **Date** | 2026-08-29 |
+| **Branch** | `feat/issue-4018-content-type-export` |
+| **Issue** | #4018 (parent #1690, FR CD-14 export) |
+| **Recommendation** | **approve** |
+| **May commit/push** | yes |
+| **Gate** | no blocking bugs |
+
+## Summary
+
+Admin REST `GET /services/contenttypes/{idOrName}/export` returns Workbench-equivalent
+`PSItemDefinition` design XML loaded through existing `IPSContentDesignWs`
+(`lock=false`, `overrideLock=false`). Peer is AS-08 template export (#4004 / PR #4009).
+Change-class closure is complete: rest DTO + adaptor method + resource + Mockito tests +
+Spring `TestContentTypeAdaptor` stub + `ContentTypesTestAdaptor` + sitemanage impl +
+adaptor tests + product-docs 8.2 + gap-map note. Import remains a later CD-14 slice.
+
+Memory patterns hit: change-class completeness (rest Spring stub + sitemanage impl);
+filename sanitizer is HTTP basename (not filesystem path join).
+
+## Cross-platform path checklist
+
+- [x] No filesystem `"/" +` / `"\\" +` construction
+- [x] Filename helper sanitizes HTTP `Content-Disposition` basename only
+- [x] Tests do not write temp files
+- [x] N/A Path/Files — no I/O
+
+## Issues
+
+None.
+
+## Tests / Maven
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 823, Failures: 0
+  (`ContentTypesResourceDetailTest` 129/0)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS;
+  Tests run: 1875, Failures: 0, Skipped: 125 (`ContentTypeAdaptorExportTest` 9/0)

--- a/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
+++ b/docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md
@@ -92,7 +92,7 @@ with a held design lock released on save). Empty list clears. Admin 403; unknown
 | System def **write** (existing field properties)     | CD-16        | **PUT `/services/systemdef` shipped** (#3958, Admin 403, lock 409). **Field create/delete shipped** (`POST /services/systemdef/fields`, `DELETE …/fields/{fieldName}`, persistable `PSField` + display mapping, Admin 403, lock 409, #3964). Control/stylesheet/flow and SPA editor still SOAP |
 | Create / delete                                      | CD-01, §5.2  | **POST `/services/contenttypes` create shipped** (#3912). Delete still SOAP design only; lock + PUT save via REST |
 | Rename                                               | CD-01, §5.2  | **REST `PUT /contenttypes/{id}/name`** (#3914, held design lock; unique, no spaces; bulk PUT does not rename) |
-| Import/export CT                                     | CD-14        | Workbench wizards                                 |
+| Import/export CT                                     | CD-14        | **REST GET export shipped** (`GET /services/contenttypes/{idOrName}/export`, Admin 403, unknown 404, no lock steal, #4018). Import + SPA wizard remain Workbench |
 | ACL                                                  | CD-19, §5.4  | Existing ACL REST may help later                  |
 | ~~Keyword write~~                                    | CD-17        | **Done** — REST + SPA + design WS (#1612/#1701)   |
 | Locale **write** (create/update/delete)              | CD-18        | **REST write shipped** (#3959, design WS + Admin 403 / lock 409) |

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-content-types
 title: Developer Content Types
-description: Lock, enable or disable, rename via REST, add or delete local fields via REST, include system or shared fields via REST, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
+description: Lock, enable or disable, rename via REST, add or delete local fields via REST, include system or shared fields via REST, export design XML via REST, save allowed workflows, templates, item-level exits, control property values, and field-rule expressions, and unlock a content type from Developer detail chrome
 version: "8.2"
 order: 42
 tags: [admin, developer, content-types]
@@ -49,7 +49,9 @@ Nested `POST /services/systemdef/fields` and
 `DELETE /services/systemdef/fields/{fieldName}` add or remove system fields
 (backend column + display mapping). Duplicate field names are **409**.
 System-mandatory and system-internal fields cannot be deleted (**400**). An SPA
-editor is not in this chrome. See
+editor is not in this chrome. Admin `GET /services/contenttypes/{idOrName}/export`
+downloads Workbench-equivalent design XML (CD-14; no lock steal). Import of that
+XML and an SPA export wizard are not in this chrome. See
 [REST API](id:developer-rest).
 
 This is **not** the full Workbench field-rule editor. The detail table still

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -302,7 +302,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | List | `GET /services/contenttypes` | Name, label, description, guid |
 | Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. The new type is then `GET /services/contenttypes/{name}` **200**. Duplicate name is **409** (catalog check and persist-time unique-name failure), including reserved system types such as **Folder**. Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Non-Admin is **403**. Rename uses `PUT .../name`. Delete uses `DELETE .../{idOrName}`. |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `enabled`, `designGaps` |
-| Export | `GET /services/contenttypes/{idOrName}/export` | **Admin.** CD-14 export of Workbench-equivalent design XML (`IPSContentDesignWs.loadContentTypes` with `lock=false`, `overrideLock=false` — the lock is **not** stolen). `Content-Type: application/xml` and `Content-Disposition: attachment` with a filename derived from the **type name** (for example `percPage.xml`). Unknown id/name is **404**. Non-Admin is **403**. **Import is not implemented** on this path (later CD-14 slice). No SPA export wizard. |
+| Export | `GET /services/contenttypes/{idOrName}/export` | **Admin.** CD-14 export of Workbench-equivalent design XML (`IPSContentDesignWs.loadContentTypes` with `lock=false`, `overrideLock=false` — the lock is **not** stolen). `Content-Type: application/xml` and `Content-Disposition: attachment` with a filename derived from the **type name** (for example `percPage.xml`). Path separators and Windows-invalid characters (`* ? < > \| :`) are replaced with `_`. The header includes an ASCII `filename` fallback and RFC 5987 `filename*` for non-ASCII names. Unknown id/name is **404**. Non-Admin is **403**. **Import is not implemented** on this path (later CD-14 slice). No SPA export wizard. |
 | Allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` | Read-only list of associated templates (CD-12). No lock required. Empty list means none. Same set as `ContentTypeDetail.allowedTemplates`. |
 | Item-level exits | `GET /services/contenttypes/{idOrName}/itemExits` | Item-level input/output translations, validations, and pipe pre/post exits (CD-09). No lock required. Empty lists mean none. Apply-when conditions are a read-only summary. Jackson root wrap is `ContentTypeItemExits`. |
 | Replace item-level exits | `PUT /services/contenttypes/{idOrName}/itemExits` | Full replace of item-level translations/validations via `IPSContentDesignWs.saveContentTypes` (CD-09). Requires a **held** design-session lock. Empty lists clear. **409** if unlocked or locked by another user. **400** if required lists are missing or an extension FQN is invalid. `preExits`/`postExits` omitted leave pipe extensions unchanged. Apply-when is not written. Does not acquire or release the lock. |
@@ -345,7 +345,10 @@ Lock / save / unlock / create / rename / delete status codes:
 equivalent: it returns the design-object XML for one content type loaded through the
 existing content design web service (`IPSContentDesignWs`). The download uses
 `Content-Type: application/xml` and `Content-Disposition: attachment` with a filename
-derived from the **content type name** (for example `percPage.xml`).
+derived from the **content type name** (for example `percPage.xml`). Characters that
+Windows Explorer rejects in a download name (`* ? < > | :` plus path separators) are
+replaced with `_`. The header always includes an ASCII `filename=` fallback and an
+RFC 5987 `filename*=UTF-8''…` parameter so non-ASCII type names decode in browsers.
 
 | Status | Meaning |
 |--------|---------|

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -302,6 +302,7 @@ in the slot detail panel — use **Back** to return to the catalog.
 | List | `GET /services/contenttypes` | Name, label, description, guid |
 | Create | `POST /services/contenttypes` | **Admin.** Creates and **saves** a content type (`IPSContentDesignWs.createContentTypes` then `saveContentTypes` — Workbench Finish, not an unsaved stub). JSON body requires `name` (unique, case-insensitive; no spaces). Optional `label`, `description`, and `enabled` are applied before save. Omitted `enabled` **defaults to true** so the new type is usable. `200` + `ContentTypeDetail`. The new type is then `GET /services/contenttypes/{name}` **200**. Duplicate name is **409** (catalog check and persist-time unique-name failure), including reserved system types such as **Folder**. Blank / whitespace / wildcard names are **400**. Missing request session/user is **403**. Non-Admin is **403**. Rename uses `PUT .../name`. Delete uses `DELETE .../{idOrName}`. |
 | Detail | `GET /services/contenttypes/{idOrName}` | Field catalog, associations, `enabled`, `designGaps` |
+| Export | `GET /services/contenttypes/{idOrName}/export` | **Admin.** CD-14 export of Workbench-equivalent design XML (`IPSContentDesignWs.loadContentTypes` with `lock=false`, `overrideLock=false` — the lock is **not** stolen). `Content-Type: application/xml` and `Content-Disposition: attachment` with a filename derived from the **type name** (for example `percPage.xml`). Unknown id/name is **404**. Non-Admin is **403**. **Import is not implemented** on this path (later CD-14 slice). No SPA export wizard. |
 | Allowed templates | `GET /services/contenttypes/{idOrName}/allowedTemplates` | Read-only list of associated templates (CD-12). No lock required. Empty list means none. Same set as `ContentTypeDetail.allowedTemplates`. |
 | Item-level exits | `GET /services/contenttypes/{idOrName}/itemExits` | Item-level input/output translations, validations, and pipe pre/post exits (CD-09). No lock required. Empty lists mean none. Apply-when conditions are a read-only summary. Jackson root wrap is `ContentTypeItemExits`. |
 | Replace item-level exits | `PUT /services/contenttypes/{idOrName}/itemExits` | Full replace of item-level translations/validations via `IPSContentDesignWs.saveContentTypes` (CD-09). Requires a **held** design-session lock. Empty lists clear. **409** if unlocked or locked by another user. **400** if required lists are missing or an extension FQN is invalid. `preExits`/`postExits` omitted leave pipe extensions unchanged. Apply-when is not written. Does not acquire or release the lock. |
@@ -324,19 +325,40 @@ in the slot detail panel — use **Back** to return to the catalog.
 | Unlock | `POST /services/contenttypes/{idOrName}/unlock` | **Admin.** Releases a lock owned by the current session user (Workbench `releaseLocks`). Does **not** save. `204` on success. |
 | Delete | `DELETE /services/contenttypes/{idOrName}` | **Admin.** Requires a **held** design-session lock (`POST .../lock` first). Calls `IPSContentDesignWs.deleteContentTypes` with `ignoreDependencies=false`. **204** on success; a following `GET .../{idOrName}` is **404**. **409** if unlocked or locked by another user (the lock is not stolen). **404** if missing. **400** if the design web service rejects an in-use type (dependents). Does **not** cascade item delete. |
 
-Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Type-level search indexing is REST-only (`GET`/`PUT .../searchIndexing`, CD-10; no SPA Properties checkbox). Icon strategy is REST-only: **lock → PUT .../icon → unlock** (no SPA picker; no binary upload). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07). That chrome still omits `choices` on save (catalogs stay unchanged from the SPA). Integrators write choice filter, null-entry, and default-selected on the same PUT by sending `choices`. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). Include system/shared is REST-only: **lock → POST .../fields/include → unlock** (no SPA field picker). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
+Typical design-session flow: **lock → PUT save (repeatable) → unlock**. Existing PUT clients that previously lock-save-unlocked in a single request must now `POST .../lock` before PUT and `POST .../unlock` after. **Create** is a separate `POST /services/contenttypes` (persisted immediately). The Developer SPA **Content types** detail chrome exposes **Lock**, **Save**, and **Unlock** for that flow — see [Developer Content Types](id:admin-developer-content-types). Enable/disable from that chrome uses the dedicated `PUT .../enabled` after a held lock (not the bulk content-type PUT). Type-level search indexing is REST-only (`GET`/`PUT .../searchIndexing`, CD-10; no SPA Properties checkbox). Icon strategy is REST-only: **lock → PUT .../icon → unlock** (no SPA picker; no binary upload). Control property **values** use `GET`/`PUT .../fields/{fieldName}/controlProperties` after a held lock (CD-07). That chrome still omits `choices` on save (catalogs stay unchanged from the SPA). Integrators write choice filter, null-entry, and default-selected on the same PUT by sending `choices`. Local field create/delete is REST-only: **lock → POST .../fields** or **DELETE .../fields/{fieldName} → unlock** (no SPA field editor). Include system/shared is REST-only: **lock → POST .../fields/include → unlock** (no SPA field picker). **CD-14 export** is REST-only: Admin `GET /services/contenttypes/{idOrName}/export` downloads Workbench-equivalent design XML without stealing a lock (import and SPA wizard remain later). SPA create-wizard chrome is not part of this API. Rename is REST-only: **lock → PUT .../name → unlock**. Delete is REST-only in this release (no SPA chrome): **lock → DELETE → GET 404**.
 
 Lock / save / unlock / create / rename / delete status codes:
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / icon / rename succeeded (lock still held), POST create succeeded (`ContentTypeDetail`), POST local field succeeded, or POST include field succeeded |
+| `200` | Lock acquired (body is `ObjectLockSummary`), PUT save / enable / disable / icon / rename succeeded (lock still held), POST create succeeded (`ContentTypeDetail`), POST local field succeeded, POST include field succeeded, or GET export returned design XML |
 | `204` | Unlock success, content type deleted, or local field deleted |
 | `400` | Invalid PUT body (unknown field name, bad workflow/template ref, missing `enabled` or `searchIndexing` flag, invalid icon `source` or blank non-none icon `value`, invalid or colliding rename), invalid create name (blank, spaces, wildcard), invalid local-field name/`dataType`/origin, invalid include `fieldType`/`name`, DELETE field of a system/shared field, or DELETE type rejected because the type has dependents |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Content type not found, or include of an unknown system/shared catalog field |
 | `409` | No lock held, or locked by another user/session (self-only; the lock is not stolen); POST create duplicate name (catalog or persist-time), including reserved system types such as Folder; POST local field when the field name already exists on the type; POST include when the field is already on the type |
 | `500` | Design service or server failure |
+
+### Content type design XML export (CD-14)
+
+`GET /services/contenttypes/{idOrName}/export` is the Workbench **export content type**
+equivalent: it returns the design-object XML for one content type loaded through the
+existing content design web service (`IPSContentDesignWs`). The download uses
+`Content-Type: application/xml` and `Content-Disposition: attachment` with a filename
+derived from the **content type name** (for example `percPage.xml`).
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Design XML body |
+| `403` | Caller is not Admin |
+| `404` | Unknown id or name |
+
+The load is **read-only**. The server does **not** acquire or steal a design lock
+(`lock=false`, `overrideLock=false`). **Import** (POST of the same XML) is **not**
+implemented on this path — that remains a later CD-14 slice. There is no Design SPA
+export wizard; operators and integrators call this REST path directly.
+
+See also [Developer Content Types](id:admin-developer-content-types).
 
 ### Rename (CD-01)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ContentTypeAdaptor.java
@@ -79,6 +79,7 @@ import com.percussion.rest.contenttypes.ContentTypeChoiceTable;
 import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
 import com.percussion.rest.contenttypes.ContentTypeDesignLockException;
+import com.percussion.rest.contenttypes.ContentTypeExport;
 import com.percussion.rest.contenttypes.ContentTypeField;
 import com.percussion.rest.contenttypes.ContentTypeFieldConditional;
 import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
@@ -124,6 +125,7 @@ import com.percussion.webservices.content.IPSContentDesignWs;
 import com.percussion.webservices.content.PSContentWsLocator;
 import com.percussion.webservices.system.IPSSystemDesignWs;
 import com.percussion.webservices.system.PSSystemWsLocator;
+import com.percussion.xml.PSXmlDocumentBuilder;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
@@ -326,6 +328,72 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
       log.error("Failed to load content type {}: {}", idOrName, e.getMessage(), e);
       throw new RuntimeException(
           "Failed to load content type (" + e.getClass().getName() + "): " + e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public ContentTypeExport exportContentType(URI baseUri, String idOrName) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      return null;
+    }
+    try {
+      IPSGuid guid = resolveExistingContentTypeGuid(idOrName.trim());
+      if (guid == null) {
+        return null;
+      }
+      List<PSItemDefinition> loaded;
+      try {
+        loaded =
+            designSvc.loadContentTypes(
+                Collections.singletonList(guid), false, false, currentSession(), currentUser());
+      } catch (PSErrorResultsException e) {
+        if (isNotFoundError(e)) {
+          log.debug("Content type export not found {}: {}", idOrName, e.getMessage());
+          return null;
+        }
+        throw new IllegalStateException("Failed to export content type", e);
+      }
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        return null;
+      }
+      PSItemDefinition def = loaded.get(0);
+      ContentTypeExport exported = new ContentTypeExport();
+      exported.setName(def.getName());
+      exported.setXml(toDesignXml(def));
+      return exported;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalStateException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error(
+          "Failed to export content type {} ({}): {}",
+          idOrName,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new IllegalStateException("Failed to export content type", e);
+    }
+  }
+
+  /**
+   * Workbench-equivalent design XML for a loaded item definition ({@link PSItemDefinition#toXml}).
+   */
+  static String toDesignXml(PSItemDefinition def) {
+    if (def == null) {
+      throw new IllegalArgumentException("content type is required");
+    }
+    try {
+      var xml = def.toXml(PSXmlDocumentBuilder.createXmlDocument());
+      if (xml == null) {
+        throw new IllegalStateException("Failed to serialize content type design XML");
+      }
+      return PSXmlDocumentBuilder.toString(xml);
+    } catch (IllegalStateException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw new IllegalStateException("Failed to serialize content type design XML", e);
     }
   }
 
@@ -4250,12 +4318,12 @@ public class ContentTypeAdaptor implements IContentTypesAdaptor {
     } catch (RuntimeException e) {
       log.debug("Admin check failed: {}", e.getMessage());
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, save, rename, or delete content types",
+          "Admin role required to create, lock, unlock, save, rename, delete, or export content types",
           Response.Status.FORBIDDEN);
     }
     if (!allowed) {
       throw new WebApplicationException(
-          "Admin role required to create, lock, unlock, save, rename, or delete content types",
+          "Admin role required to create, lock, unlock, save, rename, delete, or export content types",
           Response.Status.FORBIDDEN);
     }
   }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorExportTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ContentTypeAdaptorExportTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSItemDefinition;
+import com.percussion.cms.objectstore.server.PSItemDefManager;
+import com.percussion.rest.contenttypes.ContentTypeExport;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.share.service.exception.PSDataServiceException;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfoBase;
+import com.percussion.webservices.content.IPSContentDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * CD-14 content-type export: Admin-only, IPSContentDesignWs load without stealing locks, XML
+ * includes the type name.
+ */
+@Tag("UnitTest")
+class ContentTypeAdaptorExportTest {
+
+  private IPSContentDesignWs designWs;
+  private IPSSystemDesignWs systemDesign;
+  private PSItemDefManager itemDefManager;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfoBase.resetRequestInfo();
+    PSRequestInfoBase.initRequestInfo(new HashMap<>());
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_JSESSIONID, "test-session");
+    PSRequestInfoBase.setRequestInfo(PSRequestInfoBase.KEY_USER, "Admin");
+    designWs = mock(IPSContentDesignWs.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    itemDefManager = mock(PSItemDefManager.class);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfoBase.resetRequestInfo();
+  }
+
+  private ContentTypeAdaptor allowAdmin() {
+    return new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> true);
+  }
+
+  /** Production no-arg Admin gate ({@code adminChecker == null} → {@code isCurrentUserAdmin}). */
+  private ContentTypeAdaptor productionAdminGate() {
+    return new ContentTypeAdaptor(
+        designWs, itemDefManager, systemDesign, (BooleanSupplier) null);
+  }
+
+  private static void injectUserService(ContentTypeAdaptor adaptor, IPSUserService users)
+      throws Exception {
+    Field field = ContentTypeAdaptor.class.getDeclaredField("userService");
+    field.setAccessible(true);
+    field.set(adaptor, users);
+  }
+
+  private static PSCurrentUser namedUser(String name) {
+    PSCurrentUser user = new PSCurrentUser();
+    user.setName(name);
+    return user;
+  }
+
+  private static PSItemDefinition stubExportDef(String name) {
+    PSItemDefinition def = mock(PSItemDefinition.class);
+    when(def.getName()).thenReturn(name);
+    when(def.toXml(any(Document.class)))
+        .thenAnswer(
+            inv -> {
+              Document doc = inv.getArgument(0);
+              Element root = doc.createElement("ItemDefData");
+              root.setAttribute("name", name);
+              Element n = doc.createElement("name");
+              n.appendChild(doc.createTextNode(name));
+              root.appendChild(n);
+              return root;
+            });
+    return def;
+  }
+
+  @Test
+  void exportByName_returnsXmlContainingName_withoutLock() throws Exception {
+    IPSGuid guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(sum.getName()).thenReturn("percPage");
+    when(sum.getLabel()).thenReturn("Page");
+    PSItemDefinition def = stubExportDef("percPage");
+    when(designWs.findContentTypes("percPage")).thenReturn(List.of(sum));
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(def));
+
+    ContentTypeExport out = allowAdmin().exportContentType(null, "percPage");
+    assertNotNull(out);
+    assertEquals("percPage", out.getName());
+    assertTrue(out.getXml().contains("percPage"), out.getXml());
+    verify(designWs).loadContentTypes(anyList(), eq(false), eq(false), any(), any());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(true), eq(true), any(), any());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void exportByNumericId_loadsReadOnly() throws Exception {
+    PSItemDefinition def = stubExportDef("percPage");
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(def));
+
+    ContentTypeExport out = allowAdmin().exportContentType(null, "311");
+    assertNotNull(out);
+    assertEquals("percPage", out.getName());
+    assertTrue(out.getXml().contains("percPage"), out.getXml());
+    verify(designWs, never()).findContentTypes(any());
+    verify(designWs, atLeastOnce())
+        .loadContentTypes(anyList(), eq(false), eq(false), any(), any());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(true), eq(true), any(), any());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void exportUnknown_returnsNull() throws Exception {
+    when(designWs.findContentTypes("missing")).thenReturn(Collections.emptyList());
+    assertNull(allowAdmin().exportContentType(null, "missing"));
+    verify(designWs, never()).loadContentTypes(anyList(), eq(false), eq(false), any(), any());
+  }
+
+  @Test
+  void exportBlank_returnsNullWithoutDesignWs() throws Exception {
+    assertNull(allowAdmin().exportContentType(null, "  "));
+    assertNull(allowAdmin().exportContentType(null, null));
+    verify(designWs, never()).findContentTypes(any());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(false), eq(false), any(), any());
+  }
+
+  @Test
+  void exportForbiddenWhenNotAdmin() throws Exception {
+    ContentTypeAdaptor denied =
+        new ContentTypeAdaptor(designWs, itemDefManager, systemDesign, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> denied.exportContentType(null, "percPage"));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).findContentTypes(any());
+    verify(designWs, never()).loadContentTypes(anyList(), eq(false), eq(false), any(), any());
+  }
+
+  @Test
+  void exportForbiddenWhenProductionAdminGateDenies() throws Exception {
+    IPSUserService users = mock(IPSUserService.class);
+    when(users.getCurrentUser()).thenReturn(namedUser("editor"));
+    when(users.isAdminUser("editor")).thenReturn(false);
+    ContentTypeAdaptor denied = productionAdminGate();
+    injectUserService(denied, users);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> denied.exportContentType(null, "percPage"));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).findContentTypes(any());
+  }
+
+  @Test
+  void exportAllowedWhenProductionAdminGateAllows() throws Exception {
+    IPSGuid guid = new PSGuid(PSTypeEnum.NODEDEF, 311L);
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(sum.getName()).thenReturn("percPage");
+    PSItemDefinition def = stubExportDef("percPage");
+    when(designWs.findContentTypes("percPage")).thenReturn(List.of(sum));
+    when(designWs.loadContentTypes(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(def));
+
+    IPSUserService users = mock(IPSUserService.class);
+    when(users.getCurrentUser()).thenReturn(namedUser("admin1"));
+    when(users.isAdminUser("admin1")).thenReturn(true);
+    ContentTypeAdaptor adaptor = productionAdminGate();
+    injectUserService(adaptor, users);
+
+    ContentTypeExport out = adaptor.exportContentType(null, "percPage");
+    assertNotNull(out);
+    assertEquals("percPage", out.getName());
+    assertTrue(out.getXml().contains("percPage"), out.getXml());
+  }
+
+  @Test
+  void isCurrentUserAdmin_falseWhenGetCurrentUserThrows() throws Exception {
+    IPSUserService users = mock(IPSUserService.class);
+    when(users.getCurrentUser()).thenThrow(new PSDataServiceException("boom"));
+    ContentTypeAdaptor adaptor = productionAdminGate();
+    injectUserService(adaptor, users);
+    assertEquals(false, adaptor.isCurrentUserAdmin());
+  }
+
+  @Test
+  void toDesignXml_nullDefThrows() {
+    assertThrows(IllegalArgumentException.class, () -> ContentTypeAdaptor.toDesignXml(null));
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeExport.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypeExport.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.contenttypes;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Workbench-equivalent content-type design XML (CD-14 export). The HTTP resource maps this to
+ * {@code application/xml} with {@code Content-Disposition} from {@link #getName()}.
+ */
+@Schema(description = "Content type design-object XML export (CD-14)")
+public class ContentTypeExport {
+
+  private String name;
+  private String xml;
+
+  public ContentTypeExport() {}
+
+  public ContentTypeExport(String name, String xml) {
+    this.name = name;
+    this.xml = xml;
+  }
+
+  @Schema(description = "Unique content type name used for the download filename")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Schema(description = "Workbench-equivalent design XML of the loaded content type")
+  public String getXml() {
+    return xml;
+  }
+
+  public void setXml(String xml) {
+    this.xml = xml;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -34,6 +34,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -949,7 +950,7 @@ public class ContentTypesResource {
       }
       String filename = exportFilename(exported.getName());
       return Response.ok(exported.getXml(), MediaType.APPLICATION_XML)
-          .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
+          .header("Content-Disposition", contentDispositionAttachment(filename))
           .build();
     } catch (WebApplicationException e) {
       throw e;
@@ -960,14 +961,25 @@ public class ContentTypesResource {
 
   /**
    * Basename for {@code Content-Disposition}. Strips characters that are unsafe in HTTP filenames
-   * (quotes, controls, path separators). Not a filesystem path.
+   * and Windows Explorer downloads (quotes, controls, path separators, {@code * ? < > |}). Not a
+   * filesystem path.
    */
   static String exportFilename(String contentTypeName) {
     String raw = contentTypeName == null ? "" : contentTypeName.trim();
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < raw.length(); i++) {
       char c = raw.charAt(i);
-      if (c <= 31 || c == 127 || c == '"' || c == '\\' || c == '/' || c == ':') {
+      if (c <= 31
+          || c == 127
+          || c == '"'
+          || c == '\\'
+          || c == '/'
+          || c == ':'
+          || c == '*'
+          || c == '?'
+          || c == '<'
+          || c == '>'
+          || c == '|') {
         sb.append('_');
       } else {
         sb.append(c);
@@ -981,6 +993,66 @@ public class ContentTypesResource {
       base = base + ".xml";
     }
     return base;
+  }
+
+  /**
+   * RFC 6266 {@code Content-Disposition}: ASCII {@code filename} fallback plus RFC 5987 {@code
+   * filename*} so non-ASCII names decode on Windows/browser clients.
+   */
+  static String contentDispositionAttachment(String filename) {
+    return "attachment; filename=\""
+        + asciiFilenameFallback(filename)
+        + "\"; filename*=UTF-8''"
+        + rfc5987Encode(filename);
+  }
+
+  static String asciiFilenameFallback(String filename) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < filename.length(); i++) {
+      char c = filename.charAt(i);
+      if (c >= 32 && c <= 126 && c != '"' && c != '\\') {
+        sb.append(c);
+      } else {
+        sb.append('_');
+      }
+    }
+    String base = sb.toString().trim();
+    boolean onlyDotsAndUnderscores = true;
+    for (int i = 0; i < base.length(); i++) {
+      char c = base.charAt(i);
+      if (c != '_' && c != '.') {
+        onlyDotsAndUnderscores = false;
+        break;
+      }
+    }
+    if (base.isEmpty() || onlyDotsAndUnderscores) {
+      return "contenttype.xml";
+    }
+    return base;
+  }
+
+  static String rfc5987Encode(String value) {
+    byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    StringBuilder sb = new StringBuilder();
+    for (byte b : bytes) {
+      int ub = b & 0xff;
+      if ((ub >= 'a' && ub <= 'z')
+          || (ub >= 'A' && ub <= 'Z')
+          || (ub >= '0' && ub <= '9')
+          || ub == '.'
+          || ub == '-'
+          || ub == '_') {
+        sb.append((char) ub);
+      } else {
+        sb.append('%');
+        String hex = Integer.toHexString(ub).toUpperCase(Locale.ROOT);
+        if (hex.length() == 1) {
+          sb.append('0');
+        }
+        sb.append(hex);
+      }
+    }
+    return sb.toString();
   }
 
   @PUT

--- a/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/ContentTypesResource.java
@@ -35,6 +35,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
+import java.util.Locale;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @PSSiteManageBean(value = "restContentTypesResource")
@@ -911,6 +912,75 @@ public class ContentTypesResource {
       // Preserve cause so log analysis retains the original stack/type
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  /**
+   * Downloads Workbench-equivalent content-type design XML (CD-14 export). Import is a later slice.
+   * Read-only: does not acquire or steal design locks.
+   *
+   * @param idOrName content type uuid or unique name
+   * @return XML attachment named from the content type name
+   */
+  @GET
+  @Path("/{idOrName}/export")
+  @Produces({MediaType.APPLICATION_XML, MediaType.TEXT_XML})
+  @Operation(
+      summary = "Export content type design XML",
+      description =
+          "Admin-only CD-14 export of one content type as Workbench-equivalent design"
+              + " XML (loaded via IPSContentDesignWs). Read-only: does not acquire or steal"
+              + " locks. Import is not implemented on this path. Content-Disposition filename"
+              + " is derived from the content type name.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Design XML",
+            content = @Content(mediaType = MediaType.APPLICATION_XML)),
+        @ApiResponse(responseCode = "403", description = "Caller is not Admin"),
+        @ApiResponse(responseCode = "404", description = "Content type not found"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response exportContentType(@PathParam("idOrName") String idOrName) {
+    try {
+      ContentTypeExport exported =
+          requireAdaptor().exportContentType(uriInfo.getBaseUri(), idOrName);
+      if (exported == null || exported.getXml() == null) {
+        throw new WebApplicationException("Content type not found: " + idOrName, 404);
+      }
+      String filename = exportFilename(exported.getName());
+      return Response.ok(exported.getXml(), MediaType.APPLICATION_XML)
+          .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
+          .build();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Basename for {@code Content-Disposition}. Strips characters that are unsafe in HTTP filenames
+   * (quotes, controls, path separators). Not a filesystem path.
+   */
+  static String exportFilename(String contentTypeName) {
+    String raw = contentTypeName == null ? "" : contentTypeName.trim();
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < raw.length(); i++) {
+      char c = raw.charAt(i);
+      if (c <= 31 || c == 127 || c == '"' || c == '\\' || c == '/' || c == ':') {
+        sb.append('_');
+      } else {
+        sb.append(c);
+      }
+    }
+    String base = sb.toString().trim();
+    if (base.isEmpty()) {
+      base = "contenttype";
+    }
+    if (!base.toLowerCase(Locale.ROOT).endsWith(".xml")) {
+      base = base + ".xml";
+    }
+    return base;
   }
 
   @PUT

--- a/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/contenttypes/IContentTypesAdaptor.java
@@ -76,6 +76,18 @@ public interface IContentTypesAdaptor {
   ContentTypeDetail getContentType(URI baseUri, String idOrName);
 
   /**
+   * Export Workbench-equivalent design XML for one content type (CD-14).
+   *
+   * <p>Read-only: loads through {@code IPSContentDesignWs} without acquiring or stealing locks.
+   * Admin only.
+   *
+   * @param baseUri the base URI (reserved for HATEOAS)
+   * @param idOrName content type uuid (numeric) or unique name
+   * @return export payload, or {@code null} if not found
+   */
+  ContentTypeExport exportContentType(URI baseUri, String idOrName);
+
+  /**
    * Update content type design fields. Requires a design-session lock already held by the current
    * user/session ({@link #lockContentType}); does not acquire or release the lock.
    *

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -1579,4 +1579,59 @@ public class ContentTypesResourceDetailTest {
                     "percPage", new ContentTypeSearchIndexing(false)));
     assertEquals(403, ex.getResponse().getStatus());
   }
+
+  @Test
+  public void exportContentTypeReturnsXmlAndFilenameFromName() {
+    ContentTypeExport exported =
+        new ContentTypeExport("percPage", "<ItemDefData><name>percPage</name></ItemDefData>");
+    when(adaptor.exportContentType(any(), eq("percPage"))).thenReturn(exported);
+
+    Response out = resource.exportContentType("percPage");
+    assertEquals(200, out.getStatus());
+    assertEquals(exported.getXml(), out.getEntity());
+    String disposition = String.valueOf(out.getHeaderString("Content-Disposition"));
+    assertTrue(disposition.contains("percPage.xml"));
+    verify(adaptor).exportContentType(any(), eq("percPage"));
+  }
+
+  @Test
+  public void exportContentTypeNotFound() {
+    when(adaptor.exportContentType(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.exportContentType("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void exportContentTypeForbidden() {
+    when(adaptor.exportContentType(any(), eq("percPage")))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.exportContentType("percPage"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void exportContentTypeWrapsFailures() {
+    when(adaptor.exportContentType(any(), eq("boom"))).thenThrow(new IllegalStateException("fail"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.exportContentType("boom"));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void exportFilenameSanitizesPathCharacters() {
+    assertEquals("percPage.xml", ContentTypesResource.exportFilename("percPage"));
+    assertEquals("a_b.xml", ContentTypesResource.exportFilename("a/b"));
+    assertEquals("contenttype.xml", ContentTypesResource.exportFilename("  "));
+  }
+
+  @Test
+  public void exportFilenameShortNamesAppendXmlWithoutThrowing() {
+    assertEquals("a.xml", ContentTypesResource.exportFilename("a"));
+    assertEquals("ab.xml", ContentTypesResource.exportFilename("ab"));
+    assertEquals("abc.xml", ContentTypesResource.exportFilename("abc"));
+    assertEquals("a.xml", ContentTypesResource.exportFilename("a.xml"));
+    assertEquals("Foo.XML", ContentTypesResource.exportFilename("Foo.XML"));
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesResourceDetailTest.java
@@ -1590,7 +1590,8 @@ public class ContentTypesResourceDetailTest {
     assertEquals(200, out.getStatus());
     assertEquals(exported.getXml(), out.getEntity());
     String disposition = String.valueOf(out.getHeaderString("Content-Disposition"));
-    assertTrue(disposition.contains("percPage.xml"));
+    assertTrue(disposition.contains("filename=\"percPage.xml\""));
+    assertTrue(disposition.contains("filename*=UTF-8''percPage.xml"));
     verify(adaptor).exportContentType(any(), eq("percPage"));
   }
 
@@ -1624,6 +1625,22 @@ public class ContentTypesResourceDetailTest {
     assertEquals("percPage.xml", ContentTypesResource.exportFilename("percPage"));
     assertEquals("a_b.xml", ContentTypesResource.exportFilename("a/b"));
     assertEquals("contenttype.xml", ContentTypesResource.exportFilename("  "));
+    assertEquals("a_b.xml", ContentTypesResource.exportFilename("a*b"));
+    assertEquals("a_b.xml", ContentTypesResource.exportFilename("a?b"));
+    assertEquals("a_b.xml", ContentTypesResource.exportFilename("a<b"));
+    assertEquals("a_b.xml", ContentTypesResource.exportFilename("a>b"));
+    assertEquals("a_b.xml", ContentTypesResource.exportFilename("a|b"));
+  }
+
+  @Test
+  public void contentDispositionAttachmentIncludesRfc5987FilenameStar() {
+    String ascii = ContentTypesResource.contentDispositionAttachment("percPage.xml");
+    assertEquals(
+        "attachment; filename=\"percPage.xml\"; filename*=UTF-8''percPage.xml", ascii);
+
+    String mixed = ContentTypesResource.contentDispositionAttachment("café.xml");
+    assertTrue(mixed.startsWith("attachment; filename=\"caf_.xml\"; filename*=UTF-8''"));
+    assertTrue(mixed.contains("filename*=UTF-8''caf%C3%A9.xml"));
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/contenttypes/ContentTypesTestAdaptor.java
@@ -220,4 +220,9 @@ public class ContentTypesTestAdaptor implements IContentTypesAdaptor {
   public ContentTypeDetail includeField(URI baseUri, String idOrName, ContentTypeField body) {
     return getContentType(baseUri, idOrName);
   }
+
+  @Override
+  public ContentTypeExport exportContentType(URI baseUri, String idOrName) {
+    return null;
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestContentTypeAdaptor.java
@@ -28,6 +28,7 @@ import com.percussion.rest.contenttypes.ContentTypeChoiceEntry;
 import com.percussion.rest.contenttypes.ContentTypeChoiceNullEntry;
 import com.percussion.rest.contenttypes.ContentTypeControlProperty;
 import com.percussion.rest.contenttypes.ContentTypeDetail;
+import com.percussion.rest.contenttypes.ContentTypeExport;
 import com.percussion.rest.contenttypes.ContentTypeField;
 import com.percussion.rest.contenttypes.ContentTypeFieldControlProperties;
 import com.percussion.rest.contenttypes.ContentTypeFieldRuleExpressions;
@@ -246,5 +247,10 @@ public class TestContentTypeAdaptor implements IContentTypesAdaptor {
   @Override
   public ContentTypeDetail includeField(URI baseUri, String idOrName, ContentTypeField body) {
     return getContentType(baseUri, idOrName);
+  }
+
+  @Override
+  public ContentTypeExport exportContentType(URI baseUri, String idOrName) {
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

Parent [#1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690). Slice [#4018](https://github.com/intersoftdatalabs-in/percussioncms/issues/4018): Admin **GET** `/services/contenttypes/{idOrName}/export` returns Workbench-equivalent content-type **design XML** loaded through existing `IPSContentDesignWs` (`lock=false`, `overrideLock=false` — does not steal locks). `Content-Disposition` filename is derived from the content type name. Unknown types **404**; non-Admin **403**.

**Out of scope (this PR):** POST import (later CD-14 slice), SPA export wizard, Template AS-08.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4018
Partial #1690 (CD-14 export only; import remains)

## Test plan

1. Mockito `ContentTypesResourceDetailTest`: 200 XML + filename from name, 404, 403, 500 wrap, filename sanitizer.
2. Spring `TestContentTypeAdaptor.exportContentType` stub so `MainTest` / rest suite load ApplicationContext (`ContentTypesTestAdaptor` also updated).
3. `ContentTypeAdaptorExportTest`: success by name (XML contains name, load with lock=false), by numeric id, 404 unknown, 403 non-Admin (including production Admin gate).
4. Review product-docs: `product-docs/8.2/developer/rest.md` (Content types / CD-14 export) and `product-docs/8.2/admin/developer-content-types.md`. Gap map: `docs/ai-generated/tasks/developer-module-p0/content-type-api-gaps.md`.

## Checklist

- [x] **Product documentation** — updated pages under `product-docs/8.2/` (`developer/rest.md`, `admin/developer-content-types.md`)
- [x] **Unit / module tests** — behavioral tests for export; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when `final`/API shape changes
- [x] **Cross-platform** — filename helper is HTTP basename sanitization, not filesystem path joins; tests do not write files

### Product-docs pointers

- Gate: root `AGENTS.md` → **Product documentation (HARD GATE)**
- Tree: `product-docs/README.md` (layout, frontmatter `id` stability, build smoke)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: 823, Failures: 0 (`ContentTypesResourceDetailTest` 129/0)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: 1875, Failures: 0, Skipped: 125 (`ContentTypeAdaptorExportTest` 9/0)
- **downstream_checked:** `IContentTypesAdaptor` gained `exportContentType` (not `final`). Grep `implements IContentTypesAdaptor` → `ContentTypeAdaptor` (updated) + `TestContentTypeAdaptor` (stub) + `ContentTypesTestAdaptor` (stub). Standalone sitemanage clean install after rest install.
- **C5 UI proof:** N/A — REST/docs only, no SPA/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

## Residual

- CD-14 POST import: https://github.com/intersoftdatalabs-in/percussioncms/issues/4021
