### PR TITLE
feat(rest): AS-01 Admin slot finder/relationship write (#4015)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-4015-slot-finder-relationship-write-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4015-slot-finder-relationship-write-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — issue #4015 REST AS-01 slot finder/relationship write
+
+**Branch:** `fix/issue-4015-slot-finder-relationship-write`  
+**Base:** `origin/main`  
+**Date:** 2026-08-30  
+**Reviewer:** Erlang (pre-commit, independent of implementer)
+
+## Summary
+
+Admin REST write of slot `finderName`, `relationshipName`, and `finderArguments` on existing
+`PUT /services/slots/{idOrName}`, plus `POST .../lock` and `POST .../unlock` so the held-lock
+contract is usable. Persistence is `IPSAssemblyDesignWs` load/save (no new SOAP). Invalid
+finder is 400, unknown slot 404, unlocked/other locker 409, non-Admin 403. GET detail
+round-trips. `SLOT_FINDER_RELATIONSHIP_WRITE` is retired. Product-docs 8.2 Developer REST
+updated.
+
+Memory patterns hit: change-class closure (rest resource + adaptor interface + Spring stub +
+sitemanage impl + adaptor tests + product-docs); behavioral tests for success/403/409/400;
+no path I/O.
+
+## Recommendation
+
+approve
+
+## Gate
+
+**May commit/push: yes**
+
+No bugs found. Behavioral tests cover finder write, lock/unlock, invalid finder, unknown
+relationship, unlocked 409, other locker 409, non-Admin 403. Spring test stub updated.
+Standalone `rest` and `projects/sitemanage` `clean install` BUILD SUCCESS.
+
+Cross-platform path checklist: N/A (no filesystem path construction).
+
+## Issues
+
+None (hard-gate).
+
+## Notes (non-blocking)
+
+- Label-only PUT still acquires+releases a lock in one request (existing behavior). Finder
+  write requires a previously held lock and keeps it (`saveSlots(..., release=false)`).
+- SPA slot-editor chrome remains out of scope (parent #1690 remainder).
+- `ISlotsAdaptor` gained `lockSlot` / `unlockSlot`; implementors grepped (SlotsAdaptor +
+  TestSlotsAdaptor only). Downstream `sitemanage` clean install green.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -316,7 +316,9 @@ Assembly **slots** used by **Developer → Slots** are exposed under `/services/
 |--------|------|---------|
 | `GET` | `/services/slots` | List slot summaries (label, name, description) |
 | `GET` | `/services/slots/{idOrName}` | Design detail (finder, associations, `designGaps`) |
-| `PUT` | `/services/slots/{idOrName}` | Update label, description, layout/styles, and/or content-type/template associations |
+| `PUT` | `/services/slots/{idOrName}` | Update label, description, layout/styles, associations, and (Admin, held lock) `finderName` / `relationshipName` / `finderArguments` |
+| `POST` | `/services/slots/{idOrName}/lock` | **Admin.** Acquire a design-session lock (does not steal) |
+| `POST` | `/services/slots/{idOrName}/unlock` | **Admin.** Release a lock owned by the current user/session |
 | `POST` | `/services/slots` | **Admin.** Create a slot (`IPSAssemblyDesignWs.createSlots` then `saveSlots`) |
 | `DELETE` | `/services/slots/{idOrName}` | **Admin.** Delete a slot (`IPSAssemblyDesignWs.deleteSlots`) |
 
@@ -331,10 +333,16 @@ Delete (`DELETE /services/slots/{idOrName}`) returns **204** when removed; a fol
 `GET` is **404**. Unknown id/name is **404**. System slots cannot be deleted (**409**).
 Locked-by-another-user is **409** (the lock is not stolen). Non-Admin is **403**.
 
-**AS-01 remainder:** finder, relationship, and `finderArguments` stay **read-only** on this
-REST surface. Content-finder / relationship write and SPA slot-editor chrome are later
-slices. Detail `designGaps` code `SLOT_FINDER_RELATIONSHIP_WRITE` records that remainder
-(`SLOT_CREATE_DELETE` is retired now that POST/DELETE ship).
+**Finder / relationship write (AS-01):** Admin `PUT /services/slots/{idOrName}` writes
+`finderName`, `relationshipName`, and `finderArguments` when those JSON fields are present
+(null omits them; empty `relationshipName` or empty `finderArguments` clears). Typical
+flow: **lock → PUT (repeatable) → unlock**. The PUT does **not** acquire or release the
+lock and does **not** steal another user's lock. Invalid finder extension is **400**.
+Unknown relationship type is **400**. Unknown slot is **404**. Unlocked or locked-by-another
+user is **409**. Non-Admin is **403**. Following `GET /services/slots/{idOrName}` round-trips
+the written finder, relationship, and arguments. SPA slot-editor chrome remains a later
+slice. Detail `designGaps` no longer includes `SLOT_FINDER_RELATIONSHIP_WRITE` (`SLOT_CREATE_DELETE`
+is already retired). Remaining gap `SLOT_ASSOC_GUIDS_ONLY` records GUID-only associations.
 
 JSON may wrap a single item as `SlotDetail`. `associations` and `designGaps` are arrays
 (`SlotAssociationSummary[]` and structured `{code,message}` gaps). Some Jackson/JAXB

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SlotsAdaptor.java
@@ -17,15 +17,22 @@
 package com.percussion.apibridge;
 
 import com.percussion.rest.DesignGap;
+import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.slots.ISlotsAdaptor;
 import com.percussion.rest.slots.SlotAssociationSummary;
 import com.percussion.rest.slots.SlotDetail;
 import com.percussion.rest.slots.SlotSummary;
+import com.percussion.services.assembly.IPSAssemblyService;
+import com.percussion.services.assembly.IPSSlotContentFinder;
 import com.percussion.services.assembly.IPSTemplateSlot;
 import com.percussion.services.assembly.IPSTemplateSlot.SlotType;
+import com.percussion.services.assembly.PSAssemblyServiceLocator;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
 import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.locking.data.PSObjectLock;
+import com.percussion.services.locking.data.PSObjectLockSummary;
 import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.user.data.PSCurrentUser;
@@ -38,6 +45,8 @@ import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
 import com.percussion.webservices.assembly.IPSAssemblyDesignWs;
 import com.percussion.webservices.assembly.PSAssemblyWsLocator;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import com.percussion.webservices.system.PSSystemWsLocator;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
@@ -65,19 +74,21 @@ public class SlotsAdaptor implements ISlotsAdaptor {
 
   private static final Logger log = LogManager.getLogger(SlotsAdaptor.class);
 
-  static final String ADMIN_REQUIRED = "Admin role required to create or delete slots";
+  static final String ADMIN_REQUIRED =
+      "Admin role required to create, delete, lock, or write slot finder/relationship";
+
+  /** Typical design-session lock duration in minutes ({@link PSObjectLock#LOCK_INTERVAL}). */
+  static final long DESIGN_LOCK_MINUTES = PSObjectLock.LOCK_INTERVAL / 60_000L;
 
   public static final List<DesignGap> SLOT_DESIGN_GAPS =
       List.of(
-          DesignGap.of(
-              "SLOT_FINDER_RELATIONSHIP_WRITE",
-              "Finder, relationship, and finderArguments are read-only on this REST API"
-                  + " (AS-01 remainder)"),
           DesignGap.of(
               "SLOT_ASSOC_GUIDS_ONLY",
               "Content-type and template names not resolved (GUIDs only)"));
 
   private final IPSAssemblyDesignWs designWs;
+  private final IPSAssemblyService assemblyService;
+  private final IPSSystemDesignWs systemDesign;
   private final BooleanSupplier adminChecker;
 
   /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
@@ -85,18 +96,36 @@ public class SlotsAdaptor implements ISlotsAdaptor {
   private IPSUserService userService;
 
   public SlotsAdaptor() {
-    this(PSAssemblyWsLocator.getAssemblyDesignWebservice(), null);
+    this(
+        PSAssemblyWsLocator.getAssemblyDesignWebservice(),
+        null,
+        PSAssemblyServiceLocator.getAssemblyService(),
+        PSSystemWsLocator.getSystemDesignWebservice());
   }
 
   /** Package-visible for unit tests. Admin is allowed so existing PUT tests stay focused. */
   SlotsAdaptor(IPSAssemblyDesignWs designWs) {
-    this(designWs, () -> true);
+    this(designWs, () -> true, null, null);
   }
 
   /** Package-visible for unit tests that inject a fake Admin gate. */
   SlotsAdaptor(IPSAssemblyDesignWs designWs, BooleanSupplier adminChecker) {
+    this(designWs, adminChecker, null, null);
+  }
+
+  /**
+   * Package-visible for unit tests that exercise finder/relationship write and design-session
+   * lock.
+   */
+  SlotsAdaptor(
+      IPSAssemblyDesignWs designWs,
+      BooleanSupplier adminChecker,
+      IPSAssemblyService assemblyService,
+      IPSSystemDesignWs systemDesign) {
     this.designWs = designWs;
     this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
+    this.assemblyService = assemblyService;
+    this.systemDesign = systemDesign;
   }
 
   @Override
@@ -159,44 +188,132 @@ public class SlotsAdaptor implements ISlotsAdaptor {
     if (body == null) {
       throw new IllegalArgumentException("body is required");
     }
-    requireSessionUserForWrite();
+    boolean finderWrite = wantsFinderWrite(body);
+    if (finderWrite) {
+      requireAdmin();
+      requireSessionUserForDesignWrite();
+    } else {
+      requireSessionUserForWrite();
+    }
     String session = currentSession();
     String user = currentUser();
+    String trimmed = idOrName.trim();
     try {
-      IPSTemplateSlot slot = resolveSlot(idOrName.trim(), true);
+      if (finderWrite) {
+        IPSTemplateSlot current = resolveSlot(trimmed, false);
+        if (current == null || current.getGUID() == null) {
+          return null;
+        }
+        requireHeldLock(current.getGUID(), "Could not save slot finder/relationship");
+        applyFinderRelationshipUpdates(body);
+      }
+      IPSTemplateSlot slot = resolveSlot(trimmed, true);
       if (slot == null) {
+        if (finderWrite) {
+          throw new WebApplicationException(
+              "Could not save slot finder/relationship; design lock required or held by another"
+                  + " user",
+              409);
+        }
         return null;
       }
-      if (body.getLabel() != null) {
-        slot.setLabel(body.getLabel());
-      }
-      if (body.getDescription() != null) {
-        slot.setDescription(body.getDescription());
-      }
-      // Non-null layout/styles replace definition maps (empty/schema-only clears to defaults).
-      if (body.getSlotLayout() != null) {
-        slot.setSlotLayout(body.getSlotLayout());
-      }
-      if (body.getSlotStyles() != null) {
-        slot.setSlotStyles(body.getSlotStyles());
-      }
-      if (body.getAssociations() != null) {
-        slot.setSlotAssociations(toAssociationPairs(body.getAssociations()));
-      }
-      designWs.saveSlots(Collections.singletonList(slot), true, session, user);
-      IPSTemplateSlot reloaded = resolveSlot(idOrName.trim(), false);
+      applyMutableSlotUpdates(slot, body);
+      // Finder write keeps the held lock (clients unlock via POST .../unlock). Label-only
+      // updates continue to acquire+release in one request.
+      designWs.saveSlots(Collections.singletonList(slot), !finderWrite, session, user);
+      IPSTemplateSlot reloaded = resolveSlot(trimmed, false);
       return reloaded != null ? toDetail(reloaded) : toDetail(slot);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | IllegalStateException | WebApplicationException e) {
       throw e;
     } catch (PSErrorResultsException e) {
+      if (finderWrite) {
+        throw new WebApplicationException(
+            "Could not save slot finder/relationship; design lock required or held by another"
+                + " user",
+            409);
+      }
       log.error("Failed to load slot for update {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to update slot", e);
     } catch (PSErrorsException e) {
+      if (finderWrite && isLockFailure(e)) {
+        throw new WebApplicationException(
+            "Could not save slot finder/relationship; design lock required or held by another"
+                + " user",
+            409);
+      }
       log.error("Failed to save slot {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to save slot", e);
     } catch (Exception e) {
       log.error("Failed to update slot {}: {}", idOrName, e.getMessage(), e);
       throw new IllegalStateException("Failed to update slot", e);
+    }
+  }
+
+  @Override
+  public ObjectLockSummary lockSlot(URI baseUri, String idOrName) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    requireSessionUserForDesignWrite();
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    try {
+      IPSTemplateSlot current = resolveSlot(trimmed, false);
+      if (current == null || current.getGUID() == null) {
+        return null;
+      }
+      IPSTemplateSlot locked = resolveSlot(trimmed, true);
+      if (locked == null || locked.getGUID() == null) {
+        throw new WebApplicationException(
+            "Could not acquire design lock for slot; locked by another user", 409);
+      }
+      return toLockSummary(currentSession(), currentUser(), remainingLockMinutes(locked.getGUID()));
+    } catch (IllegalArgumentException | IllegalStateException | WebApplicationException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      throw new WebApplicationException(
+          "Could not acquire design lock for slot; locked by another user", 409);
+    } catch (Exception e) {
+      log.error("Failed to lock slot {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to lock slot", e);
+    }
+  }
+
+  @Override
+  public Boolean unlockSlot(URI baseUri, String idOrName) {
+    requireAdmin();
+    if (StringUtils.isBlank(idOrName)) {
+      throw new IllegalArgumentException("idOrName is required");
+    }
+    requireSessionUserForDesignWrite();
+    String trimmed = idOrName.trim();
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("idOrName must not contain wildcards");
+    }
+    if (systemDesign == null) {
+      throw new IllegalStateException(
+          "Could not release slot design session; design service unavailable");
+    }
+    try {
+      IPSTemplateSlot current = resolveSlot(trimmed, false);
+      if (current == null || current.getGUID() == null) {
+        return null;
+      }
+      requireNotLockedByOther(current.getGUID(), "Could not release design lock for slot");
+      systemDesign.releaseLocks(
+          Collections.singletonList(current.getGUID()), currentSession(), currentUser());
+      return Boolean.TRUE;
+    } catch (IllegalArgumentException | IllegalStateException | WebApplicationException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      log.debug("Slot not found for unlock {}: {}", idOrName, e.getMessage());
+      return null;
+    } catch (Exception e) {
+      log.error("Failed to unlock slot {}: {}", idOrName, e.getMessage(), e);
+      throw new IllegalStateException("Failed to unlock slot", e);
     }
   }
 
@@ -493,6 +610,168 @@ public class SlotsAdaptor implements ISlotsAdaptor {
     d.setAssociations(associations.isEmpty() ? null : associations);
     d.setDesignGaps(new ArrayList<>(SLOT_DESIGN_GAPS));
     return d;
+  }
+
+  static boolean wantsFinderWrite(SlotDetail body) {
+    return body != null
+        && (body.getFinderName() != null
+            || body.getRelationshipName() != null
+            || body.getFinderArguments() != null);
+  }
+
+  private void applyMutableSlotUpdates(IPSTemplateSlot slot, SlotDetail body) {
+    if (body.getLabel() != null) {
+      slot.setLabel(body.getLabel());
+    }
+    if (body.getDescription() != null) {
+      slot.setDescription(body.getDescription());
+    }
+    // Non-null layout/styles replace definition maps (empty/schema-only clears to defaults).
+    if (body.getSlotLayout() != null) {
+      slot.setSlotLayout(body.getSlotLayout());
+    }
+    if (body.getSlotStyles() != null) {
+      slot.setSlotStyles(body.getSlotStyles());
+    }
+    if (body.getAssociations() != null) {
+      slot.setSlotAssociations(toAssociationPairs(body.getAssociations()));
+    }
+    if (body.getFinderName() != null) {
+      slot.setFinderName(body.getFinderName().trim());
+    }
+    if (body.getRelationshipName() != null) {
+      slot.setRelationshipName(body.getRelationshipName().trim());
+    }
+    if (body.getFinderArguments() != null) {
+      slot.setFinderArguments(
+          body.getFinderArguments().isEmpty() ? null : new HashMap<>(body.getFinderArguments()));
+    }
+  }
+
+  private void applyFinderRelationshipUpdates(SlotDetail body) {
+    if (body.getFinderName() != null) {
+      requireValidFinder(body.getFinderName());
+    }
+    if (body.getRelationshipName() != null) {
+      requireValidRelationship(body.getRelationshipName());
+    }
+  }
+
+  private void requireValidFinder(String finderName) {
+    if (StringUtils.isBlank(finderName)) {
+      throw new IllegalArgumentException("finderName is required");
+    }
+    if (assemblyService == null) {
+      throw new IllegalStateException("Assembly service unavailable to validate finder");
+    }
+    String trimmed = finderName.trim();
+    try {
+      IPSSlotContentFinder finder = assemblyService.loadFinder(trimmed);
+      if (finder == null) {
+        throw new IllegalArgumentException("Invalid finder extension: " + trimmed);
+      }
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid finder extension: " + trimmed, e);
+    }
+  }
+
+  private void requireValidRelationship(String relationshipName) {
+    if (StringUtils.isBlank(relationshipName)) {
+      return;
+    }
+    if (systemDesign == null) {
+      throw new IllegalStateException(
+          "Design service unavailable to validate relationship type");
+    }
+    String trimmed = relationshipName.trim();
+    try {
+      List<IPSCatalogSummary> found = systemDesign.findRelationshipTypes(trimmed, null);
+      if (found == null || found.isEmpty()) {
+        throw new IllegalArgumentException("Unknown relationship type: " + trimmed);
+      }
+      for (IPSCatalogSummary summary : found) {
+        if (summary != null && trimmed.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+          return;
+        }
+      }
+      if (found.size() == 1 && found.get(0) != null) {
+        return;
+      }
+      throw new IllegalArgumentException("Unknown relationship type: " + trimmed);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Unknown relationship type: " + trimmed, e);
+    }
+  }
+
+  private void requireHeldLock(IPSGuid slotGuid, String prefix) {
+    if (systemDesign == null) {
+      throw new IllegalStateException(prefix + "; design service unavailable");
+    }
+    List<PSObjectSummary> locked;
+    try {
+      locked = systemDesign.isLocked(Collections.singletonList(slotGuid), currentUser());
+    } catch (PSErrorResultsException e) {
+      throw new WebApplicationException(prefix + "; design lock required", 409);
+    }
+    PSObjectSummary summary = locked == null || locked.isEmpty() ? null : locked.get(0);
+    if (summary == null || !summary.isLocked()) {
+      throw new WebApplicationException(prefix + "; design lock required", 409);
+    }
+    String user = currentUser();
+    if (!summary.isLockedBy(user)) {
+      PSObjectLockSummary info = summary.getLocked();
+      String locker = info != null ? info.getLocker() : null;
+      throw new WebApplicationException(
+          locker != null ? prefix + "; locked by " + locker : prefix + "; design lock required",
+          409);
+    }
+  }
+
+  private void requireNotLockedByOther(IPSGuid slotGuid, String prefix) {
+    List<PSObjectSummary> locked;
+    try {
+      locked = systemDesign.isLocked(Collections.singletonList(slotGuid), currentUser());
+    } catch (PSErrorResultsException e) {
+      throw new WebApplicationException(prefix, 409);
+    }
+    PSObjectSummary summary = locked == null || locked.isEmpty() ? null : locked.get(0);
+    if (summary != null && summary.isLocked() && !summary.isLockedBy(currentUser())) {
+      PSObjectLockSummary info = summary.getLocked();
+      String locker = info != null ? info.getLocker() : null;
+      throw new WebApplicationException(
+          locker != null ? prefix + "; locked by " + locker : prefix, 409);
+    }
+  }
+
+  private long remainingLockMinutes(IPSGuid slotGuid) {
+    if (systemDesign == null || slotGuid == null) {
+      return DESIGN_LOCK_MINUTES;
+    }
+    try {
+      List<PSObjectSummary> locked =
+          systemDesign.isLocked(Collections.singletonList(slotGuid), currentUser());
+      if (locked != null && !locked.isEmpty() && locked.get(0) != null) {
+        PSObjectLockSummary info = locked.get(0).getLocked();
+        if (info != null && info.getRemainingTime() > 0) {
+          return info.getRemainingTime();
+        }
+      }
+    } catch (Exception e) {
+      log.debug("Could not read remaining lock time: {}", e.getMessage());
+    }
+    return DESIGN_LOCK_MINUTES;
+  }
+
+  static ObjectLockSummary toLockSummary(String session, String user, long remainingMinutes) {
+    ObjectLockSummary summary = new ObjectLockSummary();
+    summary.setSession(session);
+    summary.setLocker(user);
+    summary.setRemainingTime(remainingMinutes);
+    return summary;
   }
 
   static String labelOrName(IPSTemplateSlot slot) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DesignGapsStructuredTest.java
@@ -116,11 +116,10 @@ class DesignGapsStructuredTest {
 
   @Test
   void slotDesignGaps_areStructured() {
-    assertEquals(2, SlotsAdaptor.SLOT_DESIGN_GAPS.size());
+    assertEquals(1, SlotsAdaptor.SLOT_DESIGN_GAPS.size());
     DesignGap first = SlotsAdaptor.SLOT_DESIGN_GAPS.get(0);
-    assertEquals("SLOT_FINDER_RELATIONSHIP_WRITE", first.getCode());
-    assertTrue(first.getMessage().contains("read-only"));
-    assertEquals("SLOT_ASSOC_GUIDS_ONLY", SlotsAdaptor.SLOT_DESIGN_GAPS.get(1).getCode());
+    assertEquals("SLOT_ASSOC_GUIDS_ONLY", first.getCode());
+    assertTrue(first.getMessage().contains("GUIDs only"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SlotsAdaptorFinderWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SlotsAdaptorFinderWriteTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.ObjectLockSummary;
+import com.percussion.rest.slots.SlotDetail;
+import com.percussion.services.assembly.IPSAssemblyService;
+import com.percussion.services.assembly.IPSSlotContentFinder;
+import com.percussion.services.assembly.IPSTemplateSlot;
+
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.assembly.IPSAssemblyDesignWs;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * AS-01 remainder: Admin PUT of finderName / relationshipName / finderArguments requires a held
+ * design lock, does not steal, and round-trips on GET detail.
+ */
+@Tag("UnitTest")
+class SlotsAdaptorFinderWriteTest {
+
+  private static final String FINDER =
+      "Java/global/percussion/slotcontentfinder/sys_RelationshipContentFinder";
+
+  private IPSAssemblyDesignWs designWs;
+  private IPSAssemblyService assemblyService;
+  private IPSSystemDesignWs systemDesign;
+  private SlotsAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    designWs = mock(IPSAssemblyDesignWs.class);
+    assemblyService = mock(IPSAssemblyService.class);
+    systemDesign = mock(IPSSystemDesignWs.class);
+    adaptor = new SlotsAdaptor(designWs, () -> true, assemblyService, systemDesign);
+    guid = new PSGuid(PSTypeEnum.SLOT, 42L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void put_writesFinderRelationshipArgs_andRoundTripsOnGet() throws Exception {
+    IPSTemplateSlot slot = stubSlot("rffList");
+    stubReloadByName("rffList", slot);
+    stubHeldLock();
+    when(designWs.loadSlots(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+    when(assemblyService.loadFinder(FINDER)).thenReturn(mock(IPSSlotContentFinder.class));
+    IPSCatalogSummary rel = mock(IPSCatalogSummary.class);
+    when(rel.getName()).thenReturn("Active Assembly");
+    when(systemDesign.findRelationshipTypes(eq("Active Assembly"), isNull()))
+        .thenReturn(List.of(rel));
+    when(slot.getFinderName()).thenReturn(FINDER);
+    when(slot.getRelationshipName()).thenReturn("Active Assembly");
+    Map<String, String> args = new LinkedHashMap<>();
+    args.put("template", "rffSnTitle");
+    when(slot.getFinderArguments()).thenReturn(args);
+
+    SlotDetail body = new SlotDetail();
+    body.setFinderName(FINDER);
+    body.setRelationshipName("Active Assembly");
+    body.setFinderArguments(Map.of("template", "rffSnTitle"));
+
+    SlotDetail updated = adaptor.updateSlot(null, "rffList", body);
+
+    verify(slot).setFinderName(FINDER);
+    verify(slot).setRelationshipName("Active Assembly");
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> argsCap = ArgumentCaptor.forClass(Map.class);
+    verify(slot).setFinderArguments(argsCap.capture());
+    assertEquals("rffSnTitle", argsCap.getValue().get("template"));
+    verify(designWs).saveSlots(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(FINDER, updated.getFinderName());
+    assertEquals("Active Assembly", updated.getRelationshipName());
+    assertEquals("rffSnTitle", updated.getFinderArguments().get("template"));
+
+    SlotDetail got = adaptor.getSlot(null, "rffList");
+    assertEquals(FINDER, got.getFinderName());
+    assertEquals("Active Assembly", got.getRelationshipName());
+    assertEquals("rffSnTitle", got.getFinderArguments().get("template"));
+  }
+
+  @Test
+  void put_invalidFinder_is400() throws Exception {
+    IPSTemplateSlot slot = stubSlot("rffList");
+    stubReloadByName("rffList", slot);
+    stubHeldLock();
+    when(assemblyService.loadFinder("nope")).thenReturn(null);
+
+    SlotDetail body = new SlotDetail();
+    body.setFinderName("nope");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.updateSlot(null, "rffList", body));
+    assertTrue(ex.getMessage().contains("Invalid finder extension"), ex.getMessage());
+    verify(designWs, never()).saveSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_unknownRelationship_is400() throws Exception {
+    IPSTemplateSlot slot = stubSlot("rffList");
+    stubReloadByName("rffList", slot);
+    stubHeldLock();
+    when(systemDesign.findRelationshipTypes(eq("Missing Rel"), isNull()))
+        .thenReturn(Collections.emptyList());
+
+    SlotDetail body = new SlotDetail();
+    body.setRelationshipName("Missing Rel");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.updateSlot(null, "rffList", body));
+    assertTrue(ex.getMessage().contains("Unknown relationship type"), ex.getMessage());
+    verify(designWs, never()).saveSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_unlocked_is409() throws Exception {
+    IPSTemplateSlot slot = stubSlot("rffList");
+    stubReloadByName("rffList", slot);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(Collections.singletonList(null));
+
+    SlotDetail body = new SlotDetail();
+    body.setFinderName(FINDER);
+    when(assemblyService.loadFinder(FINDER)).thenReturn(mock(IPSSlotContentFinder.class));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.updateSlot(null, "rffList", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("lock"), ex.getMessage());
+    verify(designWs, never()).saveSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_lockedByOther_is409() throws Exception {
+    IPSTemplateSlot slot = stubSlot("rffList");
+    stubReloadByName("rffList", slot);
+    PSObjectSummary other = new PSObjectSummary(guid, "rffList");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+
+    SlotDetail body = new SlotDetail();
+    body.setFinderName(FINDER);
+    when(assemblyService.loadFinder(FINDER)).thenReturn(mock(IPSSlotContentFinder.class));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.updateSlot(null, "rffList", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("editor2"), ex.getMessage());
+    verify(designWs, never()).saveSlots(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_nonAdmin_is403() {
+    adaptor = new SlotsAdaptor(designWs, () -> false, assemblyService, systemDesign);
+    SlotDetail body = new SlotDetail();
+    body.setFinderName(FINDER);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.updateSlot(null, "rffList", body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void put_missingSession_is403() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    SlotDetail body = new SlotDetail();
+    body.setFinderName(FINDER);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.updateSlot(null, "rffList", body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void put_unknownSlot_returnsNull() throws Exception {
+    when(designWs.findSlots(eq("missing"), isNull())).thenReturn(Collections.emptyList());
+    SlotDetail body = new SlotDetail();
+    body.setFinderName(FINDER);
+    assertNull(adaptor.updateSlot(null, "missing", body));
+    verify(systemDesign, never()).isLocked(anyList(), any());
+  }
+
+  @Test
+  void lock_thenPut_thenGet_roundTrips() throws Exception {
+    IPSTemplateSlot slot = stubSlot("rffList");
+    stubReloadByName("rffList", slot);
+    stubHeldLock();
+    when(designWs.loadSlots(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+    when(assemblyService.loadFinder(FINDER)).thenReturn(mock(IPSSlotContentFinder.class));
+    when(slot.getFinderName()).thenReturn(FINDER);
+
+    ObjectLockSummary locked = adaptor.lockSlot(null, "rffList");
+    assertEquals("Admin", locked.getLocker());
+    assertEquals("test-session", locked.getSession());
+
+    SlotDetail body = new SlotDetail();
+    body.setFinderName(FINDER);
+    SlotDetail updated = adaptor.updateSlot(null, "rffList", body);
+    assertEquals(FINDER, updated.getFinderName());
+    assertEquals(FINDER, adaptor.getSlot(null, "rffList").getFinderName());
+  }
+
+  @Test
+  void lock_otherUser_is409() throws Exception {
+    IPSTemplateSlot slot = stubSlot("rffList");
+    stubReloadByName("rffList", slot);
+    when(designWs.loadSlots(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.lockSlot(null, "rffList"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void unlock_otherUser_is409() throws Exception {
+    IPSTemplateSlot slot = stubSlot("rffList");
+    stubReloadByName("rffList", slot);
+    PSObjectSummary other = new PSObjectSummary(guid, "rffList");
+    other.setLockedInfo("other-session", "editor2", 12);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(other));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.unlockSlot(null, "rffList"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(systemDesign, never()).releaseLocks(anyList(), any(), any());
+  }
+
+  @Test
+  void unlock_success() throws Exception {
+    IPSTemplateSlot slot = stubSlot("rffList");
+    stubReloadByName("rffList", slot);
+    stubHeldLock();
+    assertTrue(adaptor.unlockSlot(null, "rffList"));
+    verify(systemDesign).releaseLocks(eq(List.of(guid)), eq("test-session"), eq("Admin"));
+  }
+
+  private IPSTemplateSlot stubSlot(String name) {
+    IPSTemplateSlot slot = mock(IPSTemplateSlot.class);
+    when(slot.getName()).thenReturn(name);
+    when(slot.getLabel()).thenReturn(name);
+    when(slot.getGUID()).thenReturn(guid);
+    when(slot.isSystemSlot()).thenReturn(false);
+    return slot;
+  }
+
+  private void stubReloadByName(String name, IPSTemplateSlot slot) throws Exception {
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(sum.getName()).thenReturn(name);
+    when(sum.getLabel()).thenReturn(name);
+    when(designWs.findSlots(eq(name), isNull())).thenReturn(List.of(sum));
+    when(designWs.loadSlots(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(slot));
+  }
+
+  private void stubHeldLock() throws Exception {
+    PSObjectSummary held = new PSObjectSummary(guid, "rffList");
+    held.setLockedInfo("test-session", "Admin", 30);
+    when(systemDesign.isLocked(anyList(), eq("Admin"))).thenReturn(List.of(held));
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/slots/ISlotsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/slots/ISlotsAdaptor.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.slots;
 
+import com.percussion.rest.ObjectLockSummary;
 import java.net.URI;
 import java.util.List;
 import org.springframework.lang.Nullable;
@@ -41,10 +42,42 @@ public interface ISlotsAdaptor {
    * map replaces the definition layout/styles (empty or schema-only clears to defaults); null
    * leaves the field unchanged. Name/id is not changed via this path.
    *
+   * <p>When {@code finderName}, {@code relationshipName}, or {@code finderArguments} is non-null,
+   * those fields are written as an Admin design action. That path requires a design-session lock
+   * already held by the current user ({@link #lockSlot}), does not steal another user's lock, and
+   * does not release the lock on save. Invalid finder extensions and unknown relationship types are
+   * rejected. Empty {@code relationshipName} / empty {@code finderArguments} clear those fields.
+   *
    * @return updated detail, or {@code null} if not found
+   * @throws IllegalArgumentException when finder/relationship input is invalid
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when finder write is requested and
+   *     the caller is not Admin or has no session/user; {@code 409} when finder write is requested
+   *     and the slot is unlocked or locked by another user
    */
   @Nullable
   SlotDetail updateSlot(URI baseUri, String idOrName, SlotDetail body);
+
+  /**
+   * Acquire a self-only design-session lock via {@code IPSAssemblyDesignWs.loadSlots(lock=true,
+   * overrideLock=false)}. Admin only. Does not save and does not steal another user's lock.
+   *
+   * @return lock summary, or {@code null} if the slot is not found
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin or the
+   *     request has no session/user; {@code 409} when locked by another user
+   */
+  @Nullable
+  ObjectLockSummary lockSlot(URI baseUri, String idOrName);
+
+  /**
+   * Release a design-session lock owned by the current Admin user/session. Does not save and does
+   * not steal another user's lock.
+   *
+   * @return {@code true} when released (including already unlocked); {@code false} when not found
+   * @throws jakarta.ws.rs.WebApplicationException {@code 403} when the caller is not Admin; {@code
+   *     409} when locked by another user
+   */
+  @Nullable
+  Boolean unlockSlot(URI baseUri, String idOrName);
 
   /**
    * Create and persist a slot (Workbench Finish: {@code IPSAssemblyDesignWs.createSlots} then

--- a/rest/src/main/java/com/percussion/rest/slots/SlotDetail.java
+++ b/rest/src/main/java/com/percussion/rest/slots/SlotDetail.java
@@ -44,7 +44,18 @@ public class SlotDetail {
   private String description;
   private String slotType;
   private Boolean systemSlot;
+
+  @Schema(
+      description =
+          "Slot content-finder extension name (for example"
+              + " Java/global/percussion/slotcontentfinder/sys_RelationshipContentFinder)."
+              + " Non-null on PUT is an Admin write that requires a held design lock.")
   private String finderName;
+
+  @Schema(
+      description =
+          "Allowed relationship type name for the slot. Non-null on PUT is an Admin write that"
+              + " requires a held design lock. Empty string clears the relationship.")
   private String relationshipName;
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
+++ b/rest/src/main/java/com/percussion/rest/slots/SlotsResource.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.slots;
 
+import com.percussion.rest.ObjectLockSummary;
 import com.percussion.system.utils.PSSiteManageBean;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -105,8 +106,8 @@ public class SlotsResource {
       summary = "Get slot design detail",
       description =
           "Slot detail including finder metadata, content-type/template associations, and"
-              + " ADR-003 slot_layout / slot_styles maps. Finder/relationship write remain"
-              + " unsupported (see designGaps).",
+              + " ADR-003 slot_layout / slot_styles maps. Finder, relationship, and"
+              + " finderArguments round-trip after an Admin PUT under a held design lock.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -145,14 +146,23 @@ public class SlotsResource {
               + " associations is present (including empty), replaces the full content-type/template"
               + " association set. Non-null slotLayout/slotStyles replace definition maps (empty or"
               + " schema-only clears to defaults); omit to leave unchanged. Name/id is immutable."
-              + " Finder/relationship write remain unsupported (see designGaps).",
+              + " Non-null finderName, relationshipName, or finderArguments are Admin writes that"
+              + " require a held design-session lock (POST .../lock first). Does not acquire or"
+              + " steal the lock. Invalid finder extension or unknown relationship type is 400."
+              + " Unlocked or locked-by-another-user is 409. Non-Admin is 403.",
       responses = {
         @ApiResponse(
             responseCode = "200",
             description = "Updated",
             content = @Content(schema = @Schema(implementation = SlotDetail.class))),
-        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid input, finder extension, or relationship type"),
+        @ApiResponse(responseCode = "403", description = "Admin role required for finder write"),
         @ApiResponse(responseCode = "404", description = "Slot not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Finder write requires a held lock; unlocked or locked by another user"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
   public SlotDetail updateSlot(@PathParam("idOrName") String idOrName, SlotDetail body) {
@@ -169,6 +179,89 @@ public class SlotsResource {
     } catch (Exception e) {
       log.error(
           "Failed to update slot {} ({}): {}", idOrName, e.getClass().getName(), e.getMessage(), e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Locks an assembly slot for a design session.
+   *
+   * @param idOrName slot uuid or unique name
+   * @return lock summary
+   */
+  @POST
+  @Path("/{idOrName}/lock")
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Lock slot design session",
+      description =
+          "Admin. Acquires a self-only design-session lock via IPSAssemblyDesignWs.loadSlots"
+              + " (lock=true, overrideLock=false). Does not save. Does not steal another user's"
+              + " lock. Re-lock by the same session user extends the lock.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Locked",
+            content = @Content(schema = @Schema(implementation = ObjectLockSummary.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid id/name"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Slot not found"),
+        @ApiResponse(responseCode = "409", description = "Locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ObjectLockSummary lockSlot(@PathParam("idOrName") String idOrName) {
+    try {
+      ObjectLockSummary summary = requireAdaptor().lockSlot(uriInfo.getBaseUri(), idOrName);
+      if (summary == null) {
+        throw new WebApplicationException("Slot not found: " + idOrName, 404);
+      }
+      return summary;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), 400);
+    } catch (Exception e) {
+      log.error(
+          "Failed to lock slot {} ({}): {}", idOrName, e.getClass().getName(), e.getMessage(), e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Unlocks an assembly slot design session.
+   *
+   * @param idOrName slot uuid or unique name
+   * @return 204 when released
+   */
+  @POST
+  @Path("/{idOrName}/unlock")
+  @Operation(
+      summary = "Unlock slot design session",
+      description =
+          "Admin. Releases a design-session lock owned by the current user/session. Does not save."
+              + " Locks held by another user are not stolen (409).",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Unlocked"),
+        @ApiResponse(responseCode = "400", description = "Invalid id/name"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Slot not found"),
+        @ApiResponse(responseCode = "409", description = "Locked by another user"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response unlockSlot(@PathParam("idOrName") String idOrName) {
+    try {
+      Boolean unlocked = requireAdaptor().unlockSlot(uriInfo.getBaseUri(), idOrName);
+      if (unlocked == null || !unlocked) {
+        throw new WebApplicationException("Slot not found: " + idOrName, 404);
+      }
+      return Response.noContent().build();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), 400);
+    } catch (Exception e) {
+      log.error(
+          "Failed to unlock slot {} ({}): {}", idOrName, e.getClass().getName(), e.getMessage(), e);
       throw new WebApplicationException(e, 500);
     }
   }

--- a/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
+++ b/rest/src/test/java/com/percussion/rest/slots/SlotsResourceDetailTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.rest.DesignGap;
+import com.percussion.rest.ObjectLockSummary;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
@@ -131,16 +132,14 @@ public class SlotsResourceDetailTest {
     d.setDesignGaps(
         List.of(
             DesignGap.of(
-                "SLOT_FINDER_RELATIONSHIP_WRITE",
-                "Finder, relationship, and finderArguments are read-only on this REST API"
-                    + " (AS-01 remainder)")));
+                "SLOT_ASSOC_GUIDS_ONLY", "Content-type and template names not resolved (GUIDs only)")));
     when(adaptor.getSlot(any(), eq("target"))).thenReturn(d);
 
     SlotDetail out = resource.getSlot("target");
     assertNotNull(out.getDesignGaps());
     assertEquals(1, out.getDesignGaps().size());
-    assertEquals("SLOT_FINDER_RELATIONSHIP_WRITE", out.getDesignGaps().get(0).getCode());
-    assertTrue(out.getDesignGaps().get(0).getMessage().contains("read-only"));
+    assertEquals("SLOT_ASSOC_GUIDS_ONLY", out.getDesignGaps().get(0).getCode());
+    assertTrue(out.getDesignGaps().get(0).getMessage().contains("GUIDs only"));
   }
 
   @Test
@@ -386,5 +385,118 @@ public class SlotsResourceDetailTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> resource.deleteSlot("boom"));
     assertEquals(500, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateSlotFinderWriteSuccess() {
+    SlotDetail body = new SlotDetail();
+    body.setFinderName("Java/global/percussion/slotcontentfinder/sys_RelationshipContentFinder");
+    body.setRelationshipName("Active Assembly");
+    body.setFinderArguments(java.util.Map.of("template", "rffSnTitle"));
+    SlotDetail updated = new SlotDetail();
+    updated.setName("target");
+    updated.setFinderName(body.getFinderName());
+    updated.setRelationshipName(body.getRelationshipName());
+    updated.setFinderArguments(body.getFinderArguments());
+    when(adaptor.updateSlot(any(), eq("target"), any())).thenReturn(updated);
+    SlotDetail out = resource.updateSlot("target", body);
+    assertEquals(body.getFinderName(), out.getFinderName());
+    assertEquals("Active Assembly", out.getRelationshipName());
+    assertEquals("rffSnTitle", out.getFinderArguments().get("template"));
+  }
+
+  @Test
+  public void updateSlotInvalidFinderIs400() {
+    when(adaptor.updateSlot(any(), eq("target"), any()))
+        .thenThrow(new IllegalArgumentException("Invalid finder extension: nope"));
+    SlotDetail body = new SlotDetail();
+    body.setFinderName("nope");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.updateSlot("target", body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateSlotFinderWriteForbiddenWhenNotAdmin() {
+    when(adaptor.updateSlot(any(), eq("target"), any()))
+        .thenThrow(new WebApplicationException("Admin role required", 403));
+    SlotDetail body = new SlotDetail();
+    body.setFinderName("Java/global/percussion/slotcontentfinder/sys_RelationshipContentFinder");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.updateSlot("target", body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateSlotFinderWriteUnlockedIs409() {
+    when(adaptor.updateSlot(any(), eq("target"), any()))
+        .thenThrow(new WebApplicationException("design lock required", 409));
+    SlotDetail body = new SlotDetail();
+    body.setFinderName("Java/global/percussion/slotcontentfinder/sys_RelationshipContentFinder");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.updateSlot("target", body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnLock() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> newSlotsResourceWithoutAdaptor().lockSlot("any"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnUnlock() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> newSlotsResourceWithoutAdaptor().unlockSlot("any"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void lockSlotSuccess() {
+    ObjectLockSummary summary = new ObjectLockSummary();
+    summary.setLocker("Admin");
+    summary.setSession("test-session");
+    summary.setRemainingTime(30);
+    when(adaptor.lockSlot(any(), eq("target"))).thenReturn(summary);
+    ObjectLockSummary out = resource.lockSlot("target");
+    assertEquals("Admin", out.getLocker());
+    assertEquals(30, out.getRemainingTime());
+  }
+
+  @Test
+  public void lockSlotNotFound() {
+    when(adaptor.lockSlot(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.lockSlot("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void lockSlotConflict() {
+    when(adaptor.lockSlot(any(), eq("target")))
+        .thenThrow(new WebApplicationException("locked by editor2", 409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.lockSlot("target"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void unlockSlotSuccess() {
+    when(adaptor.unlockSlot(any(), eq("target"))).thenReturn(Boolean.TRUE);
+    Response out = resource.unlockSlot("target");
+    assertEquals(204, out.getStatus());
+    verify(adaptor).unlockSlot(any(), eq("target"));
+  }
+
+  @Test
+  public void unlockSlotNotFound() {
+    when(adaptor.unlockSlot(any(), eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.unlockSlot("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSlotsAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSlotsAdaptor.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.test.apibridge;
 
+import com.percussion.rest.ObjectLockSummary;
 import com.percussion.rest.slots.ISlotsAdaptor;
 import com.percussion.rest.slots.SlotDetail;
 import com.percussion.rest.slots.SlotSummary;
@@ -46,6 +47,16 @@ public class TestSlotsAdaptor implements ISlotsAdaptor {
   @Override
   public SlotDetail updateSlot(URI baseUri, String idOrName, SlotDetail body) {
     return null;
+  }
+
+  @Override
+  public ObjectLockSummary lockSlot(URI baseUri, String idOrName) {
+    return null;
+  }
+
+  @Override
+  public Boolean unlockSlot(URI baseUri, String idOrName) {
+    return Boolean.FALSE;
   }
 
   @Override


### PR DESCRIPTION
## Summary

Parent: #1690 (AS-01). This slice adds **Admin REST write** of slot content finder, allowed relationship type, and finder arguments on existing `PUT /services/slots/{idOrName}`.

Typical design-session flow: **`POST .../lock` → PUT (repeatable) → `POST .../unlock`**. Finder/relationship/args writes require a lock already held by the current Admin user; they do **not** steal another user's lock and do **not** release the lock on save. Persistence uses existing `IPSAssemblyDesignWs` load/save (no new SOAP).

Invalid finder extension is **400**. Unknown relationship type is **400**. Unknown slot is **404**. Unlocked or locked-by-another-user is **409**. Non-Admin is **403**. Following GET detail round-trips the written finder/relationship/args. `SLOT_FINDER_RELATIONSHIP_WRITE` is retired.

Out of scope: SPA slot-editor chrome; slot create/delete (already shipped).

Fixes #4015  
Partial #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS
3. Review `SlotsResourceDetailTest` (finder PUT 400/403/409, lock/unlock) and `SlotsAdaptorFinderWriteTest` (held lock success, unlocked 409, other locker 409, invalid finder, unknown relationship, GET round-trip)
4. Product-docs: `product-docs/8.2/developer/rest.md` Slots section — remainder read-only note removed; lock/unlock + finder write documented

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (Slots: finder/relationship/args write + lock/unlock; dropped `SLOT_FINDER_RELATIONSHIP_WRITE` remainder note)
- [x] **Unit / module tests** — Mockito `SlotsResourceDetailTest`; Spring stub `TestSlotsAdaptor`; sitemanage `SlotsAdaptorFinderWriteTest` + `DesignGapsStructuredTest`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; SPA chrome out of scope)
- [x] **Build gates** — standalone clean install of `rest` then `projects/sitemanage` (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 876, Failures: 0, Errors: 0, Skipped: 0)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 1886, Failures: 0, Errors: 0, Skipped: 125 baseline)
  - Focused: `SlotsResourceDetailTest` Tests run: 43; `SlotsAdaptorFinderWriteTest` Tests run: 12
- **downstream_checked:** `ISlotsAdaptor` implementors grepped (`SlotsAdaptor`, `TestSlotsAdaptor` only); sitemanage standalone clean install (rest API consumer)

### C5 UI proof

N/A — REST backend only; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
