### PR TITLE
feat(rest): AS-07 Admin item-filter create/update/delete (#4014)

### DIFF
--- a/docs/ai-generated/code-reviews/4014-itemfilter-write-erlang.md
+++ b/docs/ai-generated/code-reviews/4014-itemfilter-write-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review — issue #4014 REST AS-07 item-filter write
+
+**Branch:** `fix/issue-4014-itemfilter-write`  
+**Scope:** uncommitted vs HEAD (rest + sitemanage + product-docs 8.2)  
+**Date:** 2026-08-30  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class completeness (rest resource + existing adaptor interface + Spring stub + sitemanage impl + tests); Admin `IPSUserService.isAdminUser` 403; design-WS create/save/release; in-use delete 409; no stolen locks
+
+## Summary
+
+Admin POST/PUT/DELETE on `/services/itemfilters` persist assembly item filters (name, description, rules, parent filter) through existing `IItemFilterAdaptor.updateOrCreateItemFilter` / `deleteItemFilter`. sitemanage `ItemFilterAdaptor` uses `IPSSystemDesignWs.createItemFilters` / `loadItemFilters` / `saveItemFilters` / `deleteItemFilters` (same system design WS SOAP uses). No new SOAP. Duplicate name is 409. Unknown id is 404. In-use delete (content-list dependents) is 409. Non-Admin and missing session/user are 403. GET list/detail is unchanged as a catalog read and round-trips created filters.
+
+Change-class companions: OpenAPI resource, Mockito `ItemFilterResourceTest` (18), Spring `TestItemFilterAdaptor` stub (`@Component` `@Lazy`), adaptor write tests (18) plus existing safe-key tests, product-docs 8.2 developer REST AS-07 write note. Reverse-deps of `IItemFilterAdaptor` are only the production adaptor and the rest test stub; interface signatures unchanged.
+
+## Issues
+
+None that block.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction. Filter keys reject `/`, `\`, `..`, and NUL (existing `isSafeFilterKey`).
+
+## Tests / evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 877, Failures: 0 (`ItemFilterResourceTest` 18/0)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1892, Failures: 0, Skipped: 125 (`ItemFilterAdaptorWriteTest` 18/0; `ItemFilterAdaptorSafeKeyTest` 1/0)

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -350,6 +350,86 @@ The slot form stays on screen (or shows an in-panel error). It does
 still render as the human-readable **message** (fallback **code**). Load failures stay
 in the slot detail panel — use **Back** to return to the catalog.
 
+## Item filters (design catalog)
+
+Assembly **item filters** (Workbench **Item Filter** editor: name / description / rules /
+parent filter) are exposed under `/services/itemfilters` (AS-07). The REST layer is a
+thin contract over the system **design** web service (`IPSSystemDesignWs`) — create,
+update, and delete use the same `createItemFilters` / `loadItemFilters` /
+`saveItemFilters` / `deleteItemFilters` operations SOAP uses. There is no new SOAP
+surface. GET list/detail remain a catalog read of the filter service.
+
+Workbench catalog **label** is an alias of **name** (the unique catalog key).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/itemfilters` | List item filters (name, description, rules, parent) |
+| `GET` | `/services/itemfilters/{idOrName}` | Load one filter by unique name or GUID string (`type-host-uuid`) |
+| `POST` | `/services/itemfilters` | **Admin.** Create a filter (`createItemFilters` then `saveItemFilters`) |
+| `PUT` | `/services/itemfilters/{idOrName}` | **Admin.** Update description, rules, parent filter, and/or `legacyAuthtype` |
+| `DELETE` | `/services/itemfilters/{idOrName}` | **Admin.** Delete a filter (`deleteItemFilters`, `ignoreDependencies=false`) |
+
+Create (`POST /services/itemfilters`) persists immediately (Workbench Finish, not an
+unsaved stub). JSON body requires `name` (unique, case-insensitive; **no whitespace** or
+wildcards). Optional `description`, `rules[]` (`name` + `params[]` of `name`/`value`),
+`parentFilter` (by nested `name` or `filterId`), and `legacyAuthtype` are applied before
+save. Duplicate name is **409**. Blank / whitespace / wildcard names are **400**. Missing
+request session/user is **403**. Non-Admin is **403**. The new filter is then
+`GET /services/itemfilters/{name}` **200**.
+
+Update (`PUT /services/itemfilters/{idOrName}`) loads with a design lock and releases it
+on save. Name is not renamed on PUT. Omitted `rules` / `parentFilter` leave the stored
+values unchanged; send `parentFilter` with no name or id to clear the parent; send
+`rules: []` to clear rules.
+
+Delete (`DELETE /services/itemfilters/{idOrName}`) returns **204** when removed; a
+following `GET` is **404**. Unknown id/name is **404**. A filter still associated with a
+content list (or other dependents) is **409**. Locked-by-another-user is **409** (the
+lock is not stolen). Non-Admin is **403**.
+
+There is **no** Developer SPA item-filter editor in this slice — operators and
+integrators call the REST path (or Workbench).
+
+### Request / response shape
+
+JSON objects use the `ItemFilter` wire type (fields include `filterId`, `name`,
+`description`, `legacyAuthtype`, `rules[]`, and nested `parentFilter`). Prefer the
+generated OpenAPI schema as the integration source of truth.
+
+Example create body:
+
+```json
+{
+  "name": "previewPublic",
+  "description": "Public preview items",
+  "parentFilter": { "name": "public" },
+  "rules": [
+    {
+      "name": "sys_filterByPublishDate",
+      "params": [{ "name": "maxAge", "value": "30" }]
+    }
+  ]
+}
+```
+
+### Status codes and authorization
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | List / get / create / update success |
+| `204` | Delete success |
+| `400` | Invalid input (missing name, whitespace/wildcard name, unknown parent, invalid rule) |
+| `403` | Caller is not Admin, or the request has no session/user for the design session |
+| `404` | Item filter not found |
+| `409` | Duplicate name, design lock held by another user, or in-use (content-list dependents) |
+| `500` | Design service or server failure |
+
+- Callers must be authenticated. Item-filter **GET** is a catalog read. Item-filter
+  **write** requires the **Admin** role and a request session and user identity for the
+  design web service (same pattern as slots / locales design writes).
+- Create/update load or create the filter with a **held design lock** and release it on
+  save. There is no separate lock/unlock REST pair on this catalog.
+
 ## Content types (design catalog)
 
 | Operation | Path | Notes |

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ItemFilterAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ItemFilterAdaptor.java
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-// REFACTORED: CP-JAVA11
-
 package com.percussion.apibridge;
 
 import com.percussion.rest.Guid;
@@ -24,27 +22,78 @@ import com.percussion.rest.itemfilter.IItemFilterAdaptor;
 import com.percussion.rest.itemfilter.ItemFilter;
 import com.percussion.rest.itemfilter.ItemFilterRuleDefinition;
 import com.percussion.rest.itemfilter.ItemFilterRuleDefinitionParam;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.error.PSNotFoundException;
 import com.percussion.services.filter.IPSFilterService;
 import com.percussion.services.filter.IPSItemFilter;
 import com.percussion.services.filter.IPSItemFilterRuleDef;
 import com.percussion.services.filter.PSFilterException;
 import com.percussion.services.filter.PSFilterServiceLocator;
+import com.percussion.services.filter.data.PSItemFilter;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
-import java.util.*;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import com.percussion.webservices.system.PSSystemWsLocator;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 
-/** Adaptor for ItemFilter management in Percussion CMS. */
+/**
+ * Adaptor for ItemFilter management in Percussion CMS.
+ *
+ * <p>GET catalog uses {@link IPSFilterService}. Admin create/update/delete persist through {@link
+ * IPSSystemDesignWs} ({@code createItemFilters} / {@code loadItemFilters} / {@code saveItemFilters}
+ * / {@code deleteItemFilters}) — the same system design web service SOAP uses. No new SOAP
+ * methods.
+ */
 @PSSiteManageBean
 public class ItemFilterAdaptor implements IItemFilterAdaptor {
 
+  static final String ADMIN_REQUIRED = "Admin role required to create, update, or delete item filters";
+
   private final IPSFilterService filterService;
+  private final IPSSystemDesignWs designWs;
+  private final BooleanSupplier adminChecker;
   private static final Logger log = LogManager.getLogger(ItemFilterAdaptor.class);
 
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
+
   public ItemFilterAdaptor() {
-    this.filterService = PSFilterServiceLocator.getFilterService();
+    this(
+        PSFilterServiceLocator.getFilterService(),
+        PSSystemWsLocator.getSystemDesignWebservice(),
+        null);
+  }
+
+  /** Package-visible for unit tests. */
+  ItemFilterAdaptor(
+      IPSFilterService filterService, IPSSystemDesignWs designWs, BooleanSupplier adminChecker) {
+    this.filterService = filterService;
+    this.designWs = designWs;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   /**
@@ -106,13 +155,24 @@ public class ItemFilterAdaptor implements IItemFilterAdaptor {
   /**
    * Update or create an ItemFilter.
    *
+   * <p>No {@code filterId} is create (duplicate name is 409). A {@code filterId} is update (unknown
+   * id returns {@code null} → 404).
+   *
    * @param filter The filter to update or create.
    * @return The updated ItemFilter.
    */
   @Override
   public ItemFilter updateOrCreateItemFilter(ItemFilter filter) {
-    log.warn("updateOrCreateItemFilter not yet implemented");
-    return null;
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (filter == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    IPSGuid existingId = toIpsGuid(filter.getFilterId());
+    if (existingId != null) {
+      return updateFilter(existingId, filter);
+    }
+    return createFilter(filter);
   }
 
   /**
@@ -123,8 +183,34 @@ public class ItemFilterAdaptor implements IItemFilterAdaptor {
    */
   @Override
   public void deleteItemFilter(Guid itemFilterId) throws PSNotFoundException {
-    var filter = filterService.loadFilter(ApiUtils.convertGuid(itemFilterId));
-    filterService.deleteFilter(filter);
+    requireAdmin();
+    requireSessionUserForWrite();
+    IPSGuid id = toIpsGuid(itemFilterId);
+    if (id == null) {
+      throw new IllegalArgumentException("item filter id is required");
+    }
+    IPSItemFilter existing = filterService.loadFilter(id);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSItemFilter> locked =
+          designWs.loadItemFilters(List.of(existing.getGUID()), true, false, session, user);
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        throw new WebApplicationException(
+            "Could not delete item filter; design lock required or held by another user", 409);
+      }
+      designWs.deleteItemFilters(List.of(existing.getGUID()), false, session, user);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, existing.getGUID())) {
+        throw new PSNotFoundException("Item filter not found");
+      }
+      throw new WebApplicationException(
+          "Could not delete item filter; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("delete", e);
+    }
   }
 
   /**
@@ -177,5 +263,344 @@ public class ItemFilterAdaptor implements IItemFilterAdaptor {
         && key.indexOf('/') < 0
         && key.indexOf('\\') < 0
         && key.indexOf('\0') < 0;
+  }
+
+  private ItemFilter createFilter(ItemFilter body) {
+    String name = requireValidName(body.getName());
+    assertNameUnique(name);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSItemFilter> created = designWs.createItemFilters(List.of(name), session, user);
+      if (created == null || created.isEmpty() || created.get(0) == null) {
+        throw new IllegalStateException("Design WS createItemFilters returned empty");
+      }
+      PSItemFilter domain = created.get(0);
+      applyWritableFields(domain, body);
+      designWs.saveItemFilters(List.of(domain), true, session, user);
+      return reload(domain);
+    } catch (WebApplicationException | IllegalStateException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("Item filter already exists: " + name, 409);
+      }
+      throw e;
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("create", e);
+    } catch (PSFilterException e) {
+      throw new IllegalArgumentException(
+          e.getMessage() != null ? e.getMessage() : "Invalid item filter rule", e);
+    }
+  }
+
+  private ItemFilter updateFilter(IPSGuid id, ItemFilter body) {
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSItemFilter> loaded =
+          designWs.loadItemFilters(List.of(id), true, false, session, user);
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        return null;
+      }
+      PSItemFilter domain = loaded.get(0);
+      applyWritableFields(domain, body);
+      designWs.saveItemFilters(List.of(domain), true, session, user);
+      return reload(domain);
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, id)) {
+        return null;
+      }
+      if (hasLockError(e)) {
+        throw new WebApplicationException(
+            "Could not update item filter; design lock required or held by another user", 409);
+      }
+      log.error("Failed to load item filter for update: {}", id, e);
+      throw new IllegalStateException("Failed to update item filter", e);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("update", e);
+    } catch (PSFilterException e) {
+      throw new IllegalArgumentException(
+          e.getMessage() != null ? e.getMessage() : "Invalid item filter rule", e);
+    }
+  }
+
+  private void applyWritableFields(IPSItemFilter domain, ItemFilter body) throws PSFilterException {
+    if (body.getDescription() != null) {
+      domain.setDescription(body.getDescription());
+    }
+    if (body.getLegacyAuthtype() != null) {
+      domain.setLegacyAuthtypeId(body.getLegacyAuthtype());
+    }
+    applyRules(domain, body.getRules());
+    applyParent(domain, body.getParentFilter());
+  }
+
+  private void applyRules(IPSItemFilter domain, Set<ItemFilterRuleDefinition> rules)
+      throws PSFilterException {
+    if (rules == null) {
+      return;
+    }
+    Set<IPSItemFilterRuleDef> defs = new HashSet<>();
+    for (ItemFilterRuleDefinition rule : rules) {
+      if (rule == null || StringUtils.isBlank(rule.getName())) {
+        throw new IllegalArgumentException("rule name is required");
+      }
+      Map<String, String> params = new HashMap<>();
+      if (rule.getParams() != null) {
+        for (ItemFilterRuleDefinitionParam p : rule.getParams()) {
+          if (p != null && StringUtils.isNotBlank(p.getName()) && p.getValue() != null) {
+            params.put(p.getName(), p.getValue());
+          }
+        }
+      }
+      defs.add(filterService.createRuleDef(rule.getName().trim(), params));
+    }
+    domain.setRuleDefs(defs);
+  }
+
+  private void applyParent(IPSItemFilter domain, ItemFilter parentDto) {
+    if (parentDto == null) {
+      return;
+    }
+    IPSGuid parentId = toIpsGuid(parentDto.getFilterId());
+    String parentName = parentDto.getName();
+    if (parentId == null && StringUtils.isBlank(parentName)) {
+      domain.setParentFilter(null);
+      return;
+    }
+    IPSItemFilter parent = resolveParent(parentId, parentName);
+    if (parent == null) {
+      throw new IllegalArgumentException("parent filter not found");
+    }
+    if (domain.getGUID() != null
+        && parent.getGUID() != null
+        && domain.getGUID().equals(parent.getGUID())) {
+      throw new IllegalArgumentException("item filter cannot parent itself");
+    }
+    domain.setParentFilter(parent);
+  }
+
+  private IPSItemFilter resolveParent(IPSGuid parentId, String parentName) {
+    if (parentId != null) {
+      try {
+        return filterService.loadFilter(parentId);
+      } catch (PSNotFoundException e) {
+        return null;
+      }
+    }
+    if (StringUtils.isBlank(parentName) || !isSafeFilterKey(parentName.trim())) {
+      return null;
+    }
+    return filterService.findFilterByNameSafe(parentName.trim()).orElse(null);
+  }
+
+  private ItemFilter reload(IPSItemFilter saved) {
+    if (saved == null || saved.getGUID() == null) {
+      return saved == null ? null : copyFilter(saved);
+    }
+    try {
+      return copyFilter(filterService.loadFilter(saved.getGUID()));
+    } catch (PSNotFoundException e) {
+      log.debug("Could not reload item filter after write: {}", e.getMessage());
+      return copyFilter(saved);
+    }
+  }
+
+  private void assertNameUnique(String name) {
+    List<IPSCatalogSummary> existing = designWs.findItemFilters(name);
+    if (existing == null) {
+      return;
+    }
+    for (IPSCatalogSummary summary : existing) {
+      if (summary != null
+          && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+        throw new WebApplicationException("Item filter already exists: " + name, 409);
+      }
+    }
+  }
+
+  private static String requireValidName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String name = raw.trim();
+    if (containsWhitespace(name)) {
+      throw new IllegalArgumentException("name cannot contain whitespace");
+    }
+    if (name.contains("*") || name.contains("%")) {
+      throw new IllegalArgumentException("name must not contain wildcards");
+    }
+    if (!isSafeFilterKey(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return name;
+  }
+
+  private static boolean containsWhitespace(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isWhitespace(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static IPSGuid toIpsGuid(Guid guid) {
+    if (guid == null) {
+      return null;
+    }
+    String sv = guid.getStringValue();
+    if (StringUtils.isNotBlank(sv)) {
+      try {
+        return new PSGuid(sv.trim());
+      } catch (IllegalArgumentException e) {
+        log.debug("Invalid item filter GUID string: {}", e.getMessage());
+      }
+    }
+    if (guid.getType() > 0 && guid.getUuid() > 0) {
+      PSTypeEnum type = PSTypeEnum.valueOf(guid.getType());
+      if (type != null) {
+        return new PSGuid(type, guid.getUuid());
+      }
+    }
+    if (guid.getLongValue() != 0) {
+      return new PSGuid(guid.getLongValue());
+    }
+    return null;
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private static void requireSessionUserForWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for item filter design write", Response.Status.FORBIDDEN);
+    }
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+
+  static boolean isAlreadyExistsFailure(IllegalArgumentException e) {
+    return e != null && StringUtils.containsIgnoreCase(e.getMessage(), "already exists");
+  }
+
+  static boolean isNotFound(PSErrorResultsException e, IPSGuid requested) {
+    if (e == null || requested == null) {
+      return false;
+    }
+    Map<IPSGuid, Object> errors = e.getErrors();
+    Map<IPSGuid, Object> results = e.getResults();
+    boolean errored = errors != null && errors.containsKey(requested);
+    boolean hasResult = results != null && results.containsKey(requested);
+    return errored && !hasResult && !hasLockError(e);
+  }
+
+  static boolean hasLockError(PSErrorResultsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isNotLockedError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isDependencyError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return StringUtils.containsIgnoreCase(e != null ? e.getMessage() : null, "depend");
+    }
+    for (Object err : e.getErrors().values()) {
+      String msg = errorMessage(err);
+      if (StringUtils.containsIgnoreCase(msg, "depend")) {
+        return true;
+      }
+    }
+    return StringUtils.containsIgnoreCase(e.getMessage(), "depend");
+  }
+
+  private static boolean isLockErrorObject(Object err) {
+    if (err instanceof PSLockErrorException) {
+      return true;
+    }
+    if (err instanceof PSErrorException pe) {
+      String msg = pe.getErrorMessage() != null ? pe.getErrorMessage() : pe.getMessage();
+      return StringUtils.containsIgnoreCase(msg, "is not locked")
+          || StringUtils.containsIgnoreCase(msg, "not locked for");
+    }
+    return StringUtils.containsIgnoreCase(String.valueOf(err), "is not locked");
+  }
+
+  private static String errorMessage(Object err) {
+    if (err instanceof PSErrorException pe) {
+      return StringUtils.defaultIfBlank(pe.getErrorMessage(), pe.getMessage());
+    }
+    return err != null ? String.valueOf(err) : null;
+  }
+
+  private RuntimeException mapSaveOrDeleteFailure(String verb, PSErrorsException e) {
+    if (isNotLockedError(e)) {
+      return new WebApplicationException(
+          "Could not " + verb + " item filter; design lock required or held by another user", 409);
+    }
+    if (isDependencyError(e)) {
+      return new WebApplicationException(
+          "Item filter is associated with a content list or other dependents", 409);
+    }
+    log.error("Failed to {} item filter via system design WS", verb, e);
+    return new IllegalStateException("Failed to " + verb + " item filter", e);
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ItemFilterAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ItemFilterAdaptorWriteTest.java
@@ -1,0 +1,393 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.Guid;
+import com.percussion.rest.itemfilter.ItemFilter;
+import com.percussion.rest.itemfilter.ItemFilterRuleDefinition;
+import com.percussion.rest.itemfilter.ItemFilterRuleDefinitionParam;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.error.PSNotFoundException;
+import com.percussion.services.filter.IPSFilterService;
+import com.percussion.services.filter.IPSItemFilterRuleDef;
+import com.percussion.services.filter.data.PSItemFilter;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * AS-07 POST create / PUT update / DELETE persist via {@code createItemFilters}/{@code
+ * saveItemFilters}/{@code deleteItemFilters}. Admin only; unique name; in-use delete 409.
+ */
+@Tag("UnitTest")
+class ItemFilterAdaptorWriteTest {
+
+  private IPSFilterService filterService;
+  private IPSSystemDesignWs designWs;
+  private ItemFilterAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    filterService = mock(IPSFilterService.class);
+    designWs = mock(IPSSystemDesignWs.class);
+    adaptor = new ItemFilterAdaptor(filterService, designWs, () -> true);
+    guid = new PSGuid(PSTypeEnum.ITEM_FILTER, 42L);
+    when(designWs.findItemFilters(any())).thenReturn(Collections.emptyList());
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void create_usesCreateThenSaveAndReleasesLock() throws Exception {
+    PSItemFilter filter = stubFilter("preview", "created via REST");
+    when(designWs.createItemFilters(eq(List.of("preview")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(filter));
+    when(filterService.loadFilter(eq(guid))).thenReturn(filter);
+
+    ItemFilter body = new ItemFilter();
+    body.setName("preview");
+    body.setDescription("created via REST");
+
+    ItemFilter out = adaptor.updateOrCreateItemFilter(body);
+
+    assertEquals("preview", out.getName());
+    assertEquals("created via REST", out.getDescription());
+    verify(designWs).createItemFilters(eq(List.of("preview")), eq("test-session"), eq("Admin"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSItemFilter>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveItemFilters(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    verify(filter).setDescription("created via REST");
+  }
+
+  @Test
+  void create_appliesRulesAndParent() throws Exception {
+    PSItemFilter filter = stubFilter("child", "child");
+    PSItemFilter parent = stubFilter("parent", "parent filter");
+    IPSGuid parentGuid = new PSGuid(PSTypeEnum.ITEM_FILTER, 7L);
+    when(parent.getGUID()).thenReturn(parentGuid);
+    when(designWs.createItemFilters(eq(List.of("child")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(filter));
+    when(filterService.findFilterByNameSafe(eq("parent"))).thenReturn(Optional.of(parent));
+    IPSItemFilterRuleDef ruleDef = mock(IPSItemFilterRuleDef.class);
+    when(ruleDef.getRuleName()).thenReturn("sys_filterByPublishDate");
+    when(ruleDef.getGUID()).thenReturn(new PSGuid(PSTypeEnum.ITEM_FILTER, 8L));
+    when(ruleDef.getParams()).thenReturn(Map.of("maxAge", "30"));
+    when(filterService.createRuleDef(eq("sys_filterByPublishDate"), any())).thenReturn(ruleDef);
+    when(filterService.loadFilter(eq(guid))).thenReturn(filter);
+    when(filter.getParentFilter()).thenReturn(parent);
+    when(filter.getRuleDefs()).thenReturn(Set.of(ruleDef));
+
+    ItemFilter body = new ItemFilter();
+    body.setName("child");
+    ItemFilter parentDto = new ItemFilter();
+    parentDto.setName("parent");
+    body.setParentFilter(parentDto);
+    ItemFilterRuleDefinition rule = new ItemFilterRuleDefinition();
+    rule.setName("sys_filterByPublishDate");
+    ItemFilterRuleDefinitionParam param = new ItemFilterRuleDefinitionParam();
+    param.setName("maxAge");
+    param.setValue("30");
+    rule.setParams(List.of(param));
+    body.setRules(Set.of(rule));
+
+    ItemFilter out = adaptor.updateOrCreateItemFilter(body);
+
+    assertEquals("parent", out.getParentFilter().getName());
+    assertEquals(1, out.getRules().size());
+    verify(filter).setParentFilter(parent);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Set<IPSItemFilterRuleDef>> rules = ArgumentCaptor.forClass(Set.class);
+    verify(filter).setRuleDefs(rules.capture());
+    assertEquals(1, rules.getValue().size());
+  }
+
+  @Test
+  void create_duplicateName_is409BeforeCreate() throws Exception {
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("preview");
+    when(designWs.findItemFilters(eq("preview"))).thenReturn(List.of(existing));
+
+    ItemFilter body = new ItemFilter();
+    body.setName("preview");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.updateOrCreateItemFilter(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createItemFilters(anyList(), any(), any());
+    verify(designWs, never()).saveItemFilters(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_persistTimeDuplicate_is409() throws Exception {
+    when(designWs.createItemFilters(eq(List.of("preview")), eq("test-session"), eq("Admin")))
+        .thenThrow(
+            new IllegalArgumentException("The name 'preview' for type 'ITEM_FILTER' already exists."));
+    ItemFilter body = new ItemFilter();
+    body.setName("preview");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.updateOrCreateItemFilter(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveItemFilters(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_blankName_throwsBeforeDesignWs() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.updateOrCreateItemFilter(null));
+    ItemFilter blank = new ItemFilter();
+    blank.setName("  ");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.updateOrCreateItemFilter(blank));
+    assertTrue(ex.getMessage().contains("name is required"));
+    verify(designWs, never()).createItemFilters(anyList(), any(), any());
+  }
+
+  @Test
+  void create_nameWithSpaces_throwsBeforeDesignWs() {
+    ItemFilter body = new ItemFilter();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.updateOrCreateItemFilter(body));
+    assertEquals("name cannot contain whitespace", ex.getMessage());
+    verify(designWs, never()).createItemFilters(anyList(), any(), any());
+  }
+
+  @Test
+  void create_nonAdmin_is403() {
+    adaptor = new ItemFilterAdaptor(filterService, designWs, () -> false);
+    ItemFilter body = new ItemFilter();
+    body.setName("preview");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.updateOrCreateItemFilter(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).createItemFilters(anyList(), any(), any());
+  }
+
+  @Test
+  void create_missingSession_is403() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    ItemFilter body = new ItemFilter();
+    body.setName("preview");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.updateOrCreateItemFilter(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("session"), ex.getMessage());
+  }
+
+  @Test
+  void create_thenGetByName_returnsFilter() throws Exception {
+    PSItemFilter filter = stubFilter("preview", "created via REST");
+    when(designWs.createItemFilters(eq(List.of("preview")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(filter));
+    when(filterService.loadFilter(eq(guid))).thenReturn(filter);
+    when(filterService.findAllFilters()).thenReturn(List.of(filter));
+
+    ItemFilter body = new ItemFilter();
+    body.setName("preview");
+    body.setDescription("created via REST");
+
+    adaptor.updateOrCreateItemFilter(body);
+    ItemFilter got = adaptor.findItemFilter("preview");
+
+    assertEquals("preview", got.getName());
+    assertEquals("created via REST", got.getDescription());
+  }
+
+  @Test
+  void update_loadsWithLockAndSavesRulesAndParent() throws Exception {
+    PSItemFilter filter = stubFilter("preview", "old");
+    when(designWs.loadItemFilters(eq(List.of(guid)), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(filter));
+    when(filterService.loadFilter(eq(guid))).thenReturn(filter);
+    PSItemFilter parent = stubFilter("parent", "p");
+    IPSGuid parentGuid = new PSGuid(PSTypeEnum.ITEM_FILTER, 7L);
+    when(parent.getGUID()).thenReturn(parentGuid);
+    when(filterService.findFilterByNameSafe(eq("parent"))).thenReturn(Optional.of(parent));
+    IPSItemFilterRuleDef ruleDef = mock(IPSItemFilterRuleDef.class);
+    when(ruleDef.getRuleName()).thenReturn("sys_filterByPublishDate");
+    when(ruleDef.getGUID()).thenReturn(new PSGuid(PSTypeEnum.ITEM_FILTER, 8L));
+    when(ruleDef.getParams()).thenReturn(Map.of());
+    when(filterService.createRuleDef(eq("sys_filterByPublishDate"), any())).thenReturn(ruleDef);
+
+    ItemFilter body = new ItemFilter();
+    body.setFilterId(restGuid(guid));
+    body.setDescription("updated");
+    ItemFilter parentDto = new ItemFilter();
+    parentDto.setName("parent");
+    body.setParentFilter(parentDto);
+    ItemFilterRuleDefinition rule = new ItemFilterRuleDefinition();
+    rule.setName("sys_filterByPublishDate");
+    body.setRules(Set.of(rule));
+
+    ItemFilter out = adaptor.updateOrCreateItemFilter(body);
+
+    assertEquals("preview", out.getName());
+    verify(filter).setDescription("updated");
+    verify(filter).setParentFilter(parent);
+    verify(designWs).saveItemFilters(anyList(), eq(true), eq("test-session"), eq("Admin"));
+    verify(designWs, never()).createItemFilters(anyList(), any(), any());
+  }
+
+  @Test
+  void update_unknown_returnsNull() throws Exception {
+    when(designWs.loadItemFilters(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of());
+    ItemFilter body = new ItemFilter();
+    body.setFilterId(restGuid(guid));
+    body.setName("preview");
+    assertNull(adaptor.updateOrCreateItemFilter(body));
+    verify(designWs, never()).saveItemFilters(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_nonAdmin_is403() {
+    adaptor = new ItemFilterAdaptor(filterService, designWs, () -> false);
+    ItemFilter body = new ItemFilter();
+    body.setFilterId(restGuid(guid));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.updateOrCreateItemFilter(body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void delete_thenGetByName_isNotFound() throws Exception {
+    PSItemFilter filter = stubFilter("preview", "d");
+    when(filterService.loadFilter(eq(guid))).thenReturn(filter);
+    when(designWs.loadItemFilters(eq(List.of(guid)), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(filter));
+
+    adaptor.deleteItemFilter(restGuid(guid));
+    when(filterService.findAllFilters()).thenReturn(List.of());
+    assertNull(adaptor.findItemFilter("preview"));
+    verify(designWs).deleteItemFilters(eq(List.of(guid)), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void delete_inUse_is409() throws Exception {
+    PSItemFilter filter = stubFilter("preview", "d");
+    when(filterService.loadFilter(eq(guid))).thenReturn(filter);
+    when(designWs.loadItemFilters(eq(List.of(guid)), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(filter));
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(guid, new PSErrorException("Object has dependents"));
+    doThrow(errors)
+        .when(designWs)
+        .deleteItemFilters(anyList(), eq(false), any(), any());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteItemFilter(restGuid(guid)));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("content list"), ex.getMessage());
+  }
+
+  @Test
+  void delete_unknown_throwsNotFound() throws Exception {
+    when(filterService.loadFilter(eq(guid))).thenThrow(new PSNotFoundException("gone"));
+    assertThrows(PSNotFoundException.class, () -> adaptor.deleteItemFilter(restGuid(guid)));
+    verify(designWs, never()).deleteItemFilters(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_lockConflict_is409() throws Exception {
+    PSItemFilter filter = stubFilter("preview", "d");
+    when(filterService.loadFilter(eq(guid))).thenReturn(filter);
+    when(designWs.loadItemFilters(eq(List.of(guid)), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteItemFilter(restGuid(guid)));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteItemFilters(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_nonAdmin_is403() throws Exception {
+    adaptor = new ItemFilterAdaptor(filterService, designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteItemFilter(restGuid(guid)));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteItemFilters(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void toIpsGuid_parsesStringValue() {
+    Guid g = restGuid(guid);
+    IPSGuid parsed = ItemFilterAdaptor.toIpsGuid(g);
+    assertEquals(guid.toString(), parsed.toString());
+    assertNull(ItemFilterAdaptor.toIpsGuid(null));
+  }
+
+  private PSItemFilter stubFilter(String name, String description) {
+    PSItemFilter filter = mock(PSItemFilter.class);
+    when(filter.getName()).thenReturn(name);
+    when(filter.getDescription()).thenReturn(description);
+    when(filter.getGUID()).thenReturn(guid);
+    when(filter.getLegacyAuthtypeId()).thenReturn(null);
+    when(filter.getParentFilter()).thenReturn(null);
+    when(filter.getRuleDefs()).thenReturn(new HashSet<>());
+    return filter;
+  }
+
+  private static Guid restGuid(IPSGuid g) {
+    Guid out = new Guid();
+    out.setStringValue(g.toString());
+    return out;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/itemfilter/IItemFilterAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/itemfilter/IItemFilterAdaptor.java
@@ -36,8 +36,11 @@ public interface IItemFilterAdaptor {
   /**
    * Updates or creates an ItemFilter.
    *
+   * <p>Admin only. Missing {@code filterId} creates (duplicate name is 409). Present {@code
+   * filterId} updates (unknown id returns {@code null}).
+   *
    * @param filter The filter to update or create.
-   * @return The updated ItemFilter.
+   * @return The updated ItemFilter, or {@code null} when the update target is not found.
    */
   ItemFilter updateOrCreateItemFilter(ItemFilter filter);
 
@@ -45,7 +48,7 @@ public interface IItemFilterAdaptor {
    * Deletes the specified item filter.
    *
    * @param itemFilterId A valid ItemFilter id. Filter must not be associated with any ContentLists
-   *     or it won't be deleted.
+   *     or it won't be deleted (409).
    * @throws PSNotFoundException if the filter is not found.
    */
   void deleteItemFilter(Guid itemFilterId) throws PSNotFoundException;

--- a/rest/src/main/java/com/percussion/rest/itemfilter/ItemFilterResource.java
+++ b/rest/src/main/java/com/percussion/rest/itemfilter/ItemFilterResource.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.itemfilter;
 
+import com.percussion.services.error.PSNotFoundException;
 import com.percussion.system.utils.PSSiteManageBean;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -24,26 +25,37 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only item filter catalog for the Developer module (AS-07 list/detail).
+ * Assembly item filter catalog for the Developer module (AS-07).
  *
- * <p>Write endpoints remain unimplemented at the adaptor layer (later slice).
+ * <p>Admin POST/PUT/DELETE persist through {@link IItemFilterAdaptor#updateOrCreateItemFilter} and
+ * {@link IItemFilterAdaptor#deleteItemFilter} (system design WS / filter service). SPA item-filter
+ * editor chrome is out of scope.
  */
 @PSSiteManageBean(value = "restItemFilterResource")
 @Path("/itemfilters")
 @XmlRootElement
-@Tag(name = "Item Filters", description = "Item filter design catalog (read-only)")
+@Tag(name = "Item Filters", description = "Item filter design catalog (AS-07 CRUD)")
 public class ItemFilterResource {
+
+  private static final Logger log = LogManager.getLogger(ItemFilterResource.class);
 
   private final IItemFilterAdaptor adaptor;
 
@@ -60,9 +72,7 @@ public class ItemFilterResource {
   @Produces({MediaType.APPLICATION_JSON})
   @Operation(
       summary = "List item filters",
-      description =
-          "Lists assembly item filters with rules and parent linkage. Create/edit/delete are later"
-              + " slices.",
+      description = "Lists assembly item filters with rules and parent linkage.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -88,9 +98,7 @@ public class ItemFilterResource {
   @Produces({MediaType.APPLICATION_JSON})
   @Operation(
       summary = "Get item filter detail",
-      description =
-          "Loads one item filter by name or GUID string (type-host-uuid). Write remains"
-              + " unsupported.",
+      description = "Loads one item filter by name or GUID string (type-host-uuid).",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -111,6 +119,165 @@ public class ItemFilterResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  @POST
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Create item filter",
+      description =
+          "Admin. Creates and persists an assembly item filter via"
+              + " IPSSystemDesignWs.createItemFilters then saveItemFilters (held design lock,"
+              + " released on save). Name is required, unique (case-insensitive), and must not"
+              + " contain whitespace or wildcards. Optional description, rules, parent filter, and"
+              + " legacyAuthtype are applied before save. Duplicate name is 409. Workbench catalog"
+              + " label is an alias of name.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = ItemFilter.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "409", description = "A filter with that name already exists"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ItemFilter createItemFilter(ItemFilter body) {
+    try {
+      if (body != null) {
+        body.setFilterId(null);
+      }
+      ItemFilter created = requireAdaptor().updateOrCreateItemFilter(body);
+      if (created == null) {
+        throw new WebApplicationException("Failed to create item filter", 500);
+      }
+      return created;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      log.error("Failed to create item filter ({}): {}", e.getClass().getName(), e.getMessage(), e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Update item filter",
+      description =
+          "Admin. Updates description, rules, parent filter, and/or legacyAuthtype by name or"
+              + " GUID. Name is the catalog key (Workbench label aliases name) and is not renamed"
+              + " on PUT. Loads with a design lock and releases on save. Unknown id is 404."
+              + " Lock/dependency conflict is 409.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = ItemFilter.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Filter not found"),
+        @ApiResponse(responseCode = "409", description = "Design lock or dependency conflict"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ItemFilter updateItemFilter(@PathParam("idOrName") String idOrName, ItemFilter body) {
+    try {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      ItemFilter existing = requireAdaptor().findItemFilter(idOrName);
+      if (existing == null) {
+        throw new WebApplicationException("Item filter not found", 404);
+      }
+      body.setFilterId(existing.getFilterId());
+      ItemFilter updated = requireAdaptor().updateOrCreateItemFilter(body);
+      if (updated == null) {
+        throw new WebApplicationException("Item filter not found", 404);
+      }
+      return updated;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      log.error(
+          "Failed to update item filter {} ({}): {}",
+          idOrName,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete item filter",
+      description =
+          "Admin. Deletes an item filter by name or GUID via IPSSystemDesignWs.deleteItemFilters"
+              + " (ignoreDependencies=false). Unknown id is 404. In-use (associated with a content"
+              + " list) or lock conflict is 409. Following GET is 404 after a successful delete.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Filter not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Filter is associated with a content list, or design lock conflict"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteItemFilter(@PathParam("idOrName") String idOrName) {
+    try {
+      ItemFilter existing = requireAdaptor().findItemFilter(idOrName);
+      if (existing == null || existing.getFilterId() == null) {
+        throw new WebApplicationException("Item filter not found", 404);
+      }
+      requireAdaptor().deleteItemFilter(existing.getFilterId());
+      return Response.noContent().build();
+    } catch (PSNotFoundException e) {
+      throw new WebApplicationException("Item filter not found", 404);
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      log.error(
+          "Failed to delete item filter {} ({}): {}",
+          idOrName,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Admin/session 403 and duplicate/in-use 409 are
+   * already {@link WebApplicationException}s from the adaptor.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    if (e instanceof IllegalStateException) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      String lower = msg.toLowerCase();
+      if (lower.contains("lock") || lower.contains("depend")) {
+        return new WebApplicationException(msg, 409);
+      }
+      return new WebApplicationException(e, 500);
+    }
+    return new WebApplicationException(e, 500);
   }
 
   private IItemFilterAdaptor requireAdaptor() {

--- a/rest/src/test/java/com/percussion/rest/itemfilter/ItemFilterResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/itemfilter/ItemFilterResourceTest.java
@@ -19,16 +19,24 @@ package com.percussion.rest.itemfilter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.percussion.rest.Guid;
+import com.percussion.services.error.PSNotFoundException;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -94,6 +102,167 @@ public class ItemFilterResourceTest {
   }
 
   @Test
+  public void createItemFilterClearsIdAndDelegates() {
+    ItemFilter body = new ItemFilter();
+    body.setName("preview");
+    body.setFilterId(guid("0-11-1"));
+    ItemFilter created = new ItemFilter();
+    created.setName("preview");
+    created.setFilterId(guid("0-11-99"));
+    when(adaptor.updateOrCreateItemFilter(any())).thenReturn(created);
+
+    ItemFilter out = resource.createItemFilter(body);
+
+    assertEquals("preview", out.getName());
+    assertNull(body.getFilterId());
+    verify(adaptor).updateOrCreateItemFilter(body);
+  }
+
+  @Test
+  public void createItemFilterBlankNameIs400() {
+    when(adaptor.updateOrCreateItemFilter(any()))
+        .thenThrow(new IllegalArgumentException("name is required"));
+    ItemFilter body = new ItemFilter();
+    body.setName("  ");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createItemFilter(body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createItemFilterDuplicateIs409() {
+    when(adaptor.updateOrCreateItemFilter(any()))
+        .thenThrow(new WebApplicationException("Item filter already exists: preview", 409));
+    ItemFilter body = new ItemFilter();
+    body.setName("preview");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createItemFilter(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createItemFilterNonAdminIs403() {
+    when(adaptor.updateOrCreateItemFilter(any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    ItemFilter body = new ItemFilter();
+    body.setName("preview");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createItemFilter(body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateItemFilterSetsIdFromLookup() {
+    ItemFilter existing = new ItemFilter();
+    existing.setName("preview");
+    existing.setFilterId(guid("0-11-9"));
+    when(adaptor.findItemFilter(eq("preview"))).thenReturn(existing);
+    ItemFilter body = new ItemFilter();
+    body.setDescription("updated");
+    ItemFilterRuleDefinition rule = new ItemFilterRuleDefinition();
+    rule.setName("sys_filterByPublishDate");
+    body.setRules(Set.of(rule));
+    ItemFilter updated = new ItemFilter();
+    updated.setName("preview");
+    updated.setDescription("updated");
+    updated.setRules(Set.of(rule));
+    when(adaptor.updateOrCreateItemFilter(any())).thenReturn(updated);
+
+    ItemFilter out = resource.updateItemFilter("preview", body);
+
+    assertEquals("updated", out.getDescription());
+    assertEquals(1, out.getRules().size());
+    assertEquals("0-11-9", body.getFilterId().getStringValue());
+    verify(adaptor).updateOrCreateItemFilter(body);
+  }
+
+  @Test
+  public void updateItemFilterUnknownIs404() {
+    when(adaptor.findItemFilter(eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateItemFilter("missing", new ItemFilter()));
+    assertEquals(404, ex.getResponse().getStatus());
+    verify(adaptor, never()).updateOrCreateItemFilter(any());
+  }
+
+  @Test
+  public void updateItemFilterNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateItemFilter("preview", null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteItemFilterNoContent() throws Exception {
+    ItemFilter existing = new ItemFilter();
+    existing.setName("preview");
+    existing.setFilterId(guid("0-11-9"));
+    when(adaptor.findItemFilter(eq("preview"))).thenReturn(existing);
+
+    Response r = resource.deleteItemFilter("preview");
+
+    assertEquals(204, r.getStatus());
+    verify(adaptor).deleteItemFilter(existing.getFilterId());
+  }
+
+  @Test
+  public void deleteItemFilterUnknownIs404() throws Exception {
+    when(adaptor.findItemFilter(eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteItemFilter("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+    verify(adaptor, never()).deleteItemFilter(any());
+  }
+
+  @Test
+  public void deleteItemFilterInUseIs409() throws Exception {
+    ItemFilter existing = new ItemFilter();
+    existing.setName("preview");
+    existing.setFilterId(guid("0-11-9"));
+    when(adaptor.findItemFilter(eq("preview"))).thenReturn(existing);
+    doThrow(
+            new WebApplicationException(
+                "Item filter is associated with a content list or other dependents", 409))
+        .when(adaptor)
+        .deleteItemFilter(any());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteItemFilter("preview"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteItemFilterNotFoundFromAdaptorIs404() throws Exception {
+    ItemFilter existing = new ItemFilter();
+    existing.setName("preview");
+    existing.setFilterId(guid("0-11-9"));
+    when(adaptor.findItemFilter(eq("preview"))).thenReturn(existing);
+    doThrow(new PSNotFoundException("gone")).when(adaptor).deleteItemFilter(any());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteItemFilter("preview"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteItemFilterNonAdminIs403() throws Exception {
+    ItemFilter existing = new ItemFilter();
+    existing.setName("preview");
+    existing.setFilterId(guid("0-11-9"));
+    when(adaptor.findItemFilter(eq("preview"))).thenReturn(existing);
+    doThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN))
+        .when(adaptor)
+        .deleteItemFilter(any());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteItemFilter("preview"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void withoutInjectionFailsWithDiagnostic() {
     ItemFilterResource bare = new ItemFilterResource();
     WebApplicationException listEx =
@@ -105,5 +274,15 @@ public class ItemFilterResourceTest {
         assertThrows(WebApplicationException.class, () -> bare.getItemFilter("x"));
     assertEquals(500, getEx.getResponse().getStatus());
     assertInstanceOf(IllegalStateException.class, getEx.getCause());
+
+    WebApplicationException createEx =
+        assertThrows(WebApplicationException.class, () -> bare.createItemFilter(new ItemFilter()));
+    assertEquals(500, createEx.getResponse().getStatus());
+  }
+
+  private static Guid guid(String value) {
+    Guid g = new Guid();
+    g.setStringValue(value);
+    return g;
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestItemFilterAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestItemFilterAdaptor.java
@@ -23,10 +23,15 @@ import com.percussion.rest.Guid;
 import com.percussion.rest.itemfilter.IItemFilterAdaptor;
 import com.percussion.rest.itemfilter.ItemFilter;
 import java.util.List;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
-/** Test adaptor for ItemFilter API bridge. */
+/**
+ * Spring test stub for {@link IItemFilterAdaptor}. Required for ApplicationContext load after
+ * constructor injection on {@code ItemFilterResource}.
+ */
 @Component
+@Lazy
 public class TestItemFilterAdaptor implements IItemFilterAdaptor {
 
   @Override


### PR DESCRIPTION
## Summary

Admin REST **create/update/delete** for assembly item filters (AS-07) on `/services/itemfilters`. Parent epic: #1690. Slice: #4014.

`ItemFilterResource` now exposes POST (create), PUT (update description/rules/parent/`legacyAuthtype`), and DELETE. Persistence goes through existing `IItemFilterAdaptor.updateOrCreateItemFilter` / `deleteItemFilter`. sitemanage `ItemFilterAdaptor` implements writes via `IPSSystemDesignWs.createItemFilters` / `loadItemFilters` / `saveItemFilters` / `deleteItemFilters` (same system design WS SOAP uses — no new SOAP). GET list/detail is unchanged and round-trips created filters.

- Non-Admin / missing session-user → **403**
- Unknown id/name → **404**
- Duplicate name → **409**
- Delete while associated with a content list (dependents) → **409**
- DELETE **204** then GET **404**
- SPA item-filter editor chrome is **out of scope**

Fixes #4014  
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS
3. Mockito `ItemFilterResourceTest`: POST/PUT/DELETE 200/204/400/403/404/409
4. Adaptor `ItemFilterAdaptorWriteTest`: create then GET by name; update rules/parent; in-use delete 409; non-Admin 403
5. Spring `TestItemFilterAdaptor` stub still loads rest `MainTest` ApplicationContext
6. Integrator: Admin POST `/services/itemfilters` with unique `name`; GET by name 200; PUT rules/parent; DELETE 204 then GET 404; non-Admin write 403

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (Item filters design catalog / AS-07 write)
- [x] **Unit / module tests** — behavioral tests for new write logic; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; SPA editor out of scope)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); reverse-deps of `IItemFilterAdaptor` compiled (sitemanage); interface signatures unchanged
- [x] **Cross-platform** — N/A (no filesystem path/file I/O; filter keys still reject `/` `\` `..`)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 877, Failures: 0 (`ItemFilterResourceTest` 18/0)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1892, Failures: 0, Skipped: 125 (`ItemFilterAdaptorWriteTest` 18/0)
- **downstream_checked:** grep `implements IItemFilterAdaptor` → production `ItemFilterAdaptor` + rest `TestItemFilterAdaptor` only; sitemanage standalone clean install green; no `final`/`sealed` or adaptor method signature change

Erlang pre-commit: `docs/ai-generated/code-reviews/4014-itemfilter-write-erlang.md` (approve)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
