### PR TITLE
fix(system): leftover conn IPS*Errors to ConnectionErrorCodes (#4016)

### DIFF
--- a/docs/ai-generated/code-reviews/4016-conn-leftover-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/4016-conn-leftover-errorcodes-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — #4016 conn leftover IPS*Errors typed ErrorCodes
+
+**Scope:** uncommitted branch `fix/issue-4016-conn-leftover-errorcodes` vs `origin/main`  
+**Memory patterns hit:** typed `*ErrorCodes` + `IPSErrorCode` constructors; dual-write skip for `isAuditable()==false`; do not delete `IPS*Errors` interfaces; int-only reconstruction paths use `.numericCode()`; exact production exception types in tests; incomplete change-class closure (allow-list companion).  
+**Cross-platform path checklist:** N/A (no new filesystem path joins; tests construct exceptions / XML in-memory).
+
+## Summary
+
+Parent #2616 leftover slice: remaining `system/src/main/java/com/percussion/conn/` production `IPS*Errors` call-sites (`PSDesignerConnection`, `PSServerException`) now use typed `ConnectionErrorCodes` and `ServerErrorCodes.RAW_DUMP`. `PSServerException(Exception)` constructs with typed `UNKNOWN_SERVER_EXCEPTION`. Remote XML reconstruction still uses `SERVER_GENERATED_EXCEPTION.numericCode()` as the mutable int default (protocol errorCode can be overwritten). Residual allow-list shrunk by those two exact paths. Dual-write skip tests cover leftover non-auditable catalog codes; leftover `UNAUTHORIZED` remains dual-write eligible. Production exception type `PSServerException` retains typed codes. `createExceptionFromXml` default numeric code is covered. No product UI/config surface.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None.
+
+## Verification
+
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2658, Failures: 0, Skipped: 247 (`PSConnLeftoverErrorCodesSliceTest` 4/4)
+- `python scripts/verify-no-bare-ipserrors.py` — PASS
+- `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 21 passed
+
+## Notes
+
+- C2: no public/protected signature change, not `final`/`sealed`.
+- Product documentation: N/A (internal error-catalog retype; no operator/API surface change).
+- UI/Playwright C5: N/A.
+
+Memory patterns hit: missing behavioral tests; incomplete change-class closure (allow-list companion); dual-write skip when non-auditable.

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -44,8 +44,6 @@ system/Testing/cms/HttpItemCopier.java
 system/Tools/RxFix/src/com/percussion/rxfix/dbfixes/PSFixNavigation.java
 system/Tools/RxFix/src/com/percussion/rxverify/modules/PSJdbcTableCheck.java
 
-system/src/main/java/com/percussion/conn/PSDesignerConnection.java
-system/src/main/java/com/percussion/conn/PSServerException.java
 system/src/main/java/com/percussion/content/PSContentConverter.java
 system/src/main/java/com/percussion/content/PSFileConverterExit.java
 system/src/main/java/com/percussion/cx/PSFont.java

--- a/system/src/main/java/com/percussion/conn/PSDesignerConnection.java
+++ b/system/src/main/java/com/percussion/conn/PSDesignerConnection.java
@@ -17,6 +17,8 @@
 
 package com.percussion.conn;
 
+import com.intsof.percussioncms.auditlog.codes.ConnectionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.content.IPSMimeContentTypes;
 import com.percussion.error.PSException;
 import com.percussion.security.PSAuthenticationFailedException;
@@ -24,7 +26,6 @@ import com.percussion.security.PSAuthenticationRequiredException;
 import com.percussion.security.PSAuthorizationException;
 import com.percussion.security.PSEncryptionException;
 import com.percussion.security.PSEncryptor;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.system.utils.PSFormatVersion;
 import com.percussion.util.PSBase64Encoder;
 import com.percussion.util.PSBaseHttpUtils;
@@ -693,7 +694,7 @@ public class PSDesignerConnection {
              */
             String line = reader.readLine("US-ASCII");
             if (line == null) {
-              throw new PSServerException(IPSConnectionErrors.SERVER_NOT_RESPONDING, url);
+              throw new PSServerException(ConnectionErrorCodes.SERVER_NOT_RESPONDING, url);
             }
 
             String statusCode = "200";
@@ -767,7 +768,7 @@ public class PSDesignerConnection {
                   if (eMessage == null) eMessage = "";
 
                   Object[] args = {eClass, eMessage};
-                  int errorCode = IPSConnectionErrors.SERVER_GENERATED_EXCEPTION;
+                  int errorCode = ConnectionErrorCodes.SERVER_GENERATED_EXCEPTION.numericCode();
 
                   // if it's one of ours, we may be able to get more data
                   if (eClass.startsWith("com.percussion.")) {
@@ -837,7 +838,7 @@ public class PSDesignerConnection {
                   String param = w.getElementData("description");
                   if (param == null) param = "";
 
-                  throw new PSServerException(IPSServerErrors.RAW_DUMP, param);
+                  throw new PSServerException(ServerErrorCodes.RAW_DUMP, param);
                 }
 
                 return retDoc;
@@ -868,12 +869,12 @@ public class PSDesignerConnection {
                   reason = statusCode;
                 }
                 if ("401".equals(statusCode)) {
-                  throw new PSServerException(IPSConnectionErrors.UNAUTHORIZED, reason);
+                  throw new PSServerException(ConnectionErrorCodes.UNAUTHORIZED, reason);
                 }
-                throw new PSServerException(IPSConnectionErrors.UNKNOWN_SERVER_EXCEPTION, reason);
+                throw new PSServerException(ConnectionErrorCodes.UNKNOWN_SERVER_EXCEPTION, reason);
               } else {
                 Object[] args = {IPSMimeContentTypes.MIME_TYPE_TEXT_XML, contentType};
-                throw new PSServerException(IPSConnectionErrors.RESPONSE_INVALID_MIME_TYPE, args);
+                throw new PSServerException(ConnectionErrorCodes.RESPONSE_INVALID_MIME_TYPE, args);
               }
             } catch (SAXParseException e) {
               Object args[] = {
@@ -881,20 +882,20 @@ public class PSDesignerConnection {
                 String.valueOf(e.getLineNumber()),
                 String.valueOf(e.getColumnNumber())
               };
-              throw new PSServerException(IPSConnectionErrors.RESPONSE_PARSE_EXCEPTION, args);
+              throw new PSServerException(ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION, args);
             } catch (SAXException e) {
               Object args[] = {e.getMessage()};
               throw new PSServerException(
-                  IPSConnectionErrors.RESPONSE_PARSE_EXCEPTION_NOLINEINFO, args);
+                  ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION_NOLINEINFO, args);
             } catch (java.io.FileNotFoundException e) {
-              throw new PSServerException(IPSConnectionErrors.SERVER_NOT_RESPONDING, m_requestLine);
+              throw new PSServerException(ConnectionErrorCodes.SERVER_NOT_RESPONDING, m_requestLine);
             } catch (PSAuthorizationException e) {
               throw new PSServerException(e.getMessage(), e);
             } catch (Exception e) {
               if (e instanceof PSServerException) {
                 throw e;
               }
-              throw new PSServerException(IPSConnectionErrors.SERVER_NOT_RESPONDING, m_requestLine);
+              throw new PSServerException(ConnectionErrorCodes.SERVER_NOT_RESPONDING, m_requestLine);
             }
           }
         }
@@ -968,19 +969,19 @@ public class PSDesignerConnection {
         return retDoc;
       } else {
         Object[] args = {IPSMimeContentTypes.MIME_TYPE_TEXT_XML, contentType};
-        throw new PSServerException(IPSConnectionErrors.RESPONSE_INVALID_MIME_TYPE, args);
+        throw new PSServerException(ConnectionErrorCodes.RESPONSE_INVALID_MIME_TYPE, args);
       }
     } catch (SAXParseException e) {
       Object args[] = {
         e.getMessage(), String.valueOf(e.getLineNumber()), String.valueOf(e.getColumnNumber())
       };
-      throw new PSServerException(IPSConnectionErrors.RESPONSE_PARSE_EXCEPTION, args);
+      throw new PSServerException(ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION, args);
     } catch (SAXException e) {
       Object args[] = {e.getMessage()};
-      throw new PSServerException(IPSConnectionErrors.RESPONSE_PARSE_EXCEPTION_NOLINEINFO, args);
+      throw new PSServerException(ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION_NOLINEINFO, args);
     } catch (java.io.FileNotFoundException e) {
       throw new PSServerException(
-          IPSConnectionErrors.SERVER_NOT_RESPONDING, conn.getURL().toExternalForm());
+          ConnectionErrorCodes.SERVER_NOT_RESPONDING, conn.getURL().toExternalForm());
     } finally {
       if (in != null)
         try {
@@ -1016,7 +1017,7 @@ public class PSDesignerConnection {
     if (eMessage == null) eMessage = "";
 
     Object[] args = {eClass, eMessage};
-    int errorCode = IPSConnectionErrors.SERVER_GENERATED_EXCEPTION;
+    int errorCode = ConnectionErrorCodes.SERVER_GENERATED_EXCEPTION.numericCode();
 
     // if it's one of ours, we may be able to get more data
     if (eClass.startsWith("com.percussion.")) {

--- a/system/src/main/java/com/percussion/conn/PSServerException.java
+++ b/system/src/main/java/com/percussion/conn/PSServerException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.conn;
 
+import com.intsof.percussioncms.auditlog.codes.ConnectionErrorCodes;
 import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 import com.percussion.utils.exceptions.PSExceptionHelper;
@@ -99,7 +100,8 @@ public class PSServerException extends PSException {
    * @param e the exception
    */
   public PSServerException(Exception e) {
-    super(IPSConnectionErrors.UNKNOWN_SERVER_EXCEPTION, PSExceptionHelper.findRootCause(e, true));
+    super(
+        ConnectionErrorCodes.UNKNOWN_SERVER_EXCEPTION, PSExceptionHelper.findRootCause(e, true));
   }
 
   /**

--- a/system/src/test/java/com/percussion/conn/PSConnLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/conn/PSConnLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.conn;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.SystemErrorCode;
+import com.intsof.percussioncms.auditlog.codes.ConnectionErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.content.IPSMimeContentTypes;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.error.PSException;
+import com.percussion.server.IPSServerErrors;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #4016 (parent #2616): leftover {@code com.percussion.conn} production sites throw typed
+ * {@code ConnectionErrorCodes} / {@code ServerErrorCodes.RAW_DUMP} (not bare {@code IPS*Errors}
+ * ints). Dual-write is skipped where leftover connection codes are non-auditable; {@code
+ * UNAUTHORIZED} remains dual-write eligible.
+ */
+@Tag("UnitTest")
+class PSConnLeftoverErrorCodesSliceTest {
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWriteWhereNonAuditable() {
+    assertEquals(
+        IPSConnectionErrors.SERVER_NOT_RESPONDING,
+        ConnectionErrorCodes.SERVER_NOT_RESPONDING.numericCode());
+    assertEquals(
+        IPSConnectionErrors.UNKNOWN_SERVER_EXCEPTION,
+        ConnectionErrorCodes.UNKNOWN_SERVER_EXCEPTION.numericCode());
+    assertEquals(
+        IPSConnectionErrors.SERVER_GENERATED_EXCEPTION,
+        ConnectionErrorCodes.SERVER_GENERATED_EXCEPTION.numericCode());
+    assertEquals(
+        IPSConnectionErrors.RESPONSE_INVALID_MIME_TYPE,
+        ConnectionErrorCodes.RESPONSE_INVALID_MIME_TYPE.numericCode());
+    assertEquals(
+        IPSConnectionErrors.RESPONSE_PARSE_EXCEPTION,
+        ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION.numericCode());
+    assertEquals(
+        IPSConnectionErrors.RESPONSE_PARSE_EXCEPTION_NOLINEINFO,
+        ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION_NOLINEINFO.numericCode());
+    assertEquals(IPSConnectionErrors.UNAUTHORIZED, ConnectionErrorCodes.UNAUTHORIZED.numericCode());
+    assertEquals(IPSServerErrors.RAW_DUMP, ServerErrorCodes.RAW_DUMP.numericCode());
+
+    leftoverNonAuditable(ConnectionErrorCodes.SERVER_NOT_RESPONDING);
+    leftoverNonAuditable(ConnectionErrorCodes.UNKNOWN_SERVER_EXCEPTION);
+    leftoverNonAuditable(ConnectionErrorCodes.SERVER_GENERATED_EXCEPTION);
+    leftoverNonAuditable(ConnectionErrorCodes.RESPONSE_INVALID_MIME_TYPE);
+    leftoverNonAuditable(ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION);
+    leftoverNonAuditable(ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION_NOLINEINFO);
+    leftoverNonAuditable(ServerErrorCodes.RAW_DUMP);
+    leftoverAuditable(ConnectionErrorCodes.UNAUTHORIZED);
+  }
+
+  @Test
+  void leftoverProductionExceptionTypesRetainTypedCodes() {
+    leftoverNonAuditable(
+        new PSServerException(ConnectionErrorCodes.SERVER_NOT_RESPONDING, "http://cms/Designer"),
+        ConnectionErrorCodes.SERVER_NOT_RESPONDING);
+    leftoverNonAuditable(
+        new PSServerException(ServerErrorCodes.RAW_DUMP, "stack"), ServerErrorCodes.RAW_DUMP);
+    leftoverNonAuditable(
+        new PSServerException(ConnectionErrorCodes.UNKNOWN_SERVER_EXCEPTION, "io"),
+        ConnectionErrorCodes.UNKNOWN_SERVER_EXCEPTION);
+    leftoverNonAuditable(
+        new PSServerException(
+            ConnectionErrorCodes.RESPONSE_INVALID_MIME_TYPE,
+            new Object[] {IPSMimeContentTypes.MIME_TYPE_TEXT_XML, "text/html"}),
+        ConnectionErrorCodes.RESPONSE_INVALID_MIME_TYPE);
+    leftoverNonAuditable(
+        new PSServerException(
+            ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION,
+            new Object[] {"bad xml", "12", "3"}),
+        ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION);
+    leftoverNonAuditable(
+        new PSServerException(
+            ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION_NOLINEINFO, new Object[] {"bad xml"}),
+        ConnectionErrorCodes.RESPONSE_PARSE_EXCEPTION_NOLINEINFO);
+
+    RuntimeException cause = new RuntimeException("wrap");
+    PSServerException wrapped = new PSServerException(cause);
+    leftoverNonAuditable(wrapped, ConnectionErrorCodes.UNKNOWN_SERVER_EXCEPTION);
+    assertTrue(String.valueOf(wrapped.getErrorArguments()[0]).contains("wrap"));
+
+    PSServerException unauthorized =
+        new PSServerException(ConnectionErrorCodes.UNAUTHORIZED, "401");
+    assertSame(ConnectionErrorCodes.UNAUTHORIZED, unauthorized.getTypedErrorCode());
+    assertEquals(IPSConnectionErrors.UNAUTHORIZED, unauthorized.getErrorCode());
+    assertTrue(unauthorized.isAuditable());
+  }
+
+  @Test
+  void createExceptionFromXmlUsesGeneratedExceptionDefault() {
+    assertNull(PSDesignerConnection.createExceptionFromXml(null));
+
+    Document wrongDoc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = PSXmlDocumentBuilder.createRoot(wrongDoc, "NotError");
+    assertNull(PSDesignerConnection.createExceptionFromXml(wrong));
+
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, "PSXError");
+    PSXmlDocumentBuilder.addElement(doc, root, "exceptionClass", "java.lang.RuntimeException");
+    PSXmlDocumentBuilder.addElement(doc, root, "message", "boom");
+    PSException reconstructed = PSDesignerConnection.createExceptionFromXml(root);
+    assertTrue(reconstructed instanceof PSServerException);
+    assertEquals(
+        ConnectionErrorCodes.SERVER_GENERATED_EXCEPTION.numericCode(),
+        reconstructed.getErrorCode());
+    assertEquals(IPSConnectionErrors.SERVER_GENERATED_EXCEPTION, reconstructed.getErrorCode());
+  }
+
+  @Test
+  void typedProductionCtorsRejectNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSServerException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSServerException((IPSErrorCode) null, "arg"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSServerException((IPSErrorCode) null, new Object[] {"arg"}));
+  }
+
+  private static void leftoverNonAuditable(SystemErrorCode code) {
+    assertFalse(code.isAuditable(), code.toString());
+  }
+
+  private static void leftoverAuditable(SystemErrorCode code) {
+    assertTrue(code.isAuditable(), code.toString());
+  }
+
+  private static void leftoverNonAuditable(PSException ex, IPSErrorCode expected) {
+    assertEquals(expected.numericCode(), ex.getErrorCode(), expected.toString());
+    assertSame(expected, ex.getTypedErrorCode(), expected.toString());
+    assertFalse(ex.isAuditable(), expected.toString());
+    assertFalse(expected.isAuditable(), expected.toString());
+  }
+}


### PR DESCRIPTION
## Summary

Parent leftover slice of #2616. Converts remaining `system/src/main` `com.percussion.conn` production `IPS*Errors` call-sites to typed catalogs:

- `PSDesignerConnection` throws `ConnectionErrorCodes` (and `ServerErrorCodes.RAW_DUMP` for the non-200 XML dump path). Default remote XML reconstruction uses `ConnectionErrorCodes.SERVER_GENERATED_EXCEPTION.numericCode()` because the code is overwritten from the server payload.
- `PSServerException(Exception)` constructs with typed `ConnectionErrorCodes.UNKNOWN_SERVER_EXCEPTION`.

Removes those two rows from `scripts/ipserrors-residual-allowlist.txt`. Adds `PSConnLeftoverErrorCodesSliceTest` asserting typed codes on `PSServerException`, dual-write skip for non-auditable leftover codes, and `UNAUTHORIZED` remaining dual-write eligible.

Does **not** touch `cx` / `mail` / `server` leftover trees.

Fixes #4016  
Parent: #2616

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2658, Failures: 0, Skipped: 247). `PSConnLeftoverErrorCodesSliceTest` 4/4.
2. `python scripts/verify-no-bare-ipserrors.py` — PASS (conn production files no longer allow-listed).
3. `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` — 21 passed.

## Checklist

- [x] **Product documentation** — **N/A** (internal error-catalog retype; no operator-, admin-, integrator-, or end-user-facing surface)
- [x] **Unit / module tests** — leftover slice tests on exact production exception type `PSServerException`; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` BUILD SUCCESS; no skipTests
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- `modules_built=system`
- `build_evidence=cd system && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 2658, Failures: 0, Skipped: 247 (`PSConnLeftoverErrorCodesSliceTest` 4/4)
- `downstream_checked=none` (C2 did not apply: no `final`/`sealed`, no public/protected signature change)

### C5 UI proof

N/A — Java backend leftover retype, zero UI surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
