### PR TITLE
fix(sitemanage): H2 system-def PUT/add/delete durable writes (#4037)

### DIFF
--- a/docs/ai-generated/code-reviews/4037-h2-systemdef-put-add-delete-erlang.md
+++ b/docs/ai-generated/code-reviews/4037-h2-systemdef-put-add-delete-erlang.md
@@ -1,0 +1,24 @@
+# Erlang review — issue #4037 H2 system-def PUT/add/delete
+
+**Scope:** uncommitted `fix/issue-4037-h2-systemdef-put-add-delete` vs `HEAD`.
+**Recommendation:** approve
+**Gate:** May commit/push: yes
+**Memory patterns hit:** missing behavioral tests for new/changed non-trivial logic; non-portable path/file I/O (not applicable — JDBC identifiers only)
+
+## Summary
+
+H2 system-def REST writes: empty PUT no longer rewrites `ContentEditorSystemDef.xml` (stops post-save NPE); POST creates `CONTENTSTATUS` columns; DELETE drops when present and still saves XML if the column is missing; load retries once on H2 `no such column` so duplicate `sys_title` stays 409.
+
+## Issues
+
+None. Column identifiers are letter/digit/underscore only (`requireIdent` / existing field-name validator). Connections are closed in `finally`. Adaptor unit tests cover empty PUT skip-save, PUT-after-first-save, missing-column delete, duplicate-after-poisoned-load 409. In-memory H2 tests cover add/idempotent add and missing drop. Playwright REST surface passed on qa-up H2.
+
+## Cross-platform path checklist
+
+N/A for filesystem paths. DDL uses validated SQL identifiers and `PSSqlHelper.qualifyTableName` with a schema-qualified fallback (not OS separators).
+
+## Evidence
+
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS. Tests run: 1997, Failures: 0, Skipped: 125.
+- `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS. Tests run: 893, Failures: 0.
+- Playwright: `npm run test:surface -- --path tests/developer-system-def-writes.spec.js` — 1 passed. console-clean=yes (request API). server.log-clean=yes (WARN retry only; no ERROR/FATAL).

--- a/modules/perc-qa-automation/frontend/tests/developer-system-def-writes.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-system-def-writes.spec.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Live H2 REST write of content-editor system definition (CD-16 residual #4037).
+ *
+ * Add a uniquely named field, PUT a property patch (including empty fields after
+ * first save), DELETE, then catalog omits it. Duplicate sys_title stays 409.
+ *
+ * Surface:
+ *   npm run test:surface -- --path tests/developer-system-def-writes.spec.js
+ */
+
+const { test, expect } = require("@playwright/test");
+const { BASE_URL, adminBasicAuthHeaders } = require("./helpers/auth");
+
+function jsonHeaders() {
+  return {
+    ...adminBasicAuthHeaders(),
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+}
+
+function uniqueFieldName() {
+  return `qa4037f${Date.now().toString(36)}`;
+}
+
+function unwrapDetail(body) {
+  if (!body || typeof body !== "object") {
+    return body;
+  }
+  const detail = body.SystemDefDetail || body;
+  const rawFields = detail.fields;
+  let fields = [];
+  if (Array.isArray(rawFields)) {
+    fields = rawFields;
+  } else if (rawFields && Array.isArray(rawFields.SystemDefField)) {
+    fields = rawFields.SystemDefField;
+  } else if (rawFields && rawFields.SystemDefField) {
+    fields = [rawFields.SystemDefField];
+  }
+  return { ...detail, fields };
+}
+
+function fieldNames(detail) {
+  return (detail.fields || [])
+    .map((f) => (f && (f.name || f.Name)) || "")
+    .filter(Boolean);
+}
+
+test.describe("System def REST durable writes (#4037 / CD-16)", () => {
+  test("REST: empty PUT then add/patch/delete catalog omits field", async ({
+    request,
+  }) => {
+    test.setTimeout(60_000);
+    const headers = jsonHeaders();
+    const url = `${BASE_URL}/Rhythmyx/services/systemdef`;
+    const fieldName = uniqueFieldName();
+
+    const firstEmpty = await request.put(url, {
+      headers,
+      data: { SystemDefDetail: { fields: [] } },
+    });
+    expect(
+      firstEmpty.status(),
+      `first empty PUT ${url} must be 200 (was NPE 500 after XML rewrite)`,
+    ).toBe(200);
+
+    const secondEmpty = await request.put(url, {
+      headers,
+      data: { SystemDefDetail: { fields: [] } },
+    });
+    expect(
+      secondEmpty.status(),
+      `second empty PUT ${url} must stay 200 after first no-op`,
+    ).toBe(200);
+
+    const dup = await request.post(`${url}/fields`, {
+      headers,
+      data: { SystemDefField: { name: "sys_title" } },
+    });
+    expect(dup.status(), "duplicate sys_title must stay 409").toBe(409);
+
+    const added = await request.post(`${url}/fields`, {
+      headers,
+      data: { SystemDefField: { name: fieldName, searchable: true } },
+    });
+    expect(
+      added.status(),
+      `POST ${url}/fields ${fieldName} must be 200 (create CONTENTSTATUS column)`,
+    ).toBe(200);
+    const addedDetail = unwrapDetail(await added.json());
+    expect(fieldNames(addedDetail).map((n) => n.toLowerCase())).toContain(
+      fieldName.toLowerCase(),
+    );
+
+    const patched = await request.put(url, {
+      headers,
+      data: {
+        SystemDefDetail: {
+          fields: { SystemDefField: [{ name: fieldName, searchable: false }] },
+        },
+      },
+    });
+    expect(patched.status(), `PUT patch ${fieldName} must be 200`).toBe(200);
+
+    const deleted = await request.delete(
+      `${url}/fields/${encodeURIComponent(fieldName)}`,
+      { headers },
+    );
+    expect(
+      deleted.status(),
+      `DELETE ${fieldName} must be 204 (missing column must not 500)`,
+    ).toBe(204);
+
+    const catalog = await request.get(url, { headers });
+    expect(catalog.status(), "GET catalog after delete must be 200").toBe(200);
+    const after = unwrapDetail(await catalog.json());
+    expect(fieldNames(after).map((n) => n.toLowerCase())).not.toContain(
+      fieldName.toLowerCase(),
+    );
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/developer-smoke-set.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/developer-smoke-set.js
@@ -118,6 +118,12 @@ const DEVELOPER_SMOKE_SET = [
     status: "green",
   },
   {
+    id: "system-def-writes",
+    file: "developer-system-def-writes.spec.js",
+    title: "system-def: REST add/save/delete durable on H2 (#4037)",
+    status: "green",
+  },
+  {
     id: "template-source-viewer",
     file: "developer-template-source-viewer.spec.js",
     title: "template detail source shows line numbers and copy control",

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -51,7 +51,9 @@ separate singleton: Admin-only `GET /services/systemdef` and
 `PUT /services/systemdef` (patch existing field properties under a request lock).
 Nested `POST /services/systemdef/fields` and
 `DELETE /services/systemdef/fields/{fieldName}` add or remove system fields
-(backend column + display mapping). Duplicate field names are **409**.
+(backend column on `CONTENTSTATUS` plus display mapping). POST creates the
+column when it is missing; DELETE drops it when present and still succeeds if
+the column was never created. Duplicate field names are **409**.
 System-mandatory and system-internal fields cannot be deleted (**400**). An SPA
 editor is not in this chrome. Admin `GET /services/contenttypes/{idOrName}/export`
 downloads Workbench-equivalent design XML (CD-14; no lock steal). REST import of

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -53,7 +53,9 @@ Nested `POST /services/systemdef/fields` and
 `DELETE /services/systemdef/fields/{fieldName}` add or remove system fields
 (backend column on `CONTENTSTATUS` plus display mapping). POST creates the
 column when it is missing; DELETE drops it when present and still succeeds if
-the column was never created. Duplicate field names are **409**.
+the column was never created (other drop failures do not save the catalog).
+Field names cannot be SQL reserved words (`SELECT`, `USER`, `TABLE`, `ORDER`).
+Duplicate field names are **409**.
 System-mandatory and system-internal fields cannot be deleted (**400**). An SPA
 editor is not in this chrome. Admin `GET /services/contenttypes/{idOrName}/export`
 downloads Workbench-equivalent design XML (CD-14; no lock steal). REST import of

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1162,7 +1162,11 @@ PUT; unlike content-type PUT, which requires a previously held lock).
 sitemanage adaptor checks `IPSUserService.isAdminUser` for the current user and maps
 a non-Admin caller to **403**. Nested field create/delete persist a backend column
 mapping (default table `CONTENTSTATUS`) and a default `sys_EditBox` display
-mapping. Control properties, stylesheets, and application flow remain unsupported.
+mapping. **POST** creates the `CONTENTSTATUS` column when it is absent; **DELETE**
+drops that column when present and still saves the XML catalog if the column is
+already missing. A **PUT** with a null or empty `fields` array does not rewrite
+the system-definition file (the catalog is unchanged). Control properties,
+stylesheets, and application flow remain unsupported.
 
 | Method | Path | Purpose |
 |--------|------|---------|

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1164,7 +1164,9 @@ a non-Admin caller to **403**. Nested field create/delete persist a backend colu
 mapping (default table `CONTENTSTATUS`) and a default `sys_EditBox` display
 mapping. **POST** creates the `CONTENTSTATUS` column when it is absent; **DELETE**
 drops that column when present and still saves the XML catalog if the column is
-already missing. A **PUT** with a null or empty `fields` array does not rewrite
+already missing. Other `DROP COLUMN` failures (permissions, lock, or connection)
+fail the request with **500** and do **not** save the catalog. A **PUT** with a
+null or empty `fields` array does not rewrite
 the system-definition file (the catalog is unchanged). Control properties,
 stylesheets, and application flow remain unsupported.
 
@@ -1178,7 +1180,8 @@ stylesheets, and application flow remain unsupported.
 PUT may include `fields[]` to patch existing fields by `name`. Unknown field names
 are **400**. PUT does **not** create or delete fields — use nested POST/DELETE
 `.../fields`. Field `name` on create must start with a letter and may contain
-letters, digits, or underscore (no spaces or path characters). Duplicate field
+letters, digits, or underscore (no spaces, path characters, or SQL reserved
+words such as `SELECT`, `USER`, `TABLE`, or `ORDER`). Duplicate field
 names (case-insensitive) are **409**. `occurrence` and `required`
 map to the same dimension: when both are sent they must agree (`required=true`
 with `required` / `oneOrMore`; `required=false` with `optional` / `zeroOrMore` /
@@ -1226,7 +1229,7 @@ Prefer the generated OpenAPI schema as the integration source of truth.
 |--------|-----------------|
 | `200` | Catalog, save, or add-field |
 | `204` | Field deleted |
-| `400` | Missing body, unknown field, invalid name/`dataType`, conflicting `occurrence`/`required`, or delete of a system-mandatory / system-internal field |
+| `400` | Missing body, unknown field, invalid name/`dataType` (including SQL reserved identifiers), conflicting `occurrence`/`required`, or delete of a system-mandatory / system-internal field |
 | `403` | Caller is not Admin, or the request has no session/user (writes) |
 | `409` | Duplicate field name, system definition locked by another user, or design lock required for save |
 | `500` | Design service or server failure |

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/JdbcSystemDefColumnSchema.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/JdbcSystemDefColumnSchema.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import com.percussion.design.objectstore.PSField;
+import com.percussion.server.PSServer;
+import com.percussion.tablefactory.PSJdbcDbmsDef;
+import com.percussion.tablefactory.PSJdbcTableFactory;
+import com.percussion.util.PSSqlHelper;
+import com.percussion.utils.jdbc.PSJdbcUtils;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * JDBC create/drop of system-def backend columns. Identifiers are restricted to letter / digit /
+ * underscore names already validated by {@link SystemDefAdaptor#validateFieldName(String)} and
+ * {@link SystemDefAdaptor#columnNameForField(String)}.
+ */
+final class JdbcSystemDefColumnSchema implements SystemDefColumnSchema {
+
+  private static final Logger log = LogManager.getLogger(JdbcSystemDefColumnSchema.class);
+
+  private static final int DEFAULT_TEXT_SIZE = 50;
+
+  private final Supplier<Connection> connectionFactory;
+
+  JdbcSystemDefColumnSchema() {
+    this(JdbcSystemDefColumnSchema::openRepositoryConnection);
+  }
+
+  JdbcSystemDefColumnSchema(Supplier<Connection> connectionFactory) {
+    this.connectionFactory = connectionFactory != null ? connectionFactory : () -> null;
+  }
+
+  @Override
+  public void ensureColumn(
+      String tableName, String columnName, String fieldDataType, String dataFormat) {
+    String table = requireIdent(tableName, "table");
+    String column = requireIdent(columnName, "column");
+    withConnection(
+        conn -> {
+          if (columnExists(conn, table, column)) {
+            return;
+          }
+          String sql = addColumnSql(conn, table, column, fieldDataType, dataFormat);
+          log.info("Adding system-def column: {}", sql);
+          try (Statement st = conn.createStatement()) {
+            st.execute(sql);
+          }
+        });
+  }
+
+  @Override
+  public void dropColumnIfPresent(String tableName, String columnName) {
+    String table = requireIdent(tableName, "table");
+    String column = requireIdent(columnName, "column");
+    withConnection(
+        conn -> {
+          if (!columnExists(conn, table, column)) {
+            return;
+          }
+          String sql = "ALTER TABLE " + tableRef(conn, table) + " DROP COLUMN " + column;
+          log.info("Dropping system-def column: {}", sql);
+          try (Statement st = conn.createStatement()) {
+            st.execute(sql);
+          } catch (SQLException e) {
+            if (SystemDefAdaptor.isMissingColumnFailure(e)) {
+              log.warn("System-def column already absent, skipping drop: {}.{}", table, column);
+              return;
+            }
+            throw e;
+          }
+        });
+  }
+
+  static boolean columnExists(Connection conn, String table, String column) throws SQLException {
+    DatabaseMetaData md = conn.getMetaData();
+    String catalog = conn.getCatalog();
+    String schema = safeSchema(conn);
+    if (findColumn(md, catalog, schema, table, column)) {
+      return true;
+    }
+    String upperTable = table.toUpperCase(Locale.ROOT);
+    String upperColumn = column.toUpperCase(Locale.ROOT);
+    if (!upperTable.equals(table) || !upperColumn.equals(column)) {
+      if (findColumn(md, catalog, schema, upperTable, upperColumn)) {
+        return true;
+      }
+    }
+    if (schema != null && !schema.equals(schema.toUpperCase(Locale.ROOT))) {
+      return findColumn(
+          md, catalog, schema.toUpperCase(Locale.ROOT), upperTable, upperColumn);
+    }
+    return false;
+  }
+
+  private static boolean findColumn(
+      DatabaseMetaData md, String catalog, String schema, String table, String column)
+      throws SQLException {
+    try (ResultSet rs = md.getColumns(catalog, schema, table, column)) {
+      return rs.next();
+    }
+  }
+
+  static String addColumnSql(
+      Connection conn, String table, String column, String fieldDataType, String dataFormat)
+      throws SQLException {
+    String type = nativeType(conn, fieldDataType, dataFormat);
+    String tableSql = tableRef(conn, table);
+    String product = databaseProduct(conn);
+    String nullClause = nullClause(conn);
+    if (isOracle(product)) {
+      return "ALTER TABLE " + tableSql + " ADD (" + column + " " + type + ")";
+    }
+    if (isSqlServer(product, conn)) {
+      return "ALTER TABLE " + tableSql + " ADD " + column + " " + type + nullClause;
+    }
+    return "ALTER TABLE " + tableSql + " ADD COLUMN " + column + " " + type + nullClause;
+  }
+
+  static String nativeType(Connection conn, String fieldDataType, String dataFormat)
+      throws SQLException {
+    String product = databaseProduct(conn);
+    String dt = fieldDataType == null ? PSField.DT_TEXT : fieldDataType.trim().toLowerCase(Locale.ROOT);
+    if (PSField.DT_INTEGER.equals(dt)) {
+      return isOracle(product) ? "NUMBER(10)" : "INTEGER";
+    }
+    if (PSField.DT_DATETIME.equals(dt) || PSField.DT_DATE.equals(dt)) {
+      if (isSqlServer(product, conn)) {
+        return "DATETIME";
+      }
+      return "TIMESTAMP";
+    }
+    int size = parseTextSize(dataFormat);
+    if (isSqlServer(product, conn)) {
+      return "NVARCHAR(" + size + ")";
+    }
+    if (isOracle(product)) {
+      return "VARCHAR2(" + size + ")";
+    }
+    return "VARCHAR(" + size + ")";
+  }
+
+  static int parseTextSize(String dataFormat) {
+    if (StringUtils.isBlank(dataFormat)) {
+      return DEFAULT_TEXT_SIZE;
+    }
+    try {
+      int parsed = Integer.parseInt(dataFormat.trim());
+      return parsed > 0 ? parsed : DEFAULT_TEXT_SIZE;
+    } catch (NumberFormatException e) {
+      return DEFAULT_TEXT_SIZE;
+    }
+  }
+
+  private static String nullClause(Connection conn) throws SQLException {
+    String driver = driverName(conn);
+    if (StringUtils.isBlank(driver)) {
+      return "";
+    }
+    try {
+      return PSSqlHelper.getNullColumnSpecifier(driver);
+    } catch (RuntimeException e) {
+      return "";
+    }
+  }
+
+  static String tableRef(Connection conn, String table) throws SQLException {
+    try {
+      return PSSqlHelper.qualifyTableName(table);
+    } catch (Exception e) {
+      String schema = safeSchema(conn);
+      if (StringUtils.isNotBlank(schema)) {
+        return schema + "." + table;
+      }
+      return table;
+    }
+  }
+
+  private static String safeSchema(Connection conn) {
+    try {
+      return conn.getSchema();
+    } catch (SQLException e) {
+      return null;
+    }
+  }
+
+  private static String databaseProduct(Connection conn) throws SQLException {
+    String product = conn.getMetaData().getDatabaseProductName();
+    return product == null ? "" : product;
+  }
+
+  private static String driverName(Connection conn) throws SQLException {
+    String url = conn.getMetaData().getURL();
+    if (StringUtils.isBlank(url)) {
+      return "";
+    }
+    return PSJdbcUtils.getDriverFromUrl(url);
+  }
+
+  private static boolean isOracle(String product) {
+    return product.toLowerCase(Locale.ROOT).contains("oracle");
+  }
+
+  private static boolean isSqlServer(String product, Connection conn) throws SQLException {
+    String lower = product.toLowerCase(Locale.ROOT);
+    if (lower.contains("microsoft") || lower.contains("sql server")) {
+      return true;
+    }
+    String driver = driverName(conn);
+    return PSJdbcUtils.JTDS_DRIVER.equals(driver)
+        || PSJdbcUtils.MICROSOFT_DRIVER.equals(driver)
+        || PSJdbcUtils.SPRINTA.equals(driver);
+  }
+
+  static String requireIdent(String raw, String label) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException(label + " is required");
+    }
+    String trimmed = raw.trim();
+    if (trimmed.length() > 128) {
+      throw new IllegalArgumentException(label + " exceeds maximum length");
+    }
+    char first = trimmed.charAt(0);
+    if (!Character.isLetter(first)) {
+      throw new IllegalArgumentException(label + " must start with a letter");
+    }
+    for (int i = 1; i < trimmed.length(); i++) {
+      char c = trimmed.charAt(i);
+      if (!Character.isLetterOrDigit(c) && c != '_') {
+        throw new IllegalArgumentException(label + " must be letters, digits, or underscore");
+      }
+    }
+    return trimmed;
+  }
+
+  private void withConnection(SqlConsumer consumer) {
+    Connection conn = connectionFactory.get();
+    if (conn == null) {
+      throw new IllegalStateException("No repository connection for system-def column DDL");
+    }
+    try {
+      consumer.accept(conn);
+    } catch (SQLException e) {
+      throw new IllegalStateException("System-def column DDL failed", e);
+    } finally {
+      try {
+        conn.close();
+      } catch (SQLException e) {
+        log.debug("Closing system-def column connection: {}", e.getMessage());
+      }
+    }
+  }
+
+  static Connection openRepositoryConnection() {
+    try {
+      Properties props =
+          PSJdbcDbmsDef.loadRxRepositoryProperties(PSServer.getRxDir().getAbsolutePath());
+      PSJdbcDbmsDef dbmsDef = new PSJdbcDbmsDef(props);
+      return PSJdbcTableFactory.getConnection(dbmsDef);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to open repository connection for system-def DDL", e);
+    }
+  }
+
+  @FunctionalInterface
+  private interface SqlConsumer {
+    void accept(Connection conn) throws SQLException;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/JdbcSystemDefColumnSchema.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/JdbcSystemDefColumnSchema.java
@@ -28,8 +28,12 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -45,6 +49,84 @@ final class JdbcSystemDefColumnSchema implements SystemDefColumnSchema {
   private static final Logger log = LogManager.getLogger(JdbcSystemDefColumnSchema.class);
 
   private static final int DEFAULT_TEXT_SIZE = 50;
+
+  /**
+   * Unquoted DDL reserved words (ANSI subset plus H2 {@code VALUE}/{@code DAY}). Field names are
+   * validated before ALTER TABLE so a reserved identifier fails fast instead of at the backend.
+   */
+  private static final Set<String> SQL_RESERVED =
+      Set.of(
+          "ADD",
+          "ALL",
+          "ALTER",
+          "AND",
+          "AS",
+          "ASC",
+          "BETWEEN",
+          "BY",
+          "CASCADE",
+          "CASE",
+          "CHECK",
+          "COLUMN",
+          "CONSTRAINT",
+          "CREATE",
+          "CROSS",
+          "DATE",
+          "DAY",
+          "DEFAULT",
+          "DELETE",
+          "DESC",
+          "DISTINCT",
+          "DROP",
+          "ELSE",
+          "END",
+          "EXISTS",
+          "FALSE",
+          "FETCH",
+          "FOR",
+          "FOREIGN",
+          "FROM",
+          "FULL",
+          "GRANT",
+          "GROUP",
+          "HAVING",
+          "IN",
+          "INDEX",
+          "INNER",
+          "INSERT",
+          "INTO",
+          "IS",
+          "JOIN",
+          "KEY",
+          "LEFT",
+          "LIKE",
+          "LIMIT",
+          "NOT",
+          "NULL",
+          "ON",
+          "OR",
+          "ORDER",
+          "OUTER",
+          "PRIMARY",
+          "REFERENCES",
+          "RESTRICT",
+          "RIGHT",
+          "SELECT",
+          "SET",
+          "TABLE",
+          "THEN",
+          "TRUE",
+          "UNION",
+          "UNIQUE",
+          "UPDATE",
+          "USER",
+          "USING",
+          "VALUE",
+          "VALUES",
+          "VIEW",
+          "WHEN",
+          "WHERE",
+          "WITH");
 
   private final Supplier<Connection> connectionFactory;
 
@@ -100,29 +182,73 @@ final class JdbcSystemDefColumnSchema implements SystemDefColumnSchema {
   static boolean columnExists(Connection conn, String table, String column) throws SQLException {
     DatabaseMetaData md = conn.getMetaData();
     String catalog = conn.getCatalog();
-    String schema = safeSchema(conn);
-    if (findColumn(md, catalog, schema, table, column)) {
-      return true;
-    }
-    String upperTable = table.toUpperCase(Locale.ROOT);
-    String upperColumn = column.toUpperCase(Locale.ROOT);
-    if (!upperTable.equals(table) || !upperColumn.equals(column)) {
-      if (findColumn(md, catalog, schema, upperTable, upperColumn)) {
-        return true;
+    for (String schema : schemaCandidates(md, safeSchema(conn))) {
+      for (String tbl : identCases(table)) {
+        for (String col : identCases(column)) {
+          if (findColumn(md, catalog, schema, tbl, col)) {
+            return true;
+          }
+        }
       }
     }
-    if (schema != null && !schema.equals(schema.toUpperCase(Locale.ROOT))) {
-      return findColumn(
-          md, catalog, schema.toUpperCase(Locale.ROOT), upperTable, upperColumn);
-    }
     return false;
+  }
+
+  /**
+   * Original, upper, and lower identifier spellings. Always includes the folded forms even when
+   * the input is already uppercase so H2 {@code DATABASE_TO_UPPER=FALSE} and MySQL
+   * {@code lower_case_table_names=1} still match stored lowercase metadata.
+   */
+  static List<String> identCases(String ident) {
+    LinkedHashSet<String> out = new LinkedHashSet<>();
+    if (ident != null) {
+      out.add(ident);
+      out.add(ident.toUpperCase(Locale.ROOT));
+      out.add(ident.toLowerCase(Locale.ROOT));
+    }
+    return new ArrayList<>(out);
+  }
+
+  /**
+   * Schema spellings to probe. {@code null} JDBC schema still tries {@link
+   * DatabaseMetaData#getUserName()} because Oracle and similar catalogs require a schema.
+   */
+  static List<String> schemaCandidates(DatabaseMetaData md, String schema) {
+    LinkedHashSet<String> out = new LinkedHashSet<>();
+    if (StringUtils.isNotBlank(schema)) {
+      out.add(schema);
+      out.add(schema.toUpperCase(Locale.ROOT));
+      out.add(schema.toLowerCase(Locale.ROOT));
+    } else {
+      out.add(null);
+      try {
+        String user = md != null ? md.getUserName() : null;
+        if (StringUtils.isNotBlank(user)) {
+          out.add(user);
+          out.add(user.toUpperCase(Locale.ROOT));
+          out.add(user.toLowerCase(Locale.ROOT));
+        }
+      } catch (SQLException e) {
+        log.debug("Could not read JDBC user for schema fallback: {}", e.getMessage());
+      }
+    }
+    return new ArrayList<>(out);
   }
 
   private static boolean findColumn(
       DatabaseMetaData md, String catalog, String schema, String table, String column)
       throws SQLException {
-    try (ResultSet rs = md.getColumns(catalog, schema, table, column)) {
-      return rs.next();
+    try {
+      try (ResultSet rs = md.getColumns(catalog, schema, table, column)) {
+        return rs.next();
+      }
+    } catch (SQLException e) {
+      if (schema == null) {
+        log.debug(
+            "Null-schema column probe failed for {}.{}: {}", table, column, e.getMessage());
+        return false;
+      }
+      throw e;
     }
   }
 
@@ -255,7 +381,14 @@ final class JdbcSystemDefColumnSchema implements SystemDefColumnSchema {
         throw new IllegalArgumentException(label + " must be letters, digits, or underscore");
       }
     }
+    if (isSqlReservedIdent(trimmed)) {
+      throw new IllegalArgumentException(label + " is a reserved SQL identifier");
+    }
     return trimmed;
+  }
+
+  static boolean isSqlReservedIdent(String ident) {
+    return ident != null && SQL_RESERVED.contains(ident.toUpperCase(Locale.ROOT));
   }
 
   private void withConnection(SqlConsumer consumer) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
@@ -48,6 +48,7 @@ import com.percussion.webservices.content.PSContentWsLocator;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -55,6 +56,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -88,6 +90,9 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
   private static final String DEFAULT_TEXT_CONTROL = "sys_EditBox";
 
   private static final String DEFAULT_TABLE_ALIAS = "CONTENTSTATUS";
+
+  private static final Pattern QUOTED_COLUMN_NOT_FOUND =
+      Pattern.compile("column\\s+[\"'`][^\"'`]+[\"'`]\\s+not found");
 
   private final IPSContentDesignWs designWs;
   private final Supplier<PSContentEditorSystemDef> systemDefLoader;
@@ -184,9 +189,6 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
       String msg = lock ? "Failed to load system def for write" : "Failed to load system def";
       log.error("Failed to load content editor system def via design WS", e);
       throw new IllegalStateException(msg, e);
-    } catch (NullPointerException e) {
-      log.error("NullPointerException loading content editor system def via design WS", e);
-      throw new IllegalStateException("Failed to load system def", e);
     }
   }
 
@@ -241,19 +243,43 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
   /**
    * True when {@code t} (or a cause) is a missing backend column, typically H2 {@code no such
    * column} after an XML-only system-def add.
+   *
+   * <p>Prefers SQLState / vendor codes (H2 {@code 42122}, JDBC {@code 42S22}, PostgreSQL {@code
+   * 42703}, Oracle {@code 904}, SQL Server {@code 207}) over loose message matching. Does not treat
+   * unrelated "column … not found" phrases (mapping / schema text) as a missing column.
    */
   static boolean isMissingColumnFailure(Throwable t) {
     for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+      if (cur instanceof SQLException sqlEx && isMissingColumnSql(sqlEx)) {
+        return true;
+      }
       String msg = cur.getMessage();
       if (msg == null) {
         continue;
       }
       String lower = msg.toLowerCase(Locale.ROOT);
       if (lower.contains("no such column")
-          || lower.contains("column not found")
-          || (lower.contains("column") && lower.contains("not found"))
+          || QUOTED_COLUMN_NOT_FOUND.matcher(lower).find()
           || lower.contains("invalid column name")
-          || lower.contains("unknown column")) {
+          || lower.contains("unknown column")
+          || lower.contains("ora-00904")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isMissingColumnSql(SQLException e) {
+    for (SQLException cur = e; cur != null; cur = cur.getNextException()) {
+      String state = cur.getSQLState();
+      if (state != null) {
+        String s = state.toUpperCase(Locale.ROOT);
+        if ("42122".equals(s) || "42S22".equals(s) || "42703".equals(s)) {
+          return true;
+        }
+      }
+      int code = cur.getErrorCode();
+      if (code == 904 || code == 207) {
         return true;
       }
     }
@@ -380,6 +406,9 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
       if (!Character.isLetterOrDigit(c) && c != '_') {
         throw new IllegalArgumentException("name must be letters, digits, or underscore");
       }
+    }
+    if (JdbcSystemDefColumnSchema.isSqlReservedIdent(trimmed)) {
+      throw new IllegalArgumentException("name is a reserved SQL identifier");
     }
     return trimmed;
   }
@@ -651,23 +680,21 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
     if (!removeFieldAndMapping(def, validated)) {
       throw new IllegalArgumentException("Unknown field: " + validated);
     }
-    saveSystemDef(def, session, user);
     try {
       columnSchema.dropColumnIfPresent(
           tableAliasForSystemDef(def), columnNameForField(validated));
     } catch (RuntimeException e) {
-      if (isMissingColumnFailure(e)) {
-        log.warn(
-            "Skipping drop of missing system-def column for field {}: {}",
-            validated,
-            e.getMessage());
-      } else {
-        log.warn(
-            "System-def XML saved without dropping backend column for field {}: {}",
-            validated,
-            e.getMessage());
+      if (!isMissingColumnFailure(e)) {
+        log.error("Failed to drop backend column for system field {}", validated, e);
+        throw new IllegalStateException(
+            "Failed to drop backend column for field " + validated, e);
       }
+      log.warn(
+          "Skipping drop of missing system-def column for field {}: {}",
+          validated,
+          e.getMessage());
     }
+    saveSystemDef(def, session, user);
   }
 
   private void requireAdmin() {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefAdaptor.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
@@ -91,24 +92,42 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
   private final IPSContentDesignWs designWs;
   private final Supplier<PSContentEditorSystemDef> systemDefLoader;
   private final BooleanSupplier adminChecker;
+  private final SystemDefColumnSchema columnSchema;
 
   /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
   @Autowired(required = false)
   private IPSUserService userService;
 
   public SystemDefAdaptor() {
-    this(PSContentWsLocator.getContentDesignWebservice(), null);
+    this(
+        PSContentWsLocator.getContentDesignWebservice(),
+        null,
+        new JdbcSystemDefColumnSchema());
   }
 
   /**
    * Package-visible for unit tests that inject a fake design web service. {@code null} adminChecker
-   * uses {@link #isCurrentUserAdmin()}.
+   * uses {@link #isCurrentUserAdmin()}. Column DDL is a no-op unless the three-arg constructor is
+   * used.
    */
   SystemDefAdaptor(IPSContentDesignWs designWs, BooleanSupplier adminChecker) {
+    this(designWs, adminChecker, SystemDefColumnSchema.noop());
+  }
+
+  /**
+   * Package-visible for unit tests that inject a fake design web service and column schema.
+   * {@code null} adminChecker uses {@link #isCurrentUserAdmin()}. {@code null} columnSchema is a
+   * no-op.
+   */
+  SystemDefAdaptor(
+      IPSContentDesignWs designWs,
+      BooleanSupplier adminChecker,
+      SystemDefColumnSchema columnSchema) {
     this.designWs = designWs;
     this.systemDefLoader =
         () -> loadSystemDefFromDesignWs(designWs, currentSession(), currentUser());
     this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
+    this.columnSchema = columnSchema != null ? columnSchema : SystemDefColumnSchema.noop();
   }
 
   /**
@@ -128,6 +147,7 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
     this.designWs = null;
     this.systemDefLoader = systemDefLoader;
     this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
+    this.columnSchema = SystemDefColumnSchema.noop();
   }
 
   /**
@@ -138,9 +158,34 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
   static PSContentEditorSystemDef loadSystemDefFromDesignWs(
       IPSContentDesignWs designWs, String sessionId, String user) {
     try {
-      return designWs.loadContentEditorSystemDef(false, false, sessionId, user);
+      return loadSystemDefFromDesignWsOnce(designWs, false, sessionId, user);
+    } catch (RuntimeException e) {
+      if (!isMissingColumnFailure(e)) {
+        throw e;
+      }
+      log.warn(
+          "System def load hit missing backend column, retrying catalog: {}", e.getMessage());
+      return loadSystemDefFromDesignWsOnce(designWs, false, sessionId, user);
+    }
+  }
+
+  private static PSContentEditorSystemDef loadSystemDefFromDesignWsOnce(
+      IPSContentDesignWs designWs, boolean lock, String sessionId, String user) {
+    try {
+      PSContentEditorSystemDef def =
+          designWs.loadContentEditorSystemDef(lock, false, sessionId, user);
+      if (lock && def == null) {
+        throw new IllegalStateException("Failed to load system def for write");
+      }
+      return def;
+    } catch (PSLockErrorException e) {
+      throw mapLockConflict(e);
     } catch (PSErrorException e) {
+      String msg = lock ? "Failed to load system def for write" : "Failed to load system def";
       log.error("Failed to load content editor system def via design WS", e);
+      throw new IllegalStateException(msg, e);
+    } catch (NullPointerException e) {
+      log.error("NullPointerException loading content editor system def via design WS", e);
       throw new IllegalStateException("Failed to load system def", e);
     }
   }
@@ -168,17 +213,14 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
 
   private PSContentEditorSystemDef loadSystemDefLocked(String session, String user) {
     try {
-      PSContentEditorSystemDef def =
-          designWs.loadContentEditorSystemDef(true, false, session, user);
-      if (def == null) {
-        throw new IllegalStateException("Failed to load system def for write");
+      return loadSystemDefFromDesignWsOnce(designWs, true, session, user);
+    } catch (RuntimeException e) {
+      if (!isMissingColumnFailure(e)) {
+        throw e;
       }
-      return def;
-    } catch (PSLockErrorException e) {
-      throw mapLockConflict(e);
-    } catch (PSErrorException e) {
-      log.error("Failed to load content editor system def for write", e);
-      throw new IllegalStateException("Failed to load system def for write", e);
+      log.warn(
+          "System def locked load hit missing backend column, retrying: {}", e.getMessage());
+      return loadSystemDefFromDesignWsOnce(designWs, true, session, user);
     }
   }
 
@@ -190,7 +232,48 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
     } catch (PSErrorException e) {
       log.error("Failed to save content editor system def", e);
       throw new IllegalStateException("Failed to save system def", e);
+    } catch (NullPointerException e) {
+      log.error("NullPointerException saving content editor system def", e);
+      throw new IllegalStateException("Failed to save system def", e);
     }
+  }
+
+  /**
+   * True when {@code t} (or a cause) is a missing backend column, typically H2 {@code no such
+   * column} after an XML-only system-def add.
+   */
+  static boolean isMissingColumnFailure(Throwable t) {
+    for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+      String msg = cur.getMessage();
+      if (msg == null) {
+        continue;
+      }
+      String lower = msg.toLowerCase(Locale.ROOT);
+      if (lower.contains("no such column")
+          || lower.contains("column not found")
+          || (lower.contains("column") && lower.contains("not found"))
+          || lower.contains("invalid column name")
+          || lower.contains("unknown column")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * True when PUT {@code fields} contains at least one named patch. Null or empty (or only blank
+   * names) leaves the catalog unchanged and must not rewrite system-def XML.
+   */
+  static boolean hasFieldPatches(List<SystemDefFieldSummary> patches) {
+    if (patches == null || patches.isEmpty()) {
+      return false;
+    }
+    for (SystemDefFieldSummary patch : patches) {
+      if (patch != null && StringUtils.isNotBlank(patch.getName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   static SystemDefDesignLockException mapLockConflict(PSLockErrorException e) {
@@ -502,11 +585,17 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
   @Override
   public SystemDefDetail updateSystemDef(URI baseUri, SystemDefDetail body) {
     requireAdmin();
-    requireDesignWs();
-    requireSessionUserForWrite();
     if (body == null) {
       throw new IllegalArgumentException("body is required");
     }
+    if (!hasFieldPatches(body.getFields())) {
+      // Contract: null/empty fields leaves the catalog unchanged. Do not rewrite
+      // ContentEditorSystemDef.xml from the in-memory (fixup'd) object — that
+      // round-trip NPEs subsequent PUTs on H2.
+      return toDetail(systemDefLoader.get());
+    }
+    requireDesignWs();
+    requireSessionUserForWrite();
     String session = currentSession();
     String user = currentUser();
     PSContentEditorSystemDef def = loadSystemDefLocked(session, user);
@@ -534,7 +623,18 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
     if (fieldSet.getFieldByName(fieldName) != null) {
       throw new WebApplicationException("System field already exists: " + fieldName, 409);
     }
-    addPersistableField(def, body);
+    PSField added = addPersistableField(def, body);
+    try {
+      columnSchema.ensureColumn(
+          tableAliasForSystemDef(def),
+          columnNameForField(fieldName),
+          added.getDataType(),
+          added.getDataFormat());
+    } catch (RuntimeException e) {
+      log.error("Failed to create backend column for system field {}", fieldName, e);
+      throw new IllegalStateException(
+          "Failed to create backend column for field " + fieldName, e);
+    }
     saveSystemDef(def, session, user);
     return toDetail(def);
   }
@@ -552,6 +652,22 @@ public class SystemDefAdaptor implements ISystemDefAdaptor {
       throw new IllegalArgumentException("Unknown field: " + validated);
     }
     saveSystemDef(def, session, user);
+    try {
+      columnSchema.dropColumnIfPresent(
+          tableAliasForSystemDef(def), columnNameForField(validated));
+    } catch (RuntimeException e) {
+      if (isMissingColumnFailure(e)) {
+        log.warn(
+            "Skipping drop of missing system-def column for field {}: {}",
+            validated,
+            e.getMessage());
+      } else {
+        log.warn(
+            "System-def XML saved without dropping backend column for field {}: {}",
+            validated,
+            e.getMessage());
+      }
+    }
   }
 
   private void requireAdmin() {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefColumnSchema.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SystemDefColumnSchema.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+/**
+ * Create or drop the backend column for a persistable system-def field. Production uses JDBC
+ * against the CMS repository ({@code CONTENTSTATUS} by default). Unit tests inject a no-op or
+ * mock so they do not require a live database.
+ */
+interface SystemDefColumnSchema {
+
+  /**
+   * Create {@code tableName.columnName} when it is absent. Idempotent when the column already
+   * exists.
+   *
+   * @param tableName backend table (typically {@code CONTENTSTATUS})
+   * @param columnName column (typically the upper-cased field name)
+   * @param fieldDataType system-def field data type ({@code text}, {@code integer}, …)
+   * @param dataFormat optional size for text columns (for example {@code 50})
+   */
+  void ensureColumn(String tableName, String columnName, String fieldDataType, String dataFormat);
+
+  /**
+   * Drop {@code tableName.columnName} when it exists. Missing columns are not an error (H2
+   * {@code no such column} after an XML-only add).
+   */
+  void dropColumnIfPresent(String tableName, String columnName);
+
+  /** Test double that performs no DDL. */
+  static SystemDefColumnSchema noop() {
+    return new SystemDefColumnSchema() {
+      @Override
+      public void ensureColumn(
+          String tableName, String columnName, String fieldDataType, String dataFormat) {
+        // unit tests that do not exercise repository DDL
+      }
+
+      @Override
+      public void dropColumnIfPresent(String tableName, String columnName) {
+        // unit tests that do not exercise repository DDL
+      }
+    };
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/JdbcSystemDefColumnSchemaTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/JdbcSystemDefColumnSchemaTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class JdbcSystemDefColumnSchemaTest {
+
+  @Test
+  void ensureColumn_createsAndIsIdempotentOnH2() throws Exception {
+    String url = "jdbc:h2:mem:sysdefcol" + System.nanoTime() + ";DB_CLOSE_DELAY=-1";
+    Supplier<Connection> connections = () -> open(url);
+    try (Connection setup = connections.get();
+        Statement st = setup.createStatement()) {
+      st.execute("CREATE TABLE CONTENTSTATUS (CONTENTID INT PRIMARY KEY)");
+    }
+    JdbcSystemDefColumnSchema schema = new JdbcSystemDefColumnSchema(connections);
+
+    schema.ensureColumn("CONTENTSTATUS", "QA4037PROBE", "text", "50");
+    schema.ensureColumn("CONTENTSTATUS", "QA4037PROBE", "text", "50");
+
+    try (Connection check = connections.get()) {
+      assertTrue(JdbcSystemDefColumnSchema.columnExists(check, "CONTENTSTATUS", "QA4037PROBE"));
+    }
+  }
+
+  @Test
+  void dropColumnIfPresent_missingIsNoOpAndExistingDrops() throws Exception {
+    String url = "jdbc:h2:mem:sysdefdrop" + System.nanoTime() + ";DB_CLOSE_DELAY=-1";
+    Supplier<Connection> connections = () -> open(url);
+    try (Connection setup = connections.get();
+        Statement st = setup.createStatement()) {
+      st.execute("CREATE TABLE CONTENTSTATUS (CONTENTID INT PRIMARY KEY, QA4037PROBE VARCHAR(50))");
+    }
+    JdbcSystemDefColumnSchema schema = new JdbcSystemDefColumnSchema(connections);
+
+    schema.dropColumnIfPresent("CONTENTSTATUS", "MISSINGCOL");
+    schema.dropColumnIfPresent("CONTENTSTATUS", "QA4037PROBE");
+
+    try (Connection check = connections.get()) {
+      assertFalse(JdbcSystemDefColumnSchema.columnExists(check, "CONTENTSTATUS", "QA4037PROBE"));
+    }
+  }
+
+  @Test
+  void requireIdent_rejectsUnsafeNames() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JdbcSystemDefColumnSchema.requireIdent("CONTENT STATUS", "table"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JdbcSystemDefColumnSchema.requireIdent("x;drop", "column"));
+    assertThrows(
+        IllegalArgumentException.class, () -> JdbcSystemDefColumnSchema.requireIdent("1col", "column"));
+  }
+
+  @Test
+  void parseTextSize_defaultsWhenBlankOrInvalid() {
+    org.junit.jupiter.api.Assertions.assertEquals(50, JdbcSystemDefColumnSchema.parseTextSize(null));
+    org.junit.jupiter.api.Assertions.assertEquals(50, JdbcSystemDefColumnSchema.parseTextSize("abc"));
+    org.junit.jupiter.api.Assertions.assertEquals(80, JdbcSystemDefColumnSchema.parseTextSize("80"));
+  }
+
+  private static Connection open(String url) {
+    try {
+      return DriverManager.getConnection(url);
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/JdbcSystemDefColumnSchemaTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/JdbcSystemDefColumnSchemaTest.java
@@ -20,10 +20,16 @@ package com.percussion.apibridge;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.List;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -68,6 +74,55 @@ class JdbcSystemDefColumnSchemaTest {
   }
 
   @Test
+  void columnExists_upperInputFindsLowercaseStoredNames() throws Exception {
+    String url =
+        "jdbc:h2:mem:sysdefcase"
+            + System.nanoTime()
+            + ";DATABASE_TO_UPPER=FALSE;DB_CLOSE_DELAY=-1";
+    Supplier<Connection> connections = () -> open(url);
+    try (Connection setup = connections.get();
+        Statement st = setup.createStatement()) {
+      st.execute("CREATE TABLE contentstatus (contentid INT PRIMARY KEY, qa4037probe VARCHAR(50))");
+    }
+    try (Connection check = connections.get()) {
+      assertTrue(JdbcSystemDefColumnSchema.columnExists(check, "CONTENTSTATUS", "QA4037PROBE"));
+    }
+  }
+
+  @Test
+  void columnExists_probesLowerCaseAndNullSchemaFallback() throws Exception {
+    Connection conn = mock(Connection.class);
+    DatabaseMetaData md = mock(DatabaseMetaData.class);
+    when(conn.getMetaData()).thenReturn(md);
+    when(conn.getCatalog()).thenReturn(null);
+    when(conn.getSchema()).thenReturn(null);
+    when(md.getUserName()).thenReturn("sa");
+    when(md.getColumns(any(), any(), any(), any()))
+        .thenAnswer(
+            inv -> {
+              ResultSet rs = mock(ResultSet.class);
+              String schema = inv.getArgument(1);
+              String table = inv.getArgument(2);
+              String column = inv.getArgument(3);
+              boolean hit =
+                  "sa".equals(schema)
+                      && "contentstatus".equals(table)
+                      && "qa4037probe".equals(column);
+              when(rs.next()).thenReturn(hit);
+              return rs;
+            });
+
+    assertTrue(JdbcSystemDefColumnSchema.columnExists(conn, "CONTENTSTATUS", "QA4037PROBE"));
+  }
+
+  @Test
+  void identCases_alwaysIncludesLowerWhenInputIsUpper() {
+    List<String> cases = JdbcSystemDefColumnSchema.identCases("CONTENTSTATUS");
+    assertTrue(cases.contains("CONTENTSTATUS"));
+    assertTrue(cases.contains("contentstatus"));
+  }
+
+  @Test
   void requireIdent_rejectsUnsafeNames() {
     assertThrows(
         IllegalArgumentException.class,
@@ -77,6 +132,19 @@ class JdbcSystemDefColumnSchemaTest {
         () -> JdbcSystemDefColumnSchema.requireIdent("x;drop", "column"));
     assertThrows(
         IllegalArgumentException.class, () -> JdbcSystemDefColumnSchema.requireIdent("1col", "column"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JdbcSystemDefColumnSchema.requireIdent("SELECT", "column"));
+    assertThrows(
+        IllegalArgumentException.class, () -> JdbcSystemDefColumnSchema.requireIdent("user", "column"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JdbcSystemDefColumnSchema.requireIdent("TABLE", "table"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JdbcSystemDefColumnSchema.requireIdent("ORDER", "column"));
+    org.junit.jupiter.api.Assertions.assertEquals(
+        "CONTENTSTATUS", JdbcSystemDefColumnSchema.requireIdent("CONTENTSTATUS", "table"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
@@ -47,6 +47,7 @@ import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.content.IPSContentDesignWs;
 import jakarta.ws.rs.WebApplicationException;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -262,27 +263,44 @@ class SystemDefAdaptorTest {
     when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin"))
         .thenThrow(lockErr);
     SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    SystemDefFieldSummary patch = new SystemDefFieldSummary();
+    patch.setName("sys_title");
+    SystemDefDetail body = new SystemDefDetail();
+    body.setFields(List.of(patch));
     SystemDefDesignLockException ex =
         assertThrows(
-            SystemDefDesignLockException.class,
-            () -> adaptor.updateSystemDef(null, new SystemDefDetail()));
+            SystemDefDesignLockException.class, () -> adaptor.updateSystemDef(null, body));
     assertTrue(ex.getMessage().contains("locked by other"));
   }
 
   @Test
   void updateSystemDef_saveLockConflictIs409() throws Exception {
     IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSField field = mock(PSField.class);
+    when(field.getSubmitName()).thenReturn("sys_title");
+    when(field.getDataType()).thenReturn("text");
+    when(field.isUserSearchable()).thenReturn(true);
+    when(field.isReadOnly()).thenReturn(false);
+    when(field.getOccurrenceDimension(null)).thenReturn(PSField.OCCURRENCE_DIMENSION_OPTIONAL);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.getAllFields()).thenReturn(new PSField[] {field});
+    when(set.findFieldByName("sys_title", false)).thenReturn(field);
     PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
-    when(def.getFieldSet()).thenReturn(null);
+    when(def.getFieldSet()).thenReturn(set);
+    when(def.getCacheTimeout()).thenReturn(15);
     when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
     doThrow(new PSLockErrorException(1, "not locked", "stack"))
         .when(designWs)
         .saveContentEditorSystemDef(any(), eq(true), eq("test-session"), eq("Admin"));
     SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+    SystemDefFieldSummary patch = new SystemDefFieldSummary();
+    patch.setName("sys_title");
+    patch.setSearchable(true);
+    SystemDefDetail body = new SystemDefDetail();
+    body.setFields(List.of(patch));
     SystemDefDesignLockException ex =
         assertThrows(
-            SystemDefDesignLockException.class,
-            () -> adaptor.updateSystemDef(null, new SystemDefDetail()));
+            SystemDefDesignLockException.class, () -> adaptor.updateSystemDef(null, body));
     assertTrue(ex.getMessage().contains("design lock required"));
   }
 
@@ -547,6 +565,157 @@ class SystemDefAdaptorTest {
     assertTrue(serialized.contains("sys_custom"));
     assertTrue(serialized.contains("SYS_CUSTOM") || serialized.contains("sys_custom"));
     assertNotNull(def.getUIDefinition().getMapping("sys_custom"));
+  }
+
+  @Test
+  void hasFieldPatches_emptyIsNoOp() {
+    assertFalse(SystemDefAdaptor.hasFieldPatches(null));
+    assertFalse(SystemDefAdaptor.hasFieldPatches(List.of()));
+    SystemDefFieldSummary blank = new SystemDefFieldSummary();
+    blank.setName("  ");
+    assertFalse(SystemDefAdaptor.hasFieldPatches(List.of(blank)));
+    SystemDefFieldSummary named = new SystemDefFieldSummary();
+    named.setName("sys_title");
+    assertTrue(SystemDefAdaptor.hasFieldPatches(List.of(named)));
+  }
+
+  @Test
+  void isMissingColumnFailure_recognizesH2Messages() {
+    assertTrue(
+        SystemDefAdaptor.isMissingColumnFailure(new RuntimeException("no such column QA4030PROBE")));
+    assertTrue(
+        SystemDefAdaptor.isMissingColumnFailure(
+            new RuntimeException("Column \"QA4030PROBE\" not found")));
+    assertTrue(
+        SystemDefAdaptor.isMissingColumnFailure(
+            new IllegalStateException("wrap", new SQLException("invalid column name"))));
+    assertFalse(SystemDefAdaptor.isMissingColumnFailure(new NullPointerException()));
+    assertFalse(SystemDefAdaptor.isMissingColumnFailure(new RuntimeException("unrelated")));
+  }
+
+  @Test
+  void updateSystemDef_emptyFieldsDoesNotSave() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(def.getFieldSet()).thenReturn(null);
+    when(def.getCacheTimeout()).thenReturn(15);
+    when(designWs.loadContentEditorSystemDef(false, false, "test-session", "Admin"))
+        .thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+
+    SystemDefDetail first = adaptor.updateSystemDef(null, new SystemDefDetail());
+    SystemDefDetail second = adaptor.updateSystemDef(null, new SystemDefDetail());
+
+    assertEquals(0, first.getFieldCount());
+    assertEquals(0, second.getFieldCount());
+    verify(designWs, never()).loadContentEditorSystemDef(eq(true), anyBoolean(), any(), any());
+    verify(designWs, never()).saveContentEditorSystemDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void updateSystemDef_secondPutAfterFirstSaveDoesNotNpe() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSField field = mock(PSField.class);
+    when(field.getSubmitName()).thenReturn("sys_title");
+    when(field.getDataType()).thenReturn("text");
+    when(field.isUserSearchable()).thenReturn(true);
+    when(field.isReadOnly()).thenReturn(false);
+    when(field.getOccurrenceDimension(null)).thenReturn(PSField.OCCURRENCE_DIMENSION_OPTIONAL);
+    PSFieldSet set = mock(PSFieldSet.class);
+    when(set.getAllFields()).thenReturn(new PSField[] {field});
+    when(set.findFieldByName("sys_title", false)).thenReturn(field);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(def.getFieldSet()).thenReturn(set);
+    when(def.getCacheTimeout()).thenReturn(15);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    when(designWs.loadContentEditorSystemDef(false, false, "test-session", "Admin"))
+        .thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+
+    SystemDefFieldSummary patch = new SystemDefFieldSummary();
+    patch.setName("sys_title");
+    patch.setSearchable(true);
+    SystemDefDetail body = new SystemDefDetail();
+    body.setFields(List.of(patch));
+    adaptor.updateSystemDef(null, body);
+    SystemDefDetail after = adaptor.updateSystemDef(null, new SystemDefDetail());
+
+    assertEquals(1, after.getFieldCount());
+    verify(designWs).saveContentEditorSystemDef(eq(def), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void addField_ensuresContentStatusColumn() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefColumnSchema columns = mock(SystemDefColumnSchema.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true, columns);
+
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("sys_custom");
+    adaptor.addField(null, body);
+
+    verify(columns).ensureColumn(eq("CONTENTSTATUS"), eq("SYS_CUSTOM"), eq("text"), eq("50"));
+  }
+
+  @Test
+  void addField_duplicateAfterMissingColumnLoadIs409() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    SystemDefFieldSummary existing = new SystemDefFieldSummary();
+    existing.setName("sys_title");
+    SystemDefAdaptor.addPersistableField(def, existing);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin"))
+        .thenThrow(new RuntimeException("no such column QA4030PROBE"))
+        .thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true);
+
+    SystemDefFieldSummary body = new SystemDefFieldSummary();
+    body.setName("sys_title");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.addField(null, body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveContentEditorSystemDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void deleteField_missingColumnStillRemovesAndSkipsDrop() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefColumnSchema columns = mock(SystemDefColumnSchema.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    SystemDefFieldSummary existing = new SystemDefFieldSummary();
+    existing.setName("qa4030probe");
+    SystemDefAdaptor.addPersistableField(def, existing);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin"))
+        .thenThrow(new RuntimeException("no such column QA4030PROBE"))
+        .thenReturn(def);
+    doThrow(new IllegalStateException("no such column QA4030PROBE"))
+        .when(columns)
+        .dropColumnIfPresent("CONTENTSTATUS", "QA4030PROBE");
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true, columns);
+
+    adaptor.deleteField(null, "qa4030probe");
+
+    verify(designWs).saveContentEditorSystemDef(eq(def), eq(true), eq("test-session"), eq("Admin"));
+    assertNull(def.getFieldSet().getFieldByName("qa4030probe"));
+    verify(columns).dropColumnIfPresent("CONTENTSTATUS", "QA4030PROBE");
+  }
+
+  @Test
+  void deleteField_dropsContentStatusColumn() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefColumnSchema columns = mock(SystemDefColumnSchema.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    SystemDefFieldSummary existing = new SystemDefFieldSummary();
+    existing.setName("sys_custom");
+    SystemDefAdaptor.addPersistableField(def, existing);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true, columns);
+
+    adaptor.deleteField(null, "sys_custom");
+
+    verify(columns).dropColumnIfPresent("CONTENTSTATUS", "SYS_CUSTOM");
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SystemDefAdaptorTest.java
@@ -143,6 +143,30 @@ class SystemDefAdaptorTest {
   }
 
   @Test
+  void loadSystemDefFromDesignWs_preservesGenuineNpe() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    NullPointerException npe = new NullPointerException("design ws bug");
+    when(designWs.loadContentEditorSystemDef(false, false, "sid", "admin")).thenThrow(npe);
+
+    NullPointerException thrown =
+        assertThrows(
+            NullPointerException.class,
+            () -> SystemDefAdaptor.loadSystemDefFromDesignWs(designWs, "sid", "admin"));
+    assertSame(npe, thrown);
+  }
+
+  @Test
+  void loadSystemDefFromDesignWs_retriesMissingColumnNpe() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
+    when(designWs.loadContentEditorSystemDef(false, false, "sid", "admin"))
+        .thenThrow(new NullPointerException("no such column QA4030PROBE"))
+        .thenReturn(def);
+
+    assertSame(def, SystemDefAdaptor.loadSystemDefFromDesignWs(designWs, "sid", "admin"));
+  }
+
+  @Test
   void loadSystemDefFromDesignWs_passesNullSessionAndUserWhenRequestInfoAbsent() throws Exception {
     IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
     PSContentEditorSystemDef def = mock(PSContentEditorSystemDef.class);
@@ -589,8 +613,20 @@ class SystemDefAdaptorTest {
     assertTrue(
         SystemDefAdaptor.isMissingColumnFailure(
             new IllegalStateException("wrap", new SQLException("invalid column name"))));
+    assertTrue(SystemDefAdaptor.isMissingColumnFailure(new SQLException("x", "42122")));
+    assertTrue(SystemDefAdaptor.isMissingColumnFailure(new SQLException("x", "42S22")));
+    assertTrue(
+        SystemDefAdaptor.isMissingColumnFailure(
+            new IllegalStateException("wrap", new SQLException("x", "42703"))));
+    assertTrue(SystemDefAdaptor.isMissingColumnFailure(new SQLException("ORA-00904", "42000", 904)));
+    assertTrue(SystemDefAdaptor.isMissingColumnFailure(new SQLException("invalid column", "S0001", 207)));
     assertFalse(SystemDefAdaptor.isMissingColumnFailure(new NullPointerException()));
     assertFalse(SystemDefAdaptor.isMissingColumnFailure(new RuntimeException("unrelated")));
+    assertFalse(
+        SystemDefAdaptor.isMissingColumnFailure(new RuntimeException("column mapping not found")));
+    assertFalse(
+        SystemDefAdaptor.isMissingColumnFailure(
+            new RuntimeException("field column not found in schema")));
   }
 
   @Test
@@ -719,6 +755,26 @@ class SystemDefAdaptorTest {
   }
 
   @Test
+  void deleteField_genuineDropFailureDoesNotSave() throws Exception {
+    IPSContentDesignWs designWs = mock(IPSContentDesignWs.class);
+    SystemDefColumnSchema columns = mock(SystemDefColumnSchema.class);
+    PSContentEditorSystemDef def = newSystemDefWithEmptyFields();
+    SystemDefFieldSummary existing = new SystemDefFieldSummary();
+    existing.setName("sys_custom");
+    SystemDefAdaptor.addPersistableField(def, existing);
+    when(designWs.loadContentEditorSystemDef(true, false, "test-session", "Admin")).thenReturn(def);
+    doThrow(new IllegalStateException("permissions denied"))
+        .when(columns)
+        .dropColumnIfPresent("CONTENTSTATUS", "SYS_CUSTOM");
+    SystemDefAdaptor adaptor = new SystemDefAdaptor(designWs, () -> true, columns);
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.deleteField(null, "sys_custom"));
+    assertTrue(ex.getMessage().contains("Failed to drop backend column"));
+    verify(designWs, never()).saveContentEditorSystemDef(any(), anyBoolean(), any(), any());
+  }
+
+  @Test
   void validateFieldName_rejectsInvalid() {
     assertEquals("sys_custom", SystemDefAdaptor.validateFieldName("sys_custom"));
     assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName(" "));
@@ -730,6 +786,9 @@ class SystemDefAdaptorTest {
     assertThrows(
         IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("a\0b"));
     assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("1start"));
+    assertThrows(
+        IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("SELECT"));
+    assertThrows(IllegalArgumentException.class, () -> SystemDefAdaptor.validateFieldName("user"));
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/systemdef/ISystemDefAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/systemdef/ISystemDefAdaptor.java
@@ -35,8 +35,9 @@ public interface ISystemDefAdaptor {
    * design lock for this request and releases it on save.
    *
    * <p>Supports patches to existing fields ({@code searchable}, occurrence / required). Null or
-   * empty {@code fields} leaves the catalog unchanged. Does not create or delete fields. {@code
-   * dataType}, {@code readOnly}, and {@code cacheTimeoutMinutes} are not written.
+   * empty {@code fields} leaves the catalog unchanged and does not rewrite the system-def XML. Does
+   * not create or delete fields. {@code dataType}, {@code readOnly}, and {@code
+   * cacheTimeoutMinutes} are not written.
    *
    * @return persisted detail, never {@code null}
    * @throws IllegalArgumentException when input is invalid, a field name is unknown, or {@code


### PR DESCRIPTION
## Summary

H2 QA REST writes for the content-editor system definition (CD-16 residual of #1690 / #4030) were not durable: a first no-op `PUT /services/systemdef` rewrote `ContentEditorSystemDef.xml` from the in-memory fixup'd object so later PUTs NPE'd; `POST /services/systemdef/fields` persisted XML without a `CONTENTSTATUS` column so `DELETE`/GET 500'd with `no such column`; duplicate `sys_title` became 500 after a poisoned save.

This PR:

- Skips XML rewrite when PUT `fields` is null/empty (catalog unchanged).
- Creates the `CONTENTSTATUS` column on add; drops it on delete when present.
- Retries system-def load once on missing-column so XML save/delete and duplicate 409 still work.
- Playwright H2 surface: empty PUT twice, duplicate 409, add uniquely named field, property patch, delete, catalog omits it.

Fixes #4037. Parent: #1690. Slice of: #4030. FR: CD-16.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Adaptor unit tests: empty PUT does not save; PUT after first save; missing-column delete; duplicate after poisoned load stays 409; H2 mem add/drop columns.
2. Standalone `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1997, Failures: 0, Skipped: 125.
3. Standalone `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 893, Failures: 0 (javadoc-only adaptor contract).
4. H2 QA: `perc-devctl qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993`; copy `sitemanage`/`rest`/`perc-system` SNAPSHOTs into WAR `WEB-INF/lib`; in-cell StopJetty/StartJetty; `qa-health` RESULT:OK HTTP:200 HEALTH:healthy.
5. `npm run test:surface -- --path tests/developer-system-def-writes.spec.js` — 1 passed. console-clean=yes; server.log-clean=yes (WARN retry only).
6. Product-docs smoke: `scripts/ci-smoke-product-docs.bat` OK.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` and `product-docs/8.2/admin/developer-content-types.md` (POST creates CONTENTSTATUS column; DELETE drops if present; empty PUT does not rewrite XML)
- [x] **Unit / module tests** — `SystemDefAdaptorTest` + `JdbcSystemDefColumnSchemaTest`; sitemanage and rest standalone clean install green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/developer-system-def-writes.spec.js` (REST surface; SPA chrome is #4030/#4044)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests)
- [x] **Cross-platform** — JDBC identifiers only (letter/digit/underscore); `PSSqlHelper.qualifyTableName` with schema fallback; no OS path separators

### C3 evidence

- `modules_built`: projects/sitemanage, rest
- `build_evidence`: `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1997, Failures: 0, Skipped: 125; `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 893, Failures: 0
- `downstream_checked`: grepped `implements ISystemDefAdaptor` (`SystemDefAdaptor` + rest `TestSystemDefAdaptor`); no public method/ctor signature change (javadoc only on `ISystemDefAdaptor`); rest standalone install green

### C5 UI proof

- `qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993`
- Hot-copied `sitemanage-8.2.0-SNAPSHOT.jar`, `rest-8.2.0-SNAPSHOT.jar`, `perc-system-8.2.0-SNAPSHOT.jar` into WAR `WEB-INF/lib`; in-cell Jetty restart; `qa-health` RESULT:OK HTTP:200 HEALTH:healthy
- Playwright: `npm run test:surface -- --path tests/developer-system-def-writes.spec.js` — 1 passed
- console-clean=yes (request API, no page); server.log-clean=yes (no ERROR/FATAL; WARN missing-column retry only)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.