### PR TITLE
feat(rest): Admin POST/PUT/DELETE display formats (UI-05)

### DIFF
--- a/docs/ai-generated/code-reviews/4068-display-format-write-erlang.md
+++ b/docs/ai-generated/code-reviews/4068-display-format-write-erlang.md
@@ -1,0 +1,24 @@
+# Erlang review: #4068 REST UI-05 display format write
+
+**Branch:** `feat/issue-4068-display-format-write`  
+**Date:** 2026-08-31  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** rest adaptor Spring stub on test classpath (exact `IXxxAdaptor` type); Admin write via existing IPS*DesignWs (no new SOAP); duplicate 409 / invalid 400 / missing 404 / non-Admin 403; no lock steal (`overrideLock=false`).
+
+## Summary
+
+Admin POST/PUT/DELETE on `/services/displayformats` persist through existing `IDisplayFormatAdaptor` + `IPSUiDesignWs` (create then save / load-with-lock then save / delete). Resource maps HTTP status; adaptor owns Admin/session, unique name, and lock policy. Spring stub `DisplayFormatTestAdaptor` still implements exact `IDisplayFormatAdaptor`. Product-docs 8.2 REST notes updated. No SPA.
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable paths).
+
+## Cross-platform path checklist
+
+N/A — no file I/O or path construction.
+
+## Tests
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 914, Failures: 0; `DisplayFormatResourceTest` 21
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; `DisplayFormatAdaptorWriteTest` 19, `DisplayFormatAdaptorSafeKeyTest` 7

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1355,11 +1355,12 @@ assume the GUID is missing when `displayId` is present). See [Users, roles & sec
 for the operator Object ACL steps.
 
 Create (`POST /services/displayformats`) persists immediately (Workbench Finish, not an
-unsaved stub). JSON body requires `name` or `internalName` (unique, case-insensitive; **no
-whitespace** or wildcards). Optional `label` / `displayName` and `description` are applied
-before save. Duplicate name is **409**. Blank / whitespace / wildcard names are **400**.
-Missing request session/user is **403**. Non-Admin is **403**. The new format is then
-`GET /services/displayformats/{name}` **200**.
+unsaved stub) and returns **201 Created** with a `Location` header pointing at
+`GET /services/displayformats/{name}`. JSON body requires `name` or `internalName` (unique,
+case-insensitive; **no whitespace** or wildcards). Optional `label` / `displayName` and
+`description` are applied before save. Duplicate name is **409**. Blank / whitespace /
+wildcard names are **400**. Missing request session/user is **403**. Non-Admin is **403**.
+The new format is then `GET /services/displayformats/{name}` **200**.
 
 Update (`PUT /services/displayformats/{idOrName}`) loads with a design lock
 (`overrideLock=false`) and releases it on save. Name is not renamed on PUT. `label` /

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1331,20 +1331,48 @@ The Design SPA **Create template** action uses POST; **Delete** uses this DELETE
 ## Display formats (design catalog)
 
 Content Explorer **display format** definitions (Developer **Display Formats**) are exposed
-under `/services/displayformats`. Responses include a nested `guid` object and a plain
-`guidString` (`host-type-uuid`) so clients can load **Object ACL** via
-`GET /services/acls/object/{guid}`.
+under `/services/displayformats`. The REST layer is a thin contract over the UI **design**
+web service (`IPSUiDesignWs`) — create, update, and delete use the same
+`createDisplayFormats` / `loadDisplayFormats` / `saveDisplayFormats` /
+`deleteDisplayFormats` operations SOAP uses. There is no new SOAP surface. GET list/detail
+remain a catalog read.
+
+Responses include a nested `guid` object and a plain `guidString` (`host-type-uuid`) so
+clients can load **Object ACL** via `GET /services/acls/object/{guid}`.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/displayformats` | List formats (optional `validForFolder` / `validForViewsAndSearches`) |
 | `GET` | `/services/displayformats/{idOrName}` | Load one format by internal name or GUID string |
+| `POST` | `/services/displayformats` | **Admin.** Create a format (`createDisplayFormats` then `saveDisplayFormats`) |
+| `PUT` | `/services/displayformats/{idOrName}` | **Admin.** Update `label`/`displayName` and/or `description` |
+| `DELETE` | `/services/displayformats/{idOrName}` | **Admin.** Delete a format (`deleteDisplayFormats`, `ignoreDependencies=false`) |
 
 JSON wraps the list as `DisplayFormatList` (`{"DisplayFormatList":[…]}`) including the empty
 catalog (`{"DisplayFormatList":[]}`, not a bare `[]`) and a single item as `DisplayFormat`.
 Integrators should unwrap those envelopes and read `guid.stringValue` or `guidString` (never
 assume the GUID is missing when `displayId` is present). See [Users, roles & security](id:admin-users-roles)
 for the operator Object ACL steps.
+
+Create (`POST /services/displayformats`) persists immediately (Workbench Finish, not an
+unsaved stub). JSON body requires `name` or `internalName` (unique, case-insensitive; **no
+whitespace** or wildcards). Optional `label` / `displayName` and `description` are applied
+before save. Duplicate name is **409**. Blank / whitespace / wildcard names are **400**.
+Missing request session/user is **403**. Non-Admin is **403**. The new format is then
+`GET /services/displayformats/{name}` **200**.
+
+Update (`PUT /services/displayformats/{idOrName}`) loads with a design lock
+(`overrideLock=false`) and releases it on save. Name is not renamed on PUT. `label` /
+`displayName` and `description` round-trip. Usage flags on GET (`validForFolder`,
+`validForViewsAndSearches`, `validForRelatedContent`) are **derived from columns** the
+same way Workbench computes them — they are not independently persisted on PUT.
+
+Delete (`DELETE /services/displayformats/{idOrName}`) returns **204** when removed; a
+following `GET` is **404**. Unknown id/name is **404**. A format that still has dependents
+is **409**. Locked-by-another-user is **409** (the lock is not stolen). Non-Admin is **403**.
+
+There is **no** Developer SPA display-format editor write in this slice — operators and
+integrators call the REST path (or Workbench).
 
 ### Object ACL save (display format and peers)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -813,7 +813,7 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
     return false;
   }
 
-  static boolean isNotLockedError(PSErrorsException e) {
+  static boolean isLockError(PSErrorsException e) {
     if (e == null || e.getErrors() == null) {
       return false;
     }
@@ -861,7 +861,7 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
   }
 
   private RuntimeException mapSaveOrDeleteFailure(String verb, PSErrorsException e) {
-    if (isNotLockedError(e)) {
+    if (isLockError(e)) {
       return new WebApplicationException(
           "Could not " + verb + " display format; design lock required or held by another user",
           409);

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -30,11 +30,19 @@ import com.percussion.rest.displayformat.*;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.ui.IPSUiDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,34 +51,206 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
-/** Provides the API implementation for the Display Format Resource. */
+/**
+ * Provides the API implementation for the Display Format Resource.
+ *
+ * <p>GET catalog uses {@link IPSUiDesignWs#findDisplayFormats}. Admin create/update/delete persist
+ * through the same design WS SOAP uses ({@code createDisplayFormats} / {@code loadDisplayFormats}
+ * / {@code saveDisplayFormats} / {@code deleteDisplayFormats}). No new SOAP methods.
+ */
 @PSSiteManageBean
 @Lazy
 public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
 
+  static final String ADMIN_REQUIRED =
+      "Admin role required to create, update, or delete display formats";
+
   private static final Logger log = LogManager.getLogger(DisplayFormatAdaptor.class);
 
   private final IPSUiDesignWs designWs;
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   @Autowired
   public DisplayFormatAdaptor(IPSUiDesignWs designWs) {
+    this(designWs, null);
+  }
+
+  /** Package-visible for unit tests. */
+  DisplayFormatAdaptor(IPSUiDesignWs designWs, BooleanSupplier adminChecker) {
     this.designWs = designWs;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   @Override
   public List<DisplayFormat> createDisplayFormats(List<String> names, String session, String user) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    try {
+      List<PSDisplayFormat> created = designWs.createDisplayFormats(names, session, user);
+      if (created == null || created.isEmpty()) {
+        return new ArrayList<>();
+      }
+      List<DisplayFormat> out = new ArrayList<>(created.size());
+      for (PSDisplayFormat nativeDf : created) {
+        if (nativeDf != null) {
+          out.add(copyDisplayFormat(nativeDf));
+        }
+      }
+      return out;
+    } catch (IllegalArgumentException e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException(e.getMessage(), 409);
+      }
+      throw e;
+    } catch (PSErrorException e) {
+      throw new IllegalStateException("Failed to create display formats", e);
+    } catch (PSCmsException | PSUnknownNodeTypeException e) {
+      throw new IllegalStateException("Failed to map display formats", e);
+    }
+  }
+
+  @Override
+  public DisplayFormat createDisplayFormat(DisplayFormat body) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String name = requireValidName(firstNonBlank(body.getName(), body.getInternalName()));
+    assertNameUnique(name);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSDisplayFormat> created = designWs.createDisplayFormats(List.of(name), session, user);
+      if (created == null || created.isEmpty() || created.get(0) == null) {
+        throw new IllegalStateException("Design WS createDisplayFormats returned empty");
+      }
+      PSDisplayFormat nativeDf = created.get(0);
+      applyWritableFields(nativeDf, body);
+      designWs.saveDisplayFormats(List.of(nativeDf), true, session, user);
+      return reload(nativeDf, name);
+    } catch (WebApplicationException | IllegalStateException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("Display format already exists: " + name, 409);
+      }
+      throw e;
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("create", e);
+    } catch (PSErrorException e) {
+      throw new IllegalStateException("Failed to create display format", e);
+    } catch (PSCmsException | PSUnknownNodeTypeException e) {
+      throw new IllegalStateException("Failed to map display format", e);
+    }
+  }
+
+  @Override
+  public DisplayFormat updateDisplayFormat(String idOrName, DisplayFormat body) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    if (!isSafeDisplayFormatKey(idOrName)) {
+      return null;
+    }
+    DisplayFormat existing = findDisplayFormatByKey(idOrName);
+    if (existing == null) {
+      return null;
+    }
+    IPSGuid id = resolveGuid(existing);
+    if (id == null) {
+      return null;
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSDisplayFormat> loaded =
+          designWs.loadDisplayFormats(List.of(id), true, false, session, user);
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        throw new WebApplicationException(
+            "Could not update display format; design lock required or held by another user", 409);
+      }
+      PSDisplayFormat nativeDf = loaded.get(0);
+      applyWritableFields(nativeDf, body);
+      designWs.saveDisplayFormats(List.of(nativeDf), true, session, user);
+      return reload(nativeDf, nativeDf.getName());
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, id)) {
+        return null;
+      }
+      if (hasLockError(e)) {
+        throw new WebApplicationException(
+            "Could not update display format; design lock required or held by another user", 409);
+      }
+      log.error("Failed to load display format for update: {}", id, e);
+      throw new IllegalStateException("Failed to update display format", e);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("update", e);
+    } catch (PSCmsException | PSUnknownNodeTypeException e) {
+      throw new IllegalStateException("Failed to map display format", e);
+    }
+  }
+
+  @Override
+  public boolean deleteDisplayFormat(String idOrName) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (!isSafeDisplayFormatKey(idOrName)) {
+      return false;
+    }
+    DisplayFormat existing = findDisplayFormatByKey(idOrName);
+    if (existing == null) {
+      return false;
+    }
+    IPSGuid id = resolveGuid(existing);
+    if (id == null) {
+      return false;
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSDisplayFormat> locked =
+          designWs.loadDisplayFormats(List.of(id), true, false, session, user);
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        throw new WebApplicationException(
+            "Could not delete display format; design lock required or held by another user", 409);
+      }
+      designWs.deleteDisplayFormats(List.of(id), false, session, user);
+      return true;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, id)) {
+        return false;
+      }
+      throw new WebApplicationException(
+          "Could not delete display format; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("delete", e);
+    }
   }
 
   @Override
   public void deleteDisplayFormats(
       List<IPSGuid> ids, boolean ignoreDependencies, String session, String user) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    try {
+      designWs.deleteDisplayFormats(ids, ignoreDependencies, session, user);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("delete", e);
+    }
   }
 
   @Override
@@ -349,7 +529,44 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
   @Override
   public void saveDisplayFormats(
       List<DisplayFormat> displayFormats, boolean release, String session, String user) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    if (displayFormats == null || displayFormats.isEmpty()) {
+      throw new IllegalArgumentException("displayFormats is required");
+    }
+    List<PSDisplayFormat> natives = new ArrayList<>();
+    for (DisplayFormat dto : displayFormats) {
+      if (dto == null) {
+        continue;
+      }
+      IPSGuid id = resolveGuid(dto);
+      if (id == null) {
+        throw new IllegalArgumentException("display format guid is required to save");
+      }
+      try {
+        List<PSDisplayFormat> loaded =
+            designWs.loadDisplayFormats(List.of(id), true, false, session, user);
+        if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+          throw new WebApplicationException(
+              "Could not save display format; design lock required or held by another user", 409);
+        }
+        PSDisplayFormat nativeDf = loaded.get(0);
+        applyWritableFields(nativeDf, dto);
+        natives.add(nativeDf);
+      } catch (PSErrorResultsException e) {
+        if (hasLockError(e)) {
+          throw new WebApplicationException(
+              "Could not save display format; design lock required or held by another user", 409);
+        }
+        throw new IllegalStateException("Failed to load display format for save", e);
+      }
+    }
+    if (natives.isEmpty()) {
+      throw new IllegalArgumentException("displayFormats is required");
+    }
+    try {
+      designWs.saveDisplayFormats(natives, release, session, user);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("save", e);
+    }
   }
 
   @Override
@@ -388,5 +605,272 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
         && key.indexOf('/') < 0
         && key.indexOf('\\') < 0
         && key.indexOf('\0') < 0;
+  }
+
+  private DisplayFormat reload(PSDisplayFormat saved, String name)
+      throws PSCmsException, PSUnknownNodeTypeException {
+    if (name != null && !name.isBlank()) {
+      DisplayFormat byName = findDisplayFormat(name);
+      if (byName != null) {
+        return byName;
+      }
+    }
+    if (saved != null && saved.getGUID() != null) {
+      DisplayFormat byGuid = findDisplayFormat(saved.getGUID());
+      if (byGuid != null) {
+        return byGuid;
+      }
+    }
+    return saved == null ? null : copyDisplayFormat(saved);
+  }
+
+  private static void applyWritableFields(PSDisplayFormat nativeDf, DisplayFormat body) {
+    if (nativeDf == null || body == null) {
+      return;
+    }
+    String label = firstNonBlank(body.getLabel(), body.getDisplayName());
+    if (label != null) {
+      nativeDf.setDisplayName(label);
+    }
+    if (body.getDescription() != null) {
+      nativeDf.setDescription(body.getDescription());
+    }
+  }
+
+  private void assertNameUnique(String name) {
+    List<IPSCatalogSummary> existing;
+    try {
+      existing = designWs.findDisplayFormats(name, null);
+    } catch (RuntimeException e) {
+      log.debug("Could not catalog display formats for uniqueness: {}", e.toString());
+      return;
+    }
+    if (existing == null) {
+      return;
+    }
+    for (IPSCatalogSummary summary : existing) {
+      if (summary != null
+          && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+        throw new WebApplicationException("Display format already exists: " + name, 409);
+      }
+    }
+  }
+
+  private static String requireValidName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String name = raw.trim();
+    if (containsWhitespace(name)) {
+      throw new IllegalArgumentException("name cannot contain whitespace");
+    }
+    if (name.contains("*") || name.contains("%")) {
+      throw new IllegalArgumentException("name must not contain wildcards");
+    }
+    if (!isSafeDisplayFormatKey(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return name;
+  }
+
+  private static boolean containsWhitespace(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isWhitespace(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String firstNonBlank(String... values) {
+    if (values == null) {
+      return null;
+    }
+    for (String v : values) {
+      if (StringUtils.isNotBlank(v)) {
+        return v.trim();
+      }
+    }
+    return null;
+  }
+
+  static IPSGuid toIpsGuid(Guid guid) {
+    if (guid == null) {
+      return null;
+    }
+    String sv = guid.getStringValue();
+    if (StringUtils.isNotBlank(sv)) {
+      try {
+        return new PSGuid(sv.trim());
+      } catch (IllegalArgumentException e) {
+        log.debug("Invalid display format GUID string: {}", e.getMessage());
+      }
+    }
+    if (guid.getType() > 0 && guid.getUuid() > 0) {
+      PSTypeEnum type = PSTypeEnum.valueOf(guid.getType());
+      if (type != null) {
+        return new PSGuid(type, guid.getUuid());
+      }
+    }
+    if (guid.getLongValue() != 0) {
+      return new PSGuid(guid.getLongValue());
+    }
+    return null;
+  }
+
+  private static IPSGuid resolveGuid(DisplayFormat dto) {
+    if (dto == null) {
+      return null;
+    }
+    IPSGuid fromGuid = toIpsGuid(dto.getGuid());
+    if (fromGuid != null) {
+      return fromGuid;
+    }
+    if (StringUtils.isNotBlank(dto.getGuidString())) {
+      try {
+        return new PSGuid(dto.getGuidString().trim());
+      } catch (IllegalArgumentException e) {
+        log.debug("Invalid display format guidString: {}", e.getMessage());
+      }
+    }
+    if (dto.getDisplayId() > 0) {
+      return new PSGuid(PSTypeEnum.DISPLAY_FORMAT, dto.getDisplayId());
+    }
+    return null;
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private static void requireSessionUserForWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for display format design write",
+          Response.Status.FORBIDDEN);
+    }
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+
+  static boolean isAlreadyExistsFailure(IllegalArgumentException e) {
+    return e != null && StringUtils.containsIgnoreCase(e.getMessage(), "already exists");
+  }
+
+  static boolean isNotFound(PSErrorResultsException e, IPSGuid requested) {
+    if (e == null || requested == null) {
+      return false;
+    }
+    Map<IPSGuid, Object> errors = e.getErrors();
+    Map<IPSGuid, Object> results = e.getResults();
+    boolean errored = errors != null && errors.containsKey(requested);
+    boolean hasResult = results != null && results.containsKey(requested);
+    return errored && !hasResult && !hasLockError(e);
+  }
+
+  static boolean hasLockError(PSErrorResultsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isNotLockedError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isDependencyError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return StringUtils.containsIgnoreCase(e != null ? e.getMessage() : null, "depend");
+    }
+    for (Object err : e.getErrors().values()) {
+      String msg = errorMessage(err);
+      if (StringUtils.containsIgnoreCase(msg, "depend")) {
+        return true;
+      }
+    }
+    return StringUtils.containsIgnoreCase(e.getMessage(), "depend");
+  }
+
+  private static boolean isLockErrorObject(Object err) {
+    if (err instanceof PSLockErrorException) {
+      return true;
+    }
+    if (err instanceof PSErrorException pe) {
+      String msg = pe.getErrorMessage() != null ? pe.getErrorMessage() : pe.getMessage();
+      return StringUtils.containsIgnoreCase(msg, "is not locked")
+          || StringUtils.containsIgnoreCase(msg, "not locked for")
+          || StringUtils.containsIgnoreCase(msg, "locked by");
+    }
+    String text = String.valueOf(err);
+    return StringUtils.containsIgnoreCase(text, "is not locked")
+        || StringUtils.containsIgnoreCase(text, "locked by");
+  }
+
+  private static String errorMessage(Object err) {
+    if (err instanceof PSErrorException pe) {
+      return StringUtils.defaultIfBlank(pe.getErrorMessage(), pe.getMessage());
+    }
+    return err != null ? String.valueOf(err) : null;
+  }
+
+  private RuntimeException mapSaveOrDeleteFailure(String verb, PSErrorsException e) {
+    if (isNotLockedError(e)) {
+      return new WebApplicationException(
+          "Could not " + verb + " display format; design lock required or held by another user",
+          409);
+    }
+    if (isDependencyError(e)) {
+      return new WebApplicationException(
+          "Display format has dependents and cannot be deleted", 409);
+    }
+    log.error("Failed to {} display format via UI design WS", verb, e);
+    return new IllegalStateException("Failed to " + verb + " display format", e);
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
@@ -46,6 +46,7 @@ import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.ui.IPSUiDesignWs;
 import jakarta.ws.rs.WebApplicationException;
 import java.lang.reflect.Method;
@@ -339,6 +340,17 @@ class DisplayFormatAdaptorWriteTest {
         assertThrows(WebApplicationException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
     assertEquals(403, ex.getResponse().getStatus());
     verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void isLockError_detectsTypedLockErrorException() {
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(guid, new PSLockErrorException(0, "lock failed", "stack"));
+    assertTrue(DisplayFormatAdaptor.isLockError(errors));
+    PSErrorsException unrelated = new PSErrorsException();
+    unrelated.addError(guid, new PSErrorException("unrelated failure"));
+    assertFalse(DisplayFormatAdaptor.isLockError(unrelated));
+    assertFalse(DisplayFormatAdaptor.isLockError(null));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSDbComponent;
+import com.percussion.cms.objectstore.PSDisplayFormat;
+import com.percussion.cms.objectstore.PSKey;
+import com.percussion.rest.Guid;
+import com.percussion.rest.displayformat.DisplayFormat;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * UI-05 POST create / PUT update / DELETE persist via {@code createDisplayFormats}/{@code
+ * saveDisplayFormats}/{@code deleteDisplayFormats}. Admin only; unique name; no lock steal.
+ */
+@Tag("UnitTest")
+class DisplayFormatAdaptorWriteTest {
+
+  private IPSUiDesignWs designWs;
+  private DisplayFormatAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    designWs = mock(IPSUiDesignWs.class);
+    adaptor = new DisplayFormatAdaptor(designWs, () -> true);
+    guid = new PSGuid(PSTypeEnum.DISPLAY_FORMAT, 42L);
+    when(designWs.findDisplayFormats(any(), nullable(String.class)))
+        .thenReturn(Collections.emptyList());
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void create_usesCreateThenSaveAndReleasesLock() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    when(designWs.createDisplayFormats(eq(List.of("MyFmt")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(nativeDf));
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+
+    DisplayFormat body = new DisplayFormat();
+    body.setName("MyFmt");
+    body.setLabel("My Format");
+    body.setDescription("created via REST");
+
+    DisplayFormat out = adaptor.createDisplayFormat(body);
+
+    assertEquals("MyFmt", out.getName());
+    assertEquals("My Format", out.getLabel());
+    assertEquals("created via REST", out.getDescription());
+    verify(designWs).createDisplayFormats(eq(List.of("MyFmt")), eq("test-session"), eq("Admin"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSDisplayFormat>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs)
+        .saveDisplayFormats(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    assertEquals("My Format", saved.getValue().get(0).getDisplayName());
+    assertEquals("created via REST", saved.getValue().get(0).getDescription());
+  }
+
+  @Test
+  void create_duplicateName_is409BeforeCreate() throws Exception {
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("MyFmt");
+    when(designWs.findDisplayFormats(eq("MyFmt"), nullable(String.class)))
+        .thenReturn(List.of(existing));
+
+    DisplayFormat body = new DisplayFormat();
+    body.setName("MyFmt");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createDisplayFormat(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createDisplayFormats(anyList(), any(), any());
+    verify(designWs, never()).saveDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_persistTimeDuplicate_is409() throws Exception {
+    when(designWs.createDisplayFormats(eq(List.of("MyFmt")), eq("test-session"), eq("Admin")))
+        .thenThrow(
+            new IllegalArgumentException(
+                "The name 'MyFmt' for type 'DISPLAY_FORMAT' already exists."));
+    DisplayFormat body = new DisplayFormat();
+    body.setName("MyFmt");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createDisplayFormat(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_blankName_throwsBeforeDesignWs() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createDisplayFormat(null));
+    DisplayFormat blank = new DisplayFormat();
+    blank.setName("  ");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createDisplayFormat(blank));
+    assertTrue(ex.getMessage().contains("name is required"));
+    verify(designWs, never()).createDisplayFormats(anyList(), any(), any());
+  }
+
+  @Test
+  void create_nameWithSpaces_throwsBeforeDesignWs() {
+    DisplayFormat body = new DisplayFormat();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createDisplayFormat(body));
+    assertEquals("name cannot contain whitespace", ex.getMessage());
+    verify(designWs, never()).createDisplayFormats(anyList(), any(), any());
+  }
+
+  @Test
+  void create_wildcardName_throwsBeforeDesignWs() {
+    DisplayFormat body = new DisplayFormat();
+    body.setName("My*Fmt");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createDisplayFormat(body));
+    assertEquals("name must not contain wildcards", ex.getMessage());
+    verify(designWs, never()).createDisplayFormats(anyList(), any(), any());
+  }
+
+  @Test
+  void create_nonAdmin_is403() {
+    adaptor = new DisplayFormatAdaptor(designWs, () -> false);
+    DisplayFormat body = new DisplayFormat();
+    body.setName("MyFmt");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createDisplayFormat(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).createDisplayFormats(anyList(), any(), any());
+  }
+
+  @Test
+  void create_missingSession_is403() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    DisplayFormat body = new DisplayFormat();
+    body.setName("MyFmt");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createDisplayFormat(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("session"), ex.getMessage());
+  }
+
+  @Test
+  void create_thenGetByName_returnsFormat() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    nativeDf.setDisplayName("My Format");
+    nativeDf.setDescription("created via REST");
+    when(designWs.createDisplayFormats(eq(List.of("MyFmt")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(nativeDf));
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+
+    DisplayFormat body = new DisplayFormat();
+    body.setName("MyFmt");
+    body.setLabel("My Format");
+    body.setDescription("created via REST");
+
+    adaptor.createDisplayFormat(body);
+    DisplayFormat got = adaptor.findDisplayFormatByKey("MyFmt");
+
+    assertEquals("MyFmt", got.getName());
+    assertEquals("My Format", got.getLabel());
+    assertEquals("created via REST", got.getDescription());
+  }
+
+  @Test
+  void update_loadsWithLockAndSavesLabelDescription() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+    when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(nativeDf));
+
+    DisplayFormat body = new DisplayFormat();
+    body.setLabel("Updated");
+    body.setDescription("updated desc");
+
+    DisplayFormat out = adaptor.updateDisplayFormat("MyFmt", body);
+
+    assertEquals("MyFmt", out.getName());
+    assertEquals("Updated", out.getLabel());
+    assertEquals("updated desc", out.getDescription());
+    verify(designWs)
+        .loadDisplayFormats(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin"));
+    verify(designWs).saveDisplayFormats(anyList(), eq(true), eq("test-session"), eq("Admin"));
+    verify(designWs, never()).createDisplayFormats(anyList(), any(), any());
+  }
+
+  @Test
+  void update_unknown_returnsNull() {
+    when(designWs.findDisplayFormat(eq("missing"))).thenReturn(null);
+    DisplayFormat body = new DisplayFormat();
+    body.setLabel("Updated");
+    assertNull(adaptor.updateDisplayFormat("missing", body));
+    verify(designWs, never()).saveDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_lockConflict_is409() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+    when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(lockResultsException());
+
+    DisplayFormat body = new DisplayFormat();
+    body.setLabel("Updated");
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.updateDisplayFormat("MyFmt", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_nonAdmin_is403() {
+    adaptor = new DisplayFormatAdaptor(designWs, () -> false);
+    DisplayFormat body = new DisplayFormat();
+    body.setLabel("Updated");
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.updateDisplayFormat("MyFmt", body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void delete_thenGetByName_isNotFound() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+    when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(nativeDf));
+
+    assertTrue(adaptor.deleteDisplayFormat("MyFmt"));
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(null);
+    assertNull(adaptor.findDisplayFormatByKey("MyFmt"));
+    verify(designWs)
+        .deleteDisplayFormats(anyList(), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void delete_unknown_returnsFalse() {
+    when(designWs.findDisplayFormat(eq("missing"))).thenReturn(null);
+    assertFalse(adaptor.deleteDisplayFormat("missing"));
+    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_lockConflict_is409() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+    when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_inUse_is409() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+    when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(nativeDf));
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(guid, new PSErrorException("Object has dependents"));
+    doThrow(errors)
+        .when(designWs)
+        .deleteDisplayFormats(anyList(), eq(false), any(), any());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("depend"), ex.getMessage());
+  }
+
+  @Test
+  void delete_nonAdmin_is403() {
+    adaptor = new DisplayFormatAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void toIpsGuid_parsesStringValue() {
+    Guid g = restGuid(guid);
+    IPSGuid parsed = DisplayFormatAdaptor.toIpsGuid(g);
+    assertEquals(guid.toString(), parsed.toString());
+    assertNull(DisplayFormatAdaptor.toIpsGuid(null));
+  }
+
+  private PSErrorResultsException lockResultsException() {
+    PSErrorResultsException e = new PSErrorResultsException();
+    e.addError(guid, new PSErrorException("Object is locked by another user"));
+    return e;
+  }
+
+  private static PSDisplayFormat nativeDisplayFormat(int displayId, String name) throws Exception {
+    PSDisplayFormat nativeDf = new PSDisplayFormat();
+    PSKey key = PSDisplayFormat.createKey(new String[] {String.valueOf(displayId)});
+    Method setKey = PSDbComponent.class.getDeclaredMethod("setKey", PSKey.class);
+    setKey.setAccessible(true);
+    setKey.invoke(nativeDf, key);
+    nativeDf.setName(name);
+    nativeDf.setInternalName(name);
+    return nativeDf;
+  }
+
+  private static Guid restGuid(IPSGuid g) {
+    Guid out = new Guid();
+    out.setStringValue(g.toString());
+    return out;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormat.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormat.java
@@ -59,6 +59,33 @@ public class DisplayFormat {
 
   public DisplayFormat() {}
 
+  /**
+   * Copy writable fields for POST create without mutating {@code source}. Identity ({@code guid},
+   * {@code guidString}, {@code displayId}) is left unset so create cannot reuse a client id.
+   */
+  public static DisplayFormat copyForCreate(DisplayFormat source) {
+    DisplayFormat copy = new DisplayFormat();
+    if (source == null) {
+      return copy;
+    }
+    copy.setName(source.getName());
+    copy.setLabel(source.getLabel());
+    copy.setValidForRelatedContent(source.isValidForRelatedContent());
+    copy.setSortedColumnNames(source.getSortedColumnNames());
+    copy.setAscendingSort(source.isAscendingSort());
+    copy.setDescendingSort(source.isDescendingSort());
+    copy.setValidForViewsAndSearches(source.isValidForViewsAndSearches());
+    copy.setValidForFolder(source.isValidForFolder());
+    copy.setInvalidFolderFieldNames(source.getInvalidFolderFieldNames());
+    copy.setProperties(source.getProperties());
+    copy.setColumns(source.getColumns());
+    copy.setInternalName(source.getInternalName());
+    copy.setAllowedCommunities(source.getAllowedCommunities());
+    copy.setDescription(source.getDescription());
+    copy.setDisplayName(source.getDisplayName());
+    return copy;
+  }
+
   public String getDescription() {
     return description;
   }

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
@@ -35,8 +35,11 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.net.URI;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
@@ -61,6 +64,8 @@ public class DisplayFormatResource {
 
   private final IDisplayFormatAdaptor adaptor;
 
+  @Context private UriInfo uriInfo;
+
   public DisplayFormatResource() {
     this.adaptor = null;
   }
@@ -68,6 +73,11 @@ public class DisplayFormatResource {
   @Autowired
   public DisplayFormatResource(IDisplayFormatAdaptor adaptor) {
     this.adaptor = adaptor;
+  }
+
+  /** Package-private test hook so unit tests need not reflect on {@code uriInfo}. */
+  void setUriInfo(UriInfo uriInfo) {
+    this.uriInfo = uriInfo;
   }
 
   @GET
@@ -173,7 +183,7 @@ public class DisplayFormatResource {
               + " columns (same as Workbench).",
       responses = {
         @ApiResponse(
-            responseCode = "200",
+            responseCode = "201",
             description = "Created",
             content = @Content(schema = @Schema(implementation = DisplayFormat.class))),
         @ApiResponse(responseCode = "400", description = "Invalid name"),
@@ -185,18 +195,19 @@ public class DisplayFormatResource {
             description = "A display format with that name already exists"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
-  public DisplayFormat createDisplayFormat(DisplayFormat body) {
+  public Response createDisplayFormat(DisplayFormat body) {
     try {
-      if (body != null) {
-        body.setGuid(null);
-        body.setGuidString(null);
-        body.setDisplayId(0);
-      }
-      DisplayFormat created = requireAdaptor().createDisplayFormat(body);
+      DisplayFormat createBody = body == null ? null : DisplayFormat.copyForCreate(body);
+      DisplayFormat created = requireAdaptor().createDisplayFormat(createBody);
       if (created == null) {
         throw new WebApplicationException("Failed to create display format", 500);
       }
-      return created;
+      Response.ResponseBuilder rb = Response.status(Response.Status.CREATED).entity(created);
+      URI location = createdLocation(created);
+      if (location != null) {
+        rb.location(location);
+      }
+      return rb.build();
     } catch (RuntimeException e) {
       throw mapWriteFailure(e);
     } catch (Exception e) {
@@ -300,8 +311,9 @@ public class DisplayFormatResource {
   }
 
   /**
-   * Map adaptor write failures to HTTP status. Admin/session 403 and duplicate/lock 409 are
-   * already {@link WebApplicationException}s from the adaptor.
+   * Map adaptor write failures to HTTP status without sniffing exception text. Admin/session 403
+   * and duplicate/lock/dependency 409 must already be {@link WebApplicationException}s from the
+   * adaptor (typed {@code PSLockErrorException} / dependency errors are wrapped there).
    */
   static WebApplicationException mapWriteFailure(RuntimeException e) {
     if (e instanceof WebApplicationException wae) {
@@ -310,15 +322,31 @@ public class DisplayFormatResource {
     if (e instanceof IllegalArgumentException) {
       return new WebApplicationException(e.getMessage(), 400);
     }
-    if (e instanceof IllegalStateException) {
-      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
-      String lower = msg.toLowerCase();
-      if (lower.contains("lock") || lower.contains("depend")) {
-        return new WebApplicationException(msg, 409);
-      }
-      return new WebApplicationException(e, 500);
-    }
     return new WebApplicationException(e, 500);
+  }
+
+  private URI createdLocation(DisplayFormat created) {
+    if (uriInfo == null || created == null) {
+      return null;
+    }
+    String key =
+        firstNonBlank(created.getName(), created.getInternalName(), created.getGuidString());
+    if (key == null) {
+      return null;
+    }
+    return uriInfo.getAbsolutePathBuilder().path(key).build();
+  }
+
+  private static String firstNonBlank(String... values) {
+    if (values == null) {
+      return null;
+    }
+    for (String v : values) {
+      if (v != null && !v.isBlank()) {
+        return v.trim();
+      }
+    }
+    return null;
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
@@ -25,29 +25,39 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only display format catalog for the Developer module (UI-05 list/detail) and the modern
- * Content Explorer folder list (issue #2400 / FR-027).
+ * Display format catalog for the Developer module (UI-05 list/detail/write) and the modern Content
+ * Explorer folder list (issue #2400 / FR-027).
  *
- * <p>Write endpoints remain unimplemented at the adaptor layer (later slice).
+ * <p>Admin POST/PUT/DELETE persist through {@link IDisplayFormatAdaptor} over {@code
+ * IPSUiDesignWs} (same SOAP operations Workbench uses). Developer SPA chrome is out of scope.
  */
 @PSSiteManageBean(value = "restDisplayFormatResource")
 @Path("/displayformats")
 @XmlRootElement
-@Tag(name = "Display Formats", description = "CX display format design catalog (read-only)")
+@Tag(name = "Display Formats", description = "CX display format design catalog (UI-05 CRUD)")
 public class DisplayFormatResource {
+
+  private static final Logger log = LogManager.getLogger(DisplayFormatResource.class);
 
   private final IDisplayFormatAdaptor adaptor;
 
@@ -67,7 +77,7 @@ public class DisplayFormatResource {
       description =
           "Lists Content Explorer display formats with columns and usage flags. Optional filters"
               + " support the modern Explorer folder list (validForFolder) and search/view UIs"
-              + " (validForViewsAndSearches). Create/edit/delete are later slices.",
+              + " (validForViewsAndSearches). Admin POST/PUT/DELETE persist via IPSUiDesignWs.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -125,7 +135,7 @@ public class DisplayFormatResource {
   @Operation(
       summary = "Get display format detail",
       description =
-          "Loads one display format by internal name or GUID string. Write remains unsupported.",
+          "Loads one display format by internal name or GUID string.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -147,6 +157,168 @@ public class DisplayFormatResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  @POST
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Create display format",
+      description =
+          "Admin. Creates and persists a display format via IPSUiDesignWs.createDisplayFormats"
+              + " then saveDisplayFormats (Workbench Finish, held design lock released on save)."
+              + " Name (or internalName) is required, unique (case-insensitive), and must not"
+              + " contain whitespace or wildcards. Optional label/displayName and description are"
+              + " applied before save. Duplicate name is 409. Usage flags on GET are derived from"
+              + " columns (same as Workbench).",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = DisplayFormat.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid name"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "A display format with that name already exists"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public DisplayFormat createDisplayFormat(DisplayFormat body) {
+    try {
+      if (body != null) {
+        body.setGuid(null);
+        body.setGuidString(null);
+        body.setDisplayId(0);
+      }
+      DisplayFormat created = requireAdaptor().createDisplayFormat(body);
+      if (created == null) {
+        throw new WebApplicationException("Failed to create display format", 500);
+      }
+      return created;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      log.error(
+          "Failed to create display format ({}): {}", e.getClass().getName(), e.getMessage(), e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Update display format",
+      description =
+          "Admin. Updates label/displayName and/or description by internal name or GUID. Name is"
+              + " the catalog key and is not renamed on PUT. Loads with a design lock"
+              + " (overrideLock=false) and releases on save. Usage flags on GET remain derived"
+              + " from columns. Unknown id is 404. Lock/dependency conflict is 409.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = DisplayFormat.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Display format not found"),
+        @ApiResponse(responseCode = "409", description = "Design lock or dependency conflict"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public DisplayFormat updateDisplayFormat(
+      @PathParam("idOrName") String idOrName, DisplayFormat body) {
+    try {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      DisplayFormat existing = requireAdaptor().findDisplayFormatByKey(idOrName);
+      if (existing == null) {
+        throw new WebApplicationException("Display format not found", 404);
+      }
+      DisplayFormat updated = requireAdaptor().updateDisplayFormat(idOrName, body);
+      if (updated == null) {
+        throw new WebApplicationException("Display format not found", 404);
+      }
+      return updated;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      log.error(
+          "Failed to update display format {} ({}): {}",
+          idOrName,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete display format",
+      description =
+          "Admin. Deletes a display format by internal name or GUID via"
+              + " IPSUiDesignWs.deleteDisplayFormats (ignoreDependencies=false). Unknown id is"
+              + " 404. In-use or lock conflict is 409 (the lock is not stolen). Following GET is"
+              + " 404 after a successful delete.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Display format not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Display format has dependents, or design lock conflict"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteDisplayFormat(@PathParam("idOrName") String idOrName) {
+    try {
+      boolean deleted = requireAdaptor().deleteDisplayFormat(idOrName);
+      if (!deleted) {
+        throw new WebApplicationException("Display format not found", 404);
+      }
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      log.error(
+          "Failed to delete display format {} ({}): {}",
+          idOrName,
+          e.getClass().getName(),
+          e.getMessage(),
+          e);
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Admin/session 403 and duplicate/lock 409 are
+   * already {@link WebApplicationException}s from the adaptor.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    if (e instanceof IllegalStateException) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      String lower = msg.toLowerCase();
+      if (lower.contains("lock") || lower.contains("depend")) {
+        return new WebApplicationException(msg, 409);
+      }
+      return new WebApplicationException(e, 500);
+    }
+    return new WebApplicationException(e, 500);
   }
 
   /**

--- a/rest/src/main/java/com/percussion/rest/displayformat/IDisplayFormatAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/IDisplayFormatAdaptor.java
@@ -30,6 +30,34 @@ public interface IDisplayFormatAdaptor {
 
   List<DisplayFormat> createDisplayFormats(List<String> names, String session, String user);
 
+  /**
+   * Admin create: persist a new display format (Workbench Finish, not an unsaved stub) via {@code
+   * IPSUiDesignWs.createDisplayFormats} then {@code saveDisplayFormats}.
+   *
+   * @param body JSON body; {@code name} (or {@code internalName}) required, unique, no whitespace
+   *     or wildcards
+   * @return persisted display format
+   */
+  DisplayFormat createDisplayFormat(DisplayFormat body);
+
+  /**
+   * Admin update by internal name or GUID. Name is not renamed on PUT. Loads with a design lock
+   * ({@code overrideLock=false}) and releases on save.
+   *
+   * @param idOrName catalog key
+   * @param body fields to apply ({@code label}/{@code displayName}, {@code description})
+   * @return updated format, or {@code null} when missing
+   */
+  DisplayFormat updateDisplayFormat(String idOrName, DisplayFormat body);
+
+  /**
+   * Admin delete by internal name or GUID. Does not steal another user's lock.
+   *
+   * @param idOrName catalog key
+   * @return {@code true} when deleted, {@code false} when not found
+   */
+  boolean deleteDisplayFormat(String idOrName);
+
   void deleteDisplayFormats(
       List<IPSGuid> ids, boolean ignoreDependencies, String session, String user);
 

--- a/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
@@ -30,9 +30,13 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.percussion.rest.Guid;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
 import java.util.List;
+import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -167,21 +171,40 @@ public class DisplayFormatResourceTest {
   }
 
   @Test
-  public void createDisplayFormatClearsIdAndDelegates() {
+  public void createDisplayFormatCopiesBodyClearsIdAndReturns201() {
     DisplayFormat body = new DisplayFormat();
     body.setName("MyFmt");
     body.setDisplayId(9);
+    Guid clientGuid = new Guid("0-11-9");
+    body.setGuid(clientGuid);
+    body.setGuidString("0-11-9");
     DisplayFormat created = new DisplayFormat();
     created.setName("MyFmt");
     created.setDisplayId(99);
     when(adaptor.createDisplayFormat(any())).thenReturn(created);
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getAbsolutePathBuilder())
+        .thenReturn(UriBuilder.fromUri("http://localhost/Rhythmyx/rest/displayformats"));
+    resource.setUriInfo(uriInfo);
 
-    DisplayFormat out = resource.createDisplayFormat(body);
+    Response r = resource.createDisplayFormat(body);
 
+    assertEquals(201, r.getStatus());
+    DisplayFormat out = (DisplayFormat) r.getEntity();
     assertEquals("MyFmt", out.getName());
-    assertEquals(0, body.getDisplayId());
-    assertNull(body.getGuid());
-    verify(adaptor).createDisplayFormat(body);
+    assertEquals(99, out.getDisplayId());
+    assertEquals(9, body.getDisplayId());
+    assertSame(clientGuid, body.getGuid());
+    assertEquals("0-11-9", body.getGuidString());
+    assertEquals(
+        "http://localhost/Rhythmyx/rest/displayformats/MyFmt", r.getLocation().toString());
+    ArgumentCaptor<DisplayFormat> cap = ArgumentCaptor.forClass(DisplayFormat.class);
+    verify(adaptor).createDisplayFormat(cap.capture());
+    DisplayFormat sent = cap.getValue();
+    assertEquals("MyFmt", sent.getName());
+    assertEquals(0, sent.getDisplayId());
+    assertNull(sent.getGuid());
+    assertNull(sent.getGuidString());
   }
 
   @Test
@@ -313,5 +336,33 @@ public class DisplayFormatResourceTest {
         assertThrows(
             WebApplicationException.class, () -> bare.createDisplayFormat(new DisplayFormat()));
     assertEquals(500, createEx.getResponse().getStatus());
+  }
+
+  @Test
+  public void mapWriteFailurePreservesAdaptorWebApplicationException() {
+    WebApplicationException lock =
+        new WebApplicationException(
+            "Could not update display format; design lock required or held by another user", 409);
+    assertSame(lock, DisplayFormatResource.mapWriteFailure(lock));
+  }
+
+  @Test
+  public void mapWriteFailureIllegalArgumentIs400() {
+    WebApplicationException ex =
+        DisplayFormatResource.mapWriteFailure(new IllegalArgumentException("name is required"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void mapWriteFailureIllegalStateIs500EvenIfMessageContainsLock() {
+    IllegalStateException ise = new IllegalStateException("Failed to map display format");
+    WebApplicationException mapped = DisplayFormatResource.mapWriteFailure(ise);
+    assertEquals(500, mapped.getResponse().getStatus());
+    assertSame(ise, mapped.getCause());
+
+    WebApplicationException lockText =
+        DisplayFormatResource.mapWriteFailure(
+            new IllegalStateException("object is not locked"));
+    assertEquals(500, lockText.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
@@ -19,15 +19,19 @@ package com.percussion.rest.displayformat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -163,6 +167,136 @@ public class DisplayFormatResourceTest {
   }
 
   @Test
+  public void createDisplayFormatClearsIdAndDelegates() {
+    DisplayFormat body = new DisplayFormat();
+    body.setName("MyFmt");
+    body.setDisplayId(9);
+    DisplayFormat created = new DisplayFormat();
+    created.setName("MyFmt");
+    created.setDisplayId(99);
+    when(adaptor.createDisplayFormat(any())).thenReturn(created);
+
+    DisplayFormat out = resource.createDisplayFormat(body);
+
+    assertEquals("MyFmt", out.getName());
+    assertEquals(0, body.getDisplayId());
+    assertNull(body.getGuid());
+    verify(adaptor).createDisplayFormat(body);
+  }
+
+  @Test
+  public void createDisplayFormatBlankNameIs400() {
+    when(adaptor.createDisplayFormat(any()))
+        .thenThrow(new IllegalArgumentException("name is required"));
+    DisplayFormat body = new DisplayFormat();
+    body.setName("  ");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createDisplayFormat(body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createDisplayFormatDuplicateIs409() {
+    when(adaptor.createDisplayFormat(any()))
+        .thenThrow(new WebApplicationException("Display format already exists: MyFmt", 409));
+    DisplayFormat body = new DisplayFormat();
+    body.setName("MyFmt");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createDisplayFormat(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createDisplayFormatNonAdminIs403() {
+    when(adaptor.createDisplayFormat(any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    DisplayFormat body = new DisplayFormat();
+    body.setName("MyFmt");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createDisplayFormat(body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateDisplayFormatDelegates() {
+    DisplayFormat existing = new DisplayFormat();
+    existing.setName("MyFmt");
+    when(adaptor.findDisplayFormatByKey(eq("MyFmt"))).thenReturn(existing);
+    DisplayFormat body = new DisplayFormat();
+    body.setLabel("Updated");
+    body.setDescription("desc");
+    DisplayFormat updated = new DisplayFormat();
+    updated.setName("MyFmt");
+    updated.setLabel("Updated");
+    updated.setDescription("desc");
+    when(adaptor.updateDisplayFormat(eq("MyFmt"), any())).thenReturn(updated);
+
+    DisplayFormat out = resource.updateDisplayFormat("MyFmt", body);
+
+    assertEquals("Updated", out.getLabel());
+    assertEquals("desc", out.getDescription());
+    verify(adaptor).updateDisplayFormat("MyFmt", body);
+  }
+
+  @Test
+  public void updateDisplayFormatUnknownIs404() {
+    when(adaptor.findDisplayFormatByKey(eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateDisplayFormat("missing", new DisplayFormat()));
+    assertEquals(404, ex.getResponse().getStatus());
+    verify(adaptor, never()).updateDisplayFormat(any(), any());
+  }
+
+  @Test
+  public void updateDisplayFormatNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateDisplayFormat("MyFmt", null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteDisplayFormatNoContent() {
+    when(adaptor.deleteDisplayFormat(eq("MyFmt"))).thenReturn(true);
+
+    Response r = resource.deleteDisplayFormat("MyFmt");
+
+    assertEquals(204, r.getStatus());
+    verify(adaptor).deleteDisplayFormat("MyFmt");
+  }
+
+  @Test
+  public void deleteDisplayFormatUnknownIs404() {
+    when(adaptor.deleteDisplayFormat(eq("missing"))).thenReturn(false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteDisplayFormat("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteDisplayFormatLockConflictIs409() {
+    when(adaptor.deleteDisplayFormat(eq("MyFmt")))
+        .thenThrow(
+            new WebApplicationException(
+                "Could not delete display format; design lock required or held by another user",
+                409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteDisplayFormat("MyFmt"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteDisplayFormatNonAdminIs403() {
+    when(adaptor.deleteDisplayFormat(eq("MyFmt")))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteDisplayFormat("MyFmt"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void withoutInjectionFailsWithDiagnostic() {
     DisplayFormatResource bare = new DisplayFormatResource();
     WebApplicationException listEx =
@@ -174,5 +308,10 @@ public class DisplayFormatResourceTest {
         assertThrows(WebApplicationException.class, () -> bare.getDisplayFormat("x"));
     assertEquals(500, getEx.getResponse().getStatus());
     assertInstanceOf(IllegalStateException.class, getEx.getCause());
+
+    WebApplicationException createEx =
+        assertThrows(
+            WebApplicationException.class, () -> bare.createDisplayFormat(new DisplayFormat()));
+    assertEquals(500, createEx.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatTestAdaptor.java
@@ -35,6 +35,21 @@ public class DisplayFormatTestAdaptor implements IDisplayFormatAdaptor {
   }
 
   @Override
+  public DisplayFormat createDisplayFormat(DisplayFormat body) {
+    return null;
+  }
+
+  @Override
+  public DisplayFormat updateDisplayFormat(String idOrName, DisplayFormat body) {
+    return null;
+  }
+
+  @Override
+  public boolean deleteDisplayFormat(String idOrName) {
+    return false;
+  }
+
+  @Override
   public void deleteDisplayFormats(
       List<IPSGuid> ids, boolean ignoreDependencies, String session, String user) {
     // No-op for test adaptor

--- a/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/TestDisplayFormat.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.displayformat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.rest.Guid;
@@ -74,6 +75,31 @@ public class TestDisplayFormat {
     assertTrue(
         json.contains("\"stringValue\":\"0-11-5\"") || json.contains("\"stringValue\" : \"0-11-5\""),
         "stringValue must serialize as a JSON string: " + json);
+  }
+
+  @Test
+  public void copyForCreateOmitsIdentityAndDoesNotMutateSource() {
+    DisplayFormat source = new DisplayFormat();
+    source.setName("MyFmt");
+    source.setInternalName("MyFmt");
+    source.setLabel("Mine");
+    source.setDisplayName("Mine");
+    source.setDescription("desc");
+    source.setDisplayId(9);
+    source.setGuid(new Guid("0-11-9"));
+    source.setGuidString("0-11-9");
+
+    DisplayFormat copy = DisplayFormat.copyForCreate(source);
+
+    assertEquals("MyFmt", copy.getName());
+    assertEquals("MyFmt", copy.getInternalName());
+    assertEquals("Mine", copy.getLabel());
+    assertEquals("desc", copy.getDescription());
+    assertEquals(0, copy.getDisplayId());
+    assertNull(copy.getGuid());
+    assertNull(copy.getGuidString());
+    assertEquals(9, source.getDisplayId());
+    assertEquals("0-11-9", source.getGuidString());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Parent: #1690 (UI-05 Maintain Content Explorer display formats).

Admin REST can **create**, **save**, and **delete** display formats using existing `IDisplayFormatAdaptor` + `IPSUiDesignWs` (same SOAP operations Workbench uses — no new SOAP). POST persists immediately (Workbench Finish, not an unsaved stub). PUT round-trips `label`/`displayName` and `description`. Usage flags on GET remain derived from columns. DELETE does not steal another user's lock (`overrideLock=false`).

No Developer SPA chrome in this slice.

Fixes #4068

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Mockito `DisplayFormatResourceTest` — POST/PUT/DELETE status mapping (400/403/404/409/204).
2. Spring `DisplayFormatTestAdaptor` stub still implements exact `IDisplayFormatAdaptor` (MainTest context).
3. `DisplayFormatAdaptorWriteTest` — create then GET by name; PUT label/description; DELETE then GET 404; duplicate 409; invalid 400; non-Admin 403; lock conflict 409.
4. Standalone Maven clean install on `rest` and `projects/sitemanage`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` Display formats section (POST/PUT/DELETE, status codes, no SPA claim)
- [x] **Unit / module tests** — behavioral tests for new write paths; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 914, Failures: 0 (`DisplayFormatResourceTest` 21)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (`DisplayFormatAdaptorWriteTest` 19, `DisplayFormatAdaptorSafeKeyTest` 7)
- **downstream_checked:** grep `implements IDisplayFormatAdaptor` (only `DisplayFormatAdaptor` + `DisplayFormatTestAdaptor`); sitemanage standalone clean install (implements the rest interface)

## C5 UI proof

N/A — REST/adaptor only; no WebUI/SPA.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
