### PR TITLE
feat(rest): UI-06 search create/save/delete (#4069)

### DIFF
--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1567,13 +1567,20 @@ on the Content Type / Template / Slot detail paths described above.
 
 ## Searches catalog and execute
 
-CX design **searches** (and optionally **views**) are exposed under `/services/searches`.
+CX design **searches** (and optionally **views** on GET/execute) are exposed under
+`/services/searches`. Admin **write** (UI-06) persists through `IPSUiDesignWs`
+(`createSearches` / `loadSearches` / `saveSearches` / `deleteSearches`) — the same design
+web service SOAP uses. There is no new SOAP surface. **Do not** treat this as a Developer
+Searches SPA; chrome for create/save/delete is a later sibling.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/searches` | List search definitions (Developer catalog; views omitted) |
 | `GET` | `/services/searches?includeViews=true` | List searches **and** views (Explorer saved-search picker) |
 | `GET` | `/services/searches/{idOrName}` | Load one search or view by name, label, GUID, or numeric id |
+| `POST` | `/services/searches` | **Admin.** Create a search (`createSearches` then `saveSearches`) |
+| `PUT` | `/services/searches/{idOrName}` | **Admin.** Update label, description, type, and/or display format |
+| `DELETE` | `/services/searches/{idOrName}` | **Admin.** Delete a search (`deleteSearches`, `ignoreDependencies=false`) |
 | `POST` | `/services/searches/{idOrName}/execute` | Execute a standard/user search or view (not a custom URL) |
 
 `includeViews=true` is required for the Explorer Search panel so the default **All** view
@@ -1586,9 +1593,64 @@ the default All view.
 
 Execute looks up the same combined catalog (searches first, then views). Keys accepted:
 internal name (`View_All`), display label (`All`), GUID string, or numeric id. Custom URL
-searches and custom views return **400**.
+searches and custom views return **400**. Execute is **not** invoked when creating,
+updating, or deleting a search.
 
-POST body is the JAXB envelope `{ "SearchExecuteRequest": { … } }` (flat
+### Search write contract (Admin)
+
+Create (`POST /services/searches`) persists immediately (Workbench Finish, not an unsaved
+stub). JSON body requires `name` (unique across searches **and** views, case-insensitive;
+**no whitespace** or wildcards). Optional `label`, `description`, `type`, and
+`displayFormatId` are applied before save. Default `type` is `StandardSearch`. Accepted
+types: `StandardSearch` (`standard`), `CustomSearch` (`custom`), `Search` (user search).
+`View` is **400** — views stay on `/services/views`. Duplicate name is **409**. Blank /
+whitespace / wildcard names are **400**. Missing request session/user is **403**.
+Non-Admin is **403**. The new search is then `GET /services/searches/{name}` **200**.
+
+Update (`PUT /services/searches/{idOrName}`) loads with a design lock (`overrideLock=false`)
+and releases it on save. Name is not renamed on PUT. Omitted label / description / type /
+display format leave stored values unchanged. Unknown id/name is **404**. A view key is
+**400**. Locked-by-another-user is **409** (the lock is not stolen). Non-Admin is **403**.
+
+Delete (`DELETE /services/searches/{idOrName}`) returns **204** when removed; a following
+`GET` is **404**. Unknown id/name is **404**. Dependents or a lock held by another user are
+**409**. Non-Admin is **403**.
+
+Create/update load or create the search with a **held design lock** and release it on
+save. There is no separate lock/unlock REST pair on this catalog. Field criterion editing
+is not supported on write.
+
+JSON objects use the `SearchDef` wire type. POST/PUT JSON is wrapped under a `SearchDef`
+root (JAXB/Jackson UNWRAP_ROOT_VALUE). Prefer the generated OpenAPI schema as the
+integration source of truth.
+
+Example create body:
+
+```json
+{
+  "SearchDef": {
+    "name": "MySearch",
+    "label": "My Search",
+    "description": "Created via REST",
+    "type": "StandardSearch",
+    "displayFormatId": "1"
+  }
+}
+```
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | List / get / create / update success |
+| `204` | Delete success |
+| `400` | Invalid input (missing name, whitespace/wildcard name, invalid or View type) |
+| `403` | Caller is not Admin, or the request has no session/user for the design session |
+| `404` | Search not found |
+| `409` | Duplicate name, design lock held by another user, or dependents |
+| `500` | Design service or server failure |
+
+### Search execute body
+
+Execute POST body is the JAXB envelope `{ "SearchExecuteRequest": { … } }` (flat
 `startIndex` / `folderPath` is also accepted). Optional fields: `folderPath`,
 `startIndex` (≥ 1), `maxResults` (≥ 1), `sortColumn`, `sortOrder` (`asc` /
 `desc`). `folderPath` may be repository form (`//Sites/...`) or Explorer form

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
@@ -25,16 +25,27 @@ import com.percussion.share.dao.IPSFolderHelper;
 import com.percussion.share.data.PSItemProperties;
 import com.percussion.share.data.PSPagedObjectList;
 import com.percussion.share.service.IPSIdMapper;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.PSWebserviceUtils;
 import com.percussion.webservices.ui.IPSUiDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,8 +53,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
 /**
- * Read-only CX search definition catalog (UI-06) plus design-search execute façade for Explorer
- * (#2505 / #2409 slice B).
+ * CX search definition catalog (UI-06 list/detail/write) plus design-search execute façade for
+ * Explorer (#2505 / #2409 slice B). Admin create/save/delete persist through {@link
+ * IPSUiDesignWs} — the same design web service SOAP uses. Execute is not invoked on write.
  */
 @PSSiteManageBean
 @Lazy
@@ -51,15 +63,17 @@ public class SearchAdaptor implements ISearchAdaptor {
 
   private static final Logger log = LogManager.getLogger(SearchAdaptor.class);
 
+  static final String ADMIN_REQUIRED = "Admin role required to create, update, or delete searches";
+
   /** Product default page size when design max is unset/unlimited and client omits maxResults. */
   static final int DEFAULT_PAGE_SIZE = 25;
 
   /** Catalog-level capability notes. Attached on detail only (REST-GAPS-02 list dedup). */
   static final List<String> DESIGN_GAPS =
       List.of(
-          "Search create / update / delete not supported via this API",
           "Search field criterion editing not supported via this API",
-          "Views are a separate catalog (Developer Views / UI-07)");
+          "Views are a separate catalog (Developer Views / UI-07)",
+          "Search rename is not supported on PUT (name is the catalog key)");
 
   private static final List<String> RESULT_COLUMNS =
       List.of("sys_contentid", "sys_title", "sys_contenttypename");
@@ -67,13 +81,28 @@ public class SearchAdaptor implements ISearchAdaptor {
   private final IPSUiDesignWs designWs;
   private final IPSFolderHelper folderHelper;
   private final IPSIdMapper idMapper;
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   @Autowired
   public SearchAdaptor(
       IPSUiDesignWs designWs, IPSFolderHelper folderHelper, IPSIdMapper idMapper) {
+    this(designWs, folderHelper, idMapper, null);
+  }
+
+  /** Package-visible for unit tests. */
+  SearchAdaptor(
+      IPSUiDesignWs designWs,
+      IPSFolderHelper folderHelper,
+      IPSIdMapper idMapper,
+      BooleanSupplier adminChecker) {
     this.designWs = designWs;
     this.folderHelper = folderHelper;
     this.idMapper = idMapper;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   @Override
@@ -125,6 +154,129 @@ public class SearchAdaptor implements ISearchAdaptor {
     } catch (RuntimeException e) {
       // list failures already wrap; propagate for 500
       throw e;
+    }
+  }
+
+  @Override
+  public SearchDef createSearch(SearchDef body) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String name = requireValidName(body.getName());
+    assertNameUnique(name);
+    String type = resolveSearchType(body.getType(), true);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSSearch> created = designWs.createSearches(List.of(name), List.of(type), session, user);
+      if (created == null || created.isEmpty() || created.get(0) == null) {
+        throw new IllegalStateException("Design WS createSearches returned empty");
+      }
+      PSSearch domain = created.get(0);
+      applyWritableFields(domain, body);
+      designWs.saveSearches(List.of(domain), true, session, user);
+      return toDef(domain, true);
+    } catch (WebApplicationException | IllegalStateException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("Search already exists: " + name, 409);
+      }
+      throw e;
+    } catch (PSLockErrorException e) {
+      throw new WebApplicationException(
+          "Could not create search; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("create", e);
+    } catch (PSErrorException e) {
+      log.error("Failed to create search {}", name, e);
+      throw new IllegalStateException("Failed to create search", e);
+    }
+  }
+
+  @Override
+  public SearchDef saveSearch(String idOrName, SearchDef body) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    if (!isSafeSearchKey(idOrName)) {
+      return null;
+    }
+    PSSearch existing = findPsSearchByKey(idOrName.trim());
+    if (existing == null) {
+      return null;
+    }
+    rejectViewWrite(existing);
+    IPSGuid id = existing.getGUID();
+    if (id == null) {
+      return null;
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSSearch> loaded =
+          designWs.loadSearches(List.of(id), true, false, session, user);
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        return null;
+      }
+      PSSearch domain = loaded.get(0);
+      applyWritableFields(domain, body);
+      designWs.saveSearches(List.of(domain), true, session, user);
+      return toDef(domain, true);
+    } catch (WebApplicationException | IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, id)) {
+        return null;
+      }
+      throw new WebApplicationException(
+          "Could not update search; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("update", e);
+    }
+  }
+
+  @Override
+  public boolean deleteSearch(String idOrName) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (!isSafeSearchKey(idOrName)) {
+      return false;
+    }
+    PSSearch existing = findPsSearchByKey(idOrName.trim());
+    if (existing == null) {
+      return false;
+    }
+    rejectViewWrite(existing);
+    IPSGuid id = existing.getGUID();
+    if (id == null) {
+      return false;
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSSearch> locked =
+          designWs.loadSearches(List.of(id), true, false, session, user);
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        throw new WebApplicationException(
+            "Could not delete search; design lock required or held by another user", 409);
+      }
+      designWs.deleteSearches(List.of(id), false, session, user);
+      return true;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, id)) {
+        return false;
+      }
+      throw new WebApplicationException(
+          "Could not delete search; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("delete", e);
     }
   }
 
@@ -548,6 +700,266 @@ public class SearchAdaptor implements ISearchAdaptor {
     g.setUuid(guid.getUUID());
     g.setUntypedString(guid.toStringUntyped());
     return g;
+  }
+
+  /**
+   * Apply GET-exposed writable fields: label, description, type, displayFormatId. Custom URL is
+   * persisted when type is custom; execute is never invoked from write.
+   */
+  static void applyWritableFields(PSSearch domain, SearchDef body) {
+    if (domain == null || body == null) {
+      return;
+    }
+    if (StringUtils.isNotBlank(body.getLabel())) {
+      domain.setDisplayName(body.getLabel().trim());
+    }
+    if (body.getDescription() != null) {
+      domain.setDescription(body.getDescription());
+    }
+    String type = resolveSearchType(body.getType(), false);
+    if (type != null) {
+      domain.setType(type);
+      if (PSSearch.TYPE_CUSTOMSEARCH.equals(type)) {
+        domain.setCustom(true);
+      }
+    }
+    if (StringUtils.isNotBlank(body.getDisplayFormatId())) {
+      domain.setDisplayFormatId(body.getDisplayFormatId().trim());
+    }
+    boolean custom =
+        domain.isCustomSearch()
+            || PSSearch.TYPE_CUSTOMSEARCH.equals(type);
+    if (custom && StringUtils.isNotBlank(body.getUrl())) {
+      domain.setUrl(body.getUrl().trim());
+    }
+  }
+
+  /**
+   * Map REST type aliases to {@link PSSearch} TYPE_* values. Blank on create defaults to
+   * {@link PSSearch#TYPE_STANDARDSEARCH}. View types are rejected (UI-07).
+   *
+   * @param creating when true, blank type becomes StandardSearch; when false, blank means leave
+   *     unchanged ({@code null})
+   */
+  static String resolveSearchType(String raw, boolean creating) {
+    if (StringUtils.isBlank(raw)) {
+      return creating ? PSSearch.TYPE_STANDARDSEARCH : null;
+    }
+    String t = raw.trim();
+    if (t.equalsIgnoreCase(PSSearch.TYPE_STANDARDSEARCH)
+        || t.equalsIgnoreCase("standard")
+        || t.equalsIgnoreCase("_standard")) {
+      return PSSearch.TYPE_STANDARDSEARCH;
+    }
+    if (t.equalsIgnoreCase(PSSearch.TYPE_CUSTOMSEARCH)
+        || t.equalsIgnoreCase("custom")
+        || t.equalsIgnoreCase("_custom")) {
+      return PSSearch.TYPE_CUSTOMSEARCH;
+    }
+    if (t.equalsIgnoreCase(PSSearch.TYPE_USERSEARCH)
+        || t.equalsIgnoreCase("user")
+        || t.equalsIgnoreCase("usersearch")) {
+      return PSSearch.TYPE_USERSEARCH;
+    }
+    if (t.equalsIgnoreCase(PSSearch.TYPE_VIEW) || t.equalsIgnoreCase("view")) {
+      throw new IllegalArgumentException(
+          "Views are not writable on /services/searches; use /services/views");
+    }
+    throw new IllegalArgumentException("Invalid search type: " + raw);
+  }
+
+  static String requireValidName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String name = raw.trim();
+    if (containsWhitespace(name)) {
+      throw new IllegalArgumentException("name cannot contain whitespace");
+    }
+    if (name.contains("*") || name.contains("%")) {
+      throw new IllegalArgumentException("name must not contain wildcards");
+    }
+    if (!isSafeSearchKey(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    if (name.length() > PSSearch.INTERNALNAME_LENGTH) {
+      throw new IllegalArgumentException(
+          "name must not exceed " + PSSearch.INTERNALNAME_LENGTH + " characters");
+    }
+    return name;
+  }
+
+  private static boolean containsWhitespace(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isWhitespace(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void assertNameUnique(String name) {
+    try {
+      if (nameExists(designWs.findSearches(name, null), name)
+          || nameExists(designWs.findViews(name, null), name)) {
+        throw new WebApplicationException("Search already exists: " + name, 409);
+      }
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorException e) {
+      log.error("Failed to catalog searches while checking uniqueness for {}", name, e);
+      throw new IllegalStateException("Failed to catalog searches", e);
+    }
+  }
+
+  static boolean nameExists(List<IPSCatalogSummary> summaries, String name) {
+    if (summaries == null || StringUtils.isBlank(name)) {
+      return false;
+    }
+    for (IPSCatalogSummary summary : summaries) {
+      if (summary != null
+          && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void rejectViewWrite(PSSearch existing) {
+    if (existing != null && existing.isView()) {
+      throw new IllegalArgumentException(
+          "Views are not writable on /services/searches; use /services/views");
+    }
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private static void requireSessionUserForWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for search design write", Response.Status.FORBIDDEN);
+    }
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+
+  static boolean isAlreadyExistsFailure(IllegalArgumentException e) {
+    return e != null && StringUtils.containsIgnoreCase(e.getMessage(), "already exists");
+  }
+
+  static boolean isNotFound(PSErrorResultsException e, IPSGuid requested) {
+    if (e == null || requested == null) {
+      return false;
+    }
+    Map<IPSGuid, Object> errors = e.getErrors();
+    Map<IPSGuid, Object> results = e.getResults();
+    boolean errored = errors != null && errors.containsKey(requested);
+    boolean hasResult = results != null && results.containsKey(requested);
+    return errored && !hasResult && !hasLockError(e);
+  }
+
+  static boolean hasLockError(PSErrorResultsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isNotLockedError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isDependencyError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return StringUtils.containsIgnoreCase(e != null ? e.getMessage() : null, "depend");
+    }
+    for (Object err : e.getErrors().values()) {
+      String msg = errorMessage(err);
+      if (StringUtils.containsIgnoreCase(msg, "depend")) {
+        return true;
+      }
+    }
+    return StringUtils.containsIgnoreCase(e.getMessage(), "depend");
+  }
+
+  private static boolean isLockErrorObject(Object err) {
+    if (err instanceof PSLockErrorException) {
+      return true;
+    }
+    if (err instanceof PSErrorException pe) {
+      String msg = pe.getErrorMessage() != null ? pe.getErrorMessage() : pe.getMessage();
+      return StringUtils.containsIgnoreCase(msg, "is not locked")
+          || StringUtils.containsIgnoreCase(msg, "not locked for");
+    }
+    return StringUtils.containsIgnoreCase(String.valueOf(err), "is not locked");
+  }
+
+  private static String errorMessage(Object err) {
+    if (err instanceof PSErrorException pe) {
+      return StringUtils.defaultIfBlank(pe.getErrorMessage(), pe.getMessage());
+    }
+    return err != null ? String.valueOf(err) : null;
+  }
+
+  private RuntimeException mapSaveOrDeleteFailure(String verb, PSErrorsException e) {
+    if (isNotLockedError(e)) {
+      return new WebApplicationException(
+          "Could not " + verb + " search; design lock required or held by another user", 409);
+    }
+    if (isDependencyError(e)) {
+      return new WebApplicationException(
+          "Search has dependents and cannot be deleted", 409);
+    }
+    log.error("Failed to {} search via UI design WS", verb, e);
+    return new IllegalStateException("Failed to " + verb + " search", e);
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorMapTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorMapTest.java
@@ -68,6 +68,9 @@ class SearchAdaptorMapTest {
     assertEquals(1, d.getFields().size());
     assertEquals("sys_title", d.getFields().get(0).getFieldName());
     assertFalse(d.getDesignGaps().isEmpty());
+    assertTrue(
+        d.getDesignGaps().stream()
+            .noneMatch(g -> g.toLowerCase().contains("create / update / delete not supported")));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorWriteTest.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSSearch;
+import com.percussion.rest.searches.SearchDef;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * UI-06 POST create / PUT update / DELETE persist via {@code createSearches}/{@code
+ * saveSearches}/{@code deleteSearches}. Admin only; unique name; no lock steal.
+ */
+@Tag("UnitTest")
+class SearchAdaptorWriteTest {
+
+  private IPSUiDesignWs designWs;
+  private SearchAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    designWs = mock(IPSUiDesignWs.class);
+    adaptor =
+        new SearchAdaptor(
+            designWs, mock(IPSFolderHelper.class), mock(IPSIdMapper.class), () -> true);
+    guid = mock(IPSGuid.class);
+    when(guid.toString()).thenReturn("0-301-42");
+    when(guid.toStringUntyped()).thenReturn("42");
+    when(guid.getHostId()).thenReturn(0L);
+    when(guid.longValue()).thenReturn(42L);
+    when(guid.getType()).thenReturn((short) 301);
+    when(guid.getUUID()).thenReturn(42);
+    when(designWs.findSearches(any(), isNull())).thenReturn(List.of());
+    when(designWs.findViews(any(), isNull())).thenReturn(List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void create_usesCreateThenSaveAndReleasesLock() throws Exception {
+    PSSearch search = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    when(search.getLabel()).thenReturn("My Search");
+    when(search.getDescription()).thenReturn("created via REST");
+    when(designWs.createSearches(
+            eq(List.of("MySearch")),
+            eq(List.of(PSSearch.TYPE_STANDARDSEARCH)),
+            eq("test-session"),
+            eq("Admin")))
+        .thenReturn(List.of(search));
+
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+    body.setLabel("My Search");
+    body.setDescription("created via REST");
+    body.setDisplayFormatId("1");
+
+    SearchDef out = adaptor.createSearch(body);
+
+    assertEquals("MySearch", out.getName());
+    assertEquals("My Search", out.getLabel());
+    assertEquals("created via REST", out.getDescription());
+    verify(designWs)
+        .createSearches(
+            eq(List.of("MySearch")),
+            eq(List.of(PSSearch.TYPE_STANDARDSEARCH)),
+            eq("test-session"),
+            eq("Admin"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSSearch>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveSearches(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    verify(search).setDisplayName("My Search");
+    verify(search).setDescription("created via REST");
+    verify(search).setDisplayFormatId("1");
+  }
+
+  @Test
+  void create_duplicateName_is409BeforeCreate() throws Exception {
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("MySearch");
+    when(designWs.findSearches(eq("MySearch"), isNull())).thenReturn(List.of(existing));
+
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSearch(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
+    verify(designWs, never()).saveSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_persistTimeDuplicate_is409() throws Exception {
+    when(designWs.createSearches(
+            eq(List.of("MySearch")),
+            eq(List.of(PSSearch.TYPE_STANDARDSEARCH)),
+            eq("test-session"),
+            eq("Admin")))
+        .thenThrow(
+            new IllegalArgumentException("The name 'MySearch' for type 'SEARCH_DEF' already exists."));
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSearch(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_blankName_throwsBeforeDesignWs() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createSearch(null));
+    SearchDef blank = new SearchDef();
+    blank.setName("  ");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createSearch(blank));
+    assertTrue(ex.getMessage().contains("name is required"));
+    verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void create_nameWithSpaces_throwsBeforeDesignWs() {
+    SearchDef body = new SearchDef();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createSearch(body));
+    assertEquals("name cannot contain whitespace", ex.getMessage());
+    verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void create_wildcardName_throwsBeforeDesignWs() {
+    SearchDef body = new SearchDef();
+    body.setName("My*Search");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createSearch(body));
+    assertEquals("name must not contain wildcards", ex.getMessage());
+  }
+
+  @Test
+  void create_viewType_is400() {
+    SearchDef body = new SearchDef();
+    body.setName("MyView");
+    body.setType("View");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createSearch(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("view"));
+    verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void create_nonAdmin_is403() {
+    adaptor =
+        new SearchAdaptor(
+            designWs, mock(IPSFolderHelper.class), mock(IPSIdMapper.class), () -> false);
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSearch(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void create_missingSession_is403() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSearch(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("session"), ex.getMessage());
+  }
+
+  @Test
+  void update_loadsWithLockNoStealAndSavesFields() throws Exception {
+    PSSearch existing = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    stubCatalogLoad(existing, false);
+    PSSearch locked = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    when(designWs.loadSearches(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    SearchDef body = new SearchDef();
+    body.setLabel("Updated");
+    body.setDescription("new desc");
+    body.setType("StandardSearch");
+    body.setDisplayFormatId("2");
+
+    SearchDef out = adaptor.saveSearch("MySearch", body);
+
+    assertEquals("MySearch", out.getName());
+    verify(locked).setDisplayName("Updated");
+    verify(locked).setDescription("new desc");
+    verify(locked).setDisplayFormatId("2");
+    verify(designWs).saveSearches(anyList(), eq(true), eq("test-session"), eq("Admin"));
+    verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
+    verify(designWs)
+        .loadSearches(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_unknown_returnsNull() throws Exception {
+    when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of());
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
+    SearchDef body = new SearchDef();
+    body.setLabel("Updated");
+    assertNull(adaptor.saveSearch("missing", body));
+    verify(designWs, never()).saveSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_view_is400() throws Exception {
+    PSSearch view = stubSearch("View_All", PSSearch.TYPE_VIEW);
+    when(view.isView()).thenReturn(true);
+    stubCatalogLoad(view, true);
+    SearchDef body = new SearchDef();
+    body.setLabel("All");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.saveSearch("View_All", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("view"));
+    verify(designWs, never()).saveSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_lockConflict_is409() throws Exception {
+    PSSearch existing = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    stubCatalogLoad(existing, false);
+    when(designWs.loadSearches(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.saveSearch("MySearch", new SearchDef()));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_nonAdmin_is403() {
+    adaptor =
+        new SearchAdaptor(
+            designWs, mock(IPSFolderHelper.class), mock(IPSIdMapper.class), () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.saveSearch("MySearch", new SearchDef()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void delete_thenFindIsMissing() throws Exception {
+    PSSearch existing = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    stubCatalogLoad(existing, false);
+    when(designWs.loadSearches(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(existing));
+
+    assertTrue(adaptor.deleteSearch("MySearch"));
+    verify(designWs)
+        .deleteSearches(eq(List.of(guid)), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void delete_unknown_returnsFalse() throws Exception {
+    when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of());
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
+    assertFalse(adaptor.deleteSearch("missing"));
+    verify(designWs, never()).deleteSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_lockConflict_is409() throws Exception {
+    PSSearch existing = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    stubCatalogLoad(existing, false);
+    when(designWs.loadSearches(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteSearch("MySearch"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_dependents_is409() throws Exception {
+    PSSearch existing = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    stubCatalogLoad(existing, false);
+    when(designWs.loadSearches(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(existing));
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(guid, new PSErrorException("Object has dependents"));
+    doThrow(errors).when(designWs).deleteSearches(anyList(), eq(false), any(), any());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteSearch("MySearch"));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("depend"), ex.getMessage());
+  }
+
+  @Test
+  void delete_nonAdmin_is403() {
+    adaptor =
+        new SearchAdaptor(
+            designWs, mock(IPSFolderHelper.class), mock(IPSIdMapper.class), () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteSearch("MySearch"));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void resolveSearchType_defaultsAndAliases() {
+    assertEquals(PSSearch.TYPE_STANDARDSEARCH, SearchAdaptor.resolveSearchType(null, true));
+    assertNull(SearchAdaptor.resolveSearchType(null, false));
+    assertEquals(PSSearch.TYPE_STANDARDSEARCH, SearchAdaptor.resolveSearchType("standard", true));
+    assertEquals(PSSearch.TYPE_CUSTOMSEARCH, SearchAdaptor.resolveSearchType("custom", false));
+    assertEquals(PSSearch.TYPE_USERSEARCH, SearchAdaptor.resolveSearchType("Search", true));
+    assertThrows(IllegalArgumentException.class, () -> SearchAdaptor.resolveSearchType("View", true));
+    assertThrows(IllegalArgumentException.class, () -> SearchAdaptor.resolveSearchType("nope", true));
+  }
+
+  @Test
+  void requireValidName_rejectsSpacesAndWildcards() {
+    assertEquals("MySearch", SearchAdaptor.requireValidName("MySearch"));
+    assertThrows(IllegalArgumentException.class, () -> SearchAdaptor.requireValidName("  "));
+    assertThrows(IllegalArgumentException.class, () -> SearchAdaptor.requireValidName("has space"));
+    assertThrows(IllegalArgumentException.class, () -> SearchAdaptor.requireValidName("x*y"));
+  }
+
+  private PSSearch stubSearch(String name, String type) {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getName()).thenReturn(name);
+    when(s.getLabel()).thenReturn(name);
+    when(s.getDescription()).thenReturn("");
+    when(s.getType()).thenReturn(type);
+    when(s.getDisplayFormatId()).thenReturn("1");
+    when(s.getUrl()).thenReturn(null);
+    when(s.getParentCategory()).thenReturn(1);
+    when(s.getMaximumResultSize()).thenReturn(100);
+    when(s.isUserSearch()).thenReturn(PSSearch.TYPE_USERSEARCH.equals(type));
+    when(s.isCustomSearch()).thenReturn(PSSearch.TYPE_CUSTOMSEARCH.equals(type));
+    when(s.isCustomView()).thenReturn(false);
+    when(s.isView()).thenReturn(PSSearch.TYPE_VIEW.equals(type));
+    when(s.isStandardSearch()).thenReturn(PSSearch.TYPE_STANDARDSEARCH.equals(type));
+    when(s.isUserCustomizable()).thenReturn(false);
+    when(s.isCaseSensitive()).thenReturn(false);
+    when(s.getFieldContainer()).thenReturn(null);
+    when(s.getGUID()).thenReturn(guid);
+    when(s.getId()).thenReturn(42);
+    return s;
+  }
+
+  private void stubCatalogLoad(PSSearch search, boolean asView) throws Exception {
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    if (asView) {
+      when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of());
+      when(designWs.findViews(isNull(), isNull())).thenReturn(List.of(sum));
+      when(designWs.loadViews(anyList(), eq(false), eq(false), any(), any()))
+          .thenReturn(List.of(search));
+    } else {
+      when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of(sum));
+      when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
+      when(designWs.loadSearches(anyList(), eq(false), eq(false), any(), any()))
+          .thenReturn(List.of(search));
+    }
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/searches/ISearchAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/searches/ISearchAdaptor.java
@@ -6,7 +6,12 @@ package com.percussion.rest.searches;
 
 import java.util.List;
 
-/** Adaptor for CX search design catalog (UI-06 read) and design-search execute façade. */
+/**
+ * Adaptor for CX search design catalog (UI-06 read/write) and design-search execute façade.
+ *
+ * <p>Write methods persist through {@code IPSUiDesignWs} create/save/delete searches. Execute is
+ * unchanged and is not invoked from write.
+ */
 public interface ISearchAdaptor {
 
   List<SearchDef> listSearches();
@@ -37,4 +42,31 @@ public interface ISearchAdaptor {
    *     (e.g. custom URL searches)
    */
   SearchExecuteResult executeSearch(String idOrName, SearchExecuteRequest request);
+
+  /**
+   * Admin. Create and persist a CX search ({@code createSearches} then {@code saveSearches}).
+   *
+   * @param body required; {@code name} is the unique catalog key
+   * @return the persisted search
+   */
+  SearchDef createSearch(SearchDef body);
+
+  /**
+   * Admin. Update and persist a CX search by name or GUID ({@code loadSearches} lock, {@code
+   * saveSearches} release). Does not steal another user's lock.
+   *
+   * @param idOrName catalog key (same rules as {@link #findSearchByKey})
+   * @param body required writable fields (label, description, type, displayFormat)
+   * @return the persisted search, or {@code null} when missing/unsafe
+   */
+  SearchDef saveSearch(String idOrName, SearchDef body);
+
+  /**
+   * Admin. Delete a CX search by name or GUID ({@code deleteSearches}, {@code
+   * ignoreDependencies=false}). Does not steal another user's lock.
+   *
+   * @param idOrName catalog key (same rules as {@link #findSearchByKey})
+   * @return {@code true} when deleted, {@code false} when missing/unsafe
+   */
+  boolean deleteSearch(String idOrName);
 }

--- a/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
+++ b/rest/src/main/java/com/percussion/rest/searches/SearchResource.java
@@ -12,8 +12,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -27,16 +29,19 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * CX search design catalog (UI-06 list/detail) plus design-search execute façade for Explorer.
+ * CX search design catalog (UI-06 list/detail/write) plus design-search execute façade for
+ * Explorer.
  *
- * <p>Developer list is searches-only. Explorer saved-search picker uses {@code
- * includeViews=true} so CX views (including {@code View_All}) appear. Dedicated view
- * management remains on {@code /services/views}.
+ * <p>Developer list is searches-only. Explorer saved-search picker uses {@code includeViews=true}
+ * so CX views (including {@code View_All}) appear. Dedicated view management remains on {@code
+ * /services/views}. Admin POST/PUT/DELETE persist through {@link ISearchAdaptor} ({@code
+ * IPSUiDesignWs} create/save/delete searches). Execute is a separate façade and is not invoked
+ * from write.
  */
 @PSSiteManageBean(value = "restSearchResource")
 @Path("/searches")
 @XmlRootElement
-@Tag(name = "Searches", description = "CX search design catalog and design-search execute")
+@Tag(name = "Searches", description = "CX search design catalog, write, and design-search execute")
 public class SearchResource {
 
   private final ISearchAdaptor adaptor;
@@ -57,7 +62,7 @@ public class SearchResource {
       description =
           "Lists Content Explorer search definitions. Pass includeViews=true to also return CX"
               + " views (Explorer saved-search picker, including the default All / View_All"
-              + " view). Create/edit/delete are later slices.",
+              + " view). Admin create/save/delete are POST/PUT/DELETE on this resource.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -85,8 +90,8 @@ public class SearchResource {
   @Operation(
       summary = "Get search detail",
       description =
-          "Loads one search by name or GUID string. Field criteria included when present. Write"
-              + " remains unsupported.",
+          "Loads one search by name or GUID string. Field criteria included when present. Admin"
+              + " write is POST/PUT/DELETE on this resource.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -152,6 +157,146 @@ public class SearchResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  @POST
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Create search",
+      description =
+          "Admin. Creates and persists a CX search via IPSUiDesignWs.createSearches then"
+              + " saveSearches (held design lock, released on save). Name is required, unique"
+              + " (case-insensitive), and must not contain whitespace or wildcards. Optional"
+              + " label, description, type (StandardSearch default; CustomSearch; Search), and"
+              + " displayFormatId are applied before save. Duplicate name is 409. Views are not"
+              + " created here (use /services/views). Execute is not invoked on write.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = SearchDef.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "409", description = "A search with that name already exists"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public SearchDef createSearch(SearchDef body) {
+    try {
+      if (body != null) {
+        body.setGuid(null);
+        body.setId(0);
+      }
+      SearchDef created = requireAdaptor().createSearch(body);
+      if (created == null) {
+        throw new WebApplicationException("Failed to create search", 500);
+      }
+      return created;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Update search",
+      description =
+          "Admin. Updates label, description, type, and/or displayFormatId by name or GUID. Name"
+              + " is the catalog key and is not renamed on PUT. Loads with a design lock"
+              + " (overrideLock=false) and releases on save. Unknown id is 404. Lock/dependency"
+              + " conflict is 409. Views are not saved here. Execute is not invoked on write.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = SearchDef.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Search not found"),
+        @ApiResponse(responseCode = "409", description = "Design lock or dependency conflict"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public SearchDef updateSearch(@PathParam("idOrName") String idOrName, SearchDef body) {
+    try {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      SearchDef updated = requireAdaptor().saveSearch(idOrName, body);
+      if (updated == null) {
+        throw new WebApplicationException("Search not found", 404);
+      }
+      return updated;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete search",
+      description =
+          "Admin. Deletes a CX search by name or GUID via IPSUiDesignWs.deleteSearches"
+              + " (ignoreDependencies=false). Unknown id is 404. Lock/dependency conflict is 409."
+              + " Following GET is 404 after a successful delete. Views are not deleted here.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Search not found"),
+        @ApiResponse(responseCode = "409", description = "Design lock or dependency conflict"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteSearch(@PathParam("idOrName") String idOrName) {
+    try {
+      boolean deleted = requireAdaptor().deleteSearch(idOrName);
+      if (!deleted) {
+        throw new WebApplicationException("Search not found", 404);
+      }
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Admin/session 403 and duplicate 409 are already
+   * {@link WebApplicationException}s from the adaptor.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    if (e instanceof IllegalStateException) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      String lower = msg.toLowerCase();
+      if (lower.contains("lock") || lower.contains("depend")) {
+        return new WebApplicationException(msg, 409);
+      }
+      return new WebApplicationException(e, 500);
+    }
+    return new WebApplicationException(e, 500);
   }
 
   private ISearchAdaptor requireAdaptor() {

--- a/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
@@ -5,6 +5,7 @@
 package com.percussion.rest.searches;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,10 +13,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -196,6 +199,126 @@ public class SearchResourceTest {
         assertThrows(
             WebApplicationException.class,
             () -> bare.executeSearch("any", new SearchExecuteRequest()));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createSearchClearsIdAndDelegates() {
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+    body.setId(9);
+    SearchDef created = new SearchDef();
+    created.setName("MySearch");
+    created.setId(42);
+    when(adaptor.createSearch(any())).thenReturn(created);
+
+    SearchDef out = resource.createSearch(body);
+
+    assertEquals("MySearch", out.getName());
+    assertEquals(0, body.getId());
+    assertNull(body.getGuid());
+    verify(adaptor).createSearch(body);
+  }
+
+  @Test
+  public void createSearchBlankNameIs400() {
+    when(adaptor.createSearch(any())).thenThrow(new IllegalArgumentException("name is required"));
+    SearchDef body = new SearchDef();
+    body.setName("  ");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createSearch(body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createSearchDuplicateIs409() {
+    when(adaptor.createSearch(any()))
+        .thenThrow(new WebApplicationException("Search already exists: MySearch", 409));
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createSearch(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createSearchNonAdminIs403() {
+    when(adaptor.createSearch(any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createSearch(body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateSearchDelegates() {
+    SearchDef body = new SearchDef();
+    body.setLabel("Updated");
+    body.setDescription("desc");
+    SearchDef updated = new SearchDef();
+    updated.setName("MySearch");
+    updated.setLabel("Updated");
+    updated.setDescription("desc");
+    when(adaptor.saveSearch(eq("MySearch"), eq(body))).thenReturn(updated);
+
+    SearchDef out = resource.updateSearch("MySearch", body);
+
+    assertEquals("Updated", out.getLabel());
+    assertEquals("desc", out.getDescription());
+    verify(adaptor).saveSearch("MySearch", body);
+  }
+
+  @Test
+  public void updateSearchUnknownIs404() {
+    when(adaptor.saveSearch(eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateSearch("missing", new SearchDef()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateSearchNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.updateSearch("MySearch", null));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).saveSearch(any(), any());
+  }
+
+  @Test
+  public void deleteSearchNoContent() {
+    when(adaptor.deleteSearch(eq("MySearch"))).thenReturn(true);
+
+    Response r = resource.deleteSearch("MySearch");
+
+    assertEquals(204, r.getStatus());
+    verify(adaptor).deleteSearch("MySearch");
+  }
+
+  @Test
+  public void deleteSearchUnknownIs404() {
+    when(adaptor.deleteSearch(eq("missing"))).thenReturn(false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteSearch("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteSearchNonAdminIs403() {
+    when(adaptor.deleteSearch(eq("MySearch")))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteSearch("MySearch"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnCreate() {
+    SearchResource bare = new SearchResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.createSearch(new SearchDef()));
     assertEquals(503, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSearchAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSearchAdaptor.java
@@ -22,10 +22,12 @@ import com.percussion.rest.searches.SearchDef;
 import com.percussion.rest.searches.SearchExecuteRequest;
 import com.percussion.rest.searches.SearchExecuteResult;
 import java.util.List;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
-/** Test adaptor for Search API bridge (MainTest Spring context). */
+/** Spring test stub for {@link ISearchAdaptor}. Required for ApplicationContext load. */
 @Component
+@Lazy
 public class TestSearchAdaptor implements ISearchAdaptor {
 
   @Override
@@ -57,5 +59,20 @@ public class TestSearchAdaptor implements ISearchAdaptor {
     empty.setTotalCount(0);
     empty.setStartIndex(1);
     return empty;
+  }
+
+  @Override
+  public SearchDef createSearch(SearchDef body) {
+    return body;
+  }
+
+  @Override
+  public SearchDef saveSearch(String idOrName, SearchDef body) {
+    return body;
+  }
+
+  @Override
+  public boolean deleteSearch(String idOrName) {
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

Parent **#1690** (UI-06). Public REST can create, save, and delete CX search definitions through existing `IPSUiDesignWs` (`createSearches` / `loadSearches` / `saveSearches` / `deleteSearches`). Execute (`POST …/execute`) is unchanged and is not invoked on write. No Developer Searches SPA.

Admin `POST /services/searches`, `PUT /services/searches/{idOrName}`, `DELETE /services/searches/{idOrName}`:

- Unique name (no whitespace/wildcards); duplicate **409**
- Invalid **400**; missing **404**; non-Admin **403**
- Design lock is held and released on save; `overrideLock=false` (no lock steal)
- PUT round-trips GET-exposed label / description / type / displayFormat; name is the catalog key (not renamed)
- Views stay on `/services/views`

Fixes #4069

## Test plan

1. Mockito: `SearchResourceTest` maps 200/204/400/403/404/409/503 for create/save/delete; existing execute tests still pass.
2. Spring: `TestSearchAdaptor` stubs new `ISearchAdaptor` write methods so `MainTest` context loads.
3. Adaptor: `SearchAdaptorWriteTest` covers create→save (lock released), duplicate 409, spaces/wildcards 400, View type 400, non-Admin 403, missing session 403, PUT lock-no-steal, DELETE 204/404/409.
4. Standalone `cd rest && ../mvnw.cmd clean install` then `cd projects/sitemanage && ../../mvnw.cmd clean install`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` Searches write contract
- [x] **Unit / module tests** — behavioral tests for new/changed logic; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST only)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: **914**, Failures: 0, Errors: 0, Skipped: 0. `SearchResourceTest` Tests run: **27**, Failures: 0.
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: **1968**, Failures: 0, Errors: 0, Skipped: 125 (baseline). `SearchAdaptorWriteTest` Tests run: **21**, Failures: 0. `SearchAdaptorExecuteTest` Tests run: **28**, Failures: 0.
- **downstream_checked:** `ISearchAdaptor` gained write methods (additive). Grep `implements ISearchAdaptor` → `SearchAdaptor` + `TestSearchAdaptor` only. Reverse-dep `projects/sitemanage` standalone clean install green.
- **C5 UI proof:** N/A (no SPA / WebUI chrome)

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
