### PR TITLE
feat(rest): UI-07 view create/save/delete (#4070)

### DIFF
--- a/docs/ai-generated/code-reviews/4070-rest-view-write-erlang.md
+++ b/docs/ai-generated/code-reviews/4070-rest-view-write-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review: #4070 REST UI-07 view write
+
+**Branch:** `feat/issue-4070-rest-view-write`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Change class:** public REST adaptor write surface (`rest` resource + `IViewAdaptor` + sitemanage apibridge + Spring test stub + product-docs)  
+**Memory patterns hit:** incomplete change-class closure; rest `MainTest` Spring stub exact adaptor type; focused `-Dtest` not sufficient without module suite
+
+## Summary
+
+Admin POST/PUT/DELETE on `/services/views` persist CX standard (field-criteria) views through existing `IPSUiDesignWs` (`createViews` / `loadViews` / `saveViews` / `deleteViews`). Execute is unchanged. Inbox/system custom-URL views are 409 on write. Duplicate 409, invalid 400, missing 404, non-Admin 403. Peer is searches write (#4069 / PR #4075).
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None.
+
+## Companions (closure)
+
+| Artifact | Status |
+|----------|--------|
+| `IViewAdaptor` create/save/delete | present |
+| `ViewResource` POST/PUT/DELETE + status mapping | present |
+| Mockito `ViewResourceTest` | present (30 tests, write + existing execute) |
+| Spring `TestViewAdaptor` exact `IViewAdaptor` | present |
+| `ViewAdaptor` persist, `overrideLock=false`, no execute on write | present |
+| `ViewAdaptorWriteTest` | present (24 tests) |
+| `product-docs/8.2/developer/rest.md` write contract (no SPA claim) | present |
+| Standalone `rest` + `projects/sitemanage` clean install | BUILD SUCCESS |
+
+## Cross-platform path checklist
+
+N/A — no filesystem path/file I/O in this diff. Catalog keys still reject `/` `\` `..` as unsafe view keys (URL-style, not OS join).
+
+## Tests / evidence
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS. Tests run: 927, Failures: 0. `ViewResourceTest` Tests run: 30.
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS. Tests run: 1992, Failures: 0, Errors: 0, Skipped: 125 (baseline). `ViewAdaptorWriteTest` Tests run: 24. `ViewAdaptorExecuteTest` Tests run: 31.
+- C2: `IViewAdaptor` gained additive write methods. Grep `implements IViewAdaptor` → `ViewAdaptor` + `TestViewAdaptor` only. Reverse-dep sitemanage standalone install green.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1406,6 +1406,11 @@ List and detail include a nested `guid` (`PSTypeEnum.VIEW_DEF` = 18, string form
 `0-18-{viewId}`) so clients can load **Object ACL**. Unwrap Jackson `ViewDef` envelopes
 and read `guid.stringValue` or synthesize from `id` when the Guid is omitted.
 
+Admin **write** persists through `IPSUiDesignWs` (`createViews` / `loadViews` / `saveViews` /
+`deleteViews`) — the same design web service SOAP uses. There is no new SOAP surface.
+**Do not** treat this as a Developer Views SPA; chrome for create/save/delete is a later
+sibling. Execute is **not** invoked when creating, updating, or deleting a view.
+
 Operators open Inbox from Explorer **Views → My Content → Inbox** (see
 [Content Explorer](id:admin-content-explorer)). Integrators run the same assignment list
 with the execute call below. `GET /services/views` includes the Inbox design view (name
@@ -1416,6 +1421,9 @@ collapses sibling CX views to `View_All`.
 |--------|------|---------|
 | `GET` | `/services/views` | List view definitions (name, category, standard vs custom URL; includes `guid`) |
 | `GET` | `/services/views/{idOrName}` | Load one view by name, numeric id, or GUID string (includes `guid` for Object ACL) |
+| `POST` | `/services/views` | **Admin.** Create a standard (field-criteria) view (`createViews` then `saveViews`) |
+| `PUT` | `/services/views/{idOrName}` | **Admin.** Update label, description, type, and/or display format |
+| `DELETE` | `/services/views/{idOrName}` | **Admin.** Delete a user/standard view (`deleteViews`, `ignoreDependencies=false`) |
 | `POST` | `/services/views/{idOrName}/execute` | Execute a **standard** (field-criteria) view or an Inbox-family **custom URL** view |
 
 ### Execute request / response
@@ -1453,9 +1461,12 @@ Successful response is a paged envelope: `children[]` (Explorer-ready rows with 
 
 | Status | Typical meaning |
 |--------|-----------------|
-| `200` | List / get / execute success |
-| `400` | Invalid execute body, or an **unsupported** custom URL view |
+| `200` | List / get / create / update / execute success |
+| `204` | Delete success |
+| `400` | Invalid input (missing name, whitespace/wildcard name, invalid or search type, custom URL on create), invalid execute body, or an **unsupported** custom URL view |
+| `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | View not found or unsafe key (blank, path separators, `..`) |
+| `409` | Duplicate name, design lock held by another user, dependents, or Inbox/system custom URL write |
 | `500` | Design or execute engine failure (standard views) |
 | `503` | Views adaptor not configured, or custom-view backend unavailable |
 
@@ -1483,12 +1494,61 @@ unavailable `sys_cxViews` resource returns **`503`**, not **`500`**.
 Standard field-criteria views (`standardView`) still execute with the same design operators,
 display format, max results, and case sensitivity stored on the view design.
 
+### View write contract (Admin)
+
+Create (`POST /services/views`) persists immediately (Workbench Finish, not an unsaved
+stub). JSON body requires `name` (unique across views **and** searches, case-insensitive;
+**no whitespace** or wildcards). Optional `label`, `description`, `type`, and
+`displayFormatId` are applied before save. Default `type` is `View`. Accepted types:
+`View` (`standard`, `standardView`). Search types (`StandardSearch`, `Search`) are
+**400** — searches stay on `/services/searches`. Custom URL (`url` set, or type
+`custom` / `CustomView`) is **400**. Duplicate name is **409**. Blank /
+whitespace / wildcard names are **400**. Missing request session/user is **403**.
+Non-Admin is **403**. The new view is then `GET /services/views/{name}` **200**.
+
+Update (`PUT /services/views/{idOrName}`) loads with a design lock (`overrideLock=false`)
+and releases it on save. Name is not renamed on PUT. Omitted label / description / type /
+display format leave stored values unchanged. Unknown id/name is **404**. Inbox-family
+and other custom URL views are **409** (not mutated; the lock is not stolen).
+Locked-by-another-user is **409**. Non-Admin is **403**.
+
+Delete (`DELETE /services/views/{idOrName}`) returns **204** when removed; a following
+`GET` is **404**. Unknown id/name is **404**. Inbox-family and other custom URL views are
+**409** (not deleted). Dependents or a lock held by another user are **409**. Non-Admin
+is **403**.
+
+Create/update load or create the view with a **held design lock** and release it on
+save. There is no separate lock/unlock REST pair on this catalog. Field criterion
+editing is not supported on write. Execute (`POST …/execute`) is unchanged.
+
+JSON objects use the `ViewDef` wire type. POST/PUT JSON is wrapped under a `ViewDef`
+root (JAXB/Jackson UNWRAP_ROOT_VALUE). Prefer the generated OpenAPI schema as the
+integration source of truth.
+
+Example create body:
+
+```json
+{
+  "ViewDef": {
+    "name": "MyView",
+    "label": "My View",
+    "description": "Created via REST",
+    "type": "View",
+    "displayFormatId": "1"
+  }
+}
+```
+
 ### Integrator notes
 
 - Keys may be the view **name**, numeric **id**, or GUID string (including untyped GUID).
-- Create / update / delete of view designs is not supported on this API (`designGaps` on detail).
-- The Developer SPA lists views via `GET`. Operator Inbox run-from-tree is Explorer
-  **Views → My Content → Inbox**, not a free-floating Inbox root.
+- Admin write is POST/PUT/DELETE on this resource. Inbox-family and custom URL views
+  cannot be updated or deleted (`409`). Field criterion editing remains a `designGaps`
+  note on detail.
+- This catalog is REST only. There is no Developer Views SPA create/save/delete in this
+  release.
+- Operator Inbox run-from-tree is Explorer **Views → My Content → Inbox**, not a
+  free-floating Inbox root.
 
 ## Workflows (design catalog)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -26,12 +26,19 @@ import com.percussion.share.dao.IPSFolderHelper;
 import com.percussion.share.data.PSItemProperties;
 import com.percussion.share.data.PSPagedObjectList;
 import com.percussion.share.service.IPSIdMapper;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.data.PSInternalRequestCallException;
 import com.percussion.server.PSInternalRequest;
 import com.percussion.server.PSServer;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.PSWebserviceUtils;
 import com.percussion.webservices.ui.IPSUiDesignWs;
 import jakarta.ws.rs.WebApplicationException;
@@ -44,6 +51,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,9 +62,11 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 /**
- * CX view definition catalog (UI-07) plus view execute façade for Explorer (#3115 / #3239). Loads
- * designs via {@link IPSUiDesignWs#findViews} / {@link IPSUiDesignWs#loadViews} — not the search
- * catalog. Standard views use the design search runner; Inbox-family custom URLs invoke {@code
+ * CX view definition catalog (UI-07 list/detail/write) plus view execute façade for Explorer
+ * (#3115 / #3239 / #4070). Loads designs via {@link IPSUiDesignWs#findViews} / {@link
+ * IPSUiDesignWs#loadViews} — not the search catalog. Admin create/save/delete persist through
+ * {@link IPSUiDesignWs} — the same design web service SOAP uses. Execute is not invoked on write.
+ * Standard views use the design search runner; Inbox-family custom URLs invoke {@code
  * sys_cxViews/*} and map {@code Item} rows to Explorer items.
  */
 @PSSiteManageBean
@@ -64,6 +74,11 @@ import org.w3c.dom.NodeList;
 public class ViewAdaptor implements IViewAdaptor {
 
   private static final Logger log = LogManager.getLogger(ViewAdaptor.class);
+
+  static final String ADMIN_REQUIRED = "Admin role required to create, update, or delete views";
+
+  static final String PROTECTED_VIEW_WRITE =
+      "Inbox-family and custom URL views cannot be updated or deleted via this API";
 
   /** Product default page size when design max is unset/unlimited and client omits maxResults. */
   static final int DEFAULT_PAGE_SIZE = 25;
@@ -93,8 +108,9 @@ public class ViewAdaptor implements IViewAdaptor {
   /** Catalog-level capability notes. Attached on detail only (REST-GAPS-02 list dedup). */
   static final List<String> DESIGN_GAPS =
       List.of(
-          "View create / update / delete not supported via this API",
           "View field criterion editing not supported via this API",
+          "View rename is not supported on PUT (name is the catalog key)",
+          "Inbox-family and custom URL views cannot be updated or deleted via this API",
           "Custom URL views outside the sys_cxViews Inbox family cannot be executed via this API",
           "Searches are a separate catalog (Developer Searches / UI-06)");
 
@@ -104,13 +120,28 @@ public class ViewAdaptor implements IViewAdaptor {
   private final IPSUiDesignWs designWs;
   private final IPSFolderHelper folderHelper;
   private final IPSIdMapper idMapper;
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   @Autowired
   public ViewAdaptor(
       IPSUiDesignWs designWs, IPSFolderHelper folderHelper, IPSIdMapper idMapper) {
+    this(designWs, folderHelper, idMapper, null);
+  }
+
+  /** Package-visible for unit tests. */
+  ViewAdaptor(
+      IPSUiDesignWs designWs,
+      IPSFolderHelper folderHelper,
+      IPSIdMapper idMapper,
+      BooleanSupplier adminChecker) {
     this.designWs = designWs;
     this.folderHelper = folderHelper;
     this.idMapper = idMapper;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   @Override
@@ -145,6 +176,128 @@ public class ViewAdaptor implements IViewAdaptor {
     } catch (RuntimeException e) {
       // list failures already wrap; propagate for 500
       throw e;
+    }
+  }
+
+  @Override
+  public ViewDef createView(ViewDef body) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String name = requireValidName(body.getName());
+    assertNameUnique(name);
+    rejectCustomUrlCreate(body);
+    resolveViewType(body.getType(), true);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSSearch> created = designWs.createViews(List.of(name), session, user);
+      if (created == null || created.isEmpty() || created.get(0) == null) {
+        throw new IllegalStateException("Design WS createViews returned empty");
+      }
+      PSSearch domain = created.get(0);
+      applyWritableFields(domain, body);
+      designWs.saveViews(List.of(domain), true, session, user);
+      return toDef(domain, true);
+    } catch (WebApplicationException | IllegalStateException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("View already exists: " + name, 409);
+      }
+      throw e;
+    } catch (PSLockErrorException e) {
+      throw new WebApplicationException(
+          "Could not create view; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("create", e);
+    } catch (PSErrorException e) {
+      log.error("Failed to create view {}", name, e);
+      throw new IllegalStateException("Failed to create view", e);
+    }
+  }
+
+  @Override
+  public ViewDef saveView(String idOrName, ViewDef body) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    if (!isSafeViewKey(idOrName)) {
+      return null;
+    }
+    PSSearch existing = findPsViewByKey(idOrName.trim());
+    if (existing == null) {
+      return null;
+    }
+    rejectProtectedViewWrite(existing);
+    IPSGuid id = safeGuid(existing);
+    if (id == null) {
+      throw new WebApplicationException(PROTECTED_VIEW_WRITE, 409);
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSSearch> loaded = designWs.loadViews(List.of(id), true, false, session, user);
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        return null;
+      }
+      PSSearch domain = loaded.get(0);
+      applyWritableFields(domain, body);
+      designWs.saveViews(List.of(domain), true, session, user);
+      return toDef(domain, true);
+    } catch (WebApplicationException | IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, id)) {
+        return null;
+      }
+      throw new WebApplicationException(
+          "Could not update view; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("update", e);
+    }
+  }
+
+  @Override
+  public boolean deleteView(String idOrName) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (!isSafeViewKey(idOrName)) {
+      return false;
+    }
+    PSSearch existing = findPsViewByKey(idOrName.trim());
+    if (existing == null) {
+      return false;
+    }
+    rejectProtectedViewWrite(existing);
+    IPSGuid id = safeGuid(existing);
+    if (id == null) {
+      throw new WebApplicationException(PROTECTED_VIEW_WRITE, 409);
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSSearch> locked = designWs.loadViews(List.of(id), true, false, session, user);
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        throw new WebApplicationException(
+            "Could not delete view; design lock required or held by another user", 409);
+      }
+      designWs.deleteViews(List.of(id), false, session, user);
+      return true;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, id)) {
+        return false;
+      }
+      throw new WebApplicationException(
+          "Could not delete view; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("delete", e);
     }
   }
 
@@ -732,6 +885,263 @@ public class ViewAdaptor implements IViewAdaptor {
     g.setUuid(guid.getUUID());
     g.setUntypedString(guid.toStringUntyped());
     return g;
+  }
+
+  /**
+   * Apply GET-exposed writable fields: label, description, type, displayFormatId. Execute is
+   * never invoked from write. Custom URL is not persisted on this slice.
+   */
+  static void applyWritableFields(PSSearch domain, ViewDef body) {
+    if (domain == null || body == null) {
+      return;
+    }
+    if (StringUtils.isNotBlank(body.getLabel())) {
+      domain.setDisplayName(body.getLabel().trim());
+    }
+    if (body.getDescription() != null) {
+      domain.setDescription(body.getDescription());
+    }
+    String type = resolveViewType(body.getType(), false);
+    if (type != null) {
+      domain.setType(type);
+    }
+    if (StringUtils.isNotBlank(body.getDisplayFormatId())) {
+      domain.setDisplayFormatId(body.getDisplayFormatId().trim());
+    }
+  }
+
+  /**
+   * Map REST type aliases to {@link PSSearch#TYPE_VIEW}. Blank on create defaults to View. Search
+   * and custom types are rejected.
+   *
+   * @param creating when true, blank type becomes View; when false, blank means leave unchanged
+   */
+  static String resolveViewType(String raw, boolean creating) {
+    if (StringUtils.isBlank(raw)) {
+      return creating ? PSSearch.TYPE_VIEW : null;
+    }
+    String t = raw.trim();
+    if (t.equalsIgnoreCase(PSSearch.TYPE_VIEW)
+        || t.equalsIgnoreCase("standard")
+        || t.equalsIgnoreCase("standardview")) {
+      return PSSearch.TYPE_VIEW;
+    }
+    if (t.equalsIgnoreCase("custom")
+        || t.equalsIgnoreCase("customview")
+        || t.equalsIgnoreCase(PSSearch.TYPE_CUSTOMSEARCH)) {
+      throw new IllegalArgumentException(
+          "Custom URL views cannot be created or updated via this API");
+    }
+    if (t.equalsIgnoreCase(PSSearch.TYPE_STANDARDSEARCH)
+        || t.equalsIgnoreCase(PSSearch.TYPE_USERSEARCH)
+        || t.equalsIgnoreCase("search")
+        || t.equalsIgnoreCase("usersearch")) {
+      throw new IllegalArgumentException(
+          "Searches are not writable on /services/views; use /services/searches");
+    }
+    throw new IllegalArgumentException("Invalid view type: " + raw);
+  }
+
+  static String requireValidName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String name = raw.trim();
+    if (containsWhitespace(name)) {
+      throw new IllegalArgumentException("name cannot contain whitespace");
+    }
+    if (name.contains("*") || name.contains("%")) {
+      throw new IllegalArgumentException("name must not contain wildcards");
+    }
+    if (!isSafeViewKey(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    if (name.length() > PSSearch.INTERNALNAME_LENGTH) {
+      throw new IllegalArgumentException(
+          "name must not exceed " + PSSearch.INTERNALNAME_LENGTH + " characters");
+    }
+    return name;
+  }
+
+  private static boolean containsWhitespace(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isWhitespace(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void assertNameUnique(String name) {
+    try {
+      if (nameExists(designWs.findViews(name, null), name)
+          || nameExists(designWs.findSearches(name, null), name)) {
+        throw new WebApplicationException("View already exists: " + name, 409);
+      }
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorException e) {
+      log.error("Failed to catalog views while checking uniqueness for {}", name, e);
+      throw new IllegalStateException("Failed to catalog views", e);
+    }
+  }
+
+  static boolean nameExists(List<IPSCatalogSummary> summaries, String name) {
+    if (summaries == null || StringUtils.isBlank(name)) {
+      return false;
+    }
+    for (IPSCatalogSummary summary : summaries) {
+      if (summary != null
+          && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static void rejectCustomUrlCreate(ViewDef body) {
+    if (body != null && StringUtils.isNotBlank(body.getUrl())) {
+      throw new IllegalArgumentException(
+          "Custom URL views cannot be created or updated via this API");
+    }
+  }
+
+  private static void rejectProtectedViewWrite(PSSearch existing) {
+    if (existing == null) {
+      return;
+    }
+    if (isInboxKey(existing.getName()) || existing.isCustomView()) {
+      throw new WebApplicationException(PROTECTED_VIEW_WRITE, 409);
+    }
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private static void requireSessionUserForWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for view design write", Response.Status.FORBIDDEN);
+    }
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+
+  static boolean isAlreadyExistsFailure(IllegalArgumentException e) {
+    return e != null && StringUtils.containsIgnoreCase(e.getMessage(), "already exists");
+  }
+
+  static boolean isNotFound(PSErrorResultsException e, IPSGuid requested) {
+    if (e == null || requested == null) {
+      return false;
+    }
+    Map<IPSGuid, Object> errors = e.getErrors();
+    Map<IPSGuid, Object> results = e.getResults();
+    boolean errored = errors != null && errors.containsKey(requested);
+    boolean hasResult = results != null && results.containsKey(requested);
+    return errored && !hasResult && !hasLockError(e);
+  }
+
+  static boolean hasLockError(PSErrorResultsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isNotLockedError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isDependencyError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return StringUtils.containsIgnoreCase(e != null ? e.getMessage() : null, "depend");
+    }
+    for (Object err : e.getErrors().values()) {
+      String msg = errorMessage(err);
+      if (StringUtils.containsIgnoreCase(msg, "depend")) {
+        return true;
+      }
+    }
+    return StringUtils.containsIgnoreCase(e.getMessage(), "depend");
+  }
+
+  private static boolean isLockErrorObject(Object err) {
+    if (err instanceof PSLockErrorException) {
+      return true;
+    }
+    if (err instanceof PSErrorException pe) {
+      String msg = pe.getErrorMessage() != null ? pe.getErrorMessage() : pe.getMessage();
+      return StringUtils.containsIgnoreCase(msg, "is not locked")
+          || StringUtils.containsIgnoreCase(msg, "not locked for");
+    }
+    return StringUtils.containsIgnoreCase(String.valueOf(err), "is not locked");
+  }
+
+  private static String errorMessage(Object err) {
+    if (err instanceof PSErrorException pe) {
+      return StringUtils.defaultIfBlank(pe.getErrorMessage(), pe.getMessage());
+    }
+    return err != null ? String.valueOf(err) : null;
+  }
+
+  private RuntimeException mapSaveOrDeleteFailure(String verb, PSErrorsException e) {
+    if (isNotLockedError(e)) {
+      return new WebApplicationException(
+          "Could not " + verb + " view; design lock required or held by another user", 409);
+    }
+    if (isDependencyError(e)) {
+      return new WebApplicationException("View has dependents and cannot be deleted", 409);
+    }
+    log.error("Failed to {} view via UI design WS", verb, e);
+    return new IllegalStateException("Failed to " + verb + " view", e);
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorMapTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorMapTest.java
@@ -75,6 +75,9 @@ class ViewAdaptorMapTest {
     assertEquals(1, d.getFields().size());
     assertEquals("sys_title", d.getFields().get(0).getFieldName());
     assertFalse(d.getDesignGaps().isEmpty());
+    assertTrue(
+        d.getDesignGaps().stream()
+            .noneMatch(g -> g.toLowerCase().contains("create / update / delete not supported")));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSSearch;
+import com.percussion.rest.views.ViewDef;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * UI-07 POST create / PUT update / DELETE persist via {@code createViews}/{@code saveViews}/{@code
+ * deleteViews}. Admin only; unique name; no lock steal; Inbox/custom URL is 409.
+ */
+@Tag("UnitTest")
+class ViewAdaptorWriteTest {
+
+  private IPSUiDesignWs designWs;
+  private ViewAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    designWs = mock(IPSUiDesignWs.class);
+    adaptor =
+        new ViewAdaptor(
+            designWs, mock(IPSFolderHelper.class), mock(IPSIdMapper.class), () -> true);
+    guid = mock(IPSGuid.class);
+    when(guid.toString()).thenReturn("0-18-42");
+    when(guid.toStringUntyped()).thenReturn("42");
+    when(guid.getHostId()).thenReturn(0L);
+    when(guid.longValue()).thenReturn(42L);
+    when(guid.getType()).thenReturn((short) 18);
+    when(guid.getUUID()).thenReturn(42);
+    when(designWs.findViews(any(), isNull())).thenReturn(List.of());
+    when(designWs.findSearches(any(), isNull())).thenReturn(List.of());
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void create_usesCreateThenSaveAndReleasesLock() throws Exception {
+    PSSearch view = stubView("MyView", false);
+    when(view.getLabel()).thenReturn("My View");
+    when(view.getDescription()).thenReturn("created via REST");
+    when(designWs.createViews(eq(List.of("MyView")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(view));
+
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    body.setLabel("My View");
+    body.setDescription("created via REST");
+    body.setDisplayFormatId("1");
+
+    ViewDef out = adaptor.createView(body);
+
+    assertEquals("MyView", out.getName());
+    assertEquals("My View", out.getLabel());
+    assertEquals("created via REST", out.getDescription());
+    verify(designWs).createViews(eq(List.of("MyView")), eq("test-session"), eq("Admin"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSSearch>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveViews(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    verify(view).setDisplayName("My View");
+    verify(view).setDescription("created via REST");
+    verify(view).setDisplayFormatId("1");
+  }
+
+  @Test
+  void create_duplicateName_is409BeforeCreate() throws Exception {
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("MyView");
+    when(designWs.findViews(eq("MyView"), isNull())).thenReturn(List.of(existing));
+
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createView(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createViews(anyList(), any(), any());
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_persistTimeDuplicate_is409() throws Exception {
+    when(designWs.createViews(eq(List.of("MyView")), eq("test-session"), eq("Admin")))
+        .thenThrow(
+            new IllegalArgumentException("The name 'MyView' for type 'SEARCH_DEF' already exists."));
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createView(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_blankName_throwsBeforeDesignWs() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createView(null));
+    ViewDef blank = new ViewDef();
+    blank.setName("  ");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createView(blank));
+    assertTrue(ex.getMessage().contains("name is required"));
+    verify(designWs, never()).createViews(anyList(), any(), any());
+  }
+
+  @Test
+  void create_nameWithSpaces_throwsBeforeDesignWs() {
+    ViewDef body = new ViewDef();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createView(body));
+    assertEquals("name cannot contain whitespace", ex.getMessage());
+    verify(designWs, never()).createViews(anyList(), any(), any());
+  }
+
+  @Test
+  void create_wildcardName_throwsBeforeDesignWs() {
+    ViewDef body = new ViewDef();
+    body.setName("My*View");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createView(body));
+    assertEquals("name must not contain wildcards", ex.getMessage());
+  }
+
+  @Test
+  void create_customUrl_is400() {
+    ViewDef body = new ViewDef();
+    body.setName("MyInbox");
+    body.setUrl("../sys_cxViews/inbox.xml");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createView(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("custom"));
+    verify(designWs, never()).createViews(anyList(), any(), any());
+  }
+
+  @Test
+  void create_searchType_is400() {
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    body.setType("StandardSearch");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createView(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("search"));
+    verify(designWs, never()).createViews(anyList(), any(), any());
+  }
+
+  @Test
+  void create_nonAdmin_is403() {
+    adaptor =
+        new ViewAdaptor(
+            designWs, mock(IPSFolderHelper.class), mock(IPSIdMapper.class), () -> false);
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createView(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).createViews(anyList(), any(), any());
+  }
+
+  @Test
+  void create_missingSession_is403() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createView(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("session"), ex.getMessage());
+  }
+
+  @Test
+  void update_loadsWithLockNoStealAndSavesFields() throws Exception {
+    PSSearch existing = stubView("MyView", false);
+    stubCatalogLoad(existing);
+    PSSearch locked = stubView("MyView", false);
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ViewDef body = new ViewDef();
+    body.setLabel("Updated");
+    body.setDescription("new desc");
+    body.setType("View");
+    body.setDisplayFormatId("2");
+
+    ViewDef out = adaptor.saveView("MyView", body);
+
+    assertEquals("MyView", out.getName());
+    verify(locked).setDisplayName("Updated");
+    verify(locked).setDescription("new desc");
+    verify(locked).setDisplayFormatId("2");
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
+    verify(designWs, never()).createViews(anyList(), any(), any());
+    verify(designWs).loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_unknown_returnsNull() throws Exception {
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
+    ViewDef body = new ViewDef();
+    body.setLabel("Updated");
+    assertNull(adaptor.saveView("missing", body));
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_inbox_is409() throws Exception {
+    PSSearch inbox = stubView("Inbox", true);
+    stubCatalogLoad(inbox);
+    ViewDef body = new ViewDef();
+    body.setLabel("Inbox");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.saveView("Inbox", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("inbox"));
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_lockConflict_is409() throws Exception {
+    PSSearch existing = stubView("MyView", false);
+    stubCatalogLoad(existing);
+    when(designWs.loadViews(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.saveView("MyView", new ViewDef()));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_nonAdmin_is403() {
+    adaptor =
+        new ViewAdaptor(
+            designWs, mock(IPSFolderHelper.class), mock(IPSIdMapper.class), () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.saveView("MyView", new ViewDef()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void delete_thenFindIsMissing() throws Exception {
+    PSSearch existing = stubView("MyView", false);
+    stubCatalogLoad(existing);
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(existing));
+
+    assertTrue(adaptor.deleteView("MyView"));
+    verify(designWs).deleteViews(eq(List.of(guid)), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void delete_unknown_returnsFalse() throws Exception {
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
+    assertFalse(adaptor.deleteView("missing"));
+    verify(designWs, never()).deleteViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_inbox_is409() throws Exception {
+    PSSearch inbox = stubView("Inbox", true);
+    stubCatalogLoad(inbox);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteView("Inbox"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteViews(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadViews(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void delete_customUrl_is409() throws Exception {
+    PSSearch custom = stubView("MyCustom", true);
+    stubCatalogLoad(custom);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteView("MyCustom"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_lockConflict_is409() throws Exception {
+    PSSearch existing = stubView("MyView", false);
+    stubCatalogLoad(existing);
+    when(designWs.loadViews(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteView("MyView"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_dependents_is409() throws Exception {
+    PSSearch existing = stubView("MyView", false);
+    stubCatalogLoad(existing);
+    when(designWs.loadViews(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(existing));
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(guid, new PSErrorException("Object has dependents"));
+    doThrow(errors).when(designWs).deleteViews(anyList(), eq(false), any(), any());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteView("MyView"));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("depend"), ex.getMessage());
+  }
+
+  @Test
+  void delete_nonAdmin_is403() {
+    adaptor =
+        new ViewAdaptor(
+            designWs, mock(IPSFolderHelper.class), mock(IPSIdMapper.class), () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteView("MyView"));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void resolveViewType_defaultsAndAliases() {
+    assertEquals(PSSearch.TYPE_VIEW, ViewAdaptor.resolveViewType(null, true));
+    assertNull(ViewAdaptor.resolveViewType(null, false));
+    assertEquals(PSSearch.TYPE_VIEW, ViewAdaptor.resolveViewType("standard", true));
+    assertEquals(PSSearch.TYPE_VIEW, ViewAdaptor.resolveViewType("View", true));
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.resolveViewType("custom", true));
+    assertThrows(
+        IllegalArgumentException.class, () -> ViewAdaptor.resolveViewType("StandardSearch", true));
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.resolveViewType("nope", true));
+  }
+
+  @Test
+  void requireValidName_rejectsSpacesAndWildcards() {
+    assertEquals("MyView", ViewAdaptor.requireValidName("MyView"));
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.requireValidName("  "));
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.requireValidName("has space"));
+    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.requireValidName("x*y"));
+  }
+
+  private PSSearch stubView(String name, boolean customUrl) {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getName()).thenReturn(name);
+    when(s.getLabel()).thenReturn(name);
+    when(s.getDescription()).thenReturn("");
+    when(s.getType()).thenReturn(PSSearch.TYPE_VIEW);
+    when(s.getDisplayFormatId()).thenReturn("1");
+    when(s.getUrl()).thenReturn(customUrl ? "../sys_cxViews/inbox.xml" : null);
+    when(s.getParentCategory()).thenReturn(1);
+    when(s.getMaximumResultSize()).thenReturn(100);
+    when(s.isUserSearch()).thenReturn(false);
+    when(s.isCustomSearch()).thenReturn(false);
+    when(s.isCustomView()).thenReturn(customUrl);
+    when(s.isView()).thenReturn(true);
+    when(s.isStandardView()).thenReturn(!customUrl);
+    when(s.isUserCustomizable()).thenReturn(false);
+    when(s.isCaseSensitive()).thenReturn(false);
+    when(s.getFieldContainer()).thenReturn(null);
+    when(s.getGUID()).thenReturn(guid);
+    when(s.getId()).thenReturn(42);
+    return s;
+  }
+
+  private void stubCatalogLoad(PSSearch search) throws Exception {
+    String catalogName = search.getName();
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(guid);
+    when(sum.getName()).thenReturn(catalogName);
+    when(designWs.findViews(isNull(), isNull())).thenReturn(List.of(sum));
+    when(designWs.loadViews(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(search));
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/views/IViewAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/views/IViewAdaptor.java
@@ -6,7 +6,12 @@ package com.percussion.rest.views;
 
 import java.util.List;
 
-/** Adaptor for CX view design catalog (UI-07 read) and view execute façade. */
+/**
+ * Adaptor for CX view design catalog (UI-07 read/write) and view execute façade.
+ *
+ * <p>Write methods persist through {@code IPSUiDesignWs} create/save/delete views. Execute is
+ * unchanged and is not invoked from write.
+ */
 public interface IViewAdaptor {
 
   List<ViewDef> listViews();
@@ -29,4 +34,34 @@ public interface IViewAdaptor {
    * @throws IllegalArgumentException when the body is invalid or the custom URL is unsupported
    */
   ViewExecuteResult executeView(String idOrName, ViewExecuteRequest request);
+
+  /**
+   * Admin. Create and persist a CX standard (field-criteria) view ({@code createViews} then
+   * {@code saveViews}).
+   *
+   * @param body required; {@code name} is the unique catalog key
+   * @return the persisted view
+   */
+  ViewDef createView(ViewDef body);
+
+  /**
+   * Admin. Update and persist a CX view by name or GUID ({@code loadViews} lock, {@code
+   * saveViews} release). Does not steal another user's lock. Inbox-family and custom URL views
+   * are not mutated.
+   *
+   * @param idOrName catalog key (same rules as {@link #findViewByKey})
+   * @param body required writable fields (label, description, type, displayFormat)
+   * @return the persisted view, or {@code null} when missing/unsafe
+   */
+  ViewDef saveView(String idOrName, ViewDef body);
+
+  /**
+   * Admin. Delete a CX view by name or GUID ({@code deleteViews}, {@code
+   * ignoreDependencies=false}). Does not steal another user's lock. Inbox-family and custom URL
+   * views return conflict (not deleted).
+   *
+   * @param idOrName catalog key (same rules as {@link #findViewByKey})
+   * @return {@code true} when deleted, {@code false} when missing/unsafe
+   */
+  boolean deleteView(String idOrName);
 }

--- a/rest/src/main/java/com/percussion/rest/views/ViewResource.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewResource.java
@@ -12,8 +12,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -25,16 +27,18 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * CX view design catalog (UI-07 list/detail) plus view execute façade for Explorer.
+ * CX view design catalog (UI-07 list/detail/write) plus view execute façade for Explorer.
  *
- * <p>Searches (UI-06) remain a separate catalog. Inbox-family custom-URL views ({@code
- * sys_cxViews/inbox} and documented peers) are executed on this same path; other custom URLs
- * return 400.
+ * <p>Searches (UI-06) remain a separate catalog. Admin POST/PUT/DELETE persist through {@link
+ * IViewAdaptor} ({@code IPSUiDesignWs} create/save/delete views). Execute is a separate façade
+ * and is not invoked from write. Inbox-family custom-URL views ({@code sys_cxViews/inbox} and
+ * documented peers) are executed on this same path; other custom URLs return 400. Inbox/system
+ * custom-URL views cannot be updated or deleted here.
  */
 @PSSiteManageBean(value = "restViewResource")
 @Path("/views")
 @XmlRootElement
-@Tag(name = "Views", description = "CX view design catalog and view execute")
+@Tag(name = "Views", description = "CX view design catalog, write, and view execute")
 public class ViewResource {
 
   private final IViewAdaptor adaptor;
@@ -52,7 +56,9 @@ public class ViewResource {
   @Produces({MediaType.APPLICATION_JSON})
   @Operation(
       summary = "List view definitions",
-      description = "Lists Content Explorer view definitions. Create/edit/delete are later slices.",
+      description =
+          "Lists Content Explorer view definitions. Admin create/save/delete are POST/PUT/DELETE"
+              + " on this resource.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -79,8 +85,8 @@ public class ViewResource {
   @Operation(
       summary = "Get view detail",
       description =
-          "Loads one view by name or GUID string. Field criteria included when present. Write"
-              + " remains unsupported.",
+          "Loads one view by name or GUID string. Field criteria included when present. Admin"
+              + " write is POST/PUT/DELETE on this resource.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -150,6 +156,155 @@ public class ViewResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  @POST
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Create view",
+      description =
+          "Admin. Creates and persists a CX standard (field-criteria) view via"
+              + " IPSUiDesignWs.createViews then saveViews (held design lock, released on save)."
+              + " Name is required, unique (case-insensitive), and must not contain whitespace"
+              + " or wildcards. Optional label, description, type (View default), and"
+              + " displayFormatId are applied before save. Duplicate name is 409. Custom URL"
+              + " views are not created here. Searches are not created here (use"
+              + " /services/searches). Execute is not invoked on write.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = ViewDef.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "409", description = "A view with that name already exists"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ViewDef createView(ViewDef body) {
+    try {
+      if (body != null) {
+        body.setGuid(null);
+        body.setId(0);
+      }
+      ViewDef created = requireAdaptor().createView(body);
+      if (created == null) {
+        throw new WebApplicationException("Failed to create view", 500);
+      }
+      return created;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Update view",
+      description =
+          "Admin. Updates label, description, type, and/or displayFormatId by name or GUID. Name"
+              + " is the catalog key and is not renamed on PUT. Loads with a design lock"
+              + " (overrideLock=false) and releases on save. Unknown id is 404. Lock/dependency"
+              + " conflict is 409. Inbox-family and custom URL views are 409 (not mutated)."
+              + " Searches are not saved here. Execute is not invoked on write.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = ViewDef.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "View not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "Design lock, dependency conflict, or Inbox/custom URL view cannot be mutated"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ViewDef updateView(@PathParam("idOrName") String idOrName, ViewDef body) {
+    try {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      ViewDef updated = requireAdaptor().saveView(idOrName, body);
+      if (updated == null) {
+        throw new WebApplicationException("View not found", 404);
+      }
+      return updated;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete view",
+      description =
+          "Admin. Deletes a CX view by name or GUID via IPSUiDesignWs.deleteViews"
+              + " (ignoreDependencies=false). Unknown id is 404. Lock/dependency conflict is 409."
+              + " Inbox-family and custom URL views are 409 (not deleted). Following GET is 404"
+              + " after a successful delete. Searches are not deleted here.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "View not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "Design lock, dependency conflict, or Inbox/custom URL view cannot be deleted"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteView(@PathParam("idOrName") String idOrName) {
+    try {
+      boolean deleted = requireAdaptor().deleteView(idOrName);
+      if (!deleted) {
+        throw new WebApplicationException("View not found", 404);
+      }
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Admin/session 403 and duplicate 409 are already
+   * {@link WebApplicationException}s from the adaptor.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    if (e instanceof IllegalStateException) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      String lower = msg.toLowerCase();
+      if (lower.contains("lock") || lower.contains("depend")) {
+        return new WebApplicationException(msg, 409);
+      }
+      return new WebApplicationException(e, 500);
+    }
+    return new WebApplicationException(e, 500);
   }
 
   private IViewAdaptor requireAdaptor() {

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestViewAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestViewAdaptor.java
@@ -46,4 +46,19 @@ public class TestViewAdaptor implements IViewAdaptor {
     empty.setStartIndex(1);
     return empty;
   }
+
+  @Override
+  public ViewDef createView(ViewDef body) {
+    return body;
+  }
+
+  @Override
+  public ViewDef saveView(String idOrName, ViewDef body) {
+    return body;
+  }
+
+  @Override
+  public boolean deleteView(String idOrName) {
+    return false;
+  }
 }

--- a/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
@@ -5,6 +5,7 @@
 package com.percussion.rest.views;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,10 +13,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -219,6 +222,151 @@ public class ViewResourceTest {
         assertThrows(
             WebApplicationException.class,
             () -> bare.executeView("any", new ViewExecuteRequest()));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createViewClearsIdAndDelegates() {
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    body.setId(9);
+    ViewDef created = new ViewDef();
+    created.setName("MyView");
+    created.setId(42);
+    when(adaptor.createView(any())).thenReturn(created);
+
+    ViewDef out = resource.createView(body);
+
+    assertEquals("MyView", out.getName());
+    assertEquals(0, body.getId());
+    assertNull(body.getGuid());
+    verify(adaptor).createView(body);
+  }
+
+  @Test
+  public void createViewBlankNameIs400() {
+    when(adaptor.createView(any())).thenThrow(new IllegalArgumentException("name is required"));
+    ViewDef body = new ViewDef();
+    body.setName("  ");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createView(body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createViewDuplicateIs409() {
+    when(adaptor.createView(any()))
+        .thenThrow(new WebApplicationException("View already exists: MyView", 409));
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createView(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createViewNonAdminIs403() {
+    when(adaptor.createView(any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createView(body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateViewDelegates() {
+    ViewDef body = new ViewDef();
+    body.setLabel("Updated");
+    body.setDescription("desc");
+    ViewDef updated = new ViewDef();
+    updated.setName("MyView");
+    updated.setLabel("Updated");
+    updated.setDescription("desc");
+    when(adaptor.saveView(eq("MyView"), eq(body))).thenReturn(updated);
+
+    ViewDef out = resource.updateView("MyView", body);
+
+    assertEquals("Updated", out.getLabel());
+    assertEquals("desc", out.getDescription());
+    verify(adaptor).saveView("MyView", body);
+  }
+
+  @Test
+  public void updateViewUnknownIs404() {
+    when(adaptor.saveView(eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateView("missing", new ViewDef()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateViewNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.updateView("MyView", null));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).saveView(any(), any());
+  }
+
+  @Test
+  public void updateViewInboxIs409() {
+    when(adaptor.saveView(eq("Inbox"), any()))
+        .thenThrow(
+            new WebApplicationException(
+                "Inbox-family and custom URL views cannot be updated or deleted via this API",
+                409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateView("Inbox", new ViewDef()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteViewNoContent() {
+    when(adaptor.deleteView(eq("MyView"))).thenReturn(true);
+
+    Response r = resource.deleteView("MyView");
+
+    assertEquals(204, r.getStatus());
+    verify(adaptor).deleteView("MyView");
+  }
+
+  @Test
+  public void deleteViewUnknownIs404() {
+    when(adaptor.deleteView(eq("missing"))).thenReturn(false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteView("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteViewNonAdminIs403() {
+    when(adaptor.deleteView(eq("MyView")))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteView("MyView"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteViewInboxIs409() {
+    when(adaptor.deleteView(eq("Inbox")))
+        .thenThrow(
+            new WebApplicationException(
+                "Inbox-family and custom URL views cannot be updated or deleted via this API",
+                409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteView("Inbox"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnCreate() {
+    ViewResource bare = new ViewResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.createView(new ViewDef()));
     assertEquals(503, ex.getResponse().getStatus());
   }
 }


### PR DESCRIPTION
## Summary

Parent **#1690** (UI-07). Public REST can create, save, and delete CX **standard** (field-criteria) views through existing `IPSUiDesignWs` (`createViews` / `loadViews` / `saveViews` / `deleteViews`). Execute (`POST …/execute`) is unchanged and is not invoked on write. No Developer Views SPA.

Admin `POST /services/views`, `PUT /services/views/{idOrName}`, `DELETE /services/views/{idOrName}`:

- Unique name (no whitespace/wildcards); duplicate **409**
- Invalid **400**; missing **404**; non-Admin **403**
- Design lock is held and released on save; `overrideLock=false` (no lock steal)
- PUT round-trips GET-exposed label / description / type / displayFormat; name is the catalog key (not renamed)
- Inbox-family and custom URL views: **409** on update/delete (no steal)
- Searches stay on `/services/searches`

Fixes #4070

## Test plan

1. Mockito: `ViewResourceTest` maps 200/204/400/403/404/409/503 for create/save/delete; existing execute tests still pass.
2. Spring: `TestViewAdaptor` stubs new `IViewAdaptor` write methods so `MainTest` context loads.
3. Adaptor: `ViewAdaptorWriteTest` covers create→save (lock released), duplicate 409, spaces/wildcards 400, custom URL create 400, search type 400, non-Admin 403, missing session 403, PUT lock-no-steal, DELETE 204/404/409, Inbox/custom URL delete 409.
4. Standalone `cd rest && ../mvnw.cmd clean install` then `cd projects/sitemanage && ../../mvnw.cmd clean install`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` Views write contract (no SPA claim)
- [x] **Unit / module tests** — behavioral tests for new/changed logic; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST only)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps when API shape changes
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: **927**, Failures: 0, Errors: 0, Skipped: 0. `ViewResourceTest` Tests run: **30**, Failures: 0.
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → **BUILD SUCCESS**. Tests run: **1992**, Failures: 0, Errors: 0, Skipped: 125 (baseline). `ViewAdaptorWriteTest` Tests run: **24**, Failures: 0. `ViewAdaptorExecuteTest` Tests run: **31**, Failures: 0.
- **downstream_checked:** `IViewAdaptor` gained write methods (additive). Grep `implements IViewAdaptor` → `ViewAdaptor` + `TestViewAdaptor` only. Reverse-dep `projects/sitemanage` standalone clean install green.
- **C5 UI proof:** N/A (no SPA / WebUI chrome)

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
