### PR TITLE
feat(webui): SPA SE-01 community create/delete (#4077)

### DIFF
--- a/WebUI/src/main/ts/api/client.ts
+++ b/WebUI/src/main/ts/api/client.ts
@@ -368,15 +368,17 @@ export async function postText<T>(
   return handleResponse<T>(response);
 }
 
-/** Sends a DELETE request. */
+/** Sends a DELETE request. Optional JSON body for bulk delete endpoints. */
 export async function del<T>(
   url: string,
   headers?: HeadersInit,
+  body?: unknown,
 ): Promise<T> {
   const response = await fetch(url, {
     method: "DELETE",
     headers: buildHeaders(headers),
     credentials: "same-origin",
+    body: body != null ? JSON.stringify(body) : undefined,
   });
   return handleResponse<T>(response);
 }

--- a/WebUI/src/main/ts/api/developer/assemblyApi.ts
+++ b/WebUI/src/main/ts/api/developer/assemblyApi.ts
@@ -17,7 +17,10 @@
 
 import { del, get, post, put } from "../client";
 import {
+  COMMUNITY_TYPE,
   normalizeDesignObjectGuid,
+  objectGuidString,
+  resolveCommunityObjectGuid,
   resolveTemplateObjectGuid,
 } from "../displayFormatGuid";
 import { PATHS } from "../paths";
@@ -399,12 +402,182 @@ export async function listCommunities(): Promise<CommunitySummary[]> {
   const payload = await get<unknown>(
     `${PATHS.COMMUNITIES}/find?name=${encodeURIComponent("*")}`,
   );
-  // CommunityList extends Array — may serialize as array or envelope
+  return unwrapCommunityList(payload);
+}
+
+/** JAXB / swagger root for POST /services/communities/bulk `List<String>` names. */
+export const COMMUNITY_NAME_LIST_ROOT = "List";
+
+/** Jackson WRAP/UNWRAP root for {@code CommunityList}. */
+export const COMMUNITY_LIST_ROOT = "CommunityList";
+
+/** Jackson WRAP/UNWRAP root for {@code GuidList} bulk delete. */
+export const GUID_LIST_ROOT = "GuidList";
+
+/** Trim a community name for create. Empty / null becomes "". */
+export function normalizeCommunityName(name: string | undefined | null): string {
+  return name == null ? "" : name.trim();
+}
+
+/**
+ * True when the (trimmed) name is accepted by REST create
+ * ({@code PSSecurityDesignWs.createCommunities} — non-blank).
+ * Spaces are allowed (unlike slots). Uniqueness is case-insensitive on the server.
+ */
+export function isValidCommunityName(name: string | undefined | null): boolean {
+  return normalizeCommunityName(name).length > 0;
+}
+
+/** Create is enabled when the community name is non-blank after trim. */
+export function isCommunityWriteReady(opts: { name: string }): boolean {
+  return isValidCommunityName(opts.name);
+}
+
+/** Wire JSON for POST /services/communities/bulk name list. */
+export function wrapCommunityNameListForWire(
+  names: string[],
+): Record<string, string[]> {
+  return { [COMMUNITY_NAME_LIST_ROOT]: names };
+}
+
+/**
+ * Wire JSON for PUT /services/communities/bulk.
+ * Envelope is parsed by rest {@code CommunityListJsonReader} (String body).
+ */
+export function wrapCommunityListForWire(
+  communities: CommunitySummary[],
+): Record<string, CommunitySummary[]> {
+  return { [COMMUNITY_LIST_ROOT]: communities };
+}
+
+/**
+ * Wire JSON for DELETE /services/communities/bulk GuidList.
+ * Envelope is parsed by rest {@code GuidListJsonReader} (String body).
+ */
+export function wrapGuidListForWire(ids: RestGuid[]): Record<string, RestGuid[]> {
+  return { [GUID_LIST_ROOT]: ids };
+}
+
+/**
+ * Flatten nested Jackson Guid wraps so {@code guid.stringValue} is usable
+ * for delete / visibility (same WRAP_ROOT_VALUE as templates).
+ */
+export function normalizeCommunitySummary<T extends CommunitySummary>(
+  item: T,
+  catalogGuid?: string | null,
+): T {
+  const gs = resolveCommunityObjectGuid(item, catalogGuid);
+  return normalizeDesignObjectGuid(item, gs);
+}
+
+/** Unwrap CommunityList array or envelope (find / create response). */
+export function unwrapCommunityList(payload: unknown): CommunitySummary[] {
   return asArray<CommunitySummary>(payload, [
-    "CommunityList",
+    COMMUNITY_LIST_ROOT,
     "Community",
     "communityList",
-  ]);
+  ]).map((row) => normalizeCommunitySummary(row));
+}
+
+/**
+ * POST /services/communities/bulk — Admin. Creates communities from names
+ * ({@code ICommunityAdaptor.createCommunities}). Blank name is 400. Duplicate
+ * is 409. Non-Admin is 403. Server persists (create+save); do not PUT the DTO.
+ */
+export async function createCommunities(
+  names: string[],
+): Promise<CommunitySummary[]> {
+  const payload = await post<unknown>(
+    `${PATHS.COMMUNITIES}/bulk`,
+    wrapCommunityNameListForWire(names),
+  );
+  return unwrapCommunityList(payload);
+}
+
+/**
+ * PUT /services/communities/bulk — Admin. Persist created/edited communities.
+ * {@code release=true} releases design locks (Workbench Finish).
+ */
+export async function saveCommunities(
+  communities: CommunitySummary[],
+  release = true,
+): Promise<void> {
+  await put(
+    `${PATHS.COMMUNITIES}/bulk`,
+    wrapCommunityListForWire(communities),
+    { release: String(release) },
+  );
+}
+
+/**
+ * Create one community by name. Server POST /bulk persists (create+save)
+ * like Workbench Finish; do not PUT the DTO back (loadCommunities NPE).
+ */
+export async function createCommunity(name: string): Promise<CommunitySummary> {
+  const trimmed = normalizeCommunityName(name);
+  const created = await createCommunities([trimmed]);
+  const first = created[0];
+  if (first) {
+    return first;
+  }
+  return { name: trimmed };
+}
+
+/**
+ * DELETE /services/communities/bulk — Admin. GuidList of communities to remove.
+ * Default {@code ignoredependencies=false}: in-use is 409 and the community remains
+ * (does not steal). Missing is 404. Non-Admin is 403.
+ */
+export async function deleteCommunities(
+  ids: RestGuid[],
+  ignoreDependencies = false,
+): Promise<void> {
+  await del(
+    `${PATHS.COMMUNITIES}/bulk`,
+    { ignoredependencies: String(ignoreDependencies) },
+    wrapGuidListForWire(ids),
+  );
+}
+
+/** Delete one community by GUID. Never sends ignoredependencies unless asked. */
+export async function deleteCommunity(
+  guid: RestGuid,
+  ignoreDependencies = false,
+): Promise<void> {
+  await deleteCommunities([guid], ignoreDependencies);
+}
+
+/** Unwrap GET `{ Community: {…} }` or a flat Community body. */
+export function unwrapCommunityDetail(payload: unknown): CommunityDetail {
+  const root = asRecord(payload);
+  if (!root) {
+    return {};
+  }
+  const nested = asRecord(root.Community ?? root.community);
+  const body = (nested ?? root) as CommunityDetail;
+  return normalizeCommunitySummary(body);
+}
+
+/**
+ * GUID for community delete / visibility. Reads nested Guid wraps and
+ * synthesizes {@code 0-13-{id}} when only the numeric id is present.
+ */
+export function communityGuidForWrite(
+  detail: CommunitySummary | null | undefined,
+  fallback?: RestGuid | null,
+): RestGuid | null {
+  const gs = resolveCommunityObjectGuid(detail, objectGuidString(fallback));
+  if (!gs) {
+    return fallback ?? null;
+  }
+  const existing =
+    detail?.guid != null && typeof detail.guid === "object" && !Array.isArray(detail.guid)
+      ? (detail.guid as RestGuid)
+      : fallback;
+  if (existing && existing.stringValue === gs) {
+    return existing;
+  }
+  return { ...(existing || {}), stringValue: gs, type: existing?.type ?? COMMUNITY_TYPE };
 }
 
 /** GET /services/communities/{idOrName} — detail with roles */
@@ -412,7 +585,8 @@ export async function getCommunityDetail(
   idOrName: string,
 ): Promise<CommunityDetail> {
   const key = encodeURIComponent(idOrName);
-  return get<CommunityDetail>(`${PATHS.COMMUNITIES}/${key}`);
+  const payload = await get<unknown>(`${PATHS.COMMUNITIES}/${key}`);
+  return unwrapCommunityDetail(payload);
 }
 
 /** GET /services/communities/roles — all roles for membership picker */

--- a/WebUI/src/main/ts/api/displayFormatGuid.ts
+++ b/WebUI/src/main/ts/api/displayFormatGuid.ts
@@ -42,6 +42,9 @@ export const ACTION_MENU_TYPE = 107;
 /** {@code PSTypeEnum.VIEW_DEF} — CX view GUID type (#3380). */
 export const VIEW_TYPE = 18;
 
+/** {@code PSTypeEnum.COMMUNITY} — community GUID type (#4077 / SE-01). */
+export const COMMUNITY_TYPE = 13;
+
 function firstNonBlankString(value: unknown): string | undefined {
   if (typeof value === "string") {
     const trimmed = value.trim();
@@ -256,6 +259,24 @@ export function resolveViewObjectGuid(
     return resolved;
   }
   return synthesizeTypedObjectGuid(VIEW_TYPE, view?.id);
+}
+
+/**
+ * Community GUID: nested Guid / guidString, then catalog, then
+ * {@code 0-13-{id}} from the native community id (#4077).
+ */
+export function resolveCommunityObjectGuid(
+  community:
+    | (DesignObjectGuidSource & { id?: number | null })
+    | null
+    | undefined,
+  catalogGuid?: string | null,
+): string | undefined {
+  const resolved = resolveDesignObjectGuid(community, catalogGuid);
+  if (resolved) {
+    return resolved;
+  }
+  return synthesizeTypedObjectGuid(COMMUNITY_TYPE, community?.id);
 }
 
 /**

--- a/WebUI/src/main/ts/developer/CommunitiesPanel.tsx
+++ b/WebUI/src/main/ts/developer/CommunitiesPanel.tsx
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listCommunities } from "../api/developer/assemblyApi";
 import type { CommunitySummary } from "../api/developer/types";
 import { CatalogHint, CatalogStatus, SimpleCatalogTable } from "./CatalogTable";
-import { monoCell, mutedCell, openButtonStyle } from "./catalogStyles";
+import { catalogColors, monoCell, mutedCell, openButtonStyle } from "./catalogStyles";
 import { CommunityDetailPanel } from "./CommunityDetailPanel";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
@@ -31,30 +31,81 @@ function openKey(c: CommunitySummary): string | null {
   return null;
 }
 
+/**
+ * SE-01 — community catalog with create / delete. Role membership stays on
+ * {@link CommunityDetailPanel}.
+ */
 export function CommunitiesPanel(): React.ReactElement {
   const [items, setItems] = useState<CommunitySummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [selected, setSelected] = useState<string | null>(null);
+  /** null = catalog; "new" = create; otherwise name or id. */
+  const [selected, setSelected] = useState<string | "new" | null>(null);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    let cancelled = false;
-    listCommunities()
-      .then((list) => {
-        if (!cancelled) setItems(list);
-      })
-      .catch((e: unknown) => {
-        if (cancelled) return;
-        setError(panelErrMsg(e, DEV_MSG.COMM_ERROR));
-        setItems([]);
-      });
+    mountedRef.current = true;
     return () => {
-      cancelled = true;
+      mountedRef.current = false;
     };
   }, []);
 
+  const reload = useCallback((opts?: { showLoading?: boolean }) => {
+    if (!mountedRef.current) {
+      return Promise.resolve();
+    }
+    if (opts?.showLoading) {
+      setItems(null);
+    }
+    setError(null);
+    return listCommunities()
+      .then((list) => {
+        if (!mountedRef.current) return;
+        setItems(list);
+      })
+      .catch((e: unknown) => {
+        if (!mountedRef.current) return;
+        setError(panelErrMsg(e, DEV_MSG.COMM_ERROR));
+        setItems([]);
+      });
+  }, []);
+
+  useEffect(() => {
+    void reload({ showLoading: true });
+  }, [reload]);
+
+  const sorted = useMemo(() => {
+    if (!items) return [];
+    return [...items].sort((a, b) =>
+      (a.label || a.name || "").localeCompare(b.label || b.name || "", undefined, {
+        sensitivity: "base",
+      }),
+    );
+  }, [items]);
+
+  function handleDeleted(): void {
+    setSelected(null);
+    void reload();
+  }
+
+  if (selected === "new") {
+    return (
+      <CommunityDetailPanel
+        idOrName={null}
+        onBack={() => setSelected(null)}
+        onSaved={() => void reload()}
+        onDeleted={handleDeleted}
+      />
+    );
+  }
+
   if (selected) {
     return (
-      <CommunityDetailPanel idOrName={selected} onBack={() => setSelected(null)} />
+      <CommunityDetailPanel
+        idOrName={selected}
+        onBack={() => setSelected(null)}
+        onSaved={() => void reload()}
+        onDeleted={handleDeleted}
+      />
     );
   }
 
@@ -66,58 +117,83 @@ export function CommunitiesPanel(): React.ReactElement {
     );
   if (items == null)
     return <CatalogStatus testId="developer-comm-loading">{DEV_MSG.COMM_LOADING}</CatalogStatus>;
-  if (items.length === 0)
-    return <CatalogStatus testId="developer-comm-empty">{DEV_MSG.COMM_EMPTY}</CatalogStatus>;
-
-  const sorted = [...items].sort((a, b) =>
-    (a.label || a.name || "").localeCompare(b.label || b.name || "", undefined, {
-      sensitivity: "base",
-    }),
-  );
 
   return (
     <div data-testid="developer-comm-panel">
-      <CatalogHint>{DEV_MSG.COMM_HINT}</CatalogHint>
-      <SimpleCatalogTable
-        tableTestId="developer-comm-table"
-        rowTestId="developer-comm-row"
-        columns={[
-          DEV_MSG.COMM_COL_LABEL,
-          DEV_MSG.COMM_COL_NAME,
-          DEV_MSG.COMM_COL_ID,
-          DEV_MSG.COMM_COL_DESCRIPTION,
-        ]}
-        rows={sorted.map((c, index) => {
-          const key = openKey(c);
-          return {
-            key: String(c.id ?? c.guid?.stringValue ?? c.name ?? `comm-${index}`),
-            cells: [
-              key ? (
-                <button
-                  key="open"
-                  type="button"
-                  style={openButtonStyle}
-                  aria-label={`Open ${c.label || c.name || key}`}
-                  onClick={() => setSelected(key)}
-                >
-                  {c.label || c.name || "—"}
-                </button>
-              ) : (
-                c.label || "—"
-              ),
-              <span key="n" style={monoCell}>
-                {c.name || "—"}
-              </span>,
-              <span key="i" style={monoCell}>
-                {c.id != null ? String(c.id) : c.guid?.stringValue || "—"}
-              </span>,
-              <span key="d" style={mutedCell}>
-                {c.description || ""}
-              </span>,
-            ],
-          };
-        })}
-      />
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "12px",
+          gap: "12px",
+          flexWrap: "wrap",
+        }}
+      >
+        <CatalogHint>{DEV_MSG.COMM_HINT}</CatalogHint>
+        <button
+          type="button"
+          data-testid="developer-comm-new"
+          onClick={() => setSelected("new")}
+          style={{
+            padding: "8px 14px",
+            background: catalogColors.accent,
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          {DEV_MSG.COMM_NEW}
+        </button>
+      </div>
+
+      {items.length === 0 ? (
+        <CatalogStatus testId="developer-comm-empty">{DEV_MSG.COMM_EMPTY}</CatalogStatus>
+      ) : (
+        <SimpleCatalogTable
+          tableTestId="developer-comm-table"
+          rowTestId="developer-comm-row"
+          columns={[
+            DEV_MSG.COMM_COL_LABEL,
+            DEV_MSG.COMM_COL_NAME,
+            DEV_MSG.COMM_COL_ID,
+            DEV_MSG.COMM_COL_DESCRIPTION,
+          ]}
+          rows={sorted.map((c, index) => {
+            const key = openKey(c);
+            return {
+              key: String(c.id ?? c.guid?.stringValue ?? c.name ?? `comm-${index}`),
+              cells: [
+                key ? (
+                  <button
+                    key="open"
+                    type="button"
+                    data-testid="developer-comm-open"
+                    data-comm-name={c.name || key}
+                    style={openButtonStyle}
+                    aria-label={`Open ${c.label || c.name || key}`}
+                    onClick={() => setSelected(key)}
+                  >
+                    {c.label || c.name || "—"}
+                  </button>
+                ) : (
+                  c.label || "—"
+                ),
+                <span key="n" style={monoCell}>
+                  {c.name || "—"}
+                </span>,
+                <span key="i" style={monoCell}>
+                  {c.id != null ? String(c.id) : c.guid?.stringValue || "—"}
+                </span>,
+                <span key="d" style={mutedCell}>
+                  {c.description || ""}
+                </span>,
+              ],
+            };
+          })}
+        />
+      )}
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/CommunityDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/CommunityDetailPanel.tsx
@@ -16,15 +16,21 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { isApiError } from "../api/client";
 import {
+  communityGuidForWrite,
+  createCommunity,
+  deleteCommunity,
   getCommunityDetail,
   getCommunityVisibility,
+  isCommunityWriteReady,
   listAvailableRoles,
   updateCommunityRoles,
 } from "../api/developer/assemblyApi";
 import type {
   CommunityDetail,
   CommunityRoleSummary,
+  CommunitySummary,
   CommunityVisibleObject,
   RestGuid,
 } from "../api/developer/types";
@@ -103,14 +109,59 @@ function formatVisibilitySummary(shown: number, total: number, filtered: boolean
   return DEV_MSG.COMM_VISIBILITY_SUMMARY_ALL.replace("{0}", String(total));
 }
 
+const fieldStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+  marginBottom: "12px",
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: "8px",
+  border: `1px solid ${catalogColors.softBorder}`,
+  borderRadius: "4px",
+  font: "inherit",
+};
+
+function createFallback(err: unknown): string {
+  if (!isApiError(err)) return DEV_MSG.COMM_SAVE_ERROR;
+  if (err.status === 409) return DEV_MSG.COMM_DUPLICATE;
+  if (err.status === 403) return DEV_MSG.COMM_FORBIDDEN;
+  if (err.status === 400) return DEV_MSG.COMM_NAME_INVALID;
+  return DEV_MSG.COMM_SAVE_ERROR;
+}
+
+function deleteFallback(err: unknown): string {
+  if (!isApiError(err)) return DEV_MSG.COMM_DELETE_ERROR;
+  if (err.status === 403) return DEV_MSG.COMM_FORBIDDEN;
+  if (err.status === 409) return DEV_MSG.COMM_IN_USE;
+  if (err.status === 404) return DEV_MSG.COMM_MISSING;
+  return DEV_MSG.COMM_DELETE_ERROR;
+}
+
+function resolveCommunityGuid(
+  detail: CommunityDetail | null,
+  fallback?: RestGuid | null,
+): RestGuid | null {
+  return communityGuidForWrite(detail, fallback);
+}
+
 export function CommunityDetailPanel({
   idOrName,
   onBack,
+  onSaved,
+  onDeleted,
 }: {
-  idOrName: string;
+  /** null = create mode */
+  idOrName: string | null;
   onBack: () => void;
+  onSaved?: (detail: CommunityDetail | CommunitySummary) => void;
+  onDeleted?: () => void;
 }): React.ReactElement {
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
+  const isNew = idOrName == null && createdKey == null;
   const [detail, setDetail] = useState<CommunityDetail | null>(null);
+  const [name, setName] = useState("");
   const [allRoles, setAllRoles] = useState<CommunityRoleSummary[]>([]);
   const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
@@ -124,6 +175,7 @@ export function CommunityDetailPanel({
   const [communityGuid, setCommunityGuid] = useState<RestGuid | null>(null);
   /** Monotonic id so stale visibility responses (type filter / remount) are ignored. */
   const visibilityReqId = useRef(0);
+  const inflight = useRef(false);
 
   const loadVisibility = useCallback((guid: RestGuid, objectType: string) => {
     const req = ++visibilityReqId.current;
@@ -145,6 +197,9 @@ export function CommunityDetailPanel({
   }, []);
 
   useEffect(() => {
+    if (idOrName == null) {
+      return;
+    }
     let cancelled = false;
     // Invalidate any in-flight visibility from a prior community / type filter.
     visibilityReqId.current += 1;
@@ -160,12 +215,13 @@ export function CommunityDetailPanel({
       .then(([d, roles]) => {
         if (cancelled) return;
         setDetail(d);
+        setName(d.name || idOrName);
         setAllRoles(roles);
         setSelectedKeys(
           new Set(asRoles(d).map((r, i) => roleKey(r, i)).filter((k) => k.length > 0)),
         );
-        const g = d.guid;
-        if (g?.stringValue || g?.uuid != null) {
+        const g = communityGuidForWrite(d);
+        if (g) {
           setCommunityGuid(g);
           const req = ++visibilityReqId.current;
           setVisibilityLoading(true);
@@ -237,27 +293,125 @@ export function CommunityDetailPanel({
     }
   }
 
+  const writeKey = idOrName || createdKey || name.trim();
+  const canCreate = isNew && !busy && isCommunityWriteReady({ name });
+
+  async function applyLoadedCommunity(
+    d: CommunityDetail,
+    roles: CommunityRoleSummary[],
+    key: string,
+  ) {
+    setDetail(d);
+    setName(d.name || key);
+    setAllRoles(roles);
+    setSelectedKeys(
+      new Set(asRoles(d).map((r, i) => roleKey(r, i)).filter((k) => k.length > 0)),
+    );
+    const g = communityGuidForWrite(d);
+    if (g) {
+      setCommunityGuid(g);
+      const req = ++visibilityReqId.current;
+      setVisibilityLoading(true);
+      setVisibilityError(null);
+      try {
+        const objs = await getCommunityVisibility(g);
+        if (req !== visibilityReqId.current) return;
+        setVisibleObjects(objs);
+        setVisibilityLoading(false);
+      } catch (err: unknown) {
+        if (req !== visibilityReqId.current) return;
+        setVisibilityLoading(false);
+        setVisibilityError(panelErrMsg(err, DEV_MSG.COMM_VISIBILITY_ERROR));
+      }
+    } else {
+      setVisibilityError(DEV_MSG.COMM_VISIBILITY_NO_GUID);
+    }
+  }
+
+  async function handleCreate(): Promise<void> {
+    if (!canCreate || inflight.current) return;
+    inflight.current = true;
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const created = await createCommunity(name);
+      const key = created.name || name.trim();
+      setCreatedKey(key);
+      setName(key);
+      try {
+        const [d, roles] = await Promise.all([getCommunityDetail(key), listAvailableRoles()]);
+        const merged: CommunityDetail = {
+          ...d,
+          guid: d.guid ?? created.guid,
+          id: d.id ?? created.id,
+          name: d.name || created.name || key,
+        };
+        await applyLoadedCommunity(merged, roles, key);
+      } catch {
+        setDetail(created as CommunityDetail);
+        setCommunityGuid(communityGuidForWrite(created));
+      }
+      setNotice(DEV_MSG.COMM_CREATED);
+      onSaved?.(created);
+    } catch (err: unknown) {
+      setError(panelErrMsg(err, createFallback(err)));
+    } finally {
+      inflight.current = false;
+      setBusy(false);
+    }
+  }
+
+  async function handleDelete(): Promise<void> {
+    if (isNew || inflight.current) return;
+    const guid = resolveCommunityGuid(detail, communityGuid);
+    if (!guid) {
+      setError(DEV_MSG.COMM_DELETE_NO_GUID);
+      return;
+    }
+    if (!window.confirm(DEV_MSG.COMM_DELETE_CONFIRM)) return;
+    inflight.current = true;
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      await deleteCommunity(guid, false);
+      setNotice(DEV_MSG.COMM_DELETED);
+      onDeleted?.();
+    } catch (err: unknown) {
+      setError(panelErrMsg(err, deleteFallback(err)));
+    } finally {
+      inflight.current = false;
+      setBusy(false);
+    }
+  }
+
   async function handleSave() {
+    if (!writeKey || inflight.current) return;
+    inflight.current = true;
     setBusy(true);
     setError(null);
     setNotice(null);
     const body = allRoles.filter((r, i) => selectedKeys.has(roleKey(r, i)));
     try {
-      const saved = await updateCommunityRoles(idOrName, body);
+      const saved = await updateCommunityRoles(writeKey, body);
       setDetail(saved);
       const nextRoles = asRoles(saved);
       setSelectedKeys(
         new Set(nextRoles.map((r, i) => roleKey(r, i)).filter((k) => k.length > 0)),
       );
       setNotice(formatSavedRolesNotice(nextRoles.length));
+      onSaved?.(saved);
     } catch (err: unknown) {
       setError(panelErrMsg(err, DEV_MSG.COMM_ROLES_SAVE_ERROR));
     } finally {
+      inflight.current = false;
       setBusy(false);
     }
   }
 
   const rolesForTable = allRoles.length > 0 ? allRoles : asRoles(detail);
+  const guidLabel = communityGuidForWrite(detail)?.stringValue;
 
   return (
     <div data-testid="developer-comm-detail">
@@ -286,13 +440,72 @@ export function CommunityDetailPanel({
         </div>
       ) : null}
 
-      {!error && detail == null ? (
+      {isNew ? (
+        <>
+          <header style={{ marginBottom: "16px" }}>
+            <h2 style={{ margin: "0 0 4px" }} data-testid="developer-comm-detail-title">
+              {DEV_MSG.COMM_NEW}
+            </h2>
+            <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>
+              {DEV_MSG.COMM_NAME_HINT}
+            </p>
+          </header>
+          <div style={fieldStyle}>
+            <label htmlFor="comm-name">{DEV_MSG.COMM_FORM_NAME}</label>
+            <input
+              id="comm-name"
+              data-testid="developer-comm-name"
+              style={{ ...inputStyle, fontFamily: "monospace" }}
+              value={name}
+              disabled={busy}
+              onChange={(e) => setName(e.target.value)}
+              autoComplete="off"
+            />
+          </div>
+          <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", marginBottom: "16px" }}>
+            <button
+              type="button"
+              data-testid="developer-comm-create"
+              aria-label={DEV_MSG.COMM_CREATE}
+              disabled={!canCreate}
+              onClick={() => void handleCreate()}
+              style={{
+                padding: "8px 16px",
+                background: canCreate ? catalogColors.accent : catalogColors.disabled,
+                color: "#fff",
+                border: "none",
+                borderRadius: "4px",
+                cursor: canCreate ? "pointer" : "not-allowed",
+              }}
+            >
+              {DEV_MSG.COMM_CREATE}
+            </button>
+            <button
+              type="button"
+              data-testid="developer-comm-cancel"
+              disabled={busy}
+              onClick={onBack}
+              style={{
+                padding: "8px 16px",
+                background: "transparent",
+                border: `1px solid ${catalogColors.softBorder}`,
+                borderRadius: "4px",
+                cursor: "pointer",
+              }}
+            >
+              {DEV_MSG.COMM_CANCEL}
+            </button>
+          </div>
+        </>
+      ) : null}
+
+      {!isNew && !error && detail == null ? (
         <div data-testid="developer-comm-detail-loading">
           {DEV_MSG.COMM_DETAIL_LOADING}
         </div>
       ) : null}
 
-      {detail ? (
+      {!isNew && detail ? (
         <>
           <header style={{ marginBottom: "16px" }}>
             <h2 style={{ margin: "0 0 4px" }} data-testid="developer-comm-detail-title">
@@ -301,7 +514,7 @@ export function CommunityDetailPanel({
             <div style={{ fontFamily: "monospace", color: catalogColors.muted }}>
               {detail.name}
               {detail.id != null ? ` · id ${detail.id}` : ""}
-              {detail.guid?.stringValue ? ` · ${detail.guid.stringValue}` : ""}
+              {guidLabel ? ` · ${guidLabel}` : ""}
             </div>
             {detail.description ? (
               <p style={{ marginTop: "8px", color: catalogColors.text }}>{detail.description}</p>
@@ -313,9 +526,28 @@ export function CommunityDetailPanel({
               </dd>
               <dt>{DEV_MSG.COMM_META_GUID}</dt>
               <dd style={{ margin: 0, ...monoCell }}>
-                {detail.guid?.stringValue || "—"}
+                {guidLabel || "—"}
               </dd>
             </dl>
+            <div style={{ marginTop: "12px" }}>
+              <button
+                type="button"
+                data-testid="developer-comm-delete"
+                aria-label={DEV_MSG.COMM_DELETE}
+                disabled={busy}
+                onClick={() => void handleDelete()}
+                style={{
+                  padding: "8px 16px",
+                  background: "#c53030",
+                  color: "#fff",
+                  border: "none",
+                  borderRadius: "4px",
+                  cursor: busy ? "wait" : "pointer",
+                }}
+              >
+                {DEV_MSG.COMM_DELETE}
+              </button>
+            </div>
           </header>
 
           <section style={{ marginBottom: "16px" }} data-testid="developer-comm-roles">

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -540,7 +540,27 @@ export const DEV_MSG_KEYS = {
   COMM_EMPTY: "perc.ui.developer@No communities returned.",
   COMM_ERROR: "perc.ui.developer@Could not load communities.",
   COMM_HINT:
-    "perc.ui.developer@Select a community to view and edit role membership and inspect object visibility. Per-object COMMUNITY ACL entries are edited on object detail panels (e.g. content types).",
+    "perc.ui.developer@Create or delete a community, then open one to edit role membership and inspect object visibility. Per-object COMMUNITY ACL entries are edited on object detail panels (e.g. content types).",
+  COMM_NEW: "perc.ui.developer@New community",
+  COMM_CREATE: "perc.ui.developer@Create community",
+  COMM_CANCEL: "perc.ui.developer@Cancel",
+  COMM_FORM_NAME: "perc.ui.developer@Name",
+  COMM_NAME_HINT:
+    "perc.ui.developer@Required unique name. Spaces are allowed. Duplicate names are rejected.",
+  COMM_NAME_INVALID: "perc.ui.developer@Community name cannot be blank.",
+  COMM_CREATED: "perc.ui.developer@Community created.",
+  COMM_DUPLICATE: "perc.ui.developer@A community with this name already exists.",
+  COMM_FORBIDDEN: "perc.ui.developer@Admin role required.",
+  COMM_SAVE_ERROR: "perc.ui.developer@Could not create community.",
+  COMM_DELETE: "perc.ui.developer@Delete community",
+  COMM_DELETE_CONFIRM:
+    "perc.ui.developer@Delete this community? Communities that are still in use cannot be deleted.",
+  COMM_DELETED: "perc.ui.developer@Community deleted.",
+  COMM_DELETE_ERROR: "perc.ui.developer@Could not delete community.",
+  COMM_IN_USE:
+    "perc.ui.developer@Community is in use and was not deleted. Dependencies were not ignored.",
+  COMM_MISSING: "perc.ui.developer@Community was not found.",
+  COMM_DELETE_NO_GUID: "perc.ui.developer@Community GUID is not available — cannot delete.",
   COMM_COL_LABEL: "perc.ui.developer@Label",
   COMM_COL_NAME: "perc.ui.developer@Name",
   COMM_COL_ID: "perc.ui.developer@Id",

--- a/WebUI/src/test/ts/api/developer/assemblyApi.communities.test.ts
+++ b/WebUI/src/test/ts/api/developer/assemblyApi.communities.test.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  COMMUNITY_LIST_ROOT,
+  COMMUNITY_NAME_LIST_ROOT,
+  GUID_LIST_ROOT,
+  createCommunities,
+  communityGuidForWrite,
+  createCommunity,
+  deleteCommunities,
+  deleteCommunity,
+  getCommunityDetail,
+  isCommunityWriteReady,
+  isValidCommunityName,
+  listCommunities,
+  normalizeCommunityName,
+  saveCommunities,
+  unwrapCommunityDetail,
+  unwrapCommunityList,
+  wrapCommunityListForWire,
+  wrapCommunityNameListForWire,
+  wrapGuidListForWire,
+} from "../../../../main/ts/api/developer/assemblyApi";
+import { PATHS } from "../../../../main/ts/api/paths";
+
+describe("community name validation (SE-01)", () => {
+  it("trims and rejects blank / whitespace names", () => {
+    expect(normalizeCommunityName("  QA  ")).toBe("QA");
+    expect(normalizeCommunityName("")).toBe("");
+    expect(normalizeCommunityName("   ")).toBe("");
+    expect(isValidCommunityName("")).toBe(false);
+    expect(isValidCommunityName("  ")).toBe(false);
+    expect(isValidCommunityName("Default")).toBe(true);
+    expect(isValidCommunityName("Swiss French")).toBe(true);
+    expect(isCommunityWriteReady({ name: "" })).toBe(false);
+    expect(isCommunityWriteReady({ name: "QA" })).toBe(true);
+  });
+});
+
+describe("community bulk wire wrap", () => {
+  it("wraps create names under List", () => {
+    expect(wrapCommunityNameListForWire(["Comm1", "Comm2"])).toEqual({
+      [COMMUNITY_NAME_LIST_ROOT]: ["Comm1", "Comm2"],
+    });
+  });
+
+  it("wraps CommunityList and GuidList envelopes for bulk JSON readers", () => {
+    const row = { name: "QA", guid: { stringValue: "0-13-42" } };
+    expect(wrapCommunityListForWire([row])).toEqual({
+      [COMMUNITY_LIST_ROOT]: [row],
+    });
+    expect(wrapGuidListForWire([{ stringValue: "0-13-42" }])).toEqual({
+      [GUID_LIST_ROOT]: [{ stringValue: "0-13-42" }],
+    });
+  });
+
+  it("unwraps CommunityList envelope and flat arrays", () => {
+    expect(
+      unwrapCommunityList({ CommunityList: [{ name: "Default" }] }),
+    ).toEqual([{ name: "Default" }]);
+    expect(unwrapCommunityList([{ name: "A" }])).toEqual([{ name: "A" }]);
+    expect(unwrapCommunityList({ Community: { name: "Solo" } })).toEqual([{ name: "Solo" }]);
+    expect(unwrapCommunityList(null)).toEqual([]);
+  });
+
+  it("normalizes nested Guid wraps on list items", () => {
+    const list = unwrapCommunityList({
+      CommunityList: [{ name: "QA", guid: { Guid: { stringValue: "0-13-42" } } }],
+    });
+    expect(list[0]?.guid?.stringValue).toBe("0-13-42");
+  });
+});
+
+describe("unwrapCommunityDetail / communityGuidForWrite (#4077)", () => {
+  it("unwraps Community root and nested Guid", () => {
+    const d = unwrapCommunityDetail({
+      Community: {
+        name: "QA",
+        id: 42,
+        guid: { Guid: { stringValue: "0-13-42", uuid: 42, type: 13 } },
+      },
+    });
+    expect(d.name).toBe("QA");
+    expect(d.guid?.stringValue).toBe("0-13-42");
+  });
+
+  it("synthesizes 0-13-{id} when Guid is missing", () => {
+    const d = unwrapCommunityDetail({ Community: { name: "QA", id: 1007 } });
+    expect(d.guid?.stringValue).toBe("0-13-1007");
+    expect(communityGuidForWrite(d)?.stringValue).toBe("0-13-1007");
+  });
+
+  it("communityGuidForWrite prefers nested Guid then fallback", () => {
+    expect(
+      communityGuidForWrite({ guid: { Guid: { stringValue: "0-13-9" } } })?.stringValue,
+    ).toBe("0-13-9");
+    expect(
+      communityGuidForWrite({ name: "QA" }, { stringValue: "0-13-8" })?.stringValue,
+    ).toBe("0-13-8");
+    expect(communityGuidForWrite({ name: "QA" })).toBeNull();
+  });
+});
+
+describe("createCommunities / saveCommunities / deleteCommunities (SE-01)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      statusText: status === 200 ? "OK" : "Error",
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("lists communities from GET find", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ CommunityList: [{ name: "Default", id: 10 }] }),
+    );
+    const list = await listCommunities();
+    expect(list).toEqual([
+      {
+        name: "Default",
+        id: 10,
+        guid: { stringValue: "0-13-10" },
+        guidString: "0-13-10",
+      },
+    ]);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(`${PATHS.COMMUNITIES}/find`);
+  });
+
+  it("POSTs create names to /services/communities/bulk", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ CommunityList: [{ name: "QA", guid: { stringValue: "0-13-42" } }] }),
+    );
+    const created = await createCommunities(["QA"]);
+    expect(created[0]?.name).toBe("QA");
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(`${PATHS.COMMUNITIES}/bulk`);
+    expect(JSON.parse(String(init.body))).toEqual({ List: ["QA"] });
+  });
+
+  it("getCommunityDetail unwraps Community root", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        Community: {
+          name: "QA",
+          id: 42,
+          guid: { Guid: { stringValue: "0-13-42" } },
+        },
+      }),
+    );
+    const d = await getCommunityDetail("QA");
+    expect(d.name).toBe("QA");
+    expect(d.guid?.stringValue).toBe("0-13-42");
+  });
+
+  it("createCommunity POSTs bulk names and does not PUT save", async () => {
+    const created = { name: "QA", guid: { stringValue: "0-13-42" } };
+    fetchMock.mockResolvedValueOnce(jsonResponse({ CommunityList: [created] }));
+    const out = await createCommunity(" QA ");
+    expect(out.name).toBe("QA");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const postInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(postInit.method).toBe("POST");
+    expect(JSON.parse(String(postInit.body))).toEqual({ List: ["QA"] });
+  });
+
+  it("saveCommunities PUTs CommunityList with release header", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await saveCommunities([{ name: "QA" }], true);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(JSON.parse(String(init.body))).toEqual({ CommunityList: [{ name: "QA" }] });
+  });
+
+  it("createCommunities blank name is 400", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: "name cannot be null or empty" }, 400),
+    );
+    await expect(createCommunities([" "])).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("createCommunities duplicate is 409", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: "Community already exists: Default" }, 409),
+    );
+    await expect(createCommunities(["Default"])).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("createCommunities non-Admin is 403", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: "Admin role required" }, 403),
+    );
+    await expect(createCommunities(["QA"])).rejects.toMatchObject({ status: 403 });
+  });
+
+  it("DELETEs GuidList without ignoredependencies by default", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await deleteCommunity({ stringValue: "0-13-42" });
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe("DELETE");
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(`${PATHS.COMMUNITIES}/bulk`);
+    expect(JSON.parse(String(init.body))).toEqual({
+      GuidList: [{ stringValue: "0-13-42" }],
+    });
+    const headers = new Headers(init.headers);
+    expect(headers.get("ignoredependencies")).toBe("false");
+  });
+
+  it("deleteCommunities in-use without ignore is 409", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: "Community has dependencies" }, 409),
+    );
+    await expect(
+      deleteCommunities([{ stringValue: "0-13-10" }], false),
+    ).rejects.toMatchObject({ status: 409 });
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers as HeadersInit);
+    expect(headers.get("ignoredependencies")).toBe("false");
+  });
+
+  it("deleteCommunities missing is 404", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ message: "not found" }, 404));
+    await expect(deleteCommunities([{ stringValue: "0-13-0" }])).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it("deleteCommunities non-Admin is 403", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: "Admin role required" }, 403),
+    );
+    await expect(deleteCommunities([{ stringValue: "0-13-42" }])).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+});

--- a/WebUI/src/test/ts/api/displayFormatGuid.test.ts
+++ b/WebUI/src/test/ts/api/displayFormatGuid.test.ts
@@ -20,6 +20,7 @@ import {
   normalizeDisplayFormatGuid,
   objectGuidString,
   resolveActionMenuObjectGuid,
+  resolveCommunityObjectGuid,
   resolveContentTypeObjectGuid,
   resolveTemplateObjectGuid,
   resolveViewObjectGuid,
@@ -84,6 +85,19 @@ describe("resolveContentTypeObjectGuid / resolveTemplateObjectGuid (#3319)", () 
       resolveActionMenuObjectGuid({ guid: { Guid: { stringValue: "0-107-4" } } }),
     ).toBe("0-107-4");
     expect(resolveActionMenuObjectGuid({}, undefined)).toBeUndefined();
+  });
+
+  it("resolves community GUID: nested, guidString, catalog, then 0-13-{id} (#4077)", () => {
+    expect(
+      resolveCommunityObjectGuid({ guid: { stringValue: "0-13-1" }, id: 9 }),
+    ).toBe("0-13-1");
+    expect(resolveCommunityObjectGuid({ guidString: "0-13-2", id: 9 })).toBe("0-13-2");
+    expect(resolveCommunityObjectGuid({ id: 9 }, " 0-13-3 ")).toBe("0-13-3");
+    expect(resolveCommunityObjectGuid({ id: 9 })).toBe("0-13-9");
+    expect(
+      resolveCommunityObjectGuid({ guid: { Guid: { stringValue: "0-13-4" } } }),
+    ).toBe("0-13-4");
+    expect(resolveCommunityObjectGuid({}, undefined)).toBeUndefined();
   });
 
   it("resolves view GUID: nested, guidString, catalog, then 0-18-{id} (#3380)", () => {

--- a/WebUI/src/test/ts/developer/CommunitiesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/CommunitiesPanel.test.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2026 Intersoft Data Labs, Inc.
  */
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionRedirectError } from "../../../main/ts/api/client";
@@ -10,9 +10,21 @@ import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
 import { CommunitiesPanel } from "../../../main/ts/developer/CommunitiesPanel";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 
-vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
-  listCommunities: vi.fn(),
-}));
+vi.mock("../../../main/ts/api/developer/assemblyApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../main/ts/api/developer/assemblyApi")
+  >();
+  return {
+    ...actual,
+    listCommunities: vi.fn(),
+    getCommunityDetail: vi.fn(),
+    listAvailableRoles: vi.fn().mockResolvedValue([]),
+    getCommunityVisibility: vi.fn().mockResolvedValue([]),
+    updateCommunityRoles: vi.fn(),
+    createCommunity: vi.fn(),
+    deleteCommunity: vi.fn(),
+  };
+});
 
 const listCommunities = assemblyApi.listCommunities as ReturnType<typeof vi.fn>;
 
@@ -43,6 +55,7 @@ describe("CommunitiesPanel", () => {
       "Default Community",
     );
     expect(screen.getByTestId("developer-comm-table").textContent).toContain("DefaultComm");
+    expect(screen.getByTestId("developer-comm-new")).toBeTruthy();
   });
 
   it("shows empty state when API returns no communities", async () => {
@@ -51,6 +64,19 @@ describe("CommunitiesPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-comm-empty")).toBeTruthy();
     });
+    expect(screen.getByTestId("developer-comm-new")).toBeTruthy();
+  });
+
+  it("opens create chrome from New community", async () => {
+    listCommunities.mockResolvedValue([]);
+    render(<CommunitiesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-new")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-comm-new"));
+    expect(screen.getByTestId("developer-comm-detail")).toBeTruthy();
+    expect(screen.getByTestId("developer-comm-create")).toBeTruthy();
+    expect(screen.getByTestId("developer-comm-name")).toBeTruthy();
   });
 
   it("shows session-redirect message via panelErrMsg", async () => {

--- a/WebUI/src/test/ts/developer/CommunityDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/CommunityDetailPanel.test.tsx
@@ -10,17 +10,27 @@ import * as assemblyApi from "../../../main/ts/api/developer/assemblyApi";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
 import { CommunityDetailPanel } from "../../../main/ts/developer/CommunityDetailPanel";
 
-vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
-  getCommunityDetail: vi.fn(),
-  listAvailableRoles: vi.fn(),
-  getCommunityVisibility: vi.fn(),
-  updateCommunityRoles: vi.fn(),
-}));
+vi.mock("../../../main/ts/api/developer/assemblyApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../main/ts/api/developer/assemblyApi")
+  >();
+  return {
+    ...actual,
+    getCommunityDetail: vi.fn(),
+    listAvailableRoles: vi.fn(),
+    getCommunityVisibility: vi.fn(),
+    updateCommunityRoles: vi.fn(),
+    createCommunity: vi.fn(),
+    deleteCommunity: vi.fn(),
+  };
+});
 
 const getCommunityDetail = assemblyApi.getCommunityDetail as ReturnType<typeof vi.fn>;
 const listAvailableRoles = assemblyApi.listAvailableRoles as ReturnType<typeof vi.fn>;
 const getCommunityVisibility = assemblyApi.getCommunityVisibility as ReturnType<typeof vi.fn>;
 const updateCommunityRoles = assemblyApi.updateCommunityRoles as ReturnType<typeof vi.fn>;
+const createCommunity = assemblyApi.createCommunity as ReturnType<typeof vi.fn>;
+const deleteCommunity = assemblyApi.deleteCommunity as ReturnType<typeof vi.fn>;
 
 const sampleDetail = {
   name: "Default",
@@ -45,6 +55,8 @@ describe("CommunityDetailPanel", () => {
     listAvailableRoles.mockReset();
     getCommunityVisibility.mockReset();
     updateCommunityRoles.mockReset();
+    createCommunity.mockReset();
+    deleteCommunity.mockReset();
     listAvailableRoles.mockResolvedValue(sampleRoles);
     getCommunityVisibility.mockResolvedValue([]);
   });
@@ -223,5 +235,212 @@ describe("CommunityDetailPanel", () => {
     expect(screen.getByTestId("developer-comm-detail-error").textContent).toBe(
       DEV_MSG.COMM_DETAIL_ERROR,
     );
+  });
+
+  it("shows 404 missing community via panelErrMsg", async () => {
+    getCommunityDetail.mockRejectedValue({
+      status: 404,
+      statusText: "Not Found",
+      body: { message: "Community not found" },
+    });
+    render(<CommunityDetailPanel idOrName="missing" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toContain(
+      DEV_MSG.COMM_DETAIL_ERROR,
+    );
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toContain(
+      "Community not found",
+    );
+    expect(screen.queryByTestId("developer-comm-roles-save")).toBeNull();
+  });
+
+  it("disables create until the name is non-blank", () => {
+    render(<CommunityDetailPanel idOrName={null} onBack={() => undefined} />);
+    const create = screen.getByTestId("developer-comm-create") as HTMLButtonElement;
+    expect(create.disabled).toBe(true);
+    fireEvent.change(screen.getByTestId("developer-comm-name"), {
+      target: { value: "   " },
+    });
+    expect(create.disabled).toBe(true);
+    fireEvent.change(screen.getByTestId("developer-comm-name"), {
+      target: { value: "QA Community" },
+    });
+    expect(create.disabled).toBe(false);
+  });
+
+  it("surfaces 400 blank name on create", async () => {
+    createCommunity.mockRejectedValue({
+      status: 400,
+      statusText: "Bad Request",
+      body: { message: "name cannot be null or empty" },
+    });
+    const onSaved = vi.fn();
+    render(
+      <CommunityDetailPanel idOrName={null} onBack={() => undefined} onSaved={onSaved} />,
+    );
+    fireEvent.change(screen.getByTestId("developer-comm-name"), {
+      target: { value: "x" },
+    });
+    fireEvent.click(screen.getByTestId("developer-comm-create"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(createCommunity).toHaveBeenCalled();
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toContain(
+      DEV_MSG.COMM_NAME_INVALID,
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("surfaces 409 duplicate name on create", async () => {
+    createCommunity.mockRejectedValue({
+      status: 409,
+      statusText: "Conflict",
+      body: { message: "Community already exists: Default" },
+    });
+    const onSaved = vi.fn();
+    render(
+      <CommunityDetailPanel idOrName={null} onBack={() => undefined} onSaved={onSaved} />,
+    );
+    fireEvent.change(screen.getByTestId("developer-comm-name"), {
+      target: { value: "Default" },
+    });
+    fireEvent.click(screen.getByTestId("developer-comm-create"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toContain(
+      DEV_MSG.COMM_DUPLICATE,
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("surfaces 403 non-Admin on create", async () => {
+    createCommunity.mockRejectedValue({
+      status: 403,
+      statusText: "Forbidden",
+      body: { message: "Admin role required" },
+    });
+    render(<CommunityDetailPanel idOrName={null} onBack={() => undefined} />);
+    fireEvent.change(screen.getByTestId("developer-comm-name"), {
+      target: { value: "QA Community" },
+    });
+    fireEvent.click(screen.getByTestId("developer-comm-create"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toContain(
+      DEV_MSG.COMM_FORBIDDEN,
+    );
+  });
+
+  it("creates a community and keeps role-association chrome", async () => {
+    createCommunity.mockResolvedValue({
+      name: "QA Community",
+      id: 42,
+      guid: { stringValue: "0-13-42" },
+    });
+    getCommunityDetail.mockResolvedValue({
+      name: "QA Community",
+      id: 42,
+      guid: { stringValue: "0-13-42" },
+      roleList: [],
+    });
+    const onSaved = vi.fn();
+    render(
+      <CommunityDetailPanel idOrName={null} onBack={() => undefined} onSaved={onSaved} />,
+    );
+    fireEvent.change(screen.getByTestId("developer-comm-name"), {
+      target: { value: "QA Community" },
+    });
+    fireEvent.click(screen.getByTestId("developer-comm-create"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-notice").textContent).toContain(
+        DEV_MSG.COMM_CREATED,
+      );
+    });
+    expect(createCommunity).toHaveBeenCalledWith("QA Community");
+    expect(onSaved).toHaveBeenCalled();
+    expect(screen.getByTestId("developer-comm-roles-save")).toBeTruthy();
+    expect(screen.getByTestId("developer-comm-delete")).toBeTruthy();
+  });
+
+  it("surfaces 409 in-use delete without ignoredependencies and does not steal", async () => {
+    getCommunityDetail.mockResolvedValue(sampleDetail);
+    deleteCommunity.mockRejectedValue({
+      status: 409,
+      statusText: "Conflict",
+      body: { message: "Community has dependencies" },
+    });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const onDeleted = vi.fn();
+    render(
+      <CommunityDetailPanel
+        idOrName="Default"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-comm-delete"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(deleteCommunity).toHaveBeenCalledWith(sampleDetail.guid, false);
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toContain(
+      DEV_MSG.COMM_IN_USE,
+    );
+    expect(onDeleted).not.toHaveBeenCalled();
+    expect(screen.getByTestId("developer-comm-detail-title")).toBeTruthy();
+    confirm.mockRestore();
+  });
+
+  it("surfaces 403 non-Admin on delete", async () => {
+    getCommunityDetail.mockResolvedValue(sampleDetail);
+    deleteCommunity.mockRejectedValue({
+      status: 403,
+      statusText: "Forbidden",
+      body: { message: "Admin role required" },
+    });
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<CommunityDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-comm-delete"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-comm-detail-error").textContent).toContain(
+      DEV_MSG.COMM_FORBIDDEN,
+    );
+    confirm.mockRestore();
+  });
+
+  it("delete success returns to catalog via onDeleted", async () => {
+    getCommunityDetail.mockResolvedValue(sampleDetail);
+    deleteCommunity.mockResolvedValue(undefined);
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const onDeleted = vi.fn();
+    render(
+      <CommunityDetailPanel
+        idOrName="Default"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-comm-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-comm-delete"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteCommunity).toHaveBeenCalledWith(sampleDetail.guid, false);
+    confirm.mockRestore();
   });
 });

--- a/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
+++ b/WebUI/src/test/ts/developer/DeveloperShell.test.tsx
@@ -288,8 +288,13 @@ vi.mock("../../../main/ts/api/developer/keywordsApi", () => ({
   deleteKeyword: vi.fn(),
 }));
 
-vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
-  listTemplates: vi.fn().mockResolvedValue([
+vi.mock("../../../main/ts/api/developer/assemblyApi", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("../../../main/ts/api/developer/assemblyApi")
+  >();
+  return {
+    ...actual,
+    listTemplates: vi.fn().mockResolvedValue([
     {
       templateId: 1,
       templateName: "perc.page",
@@ -407,7 +412,12 @@ vi.mock("../../../main/ts/api/developer/assemblyApi", () => ({
       guid: { stringValue: "0-10-1", uuid: 1 },
     },
   ]),
-}));
+  createCommunity: vi.fn(),
+  deleteCommunity: vi.fn(),
+  isCommunityWriteReady: vi.fn((opts: { name?: string }) => Boolean(opts?.name?.trim())),
+  isValidCommunityName: vi.fn((n: string) => Boolean(n?.trim())),
+  };
+});
 
 vi.mock("../../../main/ts/api/developer/pipelinesApi", () => ({
   listApplications: vi.fn().mockResolvedValue([
@@ -1258,11 +1268,10 @@ it("loads views catalog section", async () => {
     );
     (getCommunityVisibility as ReturnType<typeof vi.fn>).mockClear();
     (getCommunityDetail as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      id: 10,
       name: "Default",
       label: "Default",
       description: "Default Community",
-      // no guid
+      // no guid and no id — cannot synthesize 0-13-{id}
       roleList: [
         { roleId: 1, roleName: "Admin", roleGuid: { stringValue: "0-14-1", uuid: 1 } },
       ],

--- a/docs/ai-generated/code-reviews/4077-spa-community-create-delete-erlang.md
+++ b/docs/ai-generated/code-reviews/4077-spa-community-create-delete-erlang.md
@@ -1,0 +1,54 @@
+# Erlang review — #4077 SPA SE-01 community create/delete
+
+**Branch:** `feat/issue-4077-spa-community-create-delete`  
+**Base:** `origin/main`  
+**Date:** 2026-08-31  
+**Reviewer:** Erlang (independent of implementer)
+
+## Summary
+
+Developer → Communities catalog create/delete using existing REST
+`POST /services/communities/bulk` and `DELETE /services/communities/bulk`.
+Role-association save on the detail panel is unchanged. Server persist is
+create+save on native `PSCommunity` (Workbench Finish). SPA create is POST-only.
+Nested Jackson Guid wraps are flattened so delete has a usable GUID.
+Duplicate/in-use map to HTTP 409 without `log.error`.
+
+## Scope
+
+- `WebUI/src/main/ts/**` communities catalog/detail, assembly API, GUID helpers
+- `rest` CommunityList/GuidList JSON readers (AclList peer), write-failure map
+- `projects/sitemanage` CommunityAdaptor persist-on-create + 409 mapping
+- `system` `PSSecurityDesignWs.loadCommunities` null-slot skip
+- Playwright `developer-community-editor.spec.js`, product-docs 8.2
+- Prior memory: WRAP_ROOT_VALUE unwrap (#3039), AclList String-body readers (#3391),
+  nested Guid (#3200/#3380)
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+No remaining bugs. Behavioral tests cover 400/403/409 create, 409 in-use
+delete without `ignoredependencies`, nested Guid unwrap, persist-on-create
+duplicate. Cross-platform path review: no new filesystem path construction
+(REST/URL paths use `/` correctly). Playwright C5 passed on H2 QA.
+
+## Issues
+
+None.
+
+## Evidence
+
+- rest `mvnw clean install` BUILD SUCCESS, Tests run: 953
+- sitemanage BUILD SUCCESS, Tests run: 2016 (Failures 0)
+- perc-system BUILD SUCCESS, Tests run: 2638 (Failures 0)
+- WebUI BUILD SUCCESS, Tests 3580 passed
+- perc-qa-automation BUILD SUCCESS
+- Playwright surface `tests/developer-community-editor.spec.js` 2 passed;
+  console-clean=yes; server.log-clean=yes
+- C2: `ICommunityResource` signatures unchanged; `CommunityList`/`GuidList`
+  not made `final`; sitemanage reverse-dep installed

--- a/modules/perc-qa-automation/frontend/tests/developer-community-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-community-editor.spec.js
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Communities create / delete chrome (#4077 SE-01 / parent #1690).
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   python docker/scripts/perc-devctl.py qa-health
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/developer-community-editor.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function developerCommunitiesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "communities",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+/** Unique community name; spaces are allowed by REST. */
+function uniqueCommunityName() {
+  const a = Date.now().toString(36).replace(/[^a-z0-9]/g, "").slice(-4);
+  const b = Math.random().toString(36).replace(/[^a-z0-9]/g, "").slice(2, 6);
+  const suffix = `${a}${b}`.slice(0, 8);
+  return `QA 4077 ${suffix || "comm"}`;
+}
+
+async function openCommunitiesCatalog(page) {
+  await page.goto(developerCommunitiesUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+  const panel = page.locator('[data-testid="developer-comm-panel"]');
+  const empty = page.locator('[data-testid="developer-comm-empty"]');
+  const listError = page.locator('[data-testid="developer-comm-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer communities catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  await expect(page.locator('[data-testid="developer-comm-new"]')).toBeVisible();
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(
+    unexpectedConsole,
+    `console error: ${unexpectedConsole.join(" | ")}`,
+  ).toEqual([]);
+}
+
+test.describe("Developer community editor (#4077 / SE-01)", () => {
+  test("Admin can create a uniquely named community and delete it", async ({ page }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+    page.on("dialog", (dialog) => dialog.accept());
+
+    await loginAsAdmin(page);
+    await openCommunitiesCatalog(page);
+
+    const name = uniqueCommunityName();
+
+    await page.locator('[data-testid="developer-comm-new"]').click();
+    await expect(page.locator('[data-testid="developer-comm-detail"]')).toBeVisible();
+    const createBtn = page.locator('[data-testid="developer-comm-create"]');
+    await expect(createBtn).toBeDisabled();
+
+    await page.locator('[data-testid="developer-comm-name"]').fill("   ");
+    await expect(createBtn).toBeDisabled();
+    await page.locator('[data-testid="developer-comm-name"]').fill(name);
+    await expect(createBtn).toBeEnabled();
+    await createBtn.click();
+
+    const notice = page.locator('[data-testid="developer-comm-detail-notice"]');
+    const saveError = page.locator('[data-testid="developer-comm-detail-error"]');
+    await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+    if (await saveError.isVisible()) {
+      throw new Error(`Create failed: ${(await saveError.innerText()).trim()}`);
+    }
+    await expect(page.locator('[data-testid="developer-comm-roles-save"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    await page.locator('[data-testid="developer-comm-back"]').click();
+    await expect(page.locator('[data-testid="developer-comm-panel"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator(`[data-comm-name="${name}"]`)).toBeVisible({
+      timeout: 20_000,
+    });
+
+    await page.locator(`[data-comm-name="${name}"]`).click();
+    await expect(page.locator('[data-testid="developer-comm-detail"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-comm-roles-save"]')).toBeVisible();
+    await page.locator('[data-testid="developer-comm-delete"]').click();
+    await expect(page.locator('[data-testid="developer-comm-panel"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator(`[data-comm-name="${name}"]`)).toHaveCount(0);
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+
+  test("duplicate name 409 is surfaced in the UI", async ({ page }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+    page.on("dialog", (dialog) => dialog.accept());
+
+    await loginAsAdmin(page);
+    await openCommunitiesCatalog(page);
+
+    const name = uniqueCommunityName();
+    await page.locator('[data-testid="developer-comm-new"]').click();
+    await expect(page.locator('[data-testid="developer-comm-detail"]')).toBeVisible();
+    await page.locator('[data-testid="developer-comm-name"]').fill(name);
+    await page.locator('[data-testid="developer-comm-create"]').click();
+    const firstNotice = page.locator('[data-testid="developer-comm-detail-notice"]');
+    const firstErr = page.locator('[data-testid="developer-comm-detail-error"]');
+    await expect(firstNotice.or(firstErr).first()).toBeVisible({ timeout: 20_000 });
+    if (await firstErr.isVisible()) {
+      throw new Error(`Create failed: ${(await firstErr.innerText()).trim()}`);
+    }
+
+    await page.locator('[data-testid="developer-comm-back"]').click();
+    await expect(page.locator('[data-testid="developer-comm-new"]')).toBeVisible();
+    await page.locator('[data-testid="developer-comm-new"]').click();
+    await page.locator('[data-testid="developer-comm-name"]').fill(name);
+    await page.locator('[data-testid="developer-comm-create"]').click();
+
+    const err = page.locator('[data-testid="developer-comm-detail-error"]');
+    await expect(err).toBeVisible({ timeout: 20_000 });
+    await expect(err).toContainText(/already exists|409|duplicate/i);
+
+    await page.locator('[data-testid="developer-comm-back"]').click();
+    const openCreated = page.locator(`[data-comm-name="${name}"]`);
+    if (await openCreated.count()) {
+      await openCreated.click();
+      await expect(page.locator('[data-testid="developer-comm-delete"]')).toBeVisible();
+      await page.locator('[data-testid="developer-comm-delete"]').click();
+    }
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/modules/perc-qa-automation/frontend/tests/helpers/developer-smoke-set.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/developer-smoke-set.js
@@ -166,6 +166,13 @@ const DEVELOPER_SMOKE_SET = [
     notes: "UI-06 SPA search create/delete (#4076 / parent #1690)",
   },
   {
+    id: "community-editor",
+    file: "developer-community-editor.spec.js",
+    title: "Admin can create a uniquely named community and delete it",
+    status: "green",
+    notes: "SE-01 SPA community create/delete (#4077 / parent #1690)",
+  },
+  {
     id: "catalog-system-def",
     file: "developer-catalog-smoke.spec.js",
     title: "system-def: catalog loads without API error",

--- a/product-docs/8.2/admin/developer-communities.md
+++ b/product-docs/8.2/admin/developer-communities.md
@@ -1,0 +1,65 @@
+---
+id: admin-developer-communities
+title: Developer Communities
+description: Create and delete CMS communities from Developer Communities chrome
+version: "8.2"
+order: 45
+tags: [admin, developer, communities]
+---
+
+# Developer Communities
+
+**Developer → Communities** lists CMS communities (label, unique name, id, and
+description). Admins can **create** a community and **delete** one from this
+chrome. Open an existing community to **edit role membership** and inspect
+**object visibility**. Per-object COMMUNITY ACL entries stay on object detail
+panels (for example content types).
+
+## Product path — create and delete
+
+1. Sign in as **Admin** (create and delete require the Admin role).
+2. Open **Developer → Communities**, or deep-link
+   `spa.jsp?entry=developer&section=communities`.
+3. Click **New community**. Enter a **name** (required, unique,
+   case-insensitive). Spaces are allowed. Create stays disabled until the
+   name is non-blank after trim.
+4. Click **Create community**. A duplicate name is **409** and the editor
+   shows that the community already exists. A blank name is **400**. A
+   non-Admin session is **403**. After a successful create, the catalog
+   includes the new row when you return to the list, and the detail panel
+   still offers **role membership** save.
+5. Open an existing community and click **Delete community**, then confirm.
+   The catalog no longer lists that name. Delete of a missing community is
+   **404**. A community that is still **in use** (dependencies) is **409**
+   and remains — the SPA does **not** send `ignoredependencies` and does not
+   steal. Non-Admin is **403**.
+
+Role membership save on the same detail panel is unchanged: check roles and
+**Save roles**.
+
+## Limits
+
+- Create uses the existing bulk REST (`POST /services/communities/bulk`). The
+  server persists on create (Workbench Finish create+save). Name is the catalog
+  key. The SPA does not PUT the DTO back after create.
+- Delete uses `DELETE /services/communities/bulk` with the community GUID
+  and `ignoredependencies=false`.
+- Community visibility remains a read-only lens. Object ACL for a COMMUNITY
+  principal is edited on the object, not here.
+- Session community switch in the header is a separate membership list; it
+  is not this catalog.
+
+## REST
+
+The chrome calls:
+
+| Action | Request |
+|--------|---------|
+| List | `GET /services/communities/find?name=*` |
+| Load | `GET /services/communities/{idOrName}` |
+| Create | `POST /services/communities/bulk` (name list; server persists) |
+| Roles | `PUT /services/communities/{idOrName}/roles` |
+| Delete | `DELETE /services/communities/bulk` (GuidList; `ignoredependencies=false`) |
+
+Integrator notes: [REST API](id:developer-rest). Related security chrome:
+[Users, roles & security](id:admin-users-roles).

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -114,6 +114,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 - [Developer Slots](id:admin-developer-slots)
 - [Developer Item Filters](id:admin-developer-item-filters)
 - [Developer Searches](id:admin-developer-searches)
+- [Developer Communities](id:admin-developer-communities)
 - [Object ACL & default template](id:admin-object-acl)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)

--- a/product-docs/8.2/admin/users-roles.md
+++ b/product-docs/8.2/admin/users-roles.md
@@ -78,6 +78,23 @@ Workflow states gate who can edit and publish. Common patterns:
   documentation for your configured authenticator.
 - Protect the login endpoint behind TLS at the reverse proxy or edge.
 
+## Developer Communities (create and delete)
+
+**Developer → Communities** (deep link `spa.jsp?entry=developer&section=communities`)
+is the SPA catalog for CMS communities. Admins can **create** a uniquely named
+community and **delete** one that is not in use, without Workbench.
+
+- **New community** requires a non-blank name (spaces allowed). Duplicate
+  names are **409**. Blank names are **400**. Non-Admin is **403**.
+- **Delete community** on the detail panel removes that community from the
+  catalog. An in-use community (dependencies) is **409** and remains — the
+  SPA does not send `ignoredependencies` and does not steal.
+- Role membership on the same detail panel is unchanged (**Save roles**).
+  Session **Switch** in the header is a separate membership list; it is not
+  this catalog.
+
+See [Developer Communities](id:admin-developer-communities).
+
 ## Session community (top nav)
 
 After sign-in, the header user menu shows the **current community** next to **Signed in as**.

--- a/product-docs/8.2/developer/index.md
+++ b/product-docs/8.2/developer/index.md
@@ -32,6 +32,8 @@ Operators using **Developer → Slots** create/delete chrome: [Developer Slots](
 
 Operators using **Developer → Item Filters** create/save/delete chrome: [Developer Item Filters](id:admin-developer-item-filters).
 
+Operators using **Developer → Communities** create/delete chrome: [Developer Communities](id:admin-developer-communities).
+
 ## Architecture snapshot
 
 ```text

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -366,6 +366,37 @@ The slot form stays on screen (or shows an in-panel error). It does
 still render as the human-readable **message** (fallback **code**). Load failures stay
 in the slot detail panel — use **Back** to return to the catalog.
 
+## Communities (design catalog)
+
+CMS **communities** used by **Developer → Communities** are exposed under
+`/services/communities`. Create and delete reuse the existing bulk design
+surface (`ICommunityAdaptor.createCommunities` / `saveCommunities` /
+`deleteCommunities`). Do not invent a second REST resource.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/communities/find?name=*` | List community summaries |
+| `GET` | `/services/communities/{idOrName}` | Detail with role membership |
+| `POST` | `/services/communities/bulk` | **Admin.** Create from a name list (`{"List":["Name"]}`); server persists |
+| `PUT` | `/services/communities/bulk` | **Admin.** Persist edited communities (`release` header) |
+| `PUT` | `/services/communities/{idOrName}/roles` | Replace role membership |
+| `DELETE` | `/services/communities/bulk` | **Admin.** Delete by GuidList (`ignoredependencies` header) |
+
+Create (`POST /services/communities/bulk`) persists on the server (Workbench
+Finish create+save). JSON create body is a name list. The SPA create path does
+not PUT the DTO back. Blank / whitespace-only names are **400**. Duplicate name
+(case-insensitive) is **409**. Non-Admin is **403**. The new community is then
+`GET /services/communities/find?name=*` **200**.
+
+Delete (`DELETE /services/communities/bulk`) accepts a GuidList. The SPA sends
+`ignoredependencies=false`. Success omits the community from a following find.
+Missing is **404**. In-use (dependencies) without ignore is **409** and the
+community remains (the lock is not stolen). Non-Admin is **403**.
+
+**Developer → Communities** catalog create and delete use these bulk endpoints.
+Role-association save stays `PUT /services/communities/{idOrName}/roles`. See
+[Developer Communities](id:admin-developer-communities).
+
 ## Item filters (design catalog)
 
 Assembly **item filters** (Workbench **Item Filter** editor: name / description / rules /

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/CommunityAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/CommunityAdaptor.java
@@ -29,11 +29,14 @@ import com.percussion.rest.communities.ICommunityAdaptor;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.security.data.PSCommunity;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.security.IPSSecurityDesignWs;
+import com.percussion.webservices.PSErrorsException;
 import com.percussion.webservices.system.IPSSystemWs;
+import jakarta.ws.rs.WebApplicationException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -66,7 +69,23 @@ public class CommunityAdaptor implements ICommunityAdaptor {
     var session = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
     var user = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
 
-    var ps_communities = securityDesignWs.createCommunities(names, session, user);
+    List<PSCommunity> ps_communities;
+    try {
+      ps_communities = securityDesignWs.createCommunities(names, session, user);
+    } catch (IllegalArgumentException e) {
+      throw mapCreateNameFailure(names, e);
+    }
+    // Persist immediately (Workbench Finish / slots create+save). Do not
+    // round-trip REST DTOs through saveCommunities — convertCommunity +
+    // getRenamedCommunities/loadCommunities NPEs on unsaved stubs.
+    try {
+      securityDesignWs.saveCommunities(ps_communities, true, session, user);
+    } catch (RuntimeException e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException(communityAlreadyExistsMessage(names), 409);
+      }
+      throw new IllegalStateException("Failed to persist communities", e);
+    }
 
     for (var c : ps_communities) {
       communities.add(ApiUtils.convertPSCommunity(c));
@@ -308,8 +327,41 @@ public class CommunityAdaptor implements ICommunityAdaptor {
     var session = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
     var user = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
 
-    securityDesignWs.deleteCommunities(
-        ApiUtils.convertGuids(ids), ignoreDependencies, session, user);
+    try {
+      securityDesignWs.deleteCommunities(
+          ApiUtils.convertGuids(ids), ignoreDependencies, session, user);
+    } catch (PSErrorsException e) {
+      throw new WebApplicationException("Community has dependencies", 409);
+    }
+  }
+
+  static RuntimeException mapCreateNameFailure(List<String> names, IllegalArgumentException e) {
+    if (isAlreadyExistsFailure(e)) {
+      return new WebApplicationException(communityAlreadyExistsMessage(names), 409);
+    }
+    return e;
+  }
+
+  static String communityAlreadyExistsMessage(List<String> names) {
+    String n = "";
+    if (names != null) {
+      for (String name : names) {
+        if (StringUtils.isNotBlank(name)) {
+          n = name.trim();
+          break;
+        }
+      }
+    }
+    return StringUtils.isBlank(n) ? "Community already exists" : "Community already exists: " + n;
+  }
+
+  static boolean isAlreadyExistsFailure(Throwable t) {
+    for (Throwable cur = t; cur != null && cur != cur.getCause(); cur = cur.getCause()) {
+      if (StringUtils.containsIgnoreCase(cur.getMessage(), "already exists")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -131,6 +131,9 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
                  Rest jar also has AclListDeserializer so a stale filesystem beans.xml
                  (hot-deploy jars only) still binds {"AclList":[…]} as AclList. -->
             <ref bean="aclListJsonReader" />
+            <!-- #4077 SE-01: CommunityList / GuidList ArrayList subclass bulk save/delete. -->
+            <ref bean="communityListJsonReader" />
+            <ref bean="guidListJsonReader" />
             <!-- #3360 / #3361: Explorer folder create posts flat {name,parentPath};
                  JAXB expects AddFolderRequest root. Bind both envelopes. -->
             <ref bean="addFolderRequestJsonReader" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/CommunityAdaptorCreateDeleteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/CommunityAdaptorCreateDeleteTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.Guid;
+import com.percussion.rest.GuidList;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.security.IPSSecurityDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+class CommunityAdaptorCreateDeleteTest {
+
+  private IPSSecurityDesignWs securityDesignWs;
+  private CommunityAdaptor adaptor;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    securityDesignWs = mock(IPSSecurityDesignWs.class);
+    adaptor = new CommunityAdaptor();
+    Field field = CommunityAdaptor.class.getDeclaredField("securityDesignWs");
+    field.setAccessible(true);
+    field.set(adaptor, securityDesignWs);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void duplicateNameIs409AndDoesNotSave() {
+    when(securityDesignWs.createCommunities(anyList(), eq("test-session"), eq("Admin")))
+        .thenThrow(
+            new IllegalArgumentException(
+                "The name 'Default' for type 'COMMUNITY_DEF' already exists."));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.createCommunities(List.of("Default")));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(String.valueOf(ex.getMessage()).toLowerCase().contains("already exists"));
+    verify(securityDesignWs, never()).saveCommunities(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void blankNameStaysIllegalArgument() {
+    when(securityDesignWs.createCommunities(anyList(), eq("test-session"), eq("Admin")))
+        .thenThrow(new IllegalArgumentException("name cannot be null or empty"));
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createCommunities(List.of(" ")));
+    assertTrue(ex.getMessage().toLowerCase().contains("empty"));
+  }
+
+  @Test
+  void deleteInUseWithoutIgnoreIs409() {
+    doThrow(new PSErrorsException())
+        .when(securityDesignWs)
+        .deleteCommunities(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    GuidList ids = new GuidList();
+    Guid g = new Guid();
+    g.setStringValue("0-13-10");
+    ids.add(g);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteCommunities(ids, false));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void isAlreadyExistsFailureReadsMessage() {
+    assertTrue(
+        CommunityAdaptor.isAlreadyExistsFailure(
+            new IllegalArgumentException("The name 'QA' for type 'COMMUNITY_DEF' already exists.")));
+    assertFalse(
+        CommunityAdaptor.isAlreadyExistsFailure(
+            new IllegalArgumentException("name cannot be null or empty")));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -64,6 +64,11 @@ class CatalogRestJaxrsRegistrationTest {
   /** Display Format Object ACL save #3378 — must precede jacksonProvider. */
   private static final String ACL_LIST_JSON_READER = "aclListJsonReader";
 
+  /** SE-01 community bulk save/delete #4077 — must precede jacksonProvider. */
+  private static final String COMMUNITY_LIST_JSON_READER = "communityListJsonReader";
+
+  private static final String GUID_LIST_JSON_READER = "guidListJsonReader";
+
   /** Explorer folder create #3360 — must precede jacksonProvider. */
   private static final String ADD_FOLDER_JSON_READER = "addFolderRequestJsonReader";
 
@@ -121,6 +126,9 @@ class CatalogRestJaxrsRegistrationTest {
     int reader = providerBlock.indexOf("bean=\"" + VIEW_EXECUTE_JSON_READER + "\"");
     int searchReader = providerBlock.indexOf("bean=\"" + SEARCH_EXECUTE_JSON_READER + "\"");
     int aclReader = providerBlock.indexOf("bean=\"" + ACL_LIST_JSON_READER + "\"");
+    int communityListReader =
+        providerBlock.indexOf("bean=\"" + COMMUNITY_LIST_JSON_READER + "\"");
+    int guidListReader = providerBlock.indexOf("bean=\"" + GUID_LIST_JSON_READER + "\"");
     int addFolderReader = providerBlock.indexOf("bean=\"" + ADD_FOLDER_JSON_READER + "\"");
     int findTypesReader = providerBlock.indexOf("bean=\"" + FIND_TYPES_JSON_READER + "\"");
     int autoTranslationReader =
@@ -141,6 +149,16 @@ class CatalogRestJaxrsRegistrationTest {
         "rest-jax-rs providers must ref "
             + ACL_LIST_JSON_READER
             + " (missing → ACL bulk save ArrayList ClassCast 400)");
+    assertTrue(
+        communityListReader >= 0,
+        "rest-jax-rs providers must ref "
+            + COMMUNITY_LIST_JSON_READER
+            + " (missing → community bulk save ArrayList ClassCast 400)");
+    assertTrue(
+        guidListReader >= 0,
+        "rest-jax-rs providers must ref "
+            + GUID_LIST_JSON_READER
+            + " (missing → community bulk delete GuidList ClassCast 400)");
     assertTrue(
         addFolderReader >= 0,
         "rest-jax-rs providers must ref "
@@ -166,6 +184,12 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(
         aclReader < jackson,
         ACL_LIST_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        communityListReader < jackson,
+        COMMUNITY_LIST_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        guidListReader < jackson,
+        GUID_LIST_JSON_READER + " must be listed before jacksonProvider");
     assertTrue(
         addFolderReader < jackson,
         ADD_FOLDER_JSON_READER + " must be listed before jacksonProvider");

--- a/rest/src/main/java/com/percussion/rest/GuidList.java
+++ b/rest/src/main/java/com/percussion/rest/GuidList.java
@@ -17,15 +17,21 @@
 
 package com.percussion.rest;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.stream.Collectors;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlRootElement(name = "GuidList")
+@JsonRootName("GuidList")
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonDeserialize(using = GuidListDeserializer.class)
 @Schema(description = "A list of Guids, commonly used for bulk operations")
 public class GuidList extends ArrayList<Guid> {
   private static final long serialVersionUID = 1L;

--- a/rest/src/main/java/com/percussion/rest/GuidListDeserializer.java
+++ b/rest/src/main/java/com/percussion/rest/GuidListDeserializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+
+/**
+ * Instantiates {@link GuidList} instead of a raw {@code ArrayList} after CXF UNWRAP_ROOT_VALUE.
+ * Peer {@link com.percussion.rest.acls.AclListDeserializer}.
+ */
+public class GuidListDeserializer extends ValueDeserializer<GuidList> {
+
+  @Override
+  public GuidList deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+    if (p == null) {
+      return new GuidList();
+    }
+    JsonToken token = p.currentToken();
+    if (token == null) {
+      token = p.nextToken();
+    }
+    if (token == null || token == JsonToken.VALUE_NULL) {
+      return new GuidList();
+    }
+    JsonNode node = ctxt != null ? ctxt.readTree(p) : p.readValueAsTree();
+    return GuidListJsonReader.parseNode(node);
+  }
+
+  @Override
+  public GuidList getNullValue(DeserializationContext ctxt) {
+    return new GuidList();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/GuidListJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/GuidListJsonReader.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for GuidList bodies (DELETE {@code /services/communities/bulk} and other bulk
+ * GuidList operations).
+ *
+ * <p>Same ArrayList-subclass ClassCast / Jettison JSONObject barrier as {@code
+ * CommunityListJsonReader}. Binds {@code {"GuidList":[{…}]}}, a bare array, or JAXB nested
+ * {@code Guid}.
+ */
+@Provider
+@Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("guidListJsonReader")
+public class GuidListJsonReader implements MessageBodyReader<GuidList> {
+
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    if (type == null || !GuidList.class.isAssignableFrom(type)) {
+      return false;
+    }
+    return mediaType == null || isJsonCompatible(mediaType);
+  }
+
+  static boolean isJsonCompatible(MediaType mediaType) {
+    if (mediaType == null || mediaType.isWildcardType() || mediaType.isWildcardSubtype()) {
+      return true;
+    }
+    String subtype = mediaType.getSubtype();
+    if (subtype == null) {
+      return false;
+    }
+    String lower = subtype.toLowerCase();
+    return "json".equals(lower) || lower.endsWith("+json");
+  }
+
+  @Override
+  public GuidList readFrom(
+      Class<GuidList> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new GuidList();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new GuidList();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  public static GuidList parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new GuidList();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid GuidList", 400);
+    }
+    return parseNode(root);
+  }
+
+  public static GuidList parseNode(JsonNode root) {
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new GuidList();
+    }
+    JsonNode array = extractGuidArray(root);
+    if (array == null || !array.isArray()) {
+      throw new WebApplicationException(
+          "GuidList body must be {\"GuidList\":[…]} or a JSON array", 400);
+    }
+    GuidList list = new GuidList();
+    for (JsonNode item : array) {
+      if (item == null || item.isNull()) {
+        continue;
+      }
+      JsonNode body = item;
+      if (item.isObject() && item.get("Guid") != null && item.get("Guid").isObject()) {
+        body = item.get("Guid");
+      }
+      try {
+        list.add(MAPPER.treeToValue(body, Guid.class));
+      } catch (JacksonException e) {
+        throw new WebApplicationException(
+            e.getMessage() != null ? e.getMessage() : "Invalid Guid", 400);
+      }
+    }
+    return list;
+  }
+
+  private static JsonNode extractGuidArray(JsonNode root) {
+    if (root.isArray()) {
+      return root;
+    }
+    if (!root.isObject()) {
+      return null;
+    }
+    JsonNode nested = firstNonNull(root, "GuidList", "guidList");
+    if (nested == null) {
+      return null;
+    }
+    if (nested.isArray()) {
+      return nested;
+    }
+    if (nested.isObject()) {
+      JsonNode jaxb = firstNonNull(nested, "Guid", "guid");
+      if (jaxb != null && jaxb.isArray()) {
+        return jaxb;
+      }
+      if (jaxb != null && jaxb.isObject()) {
+        var arr = MAPPER.createArrayNode();
+        arr.add(jaxb);
+        return arr;
+      }
+    }
+    return null;
+  }
+
+  private static JsonNode firstNonNull(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && !n.isNull()) {
+        return n;
+      }
+    }
+    return null;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/communities/CommunityList.java
+++ b/rest/src/main/java/com/percussion/rest/communities/CommunityList.java
@@ -17,7 +17,9 @@
 
 package com.percussion.rest.communities;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.xml.bind.annotation.XmlRootElement;
@@ -25,12 +27,16 @@ import jakarta.xml.bind.annotation.XmlSeeAlso;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /** List of Community objects. */
 @XmlRootElement(name = "CommunityList")
+@JsonRootName("CommunityList")
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 @ArraySchema(schema = @Schema(implementation = Community.class))
 @XmlSeeAlso({Community.class})
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(using = CommunityListDeserializer.class)
 public class CommunityList extends ArrayList<Community> {
 
   private static final long serialVersionUID = 1L;

--- a/rest/src/main/java/com/percussion/rest/communities/CommunityListDeserializer.java
+++ b/rest/src/main/java/com/percussion/rest/communities/CommunityListDeserializer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.communities;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+
+/**
+ * Forces PUT {@code /services/communities/bulk} to instantiate {@link CommunityList}, not a raw
+ * {@link java.util.ArrayList}.
+ *
+ * <p>CXF {@code JacksonJsonProvider} + {@code UNWRAP_ROOT_VALUE} otherwise ClassCasts HTTP 400
+ * (peer {@code AclListDeserializer} #3391). {@link CommunityListJsonReader} is the preferred
+ * JAX-RS reader; this deserializer is the Jackson-side barrier for skip-image-build hot-deploys.
+ */
+public class CommunityListDeserializer extends ValueDeserializer<CommunityList> {
+
+  @Override
+  public CommunityList deserialize(JsonParser p, DeserializationContext ctxt)
+      throws JacksonException {
+    if (p == null) {
+      return new CommunityList();
+    }
+    JsonToken token = p.currentToken();
+    if (token == null) {
+      token = p.nextToken();
+    }
+    if (token == null || token == JsonToken.VALUE_NULL) {
+      return new CommunityList();
+    }
+    JsonNode node = ctxt != null ? ctxt.readTree(p) : p.readValueAsTree();
+    return CommunityListJsonReader.parseNode(node);
+  }
+
+  @Override
+  public CommunityList getNullValue(DeserializationContext ctxt) {
+    return new CommunityList();
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/communities/CommunityListJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/communities/CommunityListJsonReader.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.communities;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for PUT {@code /services/communities/bulk}.
+ *
+ * <p>CXF {@code UNWRAP_ROOT_VALUE} plus {@link CommunityList} extending {@link
+ * java.util.ArrayList} yields {@code ClassCastException: Cannot cast java.util.ArrayList to
+ * CommunityList} (HTTP 400). A bare JSON array is rejected by Jettison/org.json ({@code
+ * JSONObject} must begin with '{'). Peer: {@code AclListJsonReader} (#3391 / #3378).
+ *
+ * <p>Binds {@code {"CommunityList":[{…}]}}, {@code [{…}]}, or JAXB {@code
+ * {"CommunityList":{"Community":[…]}}}.
+ */
+@Provider
+@Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("communityListJsonReader")
+public class CommunityListJsonReader implements MessageBodyReader<CommunityList> {
+
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    if (type == null || !CommunityList.class.isAssignableFrom(type)) {
+      return false;
+    }
+    return mediaType == null || isJsonCompatible(mediaType);
+  }
+
+  static boolean isJsonCompatible(MediaType mediaType) {
+    if (mediaType == null || mediaType.isWildcardType() || mediaType.isWildcardSubtype()) {
+      return true;
+    }
+    String subtype = mediaType.getSubtype();
+    if (subtype == null) {
+      return false;
+    }
+    String lower = subtype.toLowerCase();
+    return "json".equals(lower) || lower.endsWith("+json");
+  }
+
+  @Override
+  public CommunityList readFrom(
+      Class<CommunityList> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new CommunityList();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new CommunityList();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  public static CommunityList parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new CommunityList();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      throw new WebApplicationException(
+          e.getMessage() != null ? e.getMessage() : "Invalid CommunityList", 400);
+    }
+    return parseNode(root);
+  }
+
+  public static CommunityList parseNode(JsonNode root) {
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new CommunityList();
+    }
+    JsonNode array = extractCommunityArray(root);
+    if (array == null || !array.isArray()) {
+      throw new WebApplicationException(
+          "CommunityList body must be {\"CommunityList\":[…]} or a JSON array", 400);
+    }
+    CommunityList list = new CommunityList();
+    for (JsonNode item : array) {
+      if (item == null || item.isNull()) {
+        continue;
+      }
+      JsonNode body = item;
+      if (item.isObject() && item.get("Community") != null && item.get("Community").isObject()) {
+        body = item.get("Community");
+      }
+      try {
+        list.add(MAPPER.treeToValue(body, Community.class));
+      } catch (JacksonException e) {
+        throw new WebApplicationException(
+            e.getMessage() != null ? e.getMessage() : "Invalid Community", 400);
+      }
+    }
+    return list;
+  }
+
+  private static JsonNode extractCommunityArray(JsonNode root) {
+    if (root.isArray()) {
+      return root;
+    }
+    if (!root.isObject()) {
+      return null;
+    }
+    JsonNode nested = firstNonNull(root, "CommunityList", "communityList");
+    if (nested == null) {
+      return null;
+    }
+    if (nested.isArray()) {
+      return nested;
+    }
+    if (nested.isObject()) {
+      JsonNode jaxb = firstNonNull(nested, "Community", "community");
+      if (jaxb != null && jaxb.isArray()) {
+        return jaxb;
+      }
+      if (jaxb != null && jaxb.isObject()) {
+        var arr = MAPPER.createArrayNode();
+        arr.add(jaxb);
+        return arr;
+      }
+    }
+    return null;
+  }
+
+  private static JsonNode firstNonNull(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && !n.isNull()) {
+        return n;
+      }
+    }
+    return null;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/communities/CommunityResource.java
+++ b/rest/src/main/java/com/percussion/rest/communities/CommunityResource.java
@@ -19,6 +19,7 @@
 package com.percussion.rest.communities;
 
 import com.percussion.rest.GuidList;
+import com.percussion.rest.GuidListJsonReader;
 import com.percussion.rest.ObjectTypeEnum;
 import com.percussion.rest.Status;
 import com.percussion.system.utils.PSSiteManageBean;
@@ -75,9 +76,8 @@ public class CommunityResource implements ICommunityResource {
           List<String> names) {
     try {
       return adaptor.createCommunities(names);
-    } catch (Exception e) {
-      log.error("An error occurred calling createCommunities", e);
-      throw new WebApplicationException(e);
+    } catch (RuntimeException e) {
+      throw mapWriteFailure("createCommunities", e);
     }
   }
 
@@ -161,7 +161,11 @@ public class CommunityResource implements ICommunityResource {
     }
   }
 
-  @Override
+  /**
+   * HTTP PUT {@code /bulk}. Body is parsed by {@link CommunityListJsonReader} so CXF
+   * Jackson/Jettison cannot bind a raw {@code ArrayList} (HTTP 400 ClassCast) or reject a bare
+   * JSON array (org.json ParseError). Peer {@code AclResource.saveAcls(String)}.
+   */
   @PUT
   @Path("/bulk")
   @ApiResponses(
@@ -176,11 +180,16 @@ public class CommunityResource implements ICommunityResource {
           "Saves the communities in the submitted list. If the release header is set, any locks"
               + " will be released. To avoid extended locks, please set the release header when"
               + " calling this method unless you really want to keep them locked.")
-  public void saveCommunities(
-      @Parameter(description = "communities", required = true) CommunityList communities,
+  public void saveCommunitiesJson(
+      @Parameter(description = "communities", required = true) String json,
       @Parameter(name = "release", allowEmptyValue = false, required = true)
           @HeaderParam(value = "release")
           boolean release) {
+    saveCommunities(CommunityListJsonReader.parse(json), release);
+  }
+
+  @Override
+  public void saveCommunities(CommunityList communities, boolean release) {
     try {
       adaptor.saveCommunities(communities, release);
     } catch (Exception e) {
@@ -189,7 +198,10 @@ public class CommunityResource implements ICommunityResource {
     }
   }
 
-  @Override
+  /**
+   * HTTP DELETE {@code /bulk}. GuidList JSON is parsed by {@link
+   * com.percussion.rest.GuidListJsonReader}.
+   */
   @DELETE
   @Path("/bulk")
   @Consumes({MediaType.APPLICATION_JSON})
@@ -203,16 +215,36 @@ public class CommunityResource implements ICommunityResource {
           "Accepts a GuidList containing the ids of the Communities to delete. If the"
               + " ignoredependencies header is set on the request, then the system won't fail the"
               + " delete if a dependency is relying on this community.")
-  public void deleteCommunities(
-      @Parameter(name = "ids") GuidList ids,
+  public void deleteCommunitiesJson(
+      @Parameter(name = "ids") String json,
       @Parameter(name = "ignoredependencies", required = true) @HeaderParam("ignoredependencies")
           boolean ignoredependencies) {
+    deleteCommunities(GuidListJsonReader.parse(json), ignoredependencies);
+  }
+
+  @Override
+  public void deleteCommunities(GuidList ids, boolean ignoredependencies) {
     try {
       adaptor.deleteCommunities(ids, ignoredependencies);
-    } catch (Exception e) {
-      log.error("An error occurred calling deleteCommunities", e);
-      throw new WebApplicationException(e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (RuntimeException e) {
+      throw mapWriteFailure("deleteCommunities", e);
     }
+  }
+
+  /**
+   * Map adaptor write failures. Duplicate / in-use are already {@link
+   * WebApplicationException} 409 from the adaptor. Blank-name IAE is 400. Do
+   * not log ERROR for 4xx (QA C5 / expected conflict).
+   */
+  static WebApplicationException mapWriteFailure(String op, RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    log.error("An error occurred calling {}", op, e);
+    return new WebApplicationException(e, 500);
   }
 
   /**

--- a/rest/src/test/java/com/percussion/rest/GuidListJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/GuidListJsonReaderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class GuidListJsonReaderTest {
+
+  @Test
+  public void parseAcceptsGuidListEnvelope() {
+    GuidList list =
+        GuidListJsonReader.parse("{\"GuidList\":[{\"stringValue\":\"0-13-42\"}]}");
+    assertInstanceOf(GuidList.class, list);
+    assertEquals(1, list.size());
+    assertEquals("0-13-42", list.get(0).getStringValue());
+  }
+
+  @Test
+  public void parseAcceptsBareArray() {
+    GuidList list = GuidListJsonReader.parse("[{\"stringValue\":\"0-13-10\"}]");
+    assertEquals(1, list.size());
+    assertEquals("0-13-10", list.get(0).getStringValue());
+  }
+
+  @Test
+  public void parseEmptyIsEmptyList() {
+    assertTrue(GuidListJsonReader.parse("  ").isEmpty());
+    assertTrue(GuidListJsonReader.parse(null).isEmpty());
+  }
+
+  @Test
+  public void parseRejectsNonListObject() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> GuidListJsonReader.parse("{\"foo\":1}"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/MainTest.java
+++ b/rest/src/test/java/com/percussion/rest/MainTest.java
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.percussion.rest.GuidListJsonReader;
 import com.percussion.rest.acls.AclListJsonReader;
+import com.percussion.rest.communities.CommunityListJsonReader;
 import com.percussion.rest.contentexplorer.folders.AddFolderRequestJsonReader;
 import com.percussion.rest.searches.SearchExecuteRequestJsonReader;
 import com.percussion.rest.errors.RestExceptionMapper;
@@ -163,6 +165,8 @@ public class MainTest {
               exceptionMapper,
               waeMapper,
               new AclListJsonReader(),
+              new CommunityListJsonReader(),
+              new GuidListJsonReader(),
               new AddFolderRequestJsonReader(),
               new SearchExecuteRequestJsonReader(),
               jacksonProvider,

--- a/rest/src/test/java/com/percussion/rest/communities/CommunityListJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/communities/CommunityListJsonReaderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.communities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class CommunityListJsonReaderTest {
+
+  private static final String ENVELOPE =
+      "{\"CommunityList\":[{\"name\":\"QA\",\"label\":\"QA\",\"id\":42,"
+          + "\"guid\":{\"stringValue\":\"0-13-42\"}}]}";
+
+  @Test
+  public void parseAcceptsCommunityListEnvelope() {
+    CommunityList list = CommunityListJsonReader.parse(ENVELOPE);
+    assertInstanceOf(CommunityList.class, list);
+    assertEquals(1, list.size());
+    assertEquals("QA", list.get(0).getName());
+    assertEquals("QA", list.get(0).getLabel());
+  }
+
+  @Test
+  public void parseAcceptsBareArray() {
+    CommunityList list = CommunityListJsonReader.parse("[{\"name\":\"QA2\"}]");
+    assertEquals(1, list.size());
+    assertEquals("QA2", list.get(0).getName());
+  }
+
+  @Test
+  public void parseEmptyIsEmptyList() {
+    assertTrue(CommunityListJsonReader.parse("  ").isEmpty());
+    assertTrue(CommunityListJsonReader.parse(null).isEmpty());
+  }
+
+  @Test
+  public void parseRejectsNonListObject() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> CommunityListJsonReader.parse("{\"foo\":1}"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void isReadableOnlyForCommunityList() {
+    CommunityListJsonReader reader = new CommunityListJsonReader();
+    assertTrue(reader.isReadable(CommunityList.class, CommunityList.class, null, null));
+    assertTrue(
+        !reader.isReadable(Community.class, Community.class, null, null));
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/communities/CommunityResourceWriteFailureTest.java
+++ b/rest/src/test/java/com/percussion/rest/communities/CommunityResourceWriteFailureTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.rest.communities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class CommunityResourceWriteFailureTest {
+
+  @Test
+  public void mapWriteFailurePreservesAdaptor409() {
+    WebApplicationException conflict =
+        new WebApplicationException("Community already exists: Default", 409);
+    assertSame(conflict, CommunityResource.mapWriteFailure("createCommunities", conflict));
+  }
+
+  @Test
+  public void mapWriteFailureIllegalArgumentIs400() {
+    WebApplicationException mapped =
+        CommunityResource.mapWriteFailure(
+            "createCommunities", new IllegalArgumentException("name cannot be null or empty"));
+    assertEquals(400, mapped.getResponse().getStatus());
+  }
+
+  @Test
+  public void mapWriteFailureUnexpectedIs500() {
+    WebApplicationException mapped =
+        CommunityResource.mapWriteFailure(
+            "deleteCommunities", new IllegalStateException("Failed to persist communities"));
+    assertEquals(500, mapped.getResponse().getStatus());
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/security/impl/PSSecurityDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/security/impl/PSSecurityDesignWs.java
@@ -258,14 +258,15 @@ public class PSSecurityDesignWs extends PSSecurityBaseWs implements
       for (int i = 0, j=0; i < ids.size(); i++)
       {
          IPSGuid id = ids.get(i);
-         if (communities.length > 0 && j < communities.length)
+         while (j < communities.length && communities[j] == null)
          {
-            if (id.equals(communities[j].getGUID()))
-            {
-               results.addResult(id, communities[j]);
-               j++;
-               continue;
-            }
+            j++;
+         }
+         if (j < communities.length && id.equals(communities[j].getGUID()))
+         {
+            results.addResult(id, communities[j]);
+            j++;
+            continue;
          }
 
          var code = WebserviceErrorCodes.OBJECT_NOT_FOUND;


### PR DESCRIPTION
## Summary

SPA SE-01 (parent **#1690**, child **#4077**): **Developer → Communities** catalog create and detail delete using existing REST `POST /services/communities/bulk` and `DELETE /services/communities/bulk`. Role-association save on the detail panel is unchanged. No new REST resources.

- Server persist-on-create (Workbench Finish create+save on native `PSCommunity`). SPA create is POST-only (does not PUT DTOs).
- Nested Jackson Guid unwrap so delete has a usable GUID (`0-13-{id}` fallback).
- Duplicate name and in-use delete (without `ignoredependencies`) are **409** and are not logged as ERROR.
- `loadCommunities` skips null array slots so unsaved/create+save does not NPE.

Fixes #4077  
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `mvnw clean install` (no skipTests) on changed modules — see C3.
2. Vitest: blank 400, duplicate 409, non-Admin 403, in-use delete 409 without ignore.
3. H2 QA: `perc-devctl qa-up` → `qa-health` → `TEST_CMS_URL` → `npm run test:surface -- --path tests/developer-community-editor.spec.js`.
4. Admin: New community unique name appears in catalog; delete removes it. Duplicate shows 409. Role save still present.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/users-roles.md`, `product-docs/8.2/admin/developer-communities.md`, `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — Vitest + rest/sitemanage unit tests; standalone clean install green
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/developer-community-editor.spec.js`
- [x] **Build gates** — standalone clean install per changed module; reverse-dep sitemanage for rest
- [x] **Cross-platform** — N/A (no new filesystem path I/O; REST/URL paths use `/`)

## C3 evidence

- **modules_built:** `WebUI`, `rest`, `projects/sitemanage`, `system`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` BUILD SUCCESS, Tests run: 953
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS, Tests run: 2016 Failures: 0
  - `cd system && ../mvnw.cmd clean install` BUILD SUCCESS, Tests run: 2638 Failures: 0
  - `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS, Tests 3580 passed
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` BUILD SUCCESS
- **downstream_checked:** `ICommunityResource` signatures unchanged; `CommunityList`/`GuidList` not made final/sealed; sitemanage standalone install as rest reverse-dep

## C5 UI proof

- `python docker/scripts/perc-devctl.py qa-health` RESULT:OK HTTP:200 HEALTH:healthy URL:http://127.0.0.1:9993/Rhythmyx/rest/mimetypes CONTAINER:perc-matrix-cms-h2
- TEST_CMS_URL=http://127.0.0.1:9993 (QA_CMS_HOST_PORT=9993)
- Hot-copy rest/sitemanage/perc-system jars into Rhythmyx WEB-INF/lib; `qa-deploy-webui`; Jetty Stop/Start inside cell (not docker restart)
- `npm run test:surface -- --path tests/developer-community-editor.spec.js` — 2 passed
- console-clean=yes (spec pageerror/console guards)
- server.log-clean=yes (no ERROR/FATAL in test window after 409 mapping)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
