### PR TITLE
feat(rest): UI-02 action menu write (#4078)

### DIFF
--- a/docs/ai-generated/code-reviews/4078-action-menu-write-erlang.md
+++ b/docs/ai-generated/code-reviews/4078-action-menu-write-erlang.md
@@ -1,0 +1,25 @@
+# Erlang review — #4078 REST UI-02 action menu write
+
+**Branch:** `feat/issue-4078-action-menu-write`  
+**Scope:** uncommitted + vs `origin/main`  
+**Memory patterns hit:** change-class closure (rest resource + `IActionMenuAdaptor` + Spring stub + sitemanage adaptor + adaptor tests + product-docs); rest `MainTest` needs exact adaptor type on test classpath; Admin/session 403 and lock-no-steal 409 from design WS peers.
+
+## Summary
+
+Admin POST/PUT/DELETE for user action menus over existing `IPSUiDesignWs.createActions` / `loadActions` / `saveActions` / `deleteActions`. Duplicate 409, invalid 400, missing 404, non-Admin 403, system menus 409 without lock steal. Collection POST is create; unimplemented allowed-transitions stub moved to `/find/transitions`. No SPA chrome.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Cross-platform path checklist
+
+N/A for filesystem I/O. `isSystemMenuPath` splits Workbench hierarchy strings (logical `/` or `\`), not OS file paths.
+
+## Issues
+
+None (bugs). Companions present: Mockito `ActionMenuResourceTest`, `ActionsTestAdaptor` Spring stub, `ActionMenuAdaptorWriteTest`, `product-docs/8.2/developer/rest.md`. Standalone `rest` and `projects/sitemanage` `mvnw.cmd clean install` BUILD SUCCESS.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1417,10 +1417,29 @@ under `/services/actions/catalog`. Each catalog and detail row includes a nested
 load **Object ACL** via `GET /services/acls/object/{guid}`. When the nested Guid is
 hard to bind, clients may also synthesize that same string from the numeric `id`.
 
+Admin **write** persists through `IPSUiDesignWs` (`createActions` / `loadActions` /
+`saveActions` / `deleteActions`) — the same design web service SOAP uses. There is
+no new SOAP surface. **Do not** treat this as a Developer Action Menus SPA; chrome
+for create/save/delete is a later sibling. Cascading children composition (UI-04)
+and usage/command/visibility tab completeness (UI-03) are later slices. Finder
+helpers (`GET /services/actions/find`, content-type and template finders) are
+unchanged.
+
+Write is **Admin** only. Name is unique (case-insensitive) and must not contain
+whitespace or wildcards. Duplicate name is **409**. Invalid name or menu type is
+**400**. Missing id/name is **404**. Non-Admin (or missing request session/user)
+is **403**. **System** menus (Workbench `Menus/System` hierarchy) cannot be
+updated or deleted — **409**; the design lock is not stolen (`overrideLock=false`).
+PUT round-trips GET detail fields already exposed (`label`, `description`,
+`menuType`, `url`). Name is the catalog key and is not renamed on PUT.
+
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/actions/catalog` | List action menus (tree roots with children) |
 | `GET` | `/services/actions/catalog/{idOrName}` | Load one menu by name, numeric id, or GUID string |
+| `POST` | `/services/actions` | **Admin.** Create a user action menu (`createActions` then `saveActions`) |
+| `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, and/or url |
+| `DELETE` | `/services/actions/{idOrName}` | **Admin.** Delete a user action menu (`deleteActions`, `ignoreDependencies=false`) |
 
 JSON may wrap a single item as `ActionMenu`. Integrators should unwrap that
 envelope and read `guid.stringValue` (never assume the GUID is missing when `id`

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1430,6 +1430,8 @@ whitespace or wildcards. Duplicate name is **409**. Invalid name or menu type is
 **400**. Missing id/name is **404**. Non-Admin (or missing request session/user)
 is **403**. **System** menus (Workbench `Menus/System` hierarchy) cannot be
 updated or deleted — **409**; the design lock is not stolen (`overrideLock=false`).
+If Workbench path resolution fails, PUT/DELETE also return **409** (fail closed)
+so a lookup error cannot bypass that protection.
 PUT round-trips GET detail fields already exposed (`label`, `description`,
 `menuType`, `url`). Name is the catalog key and is not renamed on PUT.
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -25,21 +25,40 @@ import com.percussion.cms.objectstore.PSActionVisibilityContext;
 import com.percussion.cms.objectstore.PSActionVisibilityContexts;
 import com.percussion.cms.objectstore.PSDbComponentCollection;
 import com.percussion.cms.objectstore.PSMenuModeContextMapping;
+import com.percussion.cms.objectstore.PSAction;
+import com.percussion.rest.Guid;
 import com.percussion.rest.actions.ActionMenu;
 import com.percussion.rest.actions.ActionMenuModeUIContext;
 import com.percussion.rest.actions.ActionMenuParameter;
 import com.percussion.rest.actions.ActionMenuProperty;
 import com.percussion.rest.actions.ActionMenuVisibilityContext;
 import com.percussion.rest.actions.IActionMenuAdaptor;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.legacy.PSCmsObjectMgrLocator;
 import com.percussion.services.menus.PSContentTypeActionMenuHelper;
 import com.percussion.services.menus.PSTemplateActionMenuHelper;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.ui.IPSUiDesignWs;
+import com.percussion.webservices.ui.data.ActionType;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,11 +70,28 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
 
   private static final Logger log = LogManager.getLogger(ActionMenuAdaptor.class);
 
-  private IPSUiDesignWs service;
+  static final String ADMIN_REQUIRED =
+      "Admin role required to create, update, or delete action menus";
+
+  static final String SYSTEM_MENU_WRITE =
+      "System action menus cannot be updated or deleted via this API";
+
+  private final IPSUiDesignWs service;
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   @Autowired
   public ActionMenuAdaptor(IPSUiDesignWs service) {
+    this(service, null);
+  }
+
+  /** Package-visible for unit tests. */
+  ActionMenuAdaptor(IPSUiDesignWs service, BooleanSupplier adminChecker) {
     this.service = service;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   @Override
@@ -217,6 +253,127 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     }
   }
 
+  @Override
+  public ActionMenu createActionMenu(ActionMenu body) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String name = requireValidName(body.getName());
+    assertNameUnique(name);
+    ActionType type = resolveCreateType(body);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSAction> created = service.createActions(List.of(name), List.of(type), session, user);
+      if (created == null || created.isEmpty() || created.get(0) == null) {
+        throw new IllegalStateException("Design WS createActions returned empty");
+      }
+      PSAction domain = created.get(0);
+      applyWritableFields(domain, body);
+      service.saveActions(List.of(domain), true, session, user);
+      return toDto(domain);
+    } catch (WebApplicationException | IllegalStateException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("Action menu already exists: " + name, 409);
+      }
+      throw e;
+    } catch (PSLockErrorException e) {
+      throw new WebApplicationException(
+          "Could not create action menu; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("create", e);
+    } catch (PSErrorException e) {
+      log.error("Failed to create action menu {}", name, e);
+      throw new IllegalStateException("Failed to create action menu", e);
+    }
+  }
+
+  @Override
+  public ActionMenu saveActionMenu(String idOrName, ActionMenu body) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    if (!isSafeMenuKey(idOrName)) {
+      return null;
+    }
+    PSAction existing = findPsActionByKey(idOrName.trim());
+    if (existing == null) {
+      return null;
+    }
+    rejectSystemMenuWrite(existing);
+    IPSGuid id = safeGuid(existing);
+    if (id == null) {
+      throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSAction> loaded = service.loadActions(List.of(id), true, false, session, user);
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        return null;
+      }
+      PSAction domain = loaded.get(0);
+      applyWritableFields(domain, body);
+      service.saveActions(List.of(domain), true, session, user);
+      return toDto(domain);
+    } catch (WebApplicationException | IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, id)) {
+        return null;
+      }
+      throw new WebApplicationException(
+          "Could not update action menu; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("update", e);
+    }
+  }
+
+  @Override
+  public boolean deleteActionMenu(String idOrName) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (!isSafeMenuKey(idOrName)) {
+      return false;
+    }
+    PSAction existing = findPsActionByKey(idOrName.trim());
+    if (existing == null) {
+      return false;
+    }
+    rejectSystemMenuWrite(existing);
+    IPSGuid id = safeGuid(existing);
+    if (id == null) {
+      throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
+    }
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSAction> locked = service.loadActions(List.of(id), true, false, session, user);
+      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+        throw new WebApplicationException(
+            "Could not delete action menu; design lock required or held by another user", 409);
+      }
+      service.deleteActions(List.of(id), false, session, user);
+      return true;
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (isNotFound(e, id)) {
+        return false;
+      }
+      throw new WebApplicationException(
+          "Could not delete action menu; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("delete", e);
+    }
+  }
+
   /**
    * Single path component / id token only — reject traversal and separators ({@code
    * java/path-injection}).
@@ -229,6 +386,452 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
         && key.indexOf('/') < 0
         && key.indexOf('\\') < 0
         && key.indexOf('\0') < 0;
+  }
+
+  PSAction findPsActionByKey(String idOrName) {
+    if (!isSafeMenuKey(idOrName)) {
+      return null;
+    }
+    String key = idOrName.trim();
+    try {
+      IPSGuid match = matchSummaryGuid(service.findActions(null, null, null), key);
+      if (match == null) {
+        match = parseActionGuid(key);
+      }
+      if (match == null) {
+        return null;
+      }
+      List<PSAction> loaded =
+          service.loadActions(
+              List.of(match), false, false, currentSession(), currentUser());
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        return null;
+      }
+      return loaded.get(0);
+    } catch (PSErrorResultsException e) {
+      IPSGuid requested = parseActionGuid(key);
+      if (requested != null && isNotFound(e, requested)) {
+        return null;
+      }
+      log.debug("Action menu design load failed for {}: {}", key, e.toString());
+      throw new WebApplicationException(
+          "Could not load action menu; design lock required or held by another user", 409);
+    } catch (PSErrorException e) {
+      log.error("Failed to catalog action menus while resolving {}", key, e);
+      throw new IllegalStateException("Failed to catalog action menus", e);
+    }
+  }
+
+  static IPSGuid matchSummaryGuid(List<IPSCatalogSummary> summaries, String key) {
+    if (summaries == null || StringUtils.isBlank(key)) {
+      return null;
+    }
+    for (IPSCatalogSummary summary : summaries) {
+      if (summary == null) {
+        continue;
+      }
+      if (key.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+        return summary.getGUID();
+      }
+      IPSGuid guid = summary.getGUID();
+      if (guid == null) {
+        continue;
+      }
+      if (key.equals(String.valueOf(guid.getUUID()))) {
+        return guid;
+      }
+      String gsv = guid.toString();
+      if (gsv != null && key.equalsIgnoreCase(gsv.trim())) {
+        return guid;
+      }
+    }
+    return null;
+  }
+
+  static IPSGuid parseActionGuid(String key) {
+    if (StringUtils.isBlank(key)) {
+      return null;
+    }
+    String trimmed = key.trim();
+    if (trimmed.chars().allMatch(Character::isDigit)) {
+      try {
+        return PSAction.getGuidFromId(Integer.parseInt(trimmed));
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    try {
+      PSGuid guid = new PSGuid(trimmed);
+      if (guid.getType() == 0) {
+        return new PSGuid(PSTypeEnum.ACTION, guid.getUUID());
+      }
+      return guid.getType() == PSTypeEnum.ACTION.getOrdinal() ? guid : null;
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  static void applyWritableFields(PSAction domain, ActionMenu body) {
+    if (domain == null || body == null) {
+      return;
+    }
+    if (StringUtils.isNotBlank(body.getLabel())) {
+      domain.setLabel(body.getLabel().trim());
+    }
+    if (body.getDescription() != null) {
+      domain.setDescription(body.getDescription());
+    }
+    if (body.getUrl() != null) {
+      domain.setURL(body.getUrl());
+    }
+    applyMenuType(domain, body.getMenuType());
+  }
+
+  static ActionType resolveCreateType(ActionMenu body) {
+    String raw = body == null ? null : body.getMenuType();
+    if (StringUtils.isBlank(raw)) {
+      if (body != null && StringUtils.isNotBlank(body.getUrl())) {
+        return ActionType.DYNAMIC;
+      }
+      return ActionType.CASCADING;
+    }
+    String t = raw.trim();
+    if (isItemType(t)) {
+      return ActionType.ITEM;
+    }
+    if (isDynamicType(t)) {
+      return ActionType.DYNAMIC;
+    }
+    if (isCascadingType(t) || isContextType(t)) {
+      return ActionType.CASCADING;
+    }
+    throw new IllegalArgumentException("Invalid menu type: " + raw);
+  }
+
+  static void applyMenuType(PSAction domain, String raw) {
+    if (domain == null || StringUtils.isBlank(raw)) {
+      return;
+    }
+    String t = raw.trim();
+    if (isItemType(t)) {
+      domain.setMenuType(PSAction.TYPE_MENUITEM);
+      domain.setMenuDynamic(false);
+      return;
+    }
+    if (isContextType(t)) {
+      domain.setMenuType(PSAction.TYPE_CONTEXTMENU);
+      domain.setMenuDynamic(false);
+      return;
+    }
+    if (isDynamicType(t)) {
+      domain.setMenuType(PSAction.TYPE_MENU);
+      domain.setMenuDynamic(true);
+      return;
+    }
+    if (isCascadingType(t)) {
+      domain.setMenuType(PSAction.TYPE_MENU);
+      domain.setMenuDynamic(false);
+      return;
+    }
+    throw new IllegalArgumentException("Invalid menu type: " + raw);
+  }
+
+  private static boolean isItemType(String t) {
+    return "MENUITEM".equalsIgnoreCase(t) || "item".equalsIgnoreCase(t);
+  }
+
+  private static boolean isCascadingType(String t) {
+    return PSAction.TYPE_MENU.equalsIgnoreCase(t) || "cascading".equalsIgnoreCase(t);
+  }
+
+  private static boolean isDynamicType(String t) {
+    return "DYNAMICMENU".equalsIgnoreCase(t) || "dynamic".equalsIgnoreCase(t);
+  }
+
+  private static boolean isContextType(String t) {
+    return PSAction.TYPE_CONTEXTMENU.equalsIgnoreCase(t);
+  }
+
+  static ActionMenu toDto(PSAction action) {
+    ActionMenu menu = new ActionMenu();
+    if (action == null) {
+      return menu;
+    }
+    menu.setName(action.getName());
+    menu.setLabel(action.getLabel());
+    menu.setDescription(action.getDescription());
+    menu.setUrl(action.getURL());
+    menu.setMenuType(restMenuType(action));
+    menu.setHandler(action.isClientAction() ? PSAction.HANDLER_CLIENT : PSAction.HANDLER_SERVER);
+    menu.setSortRank(action.getSortRank());
+    menu.setId(action.getId());
+    IPSGuid guid = safeGuid(action);
+    if (guid != null) {
+      menu.setGuid(copyGuid(guid));
+    }
+    return menu;
+  }
+
+  static String restMenuType(PSAction action) {
+    if (action == null) {
+      return PSAction.TYPE_MENU;
+    }
+    if (action.isDynamicMenu()) {
+      return "DYNAMICMENU";
+    }
+    return action.getMenuType();
+  }
+
+  static IPSGuid safeGuid(PSAction action) {
+    if (action == null) {
+      return null;
+    }
+    try {
+      if (action.getId() <= 0) {
+        return null;
+      }
+      return action.getGUID();
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
+  private static Guid copyGuid(IPSGuid guid) {
+    Guid g = new Guid();
+    g.setHostId(guid.getHostId());
+    g.setLongValue(guid.longValue());
+    g.setStringValue(guid.toString());
+    g.setType(guid.getType());
+    g.setUuid(guid.getUUID());
+    g.setUntypedString(guid.toStringUntyped());
+    return g;
+  }
+
+  void rejectSystemMenuWrite(PSAction existing) {
+    if (existing == null) {
+      return;
+    }
+    if (isSystemMenu(existing)) {
+      throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
+    }
+  }
+
+  boolean isSystemMenu(PSAction action) {
+    IPSGuid guid = safeGuid(action);
+    if (guid == null) {
+      return false;
+    }
+    try {
+      String path = service.objectIdToPath(guid);
+      return isSystemMenuPath(path);
+    } catch (RuntimeException e) {
+      log.debug("Could not resolve Workbench path for action {}: {}", guid, e.toString());
+      return false;
+    }
+  }
+
+  /**
+   * Workbench UI Elements {@code Menus/System} (and Menu Entries {@code System}) path segment.
+   * Package-visible for unit tests.
+   */
+  static boolean isSystemMenuPath(String path) {
+    if (StringUtils.isBlank(path)) {
+      return false;
+    }
+    String[] parts = path.split("[/\\\\]+");
+    for (String part : parts) {
+      if ("system".equalsIgnoreCase(part.trim())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static String requireValidName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String name = raw.trim();
+    if (containsWhitespace(name)) {
+      throw new IllegalArgumentException("name cannot contain whitespace");
+    }
+    if (name.contains("*") || name.contains("%")) {
+      throw new IllegalArgumentException("name must not contain wildcards");
+    }
+    if (!isSafeMenuKey(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    return name;
+  }
+
+  private static boolean containsWhitespace(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isWhitespace(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void assertNameUnique(String name) {
+    try {
+      if (nameExists(service.findActions(name, null, null), name)) {
+        throw new WebApplicationException("Action menu already exists: " + name, 409);
+      }
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorException e) {
+      log.error("Failed to catalog action menus while checking uniqueness for {}", name, e);
+      throw new IllegalStateException("Failed to catalog action menus", e);
+    }
+  }
+
+  static boolean nameExists(List<IPSCatalogSummary> summaries, String name) {
+    if (summaries == null || StringUtils.isBlank(name)) {
+      return false;
+    }
+    for (IPSCatalogSummary summary : summaries) {
+      if (summary != null
+          && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private static void requireSessionUserForWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for action menu design write",
+          Response.Status.FORBIDDEN);
+    }
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+
+  static boolean isAlreadyExistsFailure(IllegalArgumentException e) {
+    return e != null && StringUtils.containsIgnoreCase(e.getMessage(), "already exists");
+  }
+
+  static boolean isNotFound(PSErrorResultsException e, IPSGuid requested) {
+    if (e == null || requested == null) {
+      return false;
+    }
+    Map<IPSGuid, Object> errors = e.getErrors();
+    Map<IPSGuid, Object> results = e.getResults();
+    boolean errored = errors != null && errors.containsKey(requested);
+    boolean hasResult = results != null && results.containsKey(requested);
+    return errored && !hasResult && !hasLockError(e);
+  }
+
+  static boolean hasLockError(PSErrorResultsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isLockError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (isLockErrorObject(err)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static boolean isDependencyError(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return StringUtils.containsIgnoreCase(e != null ? e.getMessage() : null, "depend");
+    }
+    for (Object err : e.getErrors().values()) {
+      String msg = errorMessage(err);
+      if (StringUtils.containsIgnoreCase(msg, "depend")) {
+        return true;
+      }
+    }
+    return StringUtils.containsIgnoreCase(e.getMessage(), "depend");
+  }
+
+  private static boolean isLockErrorObject(Object err) {
+    if (err instanceof PSLockErrorException) {
+      return true;
+    }
+    if (err instanceof PSErrorException pe) {
+      String msg = pe.getErrorMessage() != null ? pe.getErrorMessage() : pe.getMessage();
+      return StringUtils.containsIgnoreCase(msg, "is not locked")
+          || StringUtils.containsIgnoreCase(msg, "not locked for")
+          || StringUtils.containsIgnoreCase(msg, "locked by");
+    }
+    String text = String.valueOf(err);
+    return StringUtils.containsIgnoreCase(text, "is not locked")
+        || StringUtils.containsIgnoreCase(text, "locked by");
+  }
+
+  private static String errorMessage(Object err) {
+    if (err instanceof PSErrorException pe) {
+      return StringUtils.defaultIfBlank(pe.getErrorMessage(), pe.getMessage());
+    }
+    return err != null ? String.valueOf(err) : null;
+  }
+
+  private RuntimeException mapSaveOrDeleteFailure(String verb, PSErrorsException e) {
+    if (isLockError(e)) {
+      return new WebApplicationException(
+          "Could not " + verb + " action menu; design lock required or held by another user",
+          409);
+    }
+    if (isDependencyError(e)) {
+      return new WebApplicationException(
+          "Action menu has dependents and cannot be deleted", 409);
+    }
+    log.error("Failed to {} action menu via UI design WS", verb, e);
+    return new IllegalStateException("Failed to " + verb + " action menu", e);
   }
 
   private ActionMenuVisibilityContext[] copyVisibilityContexts(

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -625,8 +625,10 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       String path = service.objectIdToPath(guid);
       return isSystemMenuPath(path);
     } catch (RuntimeException e) {
-      log.debug("Could not resolve Workbench path for action {}: {}", guid, e.toString());
-      return false;
+      // Fail closed: a lookup error must not skip system-menu protection.
+      log.warn(
+          "Could not resolve Workbench path for action {}; treating as system menu", guid, e);
+      return true;
     }
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSAction;
+import com.percussion.rest.actions.ActionMenu;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import com.percussion.webservices.ui.data.ActionType;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * UI-02 POST create / PUT update / DELETE persist via {@code createActions}/{@code saveActions}/{@code
+ * deleteActions}. Admin only; unique name; no lock steal; system menus are 409.
+ */
+@Tag("UnitTest")
+class ActionMenuAdaptorWriteTest {
+
+  private IPSUiDesignWs designWs;
+  private ActionMenuAdaptor adaptor;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    designWs = mock(IPSUiDesignWs.class);
+    adaptor = new ActionMenuAdaptor(designWs, () -> true);
+    when(designWs.findActions(
+            nullable(String.class), nullable(String.class), nullable(List.class)))
+        .thenReturn(List.of());
+    when(designWs.objectIdToPath(any())).thenReturn("//ContentExplorer/Menus/User/MyMenu");
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void create_usesCreateThenSaveAndReleasesLock() throws Exception {
+    PSAction action = stubAction("MyMenu", 42);
+    when(designWs.createActions(
+            eq(List.of("MyMenu")), anyList(), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(action));
+
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    body.setLabel("My Menu");
+    body.setDescription("created via REST");
+    body.setMenuType("MENU");
+    body.setUrl("");
+
+    ActionMenu out = adaptor.createActionMenu(body);
+
+    assertEquals("MyMenu", out.getName());
+    assertEquals("My Menu", out.getLabel());
+    assertEquals("created via REST", out.getDescription());
+    assertEquals(PSAction.TYPE_MENU, out.getMenuType());
+    verify(designWs)
+        .createActions(eq(List.of("MyMenu")), anyList(), eq("test-session"), eq("Admin"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<PSAction>> saved = ArgumentCaptor.forClass(List.class);
+    verify(designWs).saveActions(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
+    assertEquals(1, saved.getValue().size());
+    PSAction persisted = saved.getValue().get(0);
+    assertEquals("My Menu", persisted.getLabel());
+    assertEquals("created via REST", persisted.getDescription());
+    assertEquals(PSAction.TYPE_MENU, persisted.getMenuType());
+  }
+
+  @Test
+  void create_blankTypeWithUrl_isDynamic() throws Exception {
+    PSAction action = stubAction("DynMenu", 42);
+    when(designWs.createActions(eq(List.of("DynMenu")), anyList(), any(), any()))
+        .thenReturn(List.of(action));
+    ActionMenu body = new ActionMenu();
+    body.setName("DynMenu");
+    body.setUrl("/sys_action");
+    adaptor.createActionMenu(body);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<ActionType>> types = ArgumentCaptor.forClass(List.class);
+    verify(designWs)
+        .createActions(eq(List.of("DynMenu")), types.capture(), eq("test-session"), eq("Admin"));
+    assertEquals(ActionType.DYNAMIC, types.getValue().get(0));
+    assertEquals("/sys_action", action.getURL());
+  }
+
+  @Test
+  void create_duplicateName_is409BeforeCreate() throws Exception {
+    IPSCatalogSummary existing = mock(IPSCatalogSummary.class);
+    when(existing.getName()).thenReturn("MyMenu");
+    when(designWs.findActions(eq("MyMenu"), isNull(), isNull())).thenReturn(List.of(existing));
+
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createActionMenu(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_persistTimeDuplicate_is409() throws Exception {
+    when(designWs.createActions(eq(List.of("MyMenu")), anyList(), eq("test-session"), eq("Admin")))
+        .thenThrow(
+            new IllegalArgumentException("The name 'MyMenu' for type 'ACTION' already exists."));
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createActionMenu(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_blankName_throwsBeforeDesignWs() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createActionMenu(null));
+    ActionMenu blank = new ActionMenu();
+    blank.setName("  ");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createActionMenu(blank));
+    assertTrue(ex.getMessage().contains("name is required"));
+    verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void create_nameWithSpaces_throwsBeforeDesignWs() {
+    ActionMenu body = new ActionMenu();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createActionMenu(body));
+    assertEquals("name cannot contain whitespace", ex.getMessage());
+    verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void create_wildcardName_throwsBeforeDesignWs() {
+    ActionMenu body = new ActionMenu();
+    body.setName("My*Menu");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createActionMenu(body));
+    assertEquals("name must not contain wildcards", ex.getMessage());
+  }
+
+  @Test
+  void create_invalidType_throwsBeforeDesignWs() {
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    body.setMenuType("nope");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createActionMenu(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("menu type"));
+    verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void create_nonAdmin_is403() {
+    adaptor = new ActionMenuAdaptor(designWs, () -> false);
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createActionMenu(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void create_missingSession_is403() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createActionMenu(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("session"), ex.getMessage());
+  }
+
+  @Test
+  void update_loadsWithLockNoStealAndSavesFields() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    PSAction locked = stubAction("MyMenu", 42);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ActionMenu body = new ActionMenu();
+    body.setLabel("Updated");
+    body.setDescription("new desc");
+    body.setMenuType("MENUITEM");
+    body.setUrl("/u");
+
+    ActionMenu out = adaptor.saveActionMenu("MyMenu", body);
+
+    assertEquals("MyMenu", out.getName());
+    assertEquals("Updated", locked.getLabel());
+    assertEquals("new desc", locked.getDescription());
+    assertEquals(PSAction.TYPE_MENUITEM, locked.getMenuType());
+    assertEquals("/u", locked.getURL());
+    verify(designWs).saveActions(anyList(), eq(true), eq("test-session"), eq("Admin"));
+    verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
+    verify(designWs).loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_unknown_returnsNull() throws Exception {
+    when(designWs.findActions(
+            nullable(String.class), nullable(String.class), nullable(List.class)))
+        .thenReturn(List.of());
+    ActionMenu body = new ActionMenu();
+    body.setLabel("Updated");
+    assertNull(adaptor.saveActionMenu("missing", body));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_system_is409() throws Exception {
+    PSAction system = stubAction("Edit", 42);
+    stubCatalogLoad(system);
+    when(designWs.objectIdToPath(any())).thenReturn("//ContentExplorer/Menus/System/Edit");
+    ActionMenu body = new ActionMenu();
+    body.setLabel("Edit");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.saveActionMenu("Edit", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("system"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void update_lockConflict_is409() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.saveActionMenu("MyMenu", new ActionMenu()));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_nonAdmin_is403() {
+    adaptor = new ActionMenuAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.saveActionMenu("MyMenu", new ActionMenu()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void delete_thenFindIsMissing() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(existing));
+
+    assertTrue(adaptor.deleteActionMenu("MyMenu"));
+    verify(designWs)
+        .deleteActions(eq(List.of(existing.getGUID())), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void delete_unknown_returnsFalse() throws Exception {
+    when(designWs.findActions(
+            nullable(String.class), nullable(String.class), nullable(List.class)))
+        .thenReturn(List.of());
+    assertFalse(adaptor.deleteActionMenu("missing"));
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_system_is409() throws Exception {
+    PSAction system = stubAction("Edit", 42);
+    stubCatalogLoad(system);
+    when(designWs.objectIdToPath(any())).thenReturn("//ContentExplorer/Menus/System/Edit");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("Edit"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void delete_lockConflict_is409() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new PSErrorResultsException());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("MyMenu"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_dependents_is409() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(existing));
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(existing.getGUID(), new PSErrorException("Object has dependents"));
+    doThrow(errors).when(designWs).deleteActions(anyList(), eq(false), any(), any());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("MyMenu"));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("depend"), ex.getMessage());
+  }
+
+  @Test
+  void delete_nonAdmin_is403() {
+    adaptor = new ActionMenuAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("MyMenu"));
+    assertEquals(403, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void requireValidName_rejectsSpacesAndWildcards() {
+    assertEquals("MyMenu", ActionMenuAdaptor.requireValidName("MyMenu"));
+    assertThrows(IllegalArgumentException.class, () -> ActionMenuAdaptor.requireValidName("  "));
+    assertThrows(
+        IllegalArgumentException.class, () -> ActionMenuAdaptor.requireValidName("has space"));
+    assertThrows(IllegalArgumentException.class, () -> ActionMenuAdaptor.requireValidName("x*y"));
+  }
+
+  @Test
+  void isSystemMenuPath_matchesSystemSegment() {
+    assertTrue(ActionMenuAdaptor.isSystemMenuPath("//ContentExplorer/Menus/System/Edit"));
+    assertTrue(ActionMenuAdaptor.isSystemMenuPath("Menus\\System\\Copy"));
+    assertFalse(ActionMenuAdaptor.isSystemMenuPath("//ContentExplorer/Menus/User/MyMenu"));
+    assertFalse(ActionMenuAdaptor.isSystemMenuPath(""));
+    assertFalse(ActionMenuAdaptor.isSystemMenuPath(null));
+  }
+
+  @Test
+  void resolveCreateType_defaultsAndAliases() {
+    ActionMenu blank = new ActionMenu();
+    assertEquals(ActionType.CASCADING, ActionMenuAdaptor.resolveCreateType(blank));
+    ActionMenu withUrl = new ActionMenu();
+    withUrl.setUrl("/x");
+    assertEquals(ActionType.DYNAMIC, ActionMenuAdaptor.resolveCreateType(withUrl));
+    ActionMenu item = new ActionMenu();
+    item.setMenuType("MENUITEM");
+    assertEquals(ActionType.ITEM, ActionMenuAdaptor.resolveCreateType(item));
+    ActionMenu dyn = new ActionMenu();
+    dyn.setMenuType("dynamic");
+    assertEquals(ActionType.DYNAMIC, ActionMenuAdaptor.resolveCreateType(dyn));
+    ActionMenu bad = new ActionMenu();
+    bad.setMenuType("nope");
+    assertThrows(IllegalArgumentException.class, () -> ActionMenuAdaptor.resolveCreateType(bad));
+  }
+
+  private PSAction stubAction(String name, int id) {
+    PSAction action = new PSAction(name, name);
+    action.setGUID(new PSGuid(PSTypeEnum.ACTION, id));
+    return action;
+  }
+
+  private void stubCatalogLoad(PSAction action) throws Exception {
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getGUID()).thenReturn(action.getGUID());
+    when(sum.getName()).thenReturn(action.getName());
+    when(designWs.findActions(
+            nullable(String.class), nullable(String.class), nullable(List.class)))
+        .thenReturn(List.of(sum));
+    when(designWs.loadActions(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(action));
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -279,6 +279,21 @@ class ActionMenuAdaptorWriteTest {
   }
 
   @Test
+  void update_pathResolutionFailure_is409FailClosed() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    when(designWs.objectIdToPath(any())).thenThrow(new PSErrorsException());
+    ActionMenu body = new ActionMenu();
+    body.setLabel("Updated");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.saveActionMenu("MyMenu", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("system"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
   void update_lockConflict_is409() throws Exception {
     PSAction existing = stubAction("MyMenu", 42);
     stubCatalogLoad(existing);
@@ -330,6 +345,20 @@ class ActionMenuAdaptorWriteTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("Edit"));
     assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void delete_pathResolutionFailure_is409FailClosed() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    when(designWs.objectIdToPath(any()))
+        .thenThrow(new RuntimeException("path lookup failed"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("MyMenu"));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("system"));
     verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
     verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
   }

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.util.Arrays;
 import java.util.Collections;
@@ -69,8 +70,9 @@ public class ActionMenuResource {
   @Operation(
       summary = "List action menus (catalog)",
       description =
-          "Lists CX action menus for the Developer module. Create/edit/delete and entry"
-              + " composition remain later slices.",
+          "Lists CX action menus for the Developer module. Admin create/save/delete user menus"
+              + " via POST/PUT/DELETE on this resource. Cascading children composition and"
+              + " usage/command/visibility tabs remain later slices.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -98,8 +100,9 @@ public class ActionMenuResource {
   @Operation(
       summary = "Get action menu detail",
       description =
-          "Loads one action menu by name or numeric id. Write and cascading entry edit remain"
-              + " unsupported.",
+          "Loads one action menu by name or numeric id. Admin PUT/DELETE use"
+              + " /services/actions/{idOrName}. Cascading entry composition remains a later"
+              + " slice.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -179,19 +182,176 @@ public class ActionMenuResource {
 
   /**
    * Accepts an object with an array of content ids and assignment types and returns the allowed
-   * menus. Not implemented.
+   * menus. Not implemented. Collection {@code POST /actions} is create; this finder stays under
+   * {@code /find/transitions}.
    *
    * @param request the request payload
    * @return an empty list (not implemented)
    */
   @POST
+  @Path("/find/transitions")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @Operation(
       description =
           "Accepts an object with an array of contentid's and assignment types and returns the"
-              + " allowed menus")
+              + " allowed menus. Not implemented; returns an empty list.")
   public ActionMenuList getAllowedTransitions(AllowedWorkflowTransitionsRequest request) {
-    // Not implemented yet
+    // Not implemented yet (UI-03 later). POST /actions is Admin create.
     return new ActionMenuList();
+  }
+
+  @POST
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Create action menu",
+      description =
+          "Admin. Creates and persists a user action menu via IPSUiDesignWs.createActions then"
+              + " saveActions (Workbench Finish, held design lock released on save). Name is"
+              + " required, unique (case-insensitive), and must not contain whitespace or"
+              + " wildcards. Optional label, description, menuType, and url (GET detail fields)"
+              + " are applied before save. Duplicate name is 409. System menus are not created"
+              + " here. Cascading children composition is a later slice. This is not Developer"
+              + " Action Menus SPA chrome.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = ActionMenu.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "409", description = "A menu with that name already exists"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  /** Admin create of a user action menu. */
+  public ActionMenu createActionMenu(ActionMenu body) {
+    try {
+      if (body != null) {
+        body.setGuid(null);
+        body.setId(-1);
+      }
+      ActionMenu created = requireAdaptor().createActionMenu(body);
+      if (created == null) {
+        throw new WebApplicationException("Failed to create action menu", 500);
+      }
+      return created;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Update action menu",
+      description =
+          "Admin. Updates label, description, menuType, and/or url by name, numeric id, or GUID."
+              + " Name is the catalog key and is not renamed on PUT. Loads with a design lock"
+              + " (overrideLock=false) and releases on save. Unknown id is 404. Lock/dependency"
+              + " conflict is 409. System menus are 409 (not mutated; the lock is not stolen)."
+              + " Cascading children composition is a later slice.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = ActionMenu.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Action menu not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "Design lock, dependency conflict, or system menu cannot be mutated"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  /** Admin update of a user action menu by name, numeric id, or GUID. */
+  public ActionMenu updateActionMenu(@PathParam("idOrName") String idOrName, ActionMenu body) {
+    try {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      ActionMenu updated = requireAdaptor().saveActionMenu(idOrName, body);
+      if (updated == null) {
+        throw new WebApplicationException("Action menu not found", 404);
+      }
+      return updated;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete action menu",
+      description =
+          "Admin. Deletes a user action menu by name, numeric id, or GUID via"
+              + " IPSUiDesignWs.deleteActions (ignoreDependencies=false). Unknown id is 404."
+              + " Lock/dependency conflict is 409. System menus are 409 (not deleted; the lock"
+              + " is not stolen). Following GET /catalog/{idOrName} is 404 after a successful"
+              + " delete.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Action menu not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "Design lock, dependency conflict, or system menu cannot be deleted"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  /** Admin delete of a user action menu by name, numeric id, or GUID. */
+  public Response deleteActionMenu(@PathParam("idOrName") String idOrName) {
+    try {
+      boolean deleted = requireAdaptor().deleteActionMenu(idOrName);
+      if (!deleted) {
+        throw new WebApplicationException("Action menu not found", 404);
+      }
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Admin/session 403 and duplicate/system 409 are
+   * already {@link WebApplicationException}s from the adaptor.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    if (e instanceof IllegalStateException) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      String lower = msg.toLowerCase();
+      if (lower.contains("lock") || lower.contains("depend")) {
+        return new WebApplicationException(msg, 409);
+      }
+      return new WebApplicationException(e, 500);
+    }
+    return new WebApplicationException(e, 500);
   }
 
   @POST

--- a/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
@@ -39,4 +39,32 @@ public interface IActionMenuAdaptor {
 
   /** Resolve one menu by name or numeric id string. Returns null if missing/unsafe. */
   ActionMenu findMenuByKey(String idOrName);
+
+  /**
+   * Admin. Create and persist a user action menu ({@code createActions} then {@code saveActions}).
+   *
+   * @param body required; {@code name} is the unique catalog key
+   * @return the persisted menu
+   */
+  ActionMenu createActionMenu(ActionMenu body);
+
+  /**
+   * Admin. Update and persist a user action menu by name or GUID ({@code loadActions} lock, {@code
+   * saveActions} release). Does not steal another user's lock. System menus are not mutated.
+   *
+   * @param idOrName catalog key (same rules as {@link #findMenuByKey})
+   * @param body required writable fields (label, description, menuType, url as exposed on GET)
+   * @return the persisted menu, or {@code null} when missing/unsafe
+   */
+  ActionMenu saveActionMenu(String idOrName, ActionMenu body);
+
+  /**
+   * Admin. Delete a user action menu by name or GUID ({@code deleteActions}, {@code
+   * ignoreDependencies=false}). Does not steal another user's lock. System menus return conflict
+   * (not deleted).
+   *
+   * @param idOrName catalog key (same rules as {@link #findMenuByKey})
+   * @return {@code true} when deleted, {@code false} when missing/unsafe
+   */
+  boolean deleteActionMenu(String idOrName);
 }

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -13,10 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentCaptor;
@@ -181,6 +183,175 @@ public class ActionMenuResourceTest {
     when(adaptor.findAllowedTemplates(eq(551), eq(false)))
         .thenThrow(new IllegalArgumentException("Request can't be null"));
     ActionMenuList out = resource.getAllowedTemplateMenus(551, false);
+    assertTrue(out.isEmpty());
+  }
+
+  @Test
+  public void createActionMenuClearsIdAndDelegates() {
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    body.setId(9);
+    ActionMenu created = new ActionMenu();
+    created.setName("MyMenu");
+    created.setId(42);
+    when(adaptor.createActionMenu(any())).thenReturn(created);
+
+    ActionMenu out = resource.createActionMenu(body);
+
+    assertEquals("MyMenu", out.getName());
+    assertEquals(-1, body.getId());
+    assertEquals(null, body.getGuid());
+    verify(adaptor).createActionMenu(body);
+  }
+
+  @Test
+  public void createActionMenuBlankNameIs400() {
+    when(adaptor.createActionMenu(any())).thenThrow(new IllegalArgumentException("name is required"));
+    ActionMenu body = new ActionMenu();
+    body.setName("  ");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createActionMenu(body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createActionMenuDuplicateIs409() {
+    when(adaptor.createActionMenu(any()))
+        .thenThrow(new WebApplicationException("Action menu already exists: MyMenu", 409));
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createActionMenu(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createActionMenuNonAdminIs403() {
+    when(adaptor.createActionMenu(any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createActionMenu(body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateActionMenuDelegates() {
+    ActionMenu body = new ActionMenu();
+    body.setLabel("Updated");
+    body.setDescription("desc");
+    body.setMenuType("MENU");
+    body.setUrl("/run");
+    ActionMenu updated = new ActionMenu();
+    updated.setName("MyMenu");
+    updated.setLabel("Updated");
+    updated.setDescription("desc");
+    updated.setMenuType("MENU");
+    updated.setUrl("/run");
+    when(adaptor.saveActionMenu(eq("MyMenu"), eq(body))).thenReturn(updated);
+
+    ActionMenu out = resource.updateActionMenu("MyMenu", body);
+
+    assertEquals("Updated", out.getLabel());
+    assertEquals("desc", out.getDescription());
+    assertEquals("MENU", out.getMenuType());
+    assertEquals("/run", out.getUrl());
+    verify(adaptor).saveActionMenu("MyMenu", body);
+  }
+
+  @Test
+  public void updateActionMenuUnknownIs404() {
+    when(adaptor.saveActionMenu(eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateActionMenu("missing", new ActionMenu()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateActionMenuNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.updateActionMenu("MyMenu", null));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).saveActionMenu(any(), any());
+  }
+
+  @Test
+  public void updateActionMenuSystemIs409() {
+    when(adaptor.saveActionMenu(eq("Edit"), any()))
+        .thenThrow(
+            new WebApplicationException(
+                "System action menus cannot be updated or deleted via this API", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateActionMenu("Edit", new ActionMenu()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteActionMenuNoContent() {
+    when(adaptor.deleteActionMenu(eq("MyMenu"))).thenReturn(true);
+
+    Response r = resource.deleteActionMenu("MyMenu");
+
+    assertEquals(204, r.getStatus());
+    verify(adaptor).deleteActionMenu("MyMenu");
+  }
+
+  @Test
+  public void deleteActionMenuUnknownIs404() {
+    when(adaptor.deleteActionMenu(eq("missing"))).thenReturn(false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteActionMenu("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteActionMenuNonAdminIs403() {
+    when(adaptor.deleteActionMenu(eq("MyMenu")))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteActionMenu("MyMenu"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteActionMenuSystemIs409() {
+    when(adaptor.deleteActionMenu(eq("Edit")))
+        .thenThrow(
+            new WebApplicationException(
+                "System action menus cannot be updated or deleted via this API", 409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteActionMenu("Edit"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturns500OnCreate() {
+    ActionMenuResource bare = new ActionMenuResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.createActionMenu(new ActionMenu()));
+    assertEquals(500, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void mapWriteFailurePreservesAdaptorWebApplicationException() {
+    WebApplicationException lock = new WebApplicationException("locked", 409);
+    assertSame(lock, ActionMenuResource.mapWriteFailure(lock));
+  }
+
+  @Test
+  public void mapWriteFailureIllegalArgumentIs400() {
+    WebApplicationException mapped =
+        ActionMenuResource.mapWriteFailure(new IllegalArgumentException("name is required"));
+    assertEquals(400, mapped.getResponse().getStatus());
+  }
+
+  @Test
+  public void getAllowedTransitionsStaysEmpty() {
+    ActionMenuList out = resource.getAllowedTransitions(new AllowedWorkflowTransitionsRequest());
     assertTrue(out.isEmpty());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/actions/ActionsTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionsTestAdaptor.java
@@ -52,4 +52,19 @@ public class ActionsTestAdaptor implements IActionMenuAdaptor {
   public ActionMenu findMenuByKey(String idOrName) {
     return null;
   }
+
+  @Override
+  public ActionMenu createActionMenu(ActionMenu body) {
+    return body;
+  }
+
+  @Override
+  public ActionMenu saveActionMenu(String idOrName, ActionMenu body) {
+    return body;
+  }
+
+  @Override
+  public boolean deleteActionMenu(String idOrName) {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary

Parent **#1690** / FR **UI-02**. Admin public REST can create, save, and delete **user** action menus through existing `IPSUiDesignWs` (`createActions` then `saveActions`; `loadActions` lock with `overrideLock=false`; `deleteActions` `ignoreDependencies=false`). No new SOAP surface. No Developer Action Menus SPA chrome.

- `POST /services/actions` — unique name, no spaces/wildcards; optional GET-detail fields `label` / `description` / `menuType` / `url`
- `PUT /services/actions/{idOrName}` — round-trip those GET fields; name is the catalog key (not renamed)
- `DELETE /services/actions/{idOrName}` — following `GET /services/actions/catalog/{idOrName}` is 404
- Duplicate **409**; invalid **400**; missing **404**; non-Admin (or missing session/user) **403**; system menus (Workbench `Menus/System` path) **409** on mutate/delete (lock is not stolen)
- Unimplemented allowed-transitions stub moved to `POST /services/actions/find/transitions` so collection POST is create. Catalog GET and finder helpers unchanged.

Fixes #4078. Parent: #1690.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (includes `ActionMenuResourceTest` 29, `MainTest` Spring stub).
2. Standalone `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (includes `ActionMenuAdaptorWriteTest` 24).
3. Unit coverage: Admin create/save/delete; unique name; spaces/wildcards 400; duplicate 409; system path 409; lock conflict 409; dependents 409; non-Admin 403; missing session 403; missing 404; GET finders still delegate.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` Action menus section (write contract; no SPA claim)
- [x] **Unit / module tests** — rest Mockito resource tests + `ActionsTestAdaptor` Spring stub (exact `IActionMenuAdaptor`); sitemanage adaptor write tests; both modules green under standalone `mvnw.cmd clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; SPA chrome is a later sibling)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-dep `projects/sitemanage` built after rest (new adaptor methods)
- [x] **Cross-platform** — N/A (no filesystem path/file I/O; Workbench hierarchy path split is logical)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 957, Failures: 0, Errors: 0, Skipped: 0 (`ActionMenuResourceTest` 29)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2036, Failures: 0, Errors: 0, Skipped: 125 (`ActionMenuAdaptorWriteTest` 24)
- **downstream_checked:** `implements IActionMenuAdaptor` → `ActionMenuAdaptor` (sitemanage) + `ActionsTestAdaptor` (rest test Spring stub). No anonymous subclasses. sitemanage standalone clean install after rest install.

### C5 UI proof

N/A — REST backend / product-docs only; no WebUI SPA or Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
