### PR TITLE
fix(system): H2 Playwright search editor create listed (persist) (#4084)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-4084-search-create-persist-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4084-search-create-persist-erlang.md
@@ -1,0 +1,36 @@
+# Erlang review — issue #4084 search create persist
+
+**Branch:** `fix/issue-4084-search-create-persist`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Date:** 2026-08-31  
+**Recommendation:** approve (C5 Playwright 2 passed after catalog-first loadSearches + JDBC ensure-delete)  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for new persist logic; change-class companions (adaptor + design WS + product-docs + XML app cache); no path I/O in this diff (SQL identifiers are constants)
+
+## Summary
+
+H2 REST UI-06 create returned 200 then GET list/detail 404 because:
+
+1. `SearchAdaptor.loadCatalog` used `findSearches` + `loadSearches`, and H2 `loadSearches` remaps rows to `View_All` (same hole as UI-07). List now uses `findAllSearches()`.
+2. `updateSearches` Dataset431 (`SEARCHID` HTML IS NOT NULL) is DELETE-only (`allowInserts=no`). Injecting HTML `SEARCHID` (or inheriting it) skipped the Action/@dbAction INSERT pipe (Dataset11143, `SEARCHID` IS NULL).
+3. `getSearches*` resource cache was keyed only by `sys_lang`, so create-then-list stayed stale.
+
+Fix: clear inherited `SEARCHID` on save; skip delete-then-insert for unpersisted locks; JDBC `PSX_SEARCHES` ensure-insert when the XML resource writes 0 rows; disable `getSearches*` resource cache; adaptor reload requires catalog visibility.
+
+## Cross-platform path checklist
+
+N/A — JDBC uses constant table/column names, not filesystem paths.
+
+## Issues
+
+None (hard-gate). Behavioral tests:
+
+- `PSUiDesignWsSearchPersistTest` (6) — community/INSERT state; cache flush; `searchRowSpec` mapping; H2 mem INSERT visible to SELECT
+- `SearchAdaptorWriteTest` — create then `findAllSearches`; 500 if catalog miss; 409 duplicate
+- `PSSearchXmlRoundTripTest.standardSearchXmlIsNotAView`
+
+Product-docs (`product-docs/8.2/developer/rest.md`, `admin/developer-searches.md`) state list+GET-by-name after create.
+
+## Suggestion (non-blocking)
+
+`reloadAfterWrite` is adaptor-level insurance; the durable fix is `PSUiDesignWs.ensureSearchRowPersisted` plus Dataset11143 selection. Keep both: POST must not return 200 for a row `findSearches` cannot see.

--- a/product-docs/8.2/admin/developer-searches.md
+++ b/product-docs/8.2/admin/developer-searches.md
@@ -34,7 +34,8 @@ are not executed from this chrome.
 4. Click **Save**. A duplicate name is **409** and the editor shows that the
    search already exists. An invalid name is **400**. A non-Admin session is
    **403**. After a successful create, the name field is read-only and the
-   catalog lists the new search.
+   catalog lists the new search (the save is persisted immediately; leaving
+   and returning to the list still shows the row).
 5. Optional: change label, description, type, or display format id and
    **Save** again. Field criteria are not written.
 6. Click **Delete** and confirm. The catalog no longer lists that search.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1696,7 +1696,9 @@ stub). JSON body requires `name` (unique across searches **and** views, case-ins
 types: `StandardSearch` (`standard`), `CustomSearch` (`custom`), `Search` (user search).
 `View` is **400** — views stay on `/services/views`. Duplicate name is **409**. Blank /
 whitespace / wildcard names are **400**. Missing request session/user is **403**.
-Non-Admin is **403**. The new search is then `GET /services/searches/{name}` **200**.
+Non-Admin is **403**. The new search is then `GET /services/searches/{name}` **200**
+and is included in `GET /services/searches` (the create is durable; a second POST
+with the same name is **409**).
 
 Update (`PUT /services/searches/{idOrName}`) loads with a design lock (`overrideLock=false`)
 and releases it on save. Name is not renamed on PUT. Omitted label / description / type /

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
@@ -177,7 +177,7 @@ public class SearchAdaptor implements ISearchAdaptor {
       PSSearch domain = created.get(0);
       applyWritableFields(domain, body);
       designWs.saveSearches(List.of(domain), true, session, user);
-      return toDef(domain, true);
+      return toDef(reloadAfterWrite(domain, name, session, user), true);
     } catch (WebApplicationException | IllegalStateException e) {
       throw e;
     } catch (IllegalArgumentException e) {
@@ -226,7 +226,8 @@ public class SearchAdaptor implements ISearchAdaptor {
       PSSearch domain = loaded.get(0);
       applyWritableFields(domain, body);
       designWs.saveSearches(List.of(domain), true, session, user);
-      return toDef(domain, true);
+      String catalogName = StringUtils.defaultIfBlank(domain.getName(), idOrName.trim());
+      return toDef(reloadAfterWrite(domain, catalogName, session, user), true);
     } catch (WebApplicationException | IllegalArgumentException e) {
       throw e;
     } catch (PSErrorResultsException e) {
@@ -522,7 +523,10 @@ public class SearchAdaptor implements ISearchAdaptor {
   }
 
   private List<PSSearch> loadAllSearches() throws Exception {
-    return loadCatalog(false);
+    // find+loadSearches remaps H2 rows to View_All (same hole as UI-07).
+    // findAllSearches returns the objects already parsed from getSearches.xml.
+    List<PSSearch> all = designWs.findAllSearches();
+    return all != null ? all : List.of();
   }
 
   private List<PSSearch> loadAllViews() throws Exception {
@@ -796,6 +800,39 @@ public class SearchAdaptor implements ISearchAdaptor {
       }
     }
     return false;
+  }
+
+  /**
+   * After {@code saveSearches}, the row must be visible to {@code findSearches} (H2 REST
+   * UI-06: POST 200 then GET list/detail 404 when the XML resource cache or INSERT was
+   * skipped). Load by GUID only after the catalog lists the name.
+   */
+  private PSSearch reloadAfterWrite(PSSearch saved, String name, String session, String user) {
+    try {
+      PSSearch fromCatalog = matchLoaded(loadAllSearches(), name);
+      if (fromCatalog != null) {
+        return fromCatalog;
+      }
+      if (saved != null && saved.getGUID() != null) {
+        List<PSSearch> loaded =
+            designWs.loadSearches(List.of(saved.getGUID()), false, false, session, user);
+        if (loaded != null && !loaded.isEmpty() && loaded.get(0) != null
+            && !loaded.get(0).isView()) {
+          fromCatalog = matchLoaded(loadAllSearches(), name);
+          if (fromCatalog != null) {
+            return fromCatalog;
+          }
+        }
+      }
+    } catch (PSErrorResultsException e) {
+      log.error("Failed to reload search {} after persist", name, e);
+      throw new IllegalStateException("Failed to reload search after persist", e);
+    } catch (Exception e) {
+      log.error("Failed to reload search {} after persist", name, e);
+      throw new IllegalStateException("Failed to reload search after persist", e);
+    }
+    throw new IllegalStateException(
+        "Search was saved but is not visible to findSearches: " + name);
   }
 
   private void assertNameUnique(String name) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorExecuteTest.java
@@ -167,6 +167,7 @@ class SearchAdaptorExecuteTest {
 
   @Test
   void executeSearch_missingReturnsNull() throws Exception {
+    when(designWs.findAllSearches()).thenReturn(List.of());
     when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of());
     when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
     assertNull(adaptor.executeSearch("Missing", new SearchExecuteRequest()));
@@ -192,6 +193,7 @@ class SearchAdaptorExecuteTest {
     when(viewAll.getDisplayFormatId()).thenReturn("0-1-1");
     when(viewAll.getMaximumResultSize()).thenReturn(25);
     when(viewAll.clone()).thenReturn(viewAll);
+    when(designWs.findAllSearches()).thenThrow(new IllegalStateException("PSAction missing"));
     when(designWs.findSearches(isNull(), isNull()))
         .thenThrow(new IllegalStateException("PSAction missing"));
     stubLoadedViews(List.of(viewAll));
@@ -204,6 +206,7 @@ class SearchAdaptorExecuteTest {
 
   @Test
   void executeSearch_missingAfterSearchCatalogThrowReturnsNull() throws Exception {
+    when(designWs.findAllSearches()).thenThrow(new IllegalStateException("PSAction missing"));
     when(designWs.findSearches(isNull(), isNull()))
         .thenThrow(new IllegalStateException("PSAction missing"));
     when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
@@ -231,6 +234,7 @@ class SearchAdaptorExecuteTest {
     when(viewAll.getDisplayFormatId()).thenReturn("0-1-1");
     when(viewAll.getMaximumResultSize()).thenReturn(25);
     when(viewAll.clone()).thenReturn(viewAll);
+    when(designWs.findAllSearches()).thenReturn(List.of());
     when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of());
     stubLoadedViews(List.of(viewAll));
     doReturn(List.of(item("id-a", "Welcome"))).when(adaptor).runDesignSearch(any(PSSearch.class));
@@ -270,6 +274,7 @@ class SearchAdaptorExecuteTest {
     PSSearch viewAll = mockSearch("View_All", false, false);
     when(viewAll.getLabel()).thenReturn("All");
     when(viewAll.isCustomView()).thenReturn(false);
+    when(designWs.findAllSearches()).thenThrow(new IllegalStateException("PSAction missing"));
     when(designWs.findSearches(isNull(), isNull()))
         .thenThrow(new IllegalStateException("PSAction missing"));
     stubLoadedViews(List.of(viewAll));
@@ -422,6 +427,7 @@ class SearchAdaptorExecuteTest {
       when(s.getGUID()).thenReturn(g);
     }
     when(designWs.findSearches(isNull(), isNull())).thenReturn(summaries);
+    when(designWs.findAllSearches()).thenReturn(searches);
     when(designWs.loadSearches(anyList(), eq(false), eq(false), isNull(), isNull()))
         .thenReturn(searches);
   }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorWriteTest.java
@@ -65,7 +65,7 @@ class SearchAdaptorWriteTest {
   private IPSGuid guid;
 
   @BeforeEach
-  void setUp() {
+  void setUp() throws Exception {
     PSRequestInfo.resetRequestInfo();
     PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
     PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
@@ -82,6 +82,7 @@ class SearchAdaptorWriteTest {
     when(guid.getType()).thenReturn((short) 301);
     when(guid.getUUID()).thenReturn(42);
     when(designWs.findSearches(any(), isNull())).thenReturn(List.of());
+    when(designWs.findAllSearches()).thenReturn(List.of());
     when(designWs.findViews(any(), isNull())).thenReturn(List.of());
   }
 
@@ -101,6 +102,7 @@ class SearchAdaptorWriteTest {
             eq("test-session"),
             eq("Admin")))
         .thenReturn(List.of(search));
+    stubCatalogVisibleAfterSave(search, "MySearch");
 
     SearchDef body = new SearchDef();
     body.setName("MySearch");
@@ -126,6 +128,29 @@ class SearchAdaptorWriteTest {
     verify(search).setDisplayName("My Search");
     verify(search).setDescription("created via REST");
     verify(search).setDisplayFormatId("1");
+    verify(designWs).findSearches(eq("MySearch"), isNull());
+    verify(designWs).findAllSearches();
+  }
+
+  @Test
+  void create_failsIfNotVisibleToFindAfterSave() throws Exception {
+    PSSearch search = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    when(designWs.createSearches(
+            eq(List.of("MySearch")),
+            eq(List.of(PSSearch.TYPE_STANDARDSEARCH)),
+            eq("test-session"),
+            eq("Admin")))
+        .thenReturn(List.of(search));
+    when(designWs.findSearches(eq("MySearch"), isNull())).thenReturn(List.of());
+    when(designWs.findAllSearches()).thenReturn(List.of());
+    when(designWs.loadSearches(eq(List.of(guid)), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(search));
+
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.createSearch(body));
+    assertTrue(ex.getMessage().contains("findSearches"), ex.getMessage());
   }
 
   @Test
@@ -235,6 +260,7 @@ class SearchAdaptorWriteTest {
     PSSearch locked = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
     when(designWs.loadSearches(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(locked));
+    stubCatalogVisibleAfterSave(locked, "MySearch");
 
     SearchDef body = new SearchDef();
     body.setLabel("Updated");
@@ -404,6 +430,19 @@ class SearchAdaptorWriteTest {
     return s;
   }
 
+  private void stubCatalogVisibleAfterSave(PSSearch search, String name) throws Exception {
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getName()).thenReturn(name);
+    when(sum.getGUID()).thenReturn(guid);
+    when(designWs.findSearches(eq(name), isNull()))
+        .thenReturn(List.of())
+        .thenReturn(List.of(sum));
+    when(designWs.findAllSearches()).thenReturn(List.of(search));
+    when(designWs.loadSearches(
+            eq(List.of(guid)), eq(false), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(search));
+  }
+
   private void stubCatalogLoad(PSSearch search, boolean asView) throws Exception {
     IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
     when(sum.getGUID()).thenReturn(guid);
@@ -414,6 +453,7 @@ class SearchAdaptorWriteTest {
           .thenReturn(List.of(search));
     } else {
       when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of(sum));
+      when(designWs.findAllSearches()).thenReturn(List.of(search));
       when(designWs.findViews(isNull(), isNull())).thenReturn(List.of());
       when(designWs.loadSearches(anyList(), eq(false), eq(false), any(), any()))
           .thenReturn(List.of(search));

--- a/system/cms/content/applications/sys_DisplayFormats/sys_DisplayFormats.xml
+++ b/system/cms/content/applications/sys_DisplayFormats/sys_DisplayFormats.xml
@@ -1268,7 +1268,7 @@
 					</PSXExtensionCall>
 				</PSXExtensionCallSet>
 			</ResultDataExits>
-			<PSXResourceCacheSettings enabled="yes"
+			<PSXResourceCacheSettings enabled="no"
 				id="0">
 				<Keys>
 					<Key>
@@ -6043,7 +6043,7 @@
 					</PSXExtensionCall>
 				</PSXExtensionCallSet>
 			</ResultDataExits>
-			<PSXResourceCacheSettings enabled="yes"
+			<PSXResourceCacheSettings enabled="no"
 				id="0">
 				<Keys>
 					<Key>
@@ -6791,7 +6791,7 @@
 					</PSXExtensionCall>
 				</PSXExtensionCallSet>
 			</ResultDataExits>
-			<PSXResourceCacheSettings enabled="yes"
+			<PSXResourceCacheSettings enabled="no"
 				id="0">
 				<Keys>
 					<Key>

--- a/system/src/test/java/com/percussion/cms/objectstore/PSSearchXmlRoundTripTest.java
+++ b/system/src/test/java/com/percussion/cms/objectstore/PSSearchXmlRoundTripTest.java
@@ -118,6 +118,38 @@ public class PSSearchXmlRoundTripTest {
     assertEquals(1, props.size());
   }
 
+  /**
+   * Merged getSearches.xml StandardSearch row (Default_Search) must deserialize
+   * as a non-view so {@code findSearches} can catalog UI-06 creates.
+   */
+  private static final String DEFAULT_SEARCH_XML =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+          + "<PSXSearch state=\"db_unmodified\">\n"
+          + "   <PSXKey isPersisted=\"yes\">\n"
+          + "      <SEARCHID>0</SEARCHID>\n"
+          + "   </PSXKey>\n"
+          + "   <DISPLAYNAME>Default CX New Search</DISPLAYNAME>\n"
+          + "   <DISPLAYFORMAT>0</DISPLAYFORMAT>\n"
+          + "   <PARENTCATEGORY>5</PARENTCATEGORY>\n"
+          + "   <TYPE>StandardSearch</TYPE>\n"
+          + "   <MAXIMUMITEMS>200</MAXIMUMITEMS>\n"
+          + "   <CASESENSITIVE>0</CASESENSITIVE>\n"
+          + "   <INTERNALNAME>Default_Search</INTERNALNAME>\n"
+          + "   <DESCRIPTION>Content Explorer Search</DESCRIPTION>\n"
+          + "   <VERSION>0</VERSION>\n"
+          + "</PSXSearch>\n";
+
+  @Test
+  public void standardSearchXmlIsNotAView() throws Exception {
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(new StringReader(DEFAULT_SEARCH_XML), false);
+    PSSearch search = new PSSearch(doc.getDocumentElement());
+    assertEquals("Default_Search", search.getInternalName());
+    assertEquals(PSSearch.TYPE_STANDARDSEARCH, search.getType());
+    assertFalse(search.isView());
+    assertTrue(search.isStandardSearch());
+  }
+
   @Test
   public void viewAllXmlDeserializesViaPsSearchElementCtor() throws Exception {
     Document doc =

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsSearchPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsSearchPersistTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.webservices.ui.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.objectstore.IPSDbComponent;
+import com.percussion.cms.objectstore.PSKey;
+import com.percussion.cms.objectstore.PSSearch;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * UI-06 persist: createSearches + saveSearches must INSERT and stay visible to findSearches
+ * (H2 REST POST 200 then GET 404 / no 409 on duplicate).
+ */
+@Tag("UnitTest")
+class PSUiDesignWsSearchPersistTest {
+
+  @Test
+  void prepareSearchForSave_newKeepsCommunityAndForcesInsert() throws Exception {
+    PSSearch source = new PSSearch("MySearch");
+    source.setType(PSSearch.TYPE_STANDARDSEARCH);
+    PSKey key = PSSearch.createKey(new String[] {"1014"});
+    key.setPersisted(false);
+    source.setLocator(key);
+
+    PSSearch prepared = PSUiDesignWs.prepareSearchForSave(source);
+
+    assertNotSame(source, prepared);
+    assertFalse(prepared.isPersisted());
+    assertEquals(IPSDbComponent.DBSTATE_NEW, prepared.getState());
+    assertTrue(
+        prepared.doesPropertyHaveValue(PSSearch.PROP_COMMUNITY, PSSearch.PROP_COMMUNITY_ALL),
+        "new searches keep sys_community=-1 so the update resource can write AnyCommunity ACL");
+  }
+
+  @Test
+  void prepareSearchForSave_persistedStripsCommunity() throws Exception {
+    PSSearch source = new PSSearch("MySearch");
+    source.setType(PSSearch.TYPE_STANDARDSEARCH);
+    PSKey key = PSSearch.createKey(new String[] {"42"});
+    source.setLocator(key);
+    assertTrue(source.isPersisted());
+    assertTrue(source.doesPropertyHaveValue(PSSearch.PROP_COMMUNITY, PSSearch.PROP_COMMUNITY_ALL));
+
+    PSSearch prepared = PSUiDesignWs.prepareSearchForSave(source);
+
+    assertTrue(prepared.isPersisted());
+    assertFalse(
+        prepared.doesPropertyHaveValue(PSSearch.PROP_COMMUNITY, PSSearch.PROP_COMMUNITY_ALL),
+        "updates still strip sys_community (Workbench already processed ACLs)");
+  }
+
+  @Test
+  void invalidateSearchCatalog_doesNotThrowWhenCacheUnavailable() {
+    assertDoesNotThrow(PSUiDesignWs::invalidateSearchCatalog);
+  }
+
+  @Test
+  void searchRowSpec_mapsAssignedNewSearchForInsert() throws Exception {
+    PSSearch source = new PSSearch("QaSearch");
+    source.setType(PSSearch.TYPE_STANDARDSEARCH);
+    source.setDisplayName("QA label");
+    source.setDescription("SPA UI-06 create");
+    source.setDisplayFormatId("7");
+    PSKey key = PSSearch.createKey(new String[] {"1014"});
+    key.setPersisted(false);
+    source.setLocator(key);
+
+    PSSearch prepared = PSUiDesignWs.prepareSearchForSave(source);
+    PSUiDesignWs.SearchRowSpec spec = PSUiDesignWs.searchRowSpec(prepared);
+
+    assertEquals(1014, spec.searchId);
+    assertEquals("QaSearch", spec.internalName);
+    assertEquals("QA label", spec.displayName);
+    assertEquals(PSSearch.TYPE_STANDARDSEARCH, spec.type);
+    assertEquals(Integer.valueOf(7), spec.displayFormat);
+    assertEquals("SPA UI-06 create", spec.description);
+    assertEquals(0, spec.caseSensitive);
+    assertEquals(PSSearch.DEFAULT_MAX, spec.maximumItems);
+    assertEquals(1, spec.parentCategory);
+  }
+
+  @Test
+  void parseDisplayFormatId_blankAndInvalidDefaultToOne() {
+    assertEquals(Integer.valueOf(1), PSUiDesignWs.parseDisplayFormatId(null));
+    assertEquals(Integer.valueOf(1), PSUiDesignWs.parseDisplayFormatId(""));
+    assertEquals(Integer.valueOf(1), PSUiDesignWs.parseDisplayFormatId("nope"));
+    assertEquals(Integer.valueOf(0), PSUiDesignWs.parseDisplayFormatId("0"));
+  }
+
+  @Test
+  void insertSearchRow_isVisibleToSelectOnH2() throws Exception {
+    String url = "jdbc:h2:mem:issue4084searches" + System.nanoTime();
+    try (Connection conn = DriverManager.getConnection(url);
+        Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE PSX_SEARCHES ("
+              + "SEARCHID INTEGER NOT NULL PRIMARY KEY,"
+              + "INTERNALNAME VARCHAR(255) NOT NULL,"
+              + "DISPLAYNAME VARCHAR(255) NOT NULL,"
+              + "PARENTCATEGORY INTEGER NOT NULL,"
+              + "CUSTOMURL VARCHAR(255),"
+              + "TYPE VARCHAR(50),"
+              + "DISPLAYFORMAT INTEGER,"
+              + "MAXIMUMITEMS INTEGER NOT NULL,"
+              + "DESCRIPTION VARCHAR(255),"
+              + "CASESENSITIVE INTEGER,"
+              + "VERSION INTEGER NOT NULL)");
+      st.execute(
+          "CREATE TABLE PSX_SEARCHFIELDS (SEARCHID INTEGER NOT NULL, FIELDNAME VARCHAR(50) NOT NULL)");
+      st.execute(
+          "CREATE TABLE PSX_SEARCHPROPERTIES (PROPERTYID INTEGER NOT NULL, PROPERTYNAME VARCHAR(50) NOT NULL, PROPERTYVALUE VARCHAR(255))");
+      PSSearch source = new PSSearch("QaH2Search");
+      source.setType(PSSearch.TYPE_STANDARDSEARCH);
+      PSKey key = PSSearch.createKey(new String[] {"2048"});
+      key.setPersisted(false);
+      source.setLocator(key);
+      PSUiDesignWs.SearchRowSpec spec =
+          PSUiDesignWs.searchRowSpec(PSUiDesignWs.prepareSearchForSave(source));
+      assertFalse(PSUiDesignWs.searchRowExists(conn, spec.searchId, spec.internalName));
+      PSUiDesignWs.insertSearchRow(conn, spec);
+      assertTrue(PSUiDesignWs.searchRowExists(conn, spec.searchId, spec.internalName));
+      assertTrue(PSUiDesignWs.searchRowExists(conn, spec.searchId, "otherName"));
+      PSUiDesignWs.deleteSearchRow(conn, spec.searchId);
+      assertFalse(PSUiDesignWs.searchRowExists(conn, spec.searchId, spec.internalName));
+    }
+  }
+
+  @Test
+  void matchSearchByGuid_matchesAssignedId() throws Exception {
+    PSSearch source = new PSSearch("MatchMe");
+    source.setType(PSSearch.TYPE_STANDARDSEARCH);
+    PSKey key = PSSearch.createKey(new String[] {"77"});
+    key.setPersisted(false);
+    source.setLocator(key);
+    assertEquals(source, PSUiDesignWs.matchSearchByGuid(List.of(source), source.getGUID()));
+    assertTrue(PSUiDesignWs.matchSearchesByGuids(List.of(source), List.of(source.getGUID())).size() == 1);
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiBaseWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiBaseWs.java
@@ -131,7 +131,11 @@ public class PSUiBaseWs
 
          if (resourcePath.equals(FIND_SEARCHES))
          {
-            iReq.makeRequest();
+            // Do not call makeRequest() first: that old getResultDoc path
+            // drops StandardSearch rows on H2 (HTTP getSearches.xml lists
+            // Default_Search/RC_Search; findSearches returned empty → UI-06
+            // POST then GET 404). getResultDoc() without makeRequest uses
+            // getResultDocument (full XML, no table.xsl merge).
             doc = iReq.getResultDoc();
          }
          else

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -32,6 +32,7 @@ import com.percussion.services.assembly.impl.nav.PSNavConfig;
 import com.percussion.fastforward.managednav.PSNavException;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
+import com.percussion.server.cache.PSCacheManager;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.PSGuidUtils;
@@ -49,6 +50,7 @@ import com.percussion.services.ui.PSUiServiceLocator;
 import com.percussion.services.ui.data.PSHierarchyNode;
 import com.percussion.services.ui.data.PSHierarchyNodeProperty;
 import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.jdbc.PSConnectionHelper;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.utils.timing.PSTimer;
 import com.intsof.percussioncms.auditlog.codes.WebserviceErrorCodes;
@@ -68,6 +70,9 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.transaction.annotation.Transactional;
 import org.w3c.dom.Element;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -76,6 +81,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.naming.NamingException;
 
 
 /**
@@ -367,6 +373,12 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
 
       deleteComponents(ids, PSSearch.class, PSSearch.getComponentType(PSSearch.class), ignoreDependencies, session,
             user);
+      for (IPSGuid id : ids)
+      {
+         if (id != null)
+            ensureSearchRowDeleted(id.getUUID());
+      }
+      invalidateSearchCatalog();
    }
 
    /*
@@ -1159,21 +1171,41 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       PSWebserviceUtils.validateParameters(searches, "searches", true, session, user);
 
       List<IPSDbComponent> components = new ArrayList<>();
-      // Clean the community property from the components before saving
+      List<PSSearch> unpersisted = new ArrayList<>();
       for (PSSearch s : searches)
       {
-         s = (PSSearch) s.cloneFull();
-         String[] values = s.getPropertyValues("sys_community");
-         if (values != null)
-         {
-            for (String comm : values)
-            {
-               s.removeProperty("sys_community", comm);
-            }
-         }
-         components.add(s);
+         boolean wasNew = s != null && !s.isPersisted();
+         PSSearch prepared = prepareSearchForSave(s);
+         components.add(prepared);
+         if (wasNew || (prepared != null && !prepared.isPersisted()))
+            unpersisted.add(prepared);
       }
-      saveComponents(components, PSSearch.class, release, session, user);
+      // updateSearches Dataset431 (HTML SEARCHID IS NOT NULL) is DELETE-only
+      // (allowInserts=no). Dataset11143 (SEARCHID IS NULL) uses Action/@dbAction
+      // INSERT/UPDATE — the pipe createSearches must hit. inheritParams=true
+      // copies REST HTML params; never inject SEARCHID on save.
+      PSRequest req = (PSRequest) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
+      Object previousSearchId = req != null ? req.getParameter("SEARCHID") : null;
+      boolean clearedSearchId = false;
+      if (req != null && previousSearchId != null)
+      {
+         req.removeParameter("SEARCHID");
+         clearedSearchId = true;
+      }
+      try
+      {
+         saveComponents(components, PSSearch.class, release, session, user);
+      }
+      finally
+      {
+         if (req != null && clearedSearchId)
+            req.setParameter("SEARCHID", previousSearchId);
+      }
+      for (PSSearch prepared : unpersisted)
+      {
+         ensureSearchRowPersisted(prepared);
+      }
+      invalidateSearchCatalog();
    }
 
    /*
@@ -1467,6 +1499,10 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       {String.valueOf(id)});
       key.setPersisted(false);
       source.setLocator(key);
+      if (source.getState() != IPSDbComponent.DBSTATE_NEW)
+      {
+         source.setState(IPSDbComponent.DBSTATE_NEW);
+      }
 
       return source;
    }
@@ -1595,10 +1631,80 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
    {
       PSWebserviceUtils.validateParameters(ids, "ids", lock, session, user);
 
+      // Processor loadSearches remaps H2 rows to View_All (UI-07 hole). Catalog
+      // from getSearches.xml / findAllSearches sees JDBC-ensured creates; use it
+      // for lock+delete so REST UI-06 delete is not 409 on a visible row.
+      try
+      {
+         List<PSSearch> catalog = isView
+               ? getSearchOrViews(findComponentsByNameLabel(null, null, FIND_SEARCHES, PSSearch.XML_NODE_NAME,
+                     PSSearch.class), true)
+               : findAllSearches();
+         List<PSSearch> matched = matchSearchesByGuids(catalog, ids);
+         if (matched.size() == ids.size())
+         {
+            if (lock)
+            {
+               IPSObjectLockService lockService = PSObjectLockServiceLocator.getLockingService();
+               for (int i = 0; i < ids.size(); i++)
+               {
+                  PSSearch s = matched.get(i);
+                  Integer version = s.getVersion() != null ? s.getVersion() : Integer.valueOf(0);
+                  lockService.createLock(ids.get(i), session, user, version, overrideLock);
+               }
+            }
+            return matched;
+         }
+      }
+      catch (PSErrorException e)
+      {
+         log.debug("Search catalog load fallback to processor: {}", e.toString());
+      }
+      catch (PSLockException e)
+      {
+         PSErrorResultsException results = new PSErrorResultsException();
+         results.addError(ids.get(0), e);
+         throw results;
+      }
+
       List sv = loadComponents(ids, PSSearch.class, PSSearch.getComponentType(PSSearch.class), lock, overrideLock,
             session, user);
 
       return getSearchOrViews(sv, isView);
+   }
+
+   static PSSearch matchSearchByGuid(List<PSSearch> catalog, IPSGuid id)
+   {
+      if (catalog == null || id == null)
+         return null;
+      long want = id.longValue();
+      int uuid = id.getUUID();
+      for (PSSearch s : catalog)
+      {
+         if (s == null)
+            continue;
+         IPSGuid g = s.getGUID();
+         if (g != null && g.longValue() == want)
+            return s;
+         if (s.getId() == uuid)
+            return s;
+      }
+      return null;
+   }
+
+   static List<PSSearch> matchSearchesByGuids(List<PSSearch> catalog, List<IPSGuid> ids)
+   {
+      List<PSSearch> matched = new ArrayList<>();
+      if (ids == null)
+         return matched;
+      for (IPSGuid id : ids)
+      {
+         PSSearch hit = matchSearchByGuid(catalog, id);
+         if (hit == null)
+            return new ArrayList<>();
+         matched.add(hit);
+      }
+      return matched;
    }
 
    /**
@@ -1728,6 +1834,12 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
             try
             {
                Integer version = lockService.getLockedVersion(id);
+
+               // Unpersisted creates must INSERT, not delete-then-insert (the
+               // delete resource selects updateSearches Dataset431 via HTML
+               // SEARCHID and can leave inheritParams polluted for the save).
+               if (version != null && !component.isPersisted())
+                  version = null;
 
                if (!saveComponent(component, id, cz, results, version))
                   continue;
@@ -2061,6 +2173,259 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          log.error(PSExceptionUtils.getMessageForLog(e));
 
          throw new RuntimeException("Failed to create PSComponentProcessorProxy.");
+      }
+   }
+
+   /**
+    * Prepare a search for {@link #saveSearches}. New (unpersisted) objects keep
+    * {@code sys_community} so {@code sys_SearchCommunityHandler} can write the
+    * AnyCommunity ACL, and are forced to {@code DBSTATE_NEW} so the processor
+    * emits INSERT. Persisted updates still strip community properties (Workbench
+    * already processed ACLs on the SOAP path).
+    *
+    * @param source never {@code null}
+    * @return clone ready for the component processor, never {@code null}
+    */
+   static PSSearch prepareSearchForSave(PSSearch source)
+   {
+      if (source == null)
+         throw new IllegalArgumentException("search cannot be null");
+
+      PSSearch s = (PSSearch) source.cloneFull();
+      if (s.isPersisted())
+      {
+         String[] values = s.getPropertyValues(PSSearch.PROP_COMMUNITY);
+         if (values != null)
+         {
+            for (String comm : values)
+            {
+               s.removeProperty(PSSearch.PROP_COMMUNITY, comm);
+            }
+         }
+      }
+      else
+      {
+         PSKey key = s.getLocator();
+         key.setPersisted(false);
+         s.setLocator(key);
+         if (s.getState() != IPSDbComponent.DBSTATE_NEW)
+         {
+            s.setState(IPSDbComponent.DBSTATE_NEW);
+         }
+      }
+      return s;
+   }
+
+   /**
+    * Column values for a durable {@code PSX_SEARCHES} INSERT when the XML
+    * {@code updateSearches} resource reports success with 0 rows (H2 REST UI-06).
+    */
+   static final class SearchRowSpec
+   {
+      final int searchId;
+      final String internalName;
+      final String displayName;
+      final int parentCategory;
+      final String customUrl;
+      final String type;
+      final Integer displayFormat;
+      final int maximumItems;
+      final String description;
+      final int caseSensitive;
+      final int version;
+
+      SearchRowSpec(int searchId, String internalName, String displayName, int parentCategory,
+            String customUrl, String type, Integer displayFormat, int maximumItems, String description,
+            int caseSensitive, int version)
+      {
+         this.searchId = searchId;
+         this.internalName = internalName;
+         this.displayName = displayName;
+         this.parentCategory = parentCategory;
+         this.customUrl = customUrl;
+         this.type = type;
+         this.displayFormat = displayFormat;
+         this.maximumItems = maximumItems;
+         this.description = description;
+         this.caseSensitive = caseSensitive;
+         this.version = version;
+      }
+   }
+
+   static SearchRowSpec searchRowSpec(PSSearch search)
+   {
+      if (search == null)
+         throw new IllegalArgumentException("search cannot be null");
+      int id = search.getId();
+      if (id <= 0)
+         throw new IllegalArgumentException("search id must be assigned before persist");
+      String internal = search.getInternalName();
+      if (StringUtils.isBlank(internal))
+         throw new IllegalArgumentException("search internal name is required");
+      String display = StringUtils.defaultIfBlank(search.getDisplayName(), internal);
+      String url = StringUtils.trimToNull(search.getUrl());
+      String type = StringUtils.defaultIfBlank(search.getType(), PSSearch.TYPE_STANDARDSEARCH);
+      Integer displayFormat = parseDisplayFormatId(search.getDisplayFormatId());
+      String description = StringUtils.trimToNull(search.getDescription());
+      int version = search.getVersion() != null ? search.getVersion().intValue() : 0;
+      return new SearchRowSpec(id, internal, display, search.getParentCategory(), url, type, displayFormat,
+            search.getMaximumResultSize(), description, search.isCaseSensitive() ? 1 : 0, version);
+   }
+
+   static Integer parseDisplayFormatId(String raw)
+   {
+      if (StringUtils.isBlank(raw))
+         return Integer.valueOf(1);
+      try
+      {
+         return Integer.valueOf(raw.trim());
+      }
+      catch (NumberFormatException e)
+      {
+         return Integer.valueOf(1);
+      }
+   }
+
+   /**
+    * If {@code updateSearches} did not INSERT, write {@code PSX_SEARCHES} so
+    * {@link #findSearches} / {@link #findAllSearches} can catalog the name.
+    */
+   static void ensureSearchRowPersisted(PSSearch search)
+   {
+      SearchRowSpec spec = searchRowSpec(search);
+      Connection conn = null;
+      try
+      {
+         conn = PSConnectionHelper.getDbConnection();
+         if (searchRowExists(conn, spec.searchId, spec.internalName))
+            return;
+         try
+         {
+            insertSearchRow(conn, spec);
+         }
+         catch (SQLException insertEx)
+         {
+            if (searchRowExists(conn, spec.searchId, spec.internalName))
+               return;
+            throw insertEx;
+         }
+      }
+      catch (NamingException | SQLException e)
+      {
+         throw new IllegalStateException(
+               "Search was saved but is not visible to findSearches: " + spec.internalName, e);
+      }
+      finally
+      {
+         PSConnectionHelper.releaseDbConnection(conn);
+      }
+   }
+
+   static boolean searchRowExists(Connection conn, int searchId, String internalName) throws SQLException
+   {
+      String sql = "SELECT SEARCHID FROM PSX_SEARCHES WHERE SEARCHID = ? OR INTERNALNAME = ?";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setInt(1, searchId);
+         ps.setString(2, internalName);
+         try (ResultSet rs = ps.executeQuery())
+         {
+            return rs.next();
+         }
+      }
+   }
+
+   static void ensureSearchRowDeleted(int searchId)
+   {
+      Connection conn = null;
+      try
+      {
+         conn = PSConnectionHelper.getDbConnection();
+         deleteSearchRow(conn, searchId);
+      }
+      catch (NamingException | SQLException e)
+      {
+         log.debug("Could not JDBC-delete PSX_SEARCHES SEARCHID={}: {}", searchId, e.toString());
+      }
+      finally
+      {
+         PSConnectionHelper.releaseDbConnection(conn);
+      }
+   }
+
+   static void deleteSearchRow(Connection conn, int searchId) throws SQLException
+   {
+      try (PreparedStatement fields = conn.prepareStatement("DELETE FROM PSX_SEARCHFIELDS WHERE SEARCHID = ?"))
+      {
+         fields.setInt(1, searchId);
+         fields.executeUpdate();
+      }
+      try (PreparedStatement props = conn.prepareStatement("DELETE FROM PSX_SEARCHPROPERTIES WHERE PROPERTYID = ?"))
+      {
+         props.setInt(1, searchId);
+         props.executeUpdate();
+      }
+      try (PreparedStatement searches = conn.prepareStatement("DELETE FROM PSX_SEARCHES WHERE SEARCHID = ?"))
+      {
+         searches.setInt(1, searchId);
+         searches.executeUpdate();
+      }
+   }
+
+   static void insertSearchRow(Connection conn, SearchRowSpec spec) throws SQLException
+   {
+      String sql = "INSERT INTO PSX_SEARCHES (SEARCHID, INTERNALNAME, DISPLAYNAME, PARENTCATEGORY, "
+            + "CUSTOMURL, TYPE, DISPLAYFORMAT, MAXIMUMITEMS, DESCRIPTION, CASESENSITIVE, VERSION) "
+            + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setInt(1, spec.searchId);
+         ps.setString(2, spec.internalName);
+         ps.setString(3, spec.displayName);
+         ps.setInt(4, spec.parentCategory);
+         ps.setString(5, spec.customUrl);
+         ps.setString(6, spec.type);
+         if (spec.displayFormat == null)
+            ps.setNull(7, java.sql.Types.INTEGER);
+         else
+            ps.setInt(7, spec.displayFormat.intValue());
+         ps.setInt(8, spec.maximumItems);
+         ps.setString(9, spec.description);
+         ps.setInt(10, spec.caseSensitive);
+         ps.setInt(11, spec.version);
+         ps.executeUpdate();
+      }
+   }
+
+   /**
+    * Drop in-memory {@link #ALL_SEARCHES_CACHE_KEY} and the XML resource cache
+    * for {@code sys_DisplayFormats/getSearches} so {@link #findSearches} sees
+    * the row just saved or deleted.
+    */
+   static void invalidateSearchCatalog()
+   {
+      try
+      {
+         IPSCacheAccess cache = PSCacheAccessLocator.getCacheAccess();
+         if (cache != null)
+         {
+            cache.evict(ALL_SEARCHES_CACHE_KEY, IPSCacheAccess.IN_MEMORY_STORE);
+         }
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("Could not evict in-memory search catalog cache: {}", e.toString());
+      }
+      try
+      {
+         if (PSCacheManager.isAvailable())
+         {
+            PSCacheManager.getInstance().flushApplication("sys_DisplayFormats");
+         }
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("Could not flush sys_DisplayFormats resource cache: {}", e.toString());
       }
    }
 


### PR DESCRIPTION
## Summary

H2 REST UI-06 create (`POST /services/searches`) returned 200 then GET list/detail 404 (duplicate never 409) because `updateSearches` Dataset431 (`SEARCHID` HTML IS NOT NULL) is DELETE-only (`allowInserts=no`) and `getSearches*` result cache was keyed only by `sys_lang`. Keep the Developer Searches SPA from #4076.

`saveSearches` now clears inherited HTML `SEARCHID` so Dataset11143 (`Action/@dbAction` INSERT) is selected, JDBC-ensures `PSX_SEARCHES` when the XML resource writes 0 rows, `loadSearches`/`deleteSearches` resolve from `findAllSearches` (H2 `loadSearches` remaps to View_All), and `getSearches*` resource cache is disabled. Adaptor list uses `findAllSearches` and refuses POST 200 unless the catalog lists the name.

Fixes #4084. Parent #1690 leftover of #4081 (this PR is the persist fix — do not double-implement on #4081).

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd system && ../mvnw clean install` — BUILD SUCCESS, Tests run: 2698, Failures: 0 (`PSUiDesignWsSearchPersistTest` 7).
2. Standalone `cd projects/sitemanage && ../../mvnw clean install` — BUILD SUCCESS, Tests run: 2013, Failures: 0.
3. QA H2: existing `perc-matrix-cms-h2` `TEST_CMS_URL=http://127.0.0.1:9993`; `perc-devctl.py qa-health` RESULT:OK HEALTH:healthy.
4. Hot-deploy `perc-system-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` to `WEB-INF/lib`, copy `sys_DisplayFormats.xml` to ObjectStore, in-cell StopJetty/StartJetty (not `docker restart`).
5. `qa-health` again RESULT:OK.
6. `npm run test:surface -- --path tests/developer-search-editor.spec.js` — **2 passed** (create `[data-sr-name]` count 1; delete omits; duplicate 409 in `developer-sr-detail-error`). console-clean=yes; server.log-clean=yes (AUTH-1001 only in the test window).

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/developer-searches.md` and `product-docs/8.2/developer/rest.md` (create is durable; GET list/name 200; second POST 409)
- [x] **Unit / module tests** — `PSUiDesignWsSearchPersistTest`, `SearchAdaptorWriteTest`, `PSSearchXmlRoundTripTest`; both modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — existing `tests/developer-search-editor.spec.js` (SPA from #4076); C5 surface 2 passed on H2
- [x] **Build gates** — `system` and `projects/sitemanage` standalone clean install (no skipTests)
- [x] **Cross-platform** — JDBC uses constant table/column names (not filesystem paths)

### C3 evidence

- modules_built=`system,projects/sitemanage`
- build_evidence=`cd system && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 2698 Failures: 0; `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS Tests run: 2013 Failures: 0
- downstream_checked=`projects/sitemanage` standalone install (REST adaptor consumer of IPSUiDesignWs). No public type made final/sealed; no ctor/signature change.

### C5 UI proof

- qa-up: reused healthy `perc-matrix-cms-h2` (QA_CMS_HOST_PORT=9993); `python docker/scripts/perc-devctl.py qa-health` RESULT:OK HEALTH:healthy URL=http://127.0.0.1:9993/Rhythmyx/rest/mimetypes
- deploy: docker cp perc-system + sitemanage jars to `/opt/Percussion/jetty/base/webapps/Rhythmyx/WEB-INF/lib`; ObjectStore `sys_DisplayFormats.xml`; in-cell `/opt/Percussion/jetty/StopJetty.sh` then `StartJetty.sh` (not docker restart)
- Playwright: `npm run test:surface -- --path tests/developer-search-editor.spec.js` — 2 passed (5.0s)
- console-clean=yes (spec pageerror/console error guards)
- server.log-clean=yes (no feature ERROR/FATAL in the test window; AUTH-1001 login success)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
