### PR TITLE
test(rest): UI-06 search create persist contract coverage (#4081)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-4081-search-rest-persist-coverage-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4081-search-rest-persist-coverage-erlang.md
@@ -1,0 +1,33 @@
+# Erlang review — issue #4081 REST UI-06 search persist coverage
+
+**Branch:** `fix/issue-4081-search-rest-persist-coverage`  
+**Scope:** uncommitted vs `origin/main` (rest tests only)  
+**Date:** 2026-08-31  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** behavioral tests for write contract; exact `ISearchAdaptor` Spring stub (not a supertype); no second production persist implementation (PR #4088 owns that)
+
+## Summary
+
+#4084 / PR #4088 already implements H2 durable `POST /services/searches`. This slice adds rest-module coverage that was missing on that PR: Mockito mapping plus a persist-contract test against an **exact** `ISearchAdaptor` (create then GET/list, duplicate 409, blank/whitespace/spaces 400, DELETE 204 then GET 404). `TestSearchAdaptor` remains the Spring `MainTest` stub of type `ISearchAdaptor`.
+
+No production persist code in this diff (do not land a second `ensureSearchRowPersisted`).
+
+## Cross-platform path review
+
+N/A — no filesystem I/O. `InMemorySearchAdaptor.requireValidName` rejects `/` and `\` as **name characters** (same product rule as `SearchAdaptor.isSafeSearchKey`), not path joins.
+
+## Issues
+
+None (hard-gate).
+
+Behavioral tests:
+
+- `SearchResourcePersistContractTest` (4) — exact `ISearchAdaptor` in-memory catalog
+- `SearchResourceTest` — spaces → 400; Mockito durable create/list/delete; missing adaptor on DELETE → 503
+
+Standalone `cd rest && ../mvnw.cmd clean install` BUILD SUCCESS; Tests run: 948, Failures: 0 (`SearchResourcePersistContractTest` 4; `SearchResourceTest` 30).
+
+## Suggestion (non-blocking)
+
+Mockito `createThenGetAndListAreDurable` overlaps the persist-contract class. Keep both: one proves HTTP mapping with a mock, the other proves the same verbs against the real interface type Spring injects.

--- a/rest/src/test/java/com/percussion/rest/searches/SearchResourcePersistContractTest.java
+++ b/rest/src/test/java/com/percussion/rest/searches/SearchResourcePersistContractTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.searches;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * REST UI-06 write contract (#4081): POST is durable to GET list/detail; duplicate is 409;
+ * blank/whitespace/spaces names are 400; DELETE 204 then GET 404.
+ *
+ * <p>Uses an exact {@link ISearchAdaptor} (not a Mockito mock) so the resource mapping is
+ * proven against the same interface Spring injects. Server persist itself is PR #4088.
+ */
+@Tag("UnitTest")
+public class SearchResourcePersistContractTest {
+
+  private SearchResource resource;
+
+  @BeforeEach
+  public void setUp() {
+    resource = new SearchResource(new InMemorySearchAdaptor());
+  }
+
+  @Test
+  public void createThenGetAndListIncludeTheSearch() {
+    SearchDef body = new SearchDef();
+    body.setName("qa4081restprobe");
+    body.setLabel("QA probe");
+
+    SearchDef created = resource.createSearch(body);
+
+    assertEquals("qa4081restprobe", created.getName());
+    assertEquals("qa4081restprobe", resource.getSearch("qa4081restprobe").getName());
+    List<SearchDef> listed = resource.listSearches(false);
+    assertEquals(1, listed.size());
+    assertEquals("qa4081restprobe", listed.get(0).getName());
+    assertEquals("QA probe", listed.get(0).getLabel());
+  }
+
+  @Test
+  public void duplicateCreateIs409() {
+    SearchDef body = new SearchDef();
+    body.setName("qa4081dup");
+    resource.createSearch(body);
+
+    SearchDef again = new SearchDef();
+    again.setName("QA4081DUP");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createSearch(again));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void blankAndWhitespaceNamesAre400() {
+    assertCreateNameIs400(null);
+    SearchDef empty = new SearchDef();
+    empty.setName("");
+    assertCreateNameIs400(empty);
+    SearchDef blank = new SearchDef();
+    blank.setName("  ");
+    assertCreateNameIs400(blank);
+    SearchDef spaces = new SearchDef();
+    spaces.setName("has space");
+    assertCreateNameIs400(spaces);
+  }
+
+  @Test
+  public void deleteThenGetIs404() {
+    SearchDef body = new SearchDef();
+    body.setName("qa4081todelete");
+    resource.createSearch(body);
+
+    Response deleted = resource.deleteSearch("qa4081todelete");
+    assertEquals(204, deleted.getStatus());
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getSearch("qa4081todelete"));
+    assertEquals(404, ex.getResponse().getStatus());
+    assertTrue(resource.listSearches(false).isEmpty());
+  }
+
+  private void assertCreateNameIs400(SearchDef body) {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createSearch(body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  /**
+   * In-memory {@link ISearchAdaptor} for resource contract tests. Not a production persist
+   * implementation (that lives in {@code SearchAdaptor} / {@code IPSUiDesignWs}, PR #4088).
+   */
+  static final class InMemorySearchAdaptor implements ISearchAdaptor {
+
+    private final Map<String, SearchDef> byName = new LinkedHashMap<>();
+    private int nextId = 1014;
+
+    @Override
+    public List<SearchDef> listSearches() {
+      return listSearches(false);
+    }
+
+    @Override
+    public List<SearchDef> listSearches(boolean includeViews) {
+      List<SearchDef> out = new ArrayList<>();
+      for (SearchDef def : byName.values()) {
+        if (includeViews || !"View".equalsIgnoreCase(def.getType())) {
+          out.add(copy(def));
+        }
+      }
+      return out;
+    }
+
+    @Override
+    public SearchDef findSearchByKey(String idOrName) {
+      SearchDef stored = storedByKey(idOrName);
+      return stored != null ? copy(stored) : null;
+    }
+
+    @Override
+    public SearchExecuteResult executeSearch(String idOrName, SearchExecuteRequest request) {
+      SearchDef found = findSearchByKey(idOrName);
+      if (found == null) {
+        return null;
+      }
+      SearchExecuteResult result = new SearchExecuteResult();
+      result.setSearchName(found.getName());
+      result.setChildren(List.of());
+      result.setTotalCount(0);
+      result.setStartIndex(1);
+      return result;
+    }
+
+    @Override
+    public SearchDef createSearch(SearchDef body) {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      String name = requireValidName(body.getName());
+      String key = name.toLowerCase(Locale.ROOT);
+      if (byName.containsKey(key)) {
+        throw new WebApplicationException("Search already exists: " + name, 409);
+      }
+      SearchDef saved = copy(body);
+      saved.setName(name);
+      saved.setId(nextId++);
+      if (saved.getType() == null || saved.getType().isBlank()) {
+        saved.setType("StandardSearch");
+      }
+      byName.put(key, saved);
+      return copy(saved);
+    }
+
+    @Override
+    public SearchDef saveSearch(String idOrName, SearchDef body) {
+      SearchDef stored = storedByKey(idOrName);
+      if (stored == null) {
+        return null;
+      }
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      if (body.getLabel() != null) {
+        stored.setLabel(body.getLabel());
+      }
+      if (body.getDescription() != null) {
+        stored.setDescription(body.getDescription());
+      }
+      if (body.getType() != null) {
+        stored.setType(body.getType());
+      }
+      if (body.getDisplayFormatId() != null) {
+        stored.setDisplayFormatId(body.getDisplayFormatId());
+      }
+      return copy(stored);
+    }
+
+    @Override
+    public boolean deleteSearch(String idOrName) {
+      SearchDef stored = storedByKey(idOrName);
+      if (stored == null) {
+        return false;
+      }
+      byName.remove(stored.getName().toLowerCase(Locale.ROOT));
+      return true;
+    }
+
+    private SearchDef storedByKey(String idOrName) {
+      if (idOrName == null || idOrName.isBlank()) {
+        return null;
+      }
+      String key = idOrName.trim();
+      SearchDef by = byName.get(key.toLowerCase(Locale.ROOT));
+      if (by != null) {
+        return by;
+      }
+      for (SearchDef def : byName.values()) {
+        if (key.equals(String.valueOf(def.getId()))) {
+          return def;
+        }
+      }
+      return null;
+    }
+
+    static String requireValidName(String raw) {
+      if (raw == null || raw.isBlank()) {
+        throw new IllegalArgumentException("name is required");
+      }
+      String name = raw.trim();
+      for (int i = 0; i < name.length(); i++) {
+        if (Character.isWhitespace(name.charAt(i))) {
+          throw new IllegalArgumentException("name cannot contain whitespace");
+        }
+      }
+      if (name.contains("*") || name.contains("%")) {
+        throw new IllegalArgumentException("name must not contain wildcards");
+      }
+      if (name.contains("..") || name.indexOf('/') >= 0 || name.indexOf('\\') >= 0) {
+        throw new IllegalArgumentException("invalid name");
+      }
+      return name;
+    }
+
+    private static SearchDef copy(SearchDef src) {
+      SearchDef out = new SearchDef();
+      if (src == null) {
+        return out;
+      }
+      out.setName(src.getName());
+      out.setLabel(src.getLabel());
+      out.setDescription(src.getDescription());
+      out.setType(src.getType());
+      out.setDisplayFormatId(src.getDisplayFormatId());
+      out.setId(src.getId());
+      out.setGuid(src.getGuid());
+      return out;
+    }
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/searches/SearchResourceTest.java
@@ -19,7 +19,10 @@ import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -231,6 +234,59 @@ public class SearchResourceTest {
   }
 
   @Test
+  public void createSearchNameWithSpacesIs400() {
+    when(adaptor.createSearch(any()))
+        .thenThrow(new IllegalArgumentException("name cannot contain whitespace"));
+    SearchDef body = new SearchDef();
+    body.setName("has space");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createSearch(body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createThenGetAndListAreDurable() {
+    Map<String, SearchDef> catalog = new LinkedHashMap<>();
+    when(adaptor.createSearch(any()))
+        .thenAnswer(
+            inv -> {
+              SearchDef body = inv.getArgument(0);
+              SearchDef saved = new SearchDef();
+              saved.setName(body.getName());
+              saved.setId(1014);
+              catalog.put(body.getName().toLowerCase(Locale.ROOT), saved);
+              return saved;
+            });
+    when(adaptor.findSearchByKey(any()))
+        .thenAnswer(
+            inv -> {
+              String key = inv.getArgument(0);
+              return key == null ? null : catalog.get(key.toLowerCase(Locale.ROOT));
+            });
+    when(adaptor.listSearches(false)).thenAnswer(inv -> List.copyOf(catalog.values()));
+    when(adaptor.deleteSearch(any()))
+        .thenAnswer(
+            inv -> {
+              String key = inv.getArgument(0);
+              return key != null && catalog.remove(key.toLowerCase(Locale.ROOT)) != null;
+            });
+
+    SearchDef body = new SearchDef();
+    body.setName("qa4081restprobe");
+    SearchDef created = resource.createSearch(body);
+    assertEquals("qa4081restprobe", created.getName());
+    assertEquals("qa4081restprobe", resource.getSearch("qa4081restprobe").getName());
+    assertEquals(1, resource.listSearches(false).size());
+    assertEquals("qa4081restprobe", resource.listSearches(false).get(0).getName());
+
+    assertEquals(204, resource.deleteSearch("qa4081restprobe").getStatus());
+    WebApplicationException missing =
+        assertThrows(WebApplicationException.class, () -> resource.getSearch("qa4081restprobe"));
+    assertEquals(404, missing.getResponse().getStatus());
+    assertTrue(resource.listSearches(false).isEmpty());
+  }
+
+  @Test
   public void createSearchDuplicateIs409() {
     when(adaptor.createSearch(any()))
         .thenThrow(new WebApplicationException("Search already exists: MySearch", 409));
@@ -319,6 +375,14 @@ public class SearchResourceTest {
     SearchResource bare = new SearchResource();
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> bare.createSearch(new SearchDef()));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnDelete() {
+    SearchResource bare = new SearchResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.deleteSearch("any"));
     assertEquals(503, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestSearchAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestSearchAdaptor.java
@@ -25,7 +25,14 @@ import java.util.List;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
-/** Spring test stub for {@link ISearchAdaptor}. Required for ApplicationContext load. */
+/**
+ * Spring test stub for {@link ISearchAdaptor}. Required for ApplicationContext load.
+ *
+ * <p>Must implement the exact adaptor type {@code SearchResource} injects — a supertype stub
+ * fails {@code MainTest} / {@code RolesTest} with {@code No qualifying bean of type
+ * ISearchAdaptor}. Write methods are trivial; durable create/list/delete is covered by
+ * {@code SearchResourcePersistContractTest} and production {@code SearchAdaptor} (PR #4088).
+ */
 @Component
 @Lazy
 public class TestSearchAdaptor implements ISearchAdaptor {


### PR DESCRIPTION
## Summary

REST UI-06 search create persist leftover of parent #1690. **Do not re-implement persist** — H2 durability is PR #4088 (`fix/issue-4084-search-create-persist`). This PR adds the missing **rest Mockito + exact `ISearchAdaptor` persist-contract tests** asked on #4081.

`POST /services/searches` then `GET /services/searches/{name}` / list, duplicate **409**, blank/whitespace/spaces name **400**, `DELETE` **204** then GET **404**. Spring test stub remains exact `ISearchAdaptor` (`TestSearchAdaptor`). SPA from #4076 / #4080 is unchanged.

Fixes #4081. Parent #1690. Persist implementation: #4088 / #4084.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 948, Failures: 0 (`SearchResourcePersistContractTest` 4; `SearchResourceTest` 30).
2. No sitemanage/system change in this PR. Persist + H2 Playwright `tests/developer-search-editor.spec.js` **2 passed** on PR #4088 (do not land a second persist implementation here).

## Checklist

- [x] **Product documentation** — N/A (test-only rest coverage; persist wording is in PR #4088 `product-docs/8.2/developer/rest.md` and `admin/developer-searches.md`)
- [x] **Unit / module tests** — `SearchResourcePersistContractTest`, `SearchResourceTest`; `rest` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI change). C5 for the persist/SPA path is on PR #4088 (`developer-search-editor.spec.js` 2 passed, console-clean=yes, server.log-clean=yes)
- [x] **Build gates** — `rest` standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- modules_built=`rest`
- build_evidence=`cd rest && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 948 Failures: 0 (`SearchResourcePersistContractTest` 4; `SearchResourceTest` 30)
- downstream_checked=`none` (C2 did not apply: no type made final/sealed; no public/protected method or ctor signature change)

### C5 UI proof

N/A this PR (rest unit tests only). Persist Playwright proof is PR #4088: `npm run test:surface -- --path tests/developer-search-editor.spec.js` 2 passed on H2 `perc-matrix-cms-h2`.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
