### PR TITLE
feat(rest): Admin POST/PUT/DELETE user CE controls (UI-01) (#4087)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-4087-cecontrols-user-write-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4087-cecontrols-user-write-erlang.md
@@ -1,0 +1,52 @@
+# Erlang review: issue #4087 REST UI-01 user control write
+
+**Branch:** `feat/issue-4087-cecontrols-user-write`  
+**Scope:** `rest` CE controls resource/adaptor/DTO/tests; `projects/sitemanage` ControlAdaptor + UserControlIo; `product-docs/8.2/developer/rest.md`  
+**Base:** `origin/main`
+
+## Summary
+
+Admin POST/PUT/DELETE `/services/cecontrols` persist **user** CE controls through `PSCustomControlManager` (XSL file under `rx_resources/stylesheets/controls` + `writeImports`). System controls are 409 and packaged files are not mutated. REST only — no SPA chrome.
+
+## Recommendation
+
+**approve**
+
+## Gate
+
+**May commit/push: yes**
+
+Hard gates checked:
+
+- Behavioral tests: `ControlsResourceTest` (22) and `ControlAdaptorWriteTest` (18) cover create/duplicate/blank/whitespace/wildcard/403/system-409/delete-204/path write.
+- Change-class closure: resource + `IControlAdaptor` write methods + Mockito tests + Spring `TestControlAdaptor` (exact `IControlAdaptor`) + sitemanage adaptor + product-docs. No WebUI/Playwright (REST-only slice).
+- Cross-platform I/O: `Path.resolve` chain and `Files.writeString` / `Files.deleteIfExists`; no hardcoded OS separators for filesystem joins. Tests use `@TempDir Path` and `dir.resolve(name + ".xsl")`.
+- Spring stub type matches `IControlAdaptor`.
+- Standalone `mvnw clean install`: rest then `projects/sitemanage` both BUILD SUCCESS.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] New path logic uses `Path` / `Files`
+- [x] Tests do not assert Unix-only absolute path shapes
+- [x] Temp files use JUnit `@TempDir` (portable)
+- [x] Line-ending sensitive assertions not used on OS file `toString()`
+- [x] XSL import href `/` is URL-style (existing manager; not this slice’s filesystem join)
+
+## Issues
+
+None blocking.
+
+Nit (not a gate): optional `xslSource` parse uses product `PSXmlDocumentBuilder` (same as control-file load). Invalid source is 400.
+
+## Memory patterns hit
+
+- Incomplete change-class closure (rest Spring stub + sitemanage adaptor tests)
+- Non-portable filesystem path joins
+- Path containment uses trusted user-controls directory, not a parent derived from the name
+- rest `MainTest` needs Spring test stubs for adaptor interfaces
+
+## Builds
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 954, Failures: 0; `ControlsResourceTest` 22
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2102, Failures: 0, Skipped: 125; `ControlAdaptorWriteTest` 18

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1654,6 +1654,79 @@ Content-type detail may still include **extra** per-item gaps (for example contr
 failures); those remain on the detail payload only. Structured `{ code, message }` entries apply
 on the Content Type / Template / Slot detail paths described above.
 
+## Content editor controls (catalog)
+
+Content editor **control** definitions (Workbench / Developer **Controls**, UI-01) are exposed
+under `/services/cecontrols`. List and detail include system (packaged) and user (custom)
+controls. Backing is **ALT** — `PSSystemControlManager` / `PSCustomControlManager` — there is
+no SOAP design twin and this API does not invent one.
+
+Admin **write** persists **user** controls as an XSL file under
+`rx_resources/stylesheets/controls` plus the custom-control import list
+(`PSCustomControlManager.writeImports`). Packaged **system** controls are read-only.
+**Do not** treat this as a Developer Controls SPA; chrome for create/save/delete is a later
+sibling. Full XSL source-editor UX is not provided by this API.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/cecontrols` | List system and user CE controls |
+| `GET` | `/services/cecontrols/{name}` | Load one control by name |
+| `POST` | `/services/cecontrols` | **Admin.** Create a user control (XSL file + import list) |
+| `PUT` | `/services/cecontrols/{name}` | **Admin.** Update a user control (metadata and/or optional `xslSource`) |
+| `DELETE` | `/services/cecontrols/{name}` | **Admin.** Delete a user control (removes the user XSL file and refreshes imports) |
+
+JSON objects use the `ControlDef` wire type. POST/PUT JSON is wrapped under a `ControlDef`
+root (JAXB/Jackson UNWRAP_ROOT_VALUE). Prefer the generated OpenAPI schema as the
+integration source of truth.
+
+### Control write contract (Admin)
+
+Create (`POST /services/cecontrols`) persists immediately. JSON body requires `name` (unique
+across system **and** user controls, case-insensitive; **no whitespace** or wildcards).
+Optional `displayName`, `description`, `dimension` (`single` default; `array`; `table`),
+`choiceSet` (`none` default; `required`; `optional`), and `xslSource` are applied. When
+`xslSource` is omitted the server writes a default user-control stylesheet from that
+metadata. Duplicate name is **409**. Blank / whitespace / wildcard names are **400**.
+Non-Admin is **403**. The new control is then `GET /services/cecontrols/{name}` **200** and
+appears on `GET /services/cecontrols`.
+
+Update (`PUT /services/cecontrols/{name}`) updates a **user** control. Name is the catalog
+key and is not renamed on PUT. Omitted `xslSource` regenerates a default stylesheet from
+metadata (send `xslSource` to keep a custom stylesheet). Unknown name is **404**. A
+**system** control is **409** (packaged files are not mutated). Non-Admin is **403**.
+
+Delete (`DELETE /services/cecontrols/{name}`) returns **204** when a user control is
+removed; a following `GET` is **404**. Unknown name is **404**. A **system** control is
+**409** (not deleted). Non-Admin is **403**.
+
+There is **no** Developer SPA controls catalog create/delete in this slice — operators and
+integrators call the REST path (or Workbench).
+
+Example create body:
+
+```json
+{
+  "ControlDef": {
+    "name": "myUserControl",
+    "displayName": "My User Control",
+    "description": "Created via REST",
+    "dimension": "single",
+    "choiceSet": "none"
+  }
+}
+```
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | List / get / create / update success |
+| `204` | Delete success |
+| `400` | Invalid input (missing name, whitespace/wildcard name, invalid dimension/choiceSet/xslSource) |
+| `403` | Caller is not Admin |
+| `404` | User control not found |
+| `409` | Duplicate name, or attempt to mutate/delete a packaged system control |
+| `500` | Control manager or file I/O failure |
+| `503` | Control adaptor not configured |
+
 ## Searches catalog and execute
 
 CX design **searches** (and optionally **views** on GET/execute) are exposed under

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ControlAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ControlAdaptor.java
@@ -9,32 +9,78 @@ import com.percussion.design.objectstore.PSControlParameter;
 import com.percussion.rest.cecontrols.ControlDef;
 import com.percussion.rest.cecontrols.ControlParameter;
 import com.percussion.rest.cecontrols.IControlAdaptor;
-import com.percussion.server.PSCustomControlManager;
-import com.percussion.server.PSSystemControlManager;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
-/** CE control catalog adaptor (UI-01 read) over system + custom control managers. */
+/**
+ * CE control catalog adaptor (UI-01 read/write) over system + custom control managers. Admin
+ * create/save/delete persist user controls as XSL files under {@code
+ * rx_resources/stylesheets/controls} plus {@code PSCustomControlManager.writeImports}. System
+ * controls are never mutated.
+ */
 @PSSiteManageBean
 @Lazy
 public class ControlAdaptor implements IControlAdaptor {
 
   private static final Logger log = LogManager.getLogger(ControlAdaptor.class);
 
+  static final String ADMIN_REQUIRED =
+      "Admin role required to create, update, or delete user CE controls";
+
+  static final String SYSTEM_CONTROL_READONLY = "System controls cannot be updated or deleted";
+
+  static final int MAX_CONTROL_NAME_LENGTH = 100;
+
   /** Catalog-level capability notes (same for every control). Exposed on detail only. */
   static final List<String> DESIGN_GAPS =
       List.of(
-          "User control create / edit / delete not supported via this API",
-          "Control XSL source editing not supported via this API",
+          "Full XSL source editor UX is not provided by this API; optional xslSource may be supplied on write",
           "System controls are read-only packaged defaults");
 
-  public ControlAdaptor() {}
+  private static final List<String> DIMENSIONS = List.of("single", "array", "table");
+  private static final List<String> CHOICE_SETS = List.of("none", "required", "optional");
+
+  private final BooleanSupplier adminChecker;
+  private final UserControlIo io;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
+
+  @Autowired
+  public ControlAdaptor() {
+    this(null, null);
+  }
+
+  /** Package-visible for unit tests. */
+  ControlAdaptor(BooleanSupplier adminChecker, UserControlIo io) {
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
+    this.io = io != null ? io : new ManagerUserControlIo();
+  }
 
   @Override
   public List<ControlDef> listControls() {
@@ -56,17 +102,90 @@ public class ControlAdaptor implements IControlAdaptor {
     return null;
   }
 
+  @Override
+  public ControlDef createControl(ControlDef body) {
+    requireAdmin();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String name = requireValidName(body.getName());
+    assertNameUnique(name);
+    String dimension = resolveDimension(body.getDimension());
+    String choiceSet = resolveChoiceSet(body.getChoiceSet());
+    String xsl = resolveXslSource(name, body, null, dimension, choiceSet);
+    writeUserControlFile(name, xsl);
+    ControlDef created = findControlByName(name);
+    if (created == null) {
+      created = projectionFromBody(body, name, dimension, choiceSet, true);
+    }
+    return created;
+  }
+
+  @Override
+  public ControlDef saveControl(String name, ControlDef body) {
+    requireAdmin();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    if (!isSafeControlKey(name)) {
+      return null;
+    }
+    String key = name.trim();
+    Path existingFile = findContainedUserFile(key);
+    if (existingFile == null) {
+      rejectSystemMutation(key);
+      return null;
+    }
+    ControlDef existing = findControlByName(key);
+    String dimension =
+        body.getDimension() != null && !body.getDimension().isBlank()
+            ? resolveDimension(body.getDimension())
+            : resolveDimension(existing != null ? existing.getDimension() : null);
+    String choiceSet =
+        body.getChoiceSet() != null && !body.getChoiceSet().isBlank()
+            ? resolveChoiceSet(body.getChoiceSet())
+            : resolveChoiceSet(existing != null ? existing.getChoiceSet() : null);
+    String xsl = resolveXslSource(key, body, existing, dimension, choiceSet);
+    writeUserControlFile(key, xsl);
+    ControlDef updated = findControlByName(key);
+    if (updated == null) {
+      updated = projectionFromBody(body, key, dimension, choiceSet, true);
+    }
+    return updated;
+  }
+
+  @Override
+  public boolean deleteControl(String name) {
+    requireAdmin();
+    if (!isSafeControlKey(name)) {
+      return false;
+    }
+    String key = name.trim();
+    Path existingFile = findContainedUserFile(key);
+    if (existingFile == null) {
+      rejectSystemMutation(key);
+      return false;
+    }
+    try {
+      Files.deleteIfExists(existingFile);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to delete user control file", e);
+    }
+    io.writeImports();
+    return true;
+  }
+
   private List<ControlDef> loadCatalog(boolean includeDesignGaps) {
     Map<String, ControlDef> byName = new LinkedHashMap<>();
     for (ControlDef c : loadScope("system", includeDesignGaps)) {
       if (c.getName() != null) {
-        byName.putIfAbsent(c.getName().toLowerCase(), c);
+        byName.putIfAbsent(c.getName().toLowerCase(Locale.ROOT), c);
       }
     }
     for (ControlDef c : loadScope("user", includeDesignGaps)) {
       if (c.getName() != null) {
         // User overrides system when same name appears in both catalogs.
-        byName.put(c.getName().toLowerCase(), c);
+        byName.put(c.getName().toLowerCase(Locale.ROOT), c);
       }
     }
     return new ArrayList<>(byName.values());
@@ -75,12 +194,8 @@ public class ControlAdaptor implements IControlAdaptor {
   private List<ControlDef> loadScope(String scope, boolean includeDesignGaps) {
     List<ControlDef> out = new ArrayList<>();
     try {
-      List<PSControlMeta> metas;
-      if ("system".equals(scope)) {
-        metas = PSSystemControlManager.getInstance().getAllControls();
-      } else {
-        metas = PSCustomControlManager.getInstance().getAllControls();
-      }
+      List<PSControlMeta> metas =
+          "system".equals(scope) ? io.loadSystemControls() : io.loadUserControls();
       if (metas == null) {
         return out;
       }
@@ -133,6 +248,258 @@ public class ControlAdaptor implements IControlAdaptor {
       }
     }
     return out;
+  }
+
+  private ControlDef projectionFromBody(
+      ControlDef body, String name, String dimension, String choiceSet, boolean includeGaps) {
+    ControlDef d = new ControlDef();
+    d.setName(name);
+    d.setDisplayName(
+        StringUtils.isNotBlank(body.getDisplayName()) ? body.getDisplayName().trim() : name);
+    d.setDescription(body.getDescription() != null ? body.getDescription() : "");
+    d.setDimension(dimension);
+    d.setChoiceSet(choiceSet);
+    d.setScope("user");
+    d.setDesignGaps(includeGaps ? new ArrayList<>(DESIGN_GAPS) : null);
+    return d;
+  }
+
+  private void writeUserControlFile(String name, String xsl) {
+    Path dir = io.userControlsDirectory();
+    Path file = dir.resolve(name + ".xsl");
+    Path dirNorm = dir.toAbsolutePath().normalize();
+    Path fileNorm = file.toAbsolutePath().normalize();
+    if (!fileNorm.startsWith(dirNorm)) {
+      throw new IllegalArgumentException("invalid control file path");
+    }
+    try {
+      Files.createDirectories(dir);
+      Files.writeString(file, xsl, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to write user control file", e);
+    }
+    io.writeImports();
+  }
+
+  private Path findContainedUserFile(String name) {
+    Path file = io.findUserControlFile(name);
+    if (file == null) {
+      return null;
+    }
+    Path dir = io.userControlsDirectory().toAbsolutePath().normalize();
+    Path fileNorm = file.toAbsolutePath().normalize();
+    if (!fileNorm.startsWith(dir)) {
+      // Packaged / system path — never delete or overwrite.
+      return null;
+    }
+    return fileNorm;
+  }
+
+  private void rejectSystemMutation(String name) {
+    if (isSystemName(name)) {
+      throw new WebApplicationException(SYSTEM_CONTROL_READONLY, 409);
+    }
+  }
+
+  private boolean isSystemName(String name) {
+    try {
+      List<PSControlMeta> metas = io.loadSystemControls();
+      if (metas == null) {
+        return false;
+      }
+      for (PSControlMeta meta : metas) {
+        if (meta != null && name.equalsIgnoreCase(meta.getName())) {
+          return true;
+        }
+      }
+    } catch (RuntimeException e) {
+      log.debug("Unable to load system CE controls while checking {}: {}", name, e.getMessage());
+    }
+    return false;
+  }
+
+  private void assertNameUnique(String name) {
+    for (ControlDef existing : loadCatalog(false)) {
+      if (existing != null && name.equalsIgnoreCase(existing.getName())) {
+        throw new WebApplicationException("Control already exists: " + name, 409);
+      }
+    }
+  }
+
+  private String resolveXslSource(
+      String name, ControlDef body, ControlDef existing, String dimension, String choiceSet) {
+    if (body.getXslSource() != null && !body.getXslSource().isBlank()) {
+      validateXslSource(name, body.getXslSource());
+      return body.getXslSource();
+    }
+    String displayName =
+        firstNonBlank(
+            body.getDisplayName(), existing != null ? existing.getDisplayName() : null, name);
+    String description =
+        body.getDescription() != null
+            ? body.getDescription()
+            : (existing != null ? existing.getDescription() : "");
+    return generateDefaultXsl(name, displayName, description, dimension, choiceSet);
+  }
+
+  static void validateXslSource(String name, String xsl) {
+    try {
+      Document doc = PSXmlDocumentBuilder.createXmlDocument(new StringReader(xsl), false);
+      NodeList nodes = doc.getElementsByTagName(PSControlMeta.XML_NODE_NAME);
+      if (nodes.getLength() != 1) {
+        throw new IllegalArgumentException(
+            "xslSource must contain exactly one " + PSControlMeta.XML_NODE_NAME);
+      }
+      PSControlMeta meta = new PSControlMeta((Element) nodes.item(0));
+      if (!name.equals(meta.getName())) {
+        throw new IllegalArgumentException("xslSource control name must match " + name);
+      }
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalArgumentException("invalid xslSource", e);
+    }
+  }
+
+  static String generateDefaultXsl(
+      String name, String displayName, String description, String dimension, String choiceSet) {
+    String n = xmlEscape(name);
+    String dn = xmlEscape(displayName);
+    String desc = xmlEscape(description != null ? description : "");
+    String dim = xmlEscape(dimension);
+    String cs = xmlEscape(choiceSet);
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<xsl:stylesheet version=\"1.1\"\n"
+        + "  xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"\n"
+        + "  xmlns:psxctl=\"urn:percussion.com/control\"\n"
+        + "  xmlns=\"http://www.w3.org/1999/xhtml\"\n"
+        + "  exclude-result-prefixes=\"psxctl\">\n"
+        + "  <xsl:template match=\"/\"/>\n"
+        + "  <psxctl:ControlMeta name=\""
+        + n
+        + "\" displayName=\""
+        + dn
+        + "\" dimension=\""
+        + dim
+        + "\" choiceset=\""
+        + cs
+        + "\">\n"
+        + "    <psxctl:Description>"
+        + desc
+        + "</psxctl:Description>\n"
+        + "  </psxctl:ControlMeta>\n"
+        + "  <xsl:template match=\"Control[@name='"
+        + n
+        + "']\" mode=\"psxcontrol\">\n"
+        + "    <input type=\"text\" name=\"{@paramName}\" value=\"{Value}\"/>\n"
+        + "  </xsl:template>\n"
+        + "</xsl:stylesheet>\n";
+  }
+
+  static String xmlEscape(String raw) {
+    if (raw == null) {
+      return "";
+    }
+    return raw.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+        .replace("'", "&apos;");
+  }
+
+  static String requireValidName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String name = raw.trim();
+    if (containsWhitespace(name)) {
+      throw new IllegalArgumentException("name cannot contain whitespace");
+    }
+    if (name.contains("*") || name.contains("%")) {
+      throw new IllegalArgumentException("name must not contain wildcards");
+    }
+    if (!isSafeControlKey(name)) {
+      throw new IllegalArgumentException("invalid name");
+    }
+    if (name.length() > MAX_CONTROL_NAME_LENGTH) {
+      throw new IllegalArgumentException(
+          "name must not exceed " + MAX_CONTROL_NAME_LENGTH + " characters");
+    }
+    return name;
+  }
+
+  static String resolveDimension(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      return "single";
+    }
+    String value = raw.trim().toLowerCase(Locale.ROOT);
+    if (!DIMENSIONS.contains(value)) {
+      throw new IllegalArgumentException("dimension must be single, array, or table");
+    }
+    return value;
+  }
+
+  static String resolveChoiceSet(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      return "none";
+    }
+    String value = raw.trim().toLowerCase(Locale.ROOT);
+    if (!CHOICE_SETS.contains(value)) {
+      throw new IllegalArgumentException("choiceSet must be none, required, or optional");
+    }
+    return value;
+  }
+
+  private static boolean containsWhitespace(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      if (Character.isWhitespace(name.charAt(i))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String firstNonBlank(String... values) {
+    if (values == null) {
+      return "";
+    }
+    for (String v : values) {
+      if (StringUtils.isNotBlank(v)) {
+        return v.trim();
+      }
+    }
+    return "";
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ManagerUserControlIo.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ManagerUserControlIo.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import com.percussion.design.objectstore.PSControlMeta;
+import com.percussion.server.PSCustomControlManager;
+import com.percussion.server.PSServer;
+import com.percussion.server.PSSystemControlManager;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Production {@link UserControlIo} over {@link PSCustomControlManager} / {@link
+ * PSSystemControlManager}. Path joins use {@link Path#resolve(String)} — no hardcoded OS
+ * separators.
+ */
+final class ManagerUserControlIo implements UserControlIo {
+
+  @Override
+  public Path userControlsDirectory() {
+    File rx = PSServer.getRxDir();
+    if (rx == null) {
+      throw new IllegalStateException("Server rx dir is not available");
+    }
+    return rx.toPath().resolve("rx_resources").resolve("stylesheets").resolve("controls");
+  }
+
+  @Override
+  public void writeImports() {
+    PSCustomControlManager.getInstance().writeImports();
+  }
+
+  @Override
+  public List<PSControlMeta> loadSystemControls() {
+    List<PSControlMeta> metas = PSSystemControlManager.getInstance().getAllControls();
+    return metas != null ? metas : List.of();
+  }
+
+  @Override
+  public List<PSControlMeta> loadUserControls() {
+    List<PSControlMeta> metas = PSCustomControlManager.getInstance().getAllControls();
+    return metas != null ? metas : List.of();
+  }
+
+  @Override
+  public Path findUserControlFile(String name) {
+    File file = PSCustomControlManager.getInstance().getControlFile(name);
+    return file != null ? file.toPath() : null;
+  }
+}

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/UserControlIo.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/UserControlIo.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import com.percussion.design.objectstore.PSControlMeta;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * File-backed user CE control store used by {@link ControlAdaptor}. Production uses {@link
+ * ManagerUserControlIo}; unit tests supply a temp-directory implementation.
+ */
+interface UserControlIo {
+
+  /** Directory that holds user control {@code .xsl} files. Never {@code null}. */
+  Path userControlsDirectory();
+
+  /** Refresh custom-control import list after create/delete. */
+  void writeImports();
+
+  List<PSControlMeta> loadSystemControls();
+
+  List<PSControlMeta> loadUserControls();
+
+  /** Existing user control file, or {@code null} if none. */
+  Path findUserControlFile(String name);
+}

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ControlAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ControlAdaptorWriteTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.design.objectstore.PSControlMeta;
+import com.percussion.rest.cecontrols.ControlDef;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import jakarta.ws.rs.WebApplicationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * UI-01 POST create / PUT update / DELETE persist user CE controls as XSL files plus {@code
+ * writeImports}. Admin only; unique name; system controls 409.
+ */
+@Tag("UnitTest")
+class ControlAdaptorWriteTest {
+
+  @TempDir Path tempDir;
+
+  private TestUserControlIo io;
+  private ControlAdaptor adaptor;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    io = new TestUserControlIo(tempDir.resolve("controls"));
+    Files.createDirectories(io.dir);
+    adaptor = new ControlAdaptor(() -> true, io);
+  }
+
+  @Test
+  void create_writesXslAndRefreshesImports() {
+    ControlDef body = new ControlDef();
+    body.setName("myUserControl");
+    body.setDisplayName("My User Control");
+    body.setDescription("created via REST");
+
+    ControlDef out = adaptor.createControl(body);
+
+    assertEquals("myUserControl", out.getName());
+    assertEquals("user", out.getScope());
+    Path written = io.dir.resolve("myUserControl.xsl");
+    assertTrue(Files.isRegularFile(written));
+    assertEquals(1, io.importsWritten);
+    ControlDef fetched = adaptor.findControlByName("myUserControl");
+    assertNotNull(fetched);
+    assertEquals("myUserControl", fetched.getName());
+    assertTrue(adaptor.listControls().stream().anyMatch(c -> "myUserControl".equals(c.getName())));
+  }
+
+  @Test
+  void create_duplicateName_is409BeforeWrite() {
+    io.system.add(controlMeta("sys_EditBox"));
+    ControlDef body = new ControlDef();
+    body.setName("sys_EditBox");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createControl(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    assertFalse(Files.exists(io.dir.resolve("sys_EditBox.xsl")));
+    assertEquals(0, io.importsWritten);
+  }
+
+  @Test
+  void create_duplicateUserName_is409() {
+    ControlDef first = new ControlDef();
+    first.setName("myUserControl");
+    adaptor.createControl(first);
+    io.importsWritten = 0;
+    ControlDef dup = new ControlDef();
+    dup.setName("myUserControl");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createControl(dup));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertEquals(0, io.importsWritten);
+  }
+
+  @Test
+  void create_blankName_throws() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createControl(null));
+    ControlDef blank = new ControlDef();
+    blank.setName("  ");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createControl(blank));
+    assertTrue(ex.getMessage().contains("name is required"));
+    assertEquals(0, io.importsWritten);
+  }
+
+  @Test
+  void create_nameWithSpaces_throws() {
+    ControlDef body = new ControlDef();
+    body.setName("has space");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createControl(body));
+    assertEquals("name cannot contain whitespace", ex.getMessage());
+  }
+
+  @Test
+  void create_wildcardName_throws() {
+    ControlDef body = new ControlDef();
+    body.setName("My*Control");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createControl(body));
+    assertEquals("name must not contain wildcards", ex.getMessage());
+  }
+
+  @Test
+  void create_invalidDimension_throws() {
+    ControlDef body = new ControlDef();
+    body.setName("myUserControl");
+    body.setDimension("wide");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createControl(body));
+    assertTrue(ex.getMessage().contains("dimension"));
+    assertEquals(0, io.importsWritten);
+  }
+
+  @Test
+  void create_invalidXslSource_throws() {
+    ControlDef body = new ControlDef();
+    body.setName("myUserControl");
+    body.setXslSource("<not-xsl/>");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createControl(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("xslsource"));
+    assertEquals(0, io.importsWritten);
+  }
+
+  @Test
+  void create_nonAdmin_is403() {
+    adaptor = new ControlAdaptor(() -> false, io);
+    ControlDef body = new ControlDef();
+    body.setName("myUserControl");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createControl(body));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertEquals(ControlAdaptor.ADMIN_REQUIRED, ex.getMessage());
+    assertFalse(Files.exists(io.dir.resolve("myUserControl.xsl")));
+  }
+
+  @Test
+  void save_updatesUserFile() {
+    ControlDef created = new ControlDef();
+    created.setName("myUserControl");
+    created.setDisplayName("Original");
+    adaptor.createControl(created);
+    io.importsWritten = 0;
+
+    ControlDef body = new ControlDef();
+    body.setDisplayName("Updated");
+    body.setDescription("saved via REST");
+    ControlDef out = adaptor.saveControl("myUserControl", body);
+
+    assertEquals("myUserControl", out.getName());
+    assertEquals(1, io.importsWritten);
+    ControlDef fetched = adaptor.findControlByName("myUserControl");
+    assertNotNull(fetched);
+    assertEquals("Updated", fetched.getDisplayName());
+  }
+
+  @Test
+  void save_systemControl_is409AndDoesNotWrite() {
+    io.system.add(controlMeta("sys_EditBox"));
+    ControlDef body = new ControlDef();
+    body.setDisplayName("nope");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.saveControl("sys_EditBox", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertEquals(ControlAdaptor.SYSTEM_CONTROL_READONLY, ex.getMessage());
+    assertFalse(Files.exists(io.dir.resolve("sys_EditBox.xsl")));
+    assertEquals(0, io.importsWritten);
+  }
+
+  @Test
+  void save_missingUser_isNull() {
+    ControlDef body = new ControlDef();
+    body.setDisplayName("nope");
+    assertNull(adaptor.saveControl("missing", body));
+    assertEquals(0, io.importsWritten);
+  }
+
+  @Test
+  void delete_userControl_removesFileAndRefreshesImports() {
+    ControlDef created = new ControlDef();
+    created.setName("myUserControl");
+    adaptor.createControl(created);
+    io.importsWritten = 0;
+
+    assertTrue(adaptor.deleteControl("myUserControl"));
+    assertFalse(Files.exists(io.dir.resolve("myUserControl.xsl")));
+    assertEquals(1, io.importsWritten);
+    assertNull(adaptor.findControlByName("myUserControl"));
+  }
+
+  @Test
+  void delete_systemControl_is409AndDoesNotDelete() {
+    io.system.add(controlMeta("sys_EditBox"));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteControl("sys_EditBox"));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertEquals(ControlAdaptor.SYSTEM_CONTROL_READONLY, ex.getMessage());
+    assertEquals(0, io.importsWritten);
+  }
+
+  @Test
+  void delete_missing_isFalse() {
+    assertFalse(adaptor.deleteControl("missing"));
+  }
+
+  @Test
+  void delete_nonAdmin_is403() {
+    ControlDef created = new ControlDef();
+    created.setName("myUserControl");
+    adaptor.createControl(created);
+    adaptor = new ControlAdaptor(() -> false, io);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteControl("myUserControl"));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertTrue(Files.exists(io.dir.resolve("myUserControl.xsl")));
+  }
+
+  @Test
+  void generateDefaultXsl_isParseableWithMatchingName() throws Exception {
+    String xsl =
+        ControlAdaptor.generateDefaultXsl(
+            "myUserControl", "Label", "desc", "single", "none");
+    ControlAdaptor.validateXslSource("myUserControl", xsl);
+    assertTrue(xsl.contains("name=\"myUserControl\""));
+  }
+
+  @Test
+  void generateDefaultXsl_doesNotUseOsSeparators() {
+    String xsl = ControlAdaptor.generateDefaultXsl("ctrl", "ctrl", "", "single", "none");
+    assertFalse(xsl.contains("\\"));
+    assertFalse(xsl.contains("rx_resources"));
+  }
+
+  static final class TestUserControlIo implements UserControlIo {
+    final Path dir;
+    final List<PSControlMeta> system = new ArrayList<>();
+    int importsWritten;
+
+    TestUserControlIo(Path dir) {
+      this.dir = dir;
+    }
+
+    @Override
+    public Path userControlsDirectory() {
+      return dir;
+    }
+
+    @Override
+    public void writeImports() {
+      importsWritten++;
+    }
+
+    @Override
+    public List<PSControlMeta> loadSystemControls() {
+      return new ArrayList<>(system);
+    }
+
+    @Override
+    public List<PSControlMeta> loadUserControls() {
+      List<PSControlMeta> out = new ArrayList<>();
+      if (!Files.isDirectory(dir)) {
+        return out;
+      }
+      try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir, "*.xsl")) {
+        for (Path file : stream) {
+          try (InputStream in = Files.newInputStream(file)) {
+            Document doc = PSXmlDocumentBuilder.createXmlDocument(in, false);
+            NodeList nodes = doc.getElementsByTagName(PSControlMeta.XML_NODE_NAME);
+            for (int i = 0; i < nodes.getLength(); i++) {
+              out.add(new PSControlMeta((Element) nodes.item(i)));
+            }
+          }
+        }
+      } catch (Exception e) {
+        throw new IllegalStateException("Failed to load user control files", e);
+      }
+      return out;
+    }
+
+    @Override
+    public Path findUserControlFile(String name) {
+      Path file = dir.resolve(name + ".xsl");
+      return Files.isRegularFile(file) ? file : null;
+    }
+  }
+
+  private static PSControlMeta controlMeta(String name) {
+    try {
+      String xml =
+          "<psxctl:ControlMeta xmlns:psxctl=\"urn:percussion.com/control\" name=\""
+              + name
+              + "\" dimension=\"single\" choiceset=\"none\"/>";
+      Document doc = PSXmlDocumentBuilder.createXmlDocument(new StringReader(xml), false);
+      return new PSControlMeta(doc.getDocumentElement());
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/cecontrols/ControlDef.java
+++ b/rest/src/main/java/com/percussion/rest/cecontrols/ControlDef.java
@@ -30,6 +30,12 @@ public class ControlDef {
   private List<ControlParameter> parameters = new ArrayList<>();
   private List<String> designGaps = new ArrayList<>();
 
+  /**
+   * Optional full XSL stylesheet on write. Omitted on list/detail unless the client supplied it.
+   * When absent on POST/PUT the server generates a default user-control stylesheet from metadata.
+   */
+  private String xslSource;
+
   public ControlDef() {}
 
   public String getName() {
@@ -118,5 +124,18 @@ public class ControlDef {
 
   public void setDesignGaps(List<String> designGaps) {
     this.designGaps = designGaps;
+  }
+
+  @Schema(
+      description =
+          "Optional full XSL stylesheet for POST/PUT. When omitted the server writes a default"
+              + " user-control stylesheet from name/displayName/description/dimension/choiceSet."
+              + " Not a Developer SPA source editor.")
+  public String getXslSource() {
+    return xslSource;
+  }
+
+  public void setXslSource(String xslSource) {
+    this.xslSource = xslSource;
   }
 }

--- a/rest/src/main/java/com/percussion/rest/cecontrols/ControlsResource.java
+++ b/rest/src/main/java/com/percussion/rest/cecontrols/ControlsResource.java
@@ -11,7 +11,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -23,14 +27,16 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only content editor control catalog for the Developer module (UI-01).
+ * Content editor control catalog for the Developer module (UI-01).
  *
- * <p>User control create/edit remains a later slice.
+ * <p>Admin POST/PUT/DELETE persist <strong>user</strong> controls through {@link
+ * IControlAdaptor} ({@code PSCustomControlManager} file + import list). System controls are
+ * read-only. This resource is REST only — it does not add Developer SPA chrome.
  */
 @PSSiteManageBean(value = "restControlsResource")
 @Path("/cecontrols")
 @XmlRootElement
-@Tag(name = "CE Controls", description = "Content editor control catalog (read-only)")
+@Tag(name = "CE Controls", description = "Content editor control catalog and user-control write")
 public class ControlsResource {
 
   private final IControlAdaptor adaptor;
@@ -53,8 +59,9 @@ public class ControlsResource {
   @Operation(
       summary = "List content editor controls",
       description =
-          "Lists system and user CE controls used by content type field editors. User control"
-              + " registration remains a later slice.",
+          "Lists system and user CE controls used by content type field editors. Admin"
+              + " create/save/delete of user controls are POST/PUT/DELETE on this resource."
+              + " System controls remain read-only.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -82,7 +89,9 @@ public class ControlsResource {
   @Produces({MediaType.APPLICATION_JSON})
   @Operation(
       summary = "Get content editor control detail",
-      description = "Loads one CE control by name. Write remains unsupported.",
+      description =
+          "Loads one CE control by name. Admin write of user controls is POST/PUT/DELETE on"
+              + " this resource. System controls cannot be mutated.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -105,6 +114,131 @@ public class ControlsResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  @POST
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Create user CE control",
+      description =
+          "Admin. Creates and persists a user CE control via PSCustomControlManager (XSL file"
+              + " under rx_resources/stylesheets/controls plus import list). Name is required,"
+              + " unique (case-insensitive), and must not contain whitespace or wildcards."
+              + " Optional displayName, description, dimension (single|array|table), choiceSet"
+              + " (none|required|optional), and xslSource are applied. Duplicate name is 409."
+              + " System control names cannot be created (409). This is REST only — there is no"
+              + " Developer SPA create chrome.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = ControlDef.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "A control with that name already exists"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ControlDef createControl(ControlDef body) {
+    try {
+      ControlDef created = requireAdaptor().createControl(body);
+      if (created == null) {
+        throw new WebApplicationException("Failed to create control", 500);
+      }
+      return created;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{name}")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Update user CE control",
+      description =
+          "Admin. Updates a user CE control by name. Name is the catalog key and is not renamed"
+              + " on PUT. System controls are 409 (packaged files are not mutated). Unknown name"
+              + " is 404. Optional xslSource replaces the stylesheet; omitted xslSource"
+              + " regenerates a default stylesheet from metadata.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = ControlDef.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Control not found"),
+        @ApiResponse(responseCode = "409", description = "System control cannot be mutated"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public ControlDef updateControl(@PathParam("name") String name, ControlDef body) {
+    try {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      ControlDef updated = requireAdaptor().saveControl(name, body);
+      if (updated == null) {
+        throw new WebApplicationException("Control not found", 404);
+      }
+      return updated;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{name}")
+  @Operation(
+      summary = "Delete user CE control",
+      description =
+          "Admin. Deletes a user CE control by name (removes the user XSL file and refreshes"
+              + " imports). System controls are 409 (not deleted). Unknown name is 404."
+              + " Following GET is 404 after a successful delete.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Control not found"),
+        @ApiResponse(responseCode = "409", description = "System control cannot be deleted"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteControl(@PathParam("name") String name) {
+    try {
+      boolean deleted = requireAdaptor().deleteControl(name);
+      if (!deleted) {
+        throw new WebApplicationException("Control not found", 404);
+      }
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Admin 403, duplicate 409, and system-control 409
+   * are already {@link WebApplicationException}s from the adaptor.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    return new WebApplicationException(e, 500);
   }
 
   private IControlAdaptor requireAdaptor() {

--- a/rest/src/main/java/com/percussion/rest/cecontrols/IControlAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/cecontrols/IControlAdaptor.java
@@ -6,7 +6,13 @@ package com.percussion.rest.cecontrols;
 
 import java.util.List;
 
-/** Adaptor for content editor control catalog (UI-01 read). */
+/**
+ * Adaptor for content editor control catalog (UI-01 read/write).
+ *
+ * <p>Write methods persist <strong>user</strong> controls through {@code
+ * PSCustomControlManager} (file under {@code rx_resources/stylesheets/controls} plus import
+ * list). System controls are read-only packaged defaults.
+ */
 public interface IControlAdaptor {
 
   /** List system and user CE controls. Never null. */
@@ -14,4 +20,32 @@ public interface IControlAdaptor {
 
   /** Resolve by control name (case-insensitive). Null if missing or unsafe key. */
   ControlDef findControlByName(String name);
+
+  /**
+   * Admin. Create and persist a user CE control (XSL file + import list).
+   *
+   * @param body required; {@code name} is the unique catalog key
+   * @return the persisted control
+   */
+  ControlDef createControl(ControlDef body);
+
+  /**
+   * Admin. Update and persist a user CE control by name. Does not mutate packaged system
+   * controls.
+   *
+   * @param name catalog key (same rules as {@link #findControlByName})
+   * @param body required writable fields (displayName, description, dimension, choiceSet,
+   *     optional xslSource)
+   * @return the persisted control, or {@code null} when missing/unsafe
+   */
+  ControlDef saveControl(String name, ControlDef body);
+
+  /**
+   * Admin. Delete a user CE control by name (removes the user XSL file and refreshes imports).
+   * Does not mutate packaged system controls.
+   *
+   * @param name catalog key (same rules as {@link #findControlByName})
+   * @return {@code true} when deleted, {@code false} when missing/unsafe
+   */
+  boolean deleteControl(String name);
 }

--- a/rest/src/test/java/com/percussion/rest/cecontrols/ControlsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/cecontrols/ControlsResourceTest.java
@@ -8,12 +8,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -112,6 +115,144 @@ public class ControlsResourceTest {
     ControlsResource bare = new ControlsResource();
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> bare.getControl("any"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createControlDelegates() {
+    ControlDef body = new ControlDef();
+    body.setName("myUserControl");
+    ControlDef created = new ControlDef();
+    created.setName("myUserControl");
+    created.setScope("user");
+    when(adaptor.createControl(any())).thenReturn(created);
+
+    ControlDef out = resource.createControl(body);
+
+    assertEquals("myUserControl", out.getName());
+    assertEquals("user", out.getScope());
+    verify(adaptor).createControl(body);
+  }
+
+  @Test
+  public void createControlBlankNameIs400() {
+    when(adaptor.createControl(any())).thenThrow(new IllegalArgumentException("name is required"));
+    ControlDef body = new ControlDef();
+    body.setName("  ");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createControl(body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createControlDuplicateIs409() {
+    when(adaptor.createControl(any()))
+        .thenThrow(new WebApplicationException("Control already exists: myUserControl", 409));
+    ControlDef body = new ControlDef();
+    body.setName("myUserControl");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createControl(body));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createControlNonAdminIs403() {
+    when(adaptor.createControl(any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    ControlDef body = new ControlDef();
+    body.setName("myUserControl");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createControl(body));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateControlDelegates() {
+    ControlDef body = new ControlDef();
+    body.setDisplayName("Updated");
+    ControlDef updated = new ControlDef();
+    updated.setName("myUserControl");
+    updated.setDisplayName("Updated");
+    when(adaptor.saveControl(eq("myUserControl"), eq(body))).thenReturn(updated);
+
+    ControlDef out = resource.updateControl("myUserControl", body);
+
+    assertEquals("Updated", out.getDisplayName());
+    verify(adaptor).saveControl("myUserControl", body);
+  }
+
+  @Test
+  public void updateControlUnknownIs404() {
+    when(adaptor.saveControl(eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateControl("missing", new ControlDef()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateControlNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateControl("myUserControl", null));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).saveControl(any(), any());
+  }
+
+  @Test
+  public void updateControlSystemIs409() {
+    when(adaptor.saveControl(eq("sys_EditBox"), any()))
+        .thenThrow(new WebApplicationException("System controls cannot be updated", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateControl("sys_EditBox", new ControlDef()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteControlNoContent() {
+    when(adaptor.deleteControl(eq("myUserControl"))).thenReturn(true);
+
+    Response r = resource.deleteControl("myUserControl");
+
+    assertEquals(204, r.getStatus());
+    verify(adaptor).deleteControl("myUserControl");
+  }
+
+  @Test
+  public void deleteControlUnknownIs404() {
+    when(adaptor.deleteControl(eq("missing"))).thenReturn(false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteControl("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteControlSystemIs409() {
+    when(adaptor.deleteControl(eq("sys_EditBox")))
+        .thenThrow(new WebApplicationException("System controls cannot be deleted", 409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteControl("sys_EditBox"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteControlNonAdminIs403() {
+    when(adaptor.deleteControl(eq("myUserControl")))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteControl("myUserControl"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnCreate() {
+    ControlsResource bare = new ControlsResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.createControl(new ControlDef()));
     assertEquals(503, ex.getResponse().getStatus());
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestControlAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestControlAdaptor.java
@@ -7,10 +7,12 @@ package com.percussion.rest.test.apibridge;
 import com.percussion.rest.cecontrols.ControlDef;
 import com.percussion.rest.cecontrols.IControlAdaptor;
 import java.util.List;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /** Test adaptor for CE Controls API bridge (MainTest Spring context). */
 @Component
+@Lazy
 public class TestControlAdaptor implements IControlAdaptor {
 
   @Override
@@ -21,5 +23,20 @@ public class TestControlAdaptor implements IControlAdaptor {
   @Override
   public ControlDef findControlByName(String name) {
     return null;
+  }
+
+  @Override
+  public ControlDef createControl(ControlDef body) {
+    return body;
+  }
+
+  @Override
+  public ControlDef saveControl(String name, ControlDef body) {
+    return body;
+  }
+
+  @Override
+  public boolean deleteControl(String name) {
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

REST UI-01 user CE control **write** for parent epic #1690. Public REST can create, save, and delete **user** content-editor controls. System (packaged) controls stay read-only.

Admin `POST /services/cecontrols`, `PUT /services/cecontrols/{name}`, and `DELETE /services/cecontrols/{name}` persist through `IControlAdaptor` and `PSCustomControlManager` (XSL file under `rx_resources/stylesheets/controls` plus `writeImports`). File I/O uses portable `Path` / `Files` (no hardcoded OS separators). Unique name; no spaces/wildcards; duplicate **409**; invalid **400**; missing **404**; non-Admin **403**; system mutate/delete **409** (packaged files are not touched).

This slice is **REST only**. It does not add Developer SPA Controls chrome or an XSL source editor UX.

Fixes #4087  
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Unit: `ControlsResourceTest` maps POST/PUT/DELETE to adaptor (200/204/400/403/404/409/503).
2. Unit: `ControlAdaptorWriteTest` writes/deletes user XSL via `@TempDir Path`, unique name, system 409, Admin 403, `writeImports`.
3. Spring: `TestControlAdaptor` implements exact `IControlAdaptor` on rest test classpath (`MainTest` context).
4. Standalone `mvnw clean install` in `rest` then `projects/sitemanage` (no skipTests).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` CE controls write contract (no SPA claim)
- [x] **Unit / module tests** — behavioral tests; rest + sitemanage standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST only)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests); reverse-deps: sitemanage rebuilt against new `IControlAdaptor` methods
- [x] **Cross-platform** — `Path.resolve` / `Files`; tests use `@TempDir Path`

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: 954, Failures: 0; `ControlsResourceTest` Tests run: 22, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS**; Tests run: 2102, Failures: 0, Skipped: 125; `ControlAdaptorWriteTest` Tests run: 18, Failures: 0
- **downstream_checked:** grepped `implements IControlAdaptor` (only `ControlAdaptor` + `TestControlAdaptor`); standalone sitemanage clean install after rest install (new public adaptor methods)
- **C5 UI proof:** N/A — REST backend only, no WebUI/SPA chrome

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
