### PR TITLE
fix(sitemanage): persist user display-format DELETE via component XML (#4091)

### DIFF
--- a/docs/ai-generated/code-reviews/4091-display-format-delete-persist-erlang.md
+++ b/docs/ai-generated/code-reviews/4091-display-format-delete-persist-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review — #4091 display-format DELETE persist
+
+**Branch:** `fix/issue-4091-display-format-delete-persist`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Change class:** sitemanage apibridge DELETE persist (Workbench component XML) + Playwright companion + product-docs REST notes  
+**Memory patterns hit:** behavioral tests for new persist path; change-class Playwright + product-docs companions; do not treat locator-only SOAP as success when child XML app fails  
+
+## Summary
+
+Admin REST `DELETE /services/displayformats/{idOrName}` previously called locator-only `IPSUiDesignWs.deleteDisplayFormats`. `updateDisplayFormats` is an XML datasource (`PSTransactionSet`: `Xml Document Expected, none supplied`), so DELETE returned success-shaped errors or 400 on mark-for-deletion + `saveDisplayFormats` (that save still locator-deletes first when a lock version is present). GET stayed 200.
+
+This slice loads with a design lock, `markForDeletion()`, and persists via `PSComponentProcessorProxy.delete(IPSDbComponent)` (Workbench objectstore XML). Locator `deleteDisplayFormats` is not used on the REST single-delete path. Playwright creates a **user** format via POST (does not re-implement SPA create chrome, does not delete packaged system formats), asserts DELETE 204, GET 404, catalog omits the row. `product-docs/8.2/developer/rest.md` updated.
+
+## Recommendation
+
+approve (re-review after live H2)
+
+## Gate
+
+**May commit/push: yes**
+
+## Re-review
+
+Live H2 showed locator XML delete of a **replayed** `By_Type` with `displayId=-1` (GET-by-key replay). Added `identityMatchesKey` / catalog exact-name copy and `nativeForDelete` stub from catalog `displayId`. Playwright: 1 passed (DELETE 204, GET 404, catalog omits row). server.log: `XML delete name=qa4091… deletedRows=1`; no new ERROR/FATAL for the path.
+
+- Behavioral unit tests cover mark-for-deletion XML persist hook, no locator/saveDisplayFormats on REST delete, unknown/lock/in-use/non-admin, persist failure mapping.
+- Standalone `projects/sitemanage` `mvnw clean install` BUILD SUCCESS (Tests run: 2013, Failures: 0, Errors: 0, Skipped: 125; `DisplayFormatAdaptorWriteTest` 21/0).
+- Playwright spec added under `modules/perc-qa-automation` (C5 live H2 required before PR).
+- Cross-platform path checklist: N/A (no filesystem path joins; URL paths correctly use `/`).
+- No agent-rule file changes.
+
+## Issues
+
+None (hard-gate).
+
+### Nits (non-blocking)
+
+- `DisplayFormatResource` OpenAPI text still mentions `IPSUiDesignWs.deleteDisplayFormats`. REST module was intentionally not retouched; product-docs is the operator source of truth for this slice.
+- Production `deleteLockedViaComponentXml` (dependency check + processor + lock release) is exercised live in Playwright, not with a real processor in Surefire (injected hook in unit tests). That is the same adaptor-test split as other design-WS writes.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] Playwright uses URL paths with `/` (correct)
+- [x] Unique REST names are alphanumeric (`qa4091…`); no OS path assertions

--- a/modules/perc-qa-automation/frontend/tests/developer-display-format-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-display-format-editor.spec.js
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Display Formats REST DELETE persist (#4091 / parent #4086 / #1690).
+ *
+ * Creates a user format via Admin POST (does not re-implement SPA create chrome),
+ * asserts the catalog lists it, DELETE returns 204, following GET is 404, and the
+ * SPA catalog omits the row. Does not delete packaged system formats.
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   python docker/scripts/perc-devctl.py qa-health
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
+ *     npm run test:surface -- --path tests/developer-display-format-editor.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const {
+  catalogOpenByExactName,
+} = require("./helpers/developer-catalog-selectors");
+
+function developerDisplayFormatsUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "display-formats",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+/** REST-safe unique display-format name (no spaces, wildcards, or path characters). */
+function uniqueDisplayFormatName() {
+  const a = Date.now().toString(36).replace(/[^a-z0-9]/g, "").slice(-4);
+  const b = Math.random().toString(36).replace(/[^a-z0-9]/g, "").slice(2, 6);
+  const suffix = `${a}${b}`.slice(0, 8);
+  return `qa4091${suffix || "x"}`;
+}
+
+/**
+ * Same-origin fetch so OWASP CSRF + session cookies apply.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} path
+ * @param {string} method
+ * @param {object} [body]
+ * @returns {Promise<{status: number, text: string}>}
+ */
+async function inPageJson(page, path, method, body) {
+  return page.evaluate(
+    async ({ path: url, method: httpMethod, body: payload }) => {
+      const tokenObj = window.OWASP_CSRFTOKEN;
+      const metaToken = document.querySelector('meta[name="_csrf"]');
+      const metaHeader = document.querySelector('meta[name="_csrf_header"]');
+      const token =
+        (tokenObj && tokenObj.token) || (metaToken && metaToken.content) || "";
+      const headerName =
+        (metaHeader && metaHeader.content) || "OWASP-CSRFTOKEN";
+      const headers = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      };
+      if (token) {
+        headers[headerName] = token;
+      }
+      const res = await fetch(url, {
+        method: httpMethod,
+        credentials: "same-origin",
+        headers,
+        body:
+          payload === undefined ? undefined : JSON.stringify(payload),
+      });
+      const text = await res.text();
+      return { status: res.status, text };
+    },
+    { path, method, body },
+  );
+}
+
+async function openDisplayFormatsCatalog(page) {
+  await page.goto(developerDisplayFormatsUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+  const panel = page.locator('[data-testid="developer-df-panel"]');
+  const empty = page.locator('[data-testid="developer-df-empty"]');
+  const listError = page.locator('[data-testid="developer-df-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer display formats catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(
+    unexpectedConsole,
+    `console error: ${unexpectedConsole.join(" | ")}`,
+  ).toEqual([]);
+}
+
+function createdRow(page, formatName) {
+  return page.locator(
+    catalogOpenByExactName("developer-df-open", "data-df-name", formatName),
+  );
+}
+
+test.describe("Developer display format editor (#4091 / UI-05 DELETE persist)", () => {
+  test("Admin DELETE of a POST-created user format is 204, GET 404, catalog omits the row", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    await openDisplayFormatsCatalog(page);
+
+    const formatName = uniqueDisplayFormatName();
+    expect(formatName.startsWith("qa4091")).toBeTruthy();
+    expect(/By_Author|Default/i.test(formatName)).toBeFalsy();
+
+    const create = await inPageJson(page, "/Rhythmyx/services/displayformats", "POST", {
+      DisplayFormat: {
+        name: formatName,
+        internalName: formatName,
+        label: `${formatName} label`,
+        displayName: `${formatName} label`,
+        description: "qa4091 delete persist",
+      },
+    });
+    expect(
+      create.status,
+      `POST create should be 201 (got ${create.status}): ${create.text}`,
+    ).toBe(201);
+
+    const afterCreate = await inPageJson(
+      page,
+      `/Rhythmyx/services/displayformats/${encodeURIComponent(formatName)}`,
+      "GET",
+    );
+    expect(afterCreate.status, `GET after create (got ${afterCreate.status}): ${afterCreate.text}`).toBe(200);
+    expect(
+      afterCreate.text,
+      `GET after create must be the user format, not a packaged replay: ${afterCreate.text}`,
+    ).toMatch(new RegExp(`"name"\\s*:\\s*"${formatName}"`));
+
+    await openDisplayFormatsCatalog(page);
+    await expect(createdRow(page, formatName)).toHaveCount(1, { timeout: 20_000 });
+
+    const del = await inPageJson(
+      page,
+      `/Rhythmyx/services/displayformats/${encodeURIComponent(formatName)}`,
+      "DELETE",
+    );
+    expect(
+      del.status,
+      `DELETE should be 204 (got ${del.status}): ${del.text}`,
+    ).toBe(204);
+
+    const afterDelete = await inPageJson(
+      page,
+      `/Rhythmyx/services/displayformats/${encodeURIComponent(formatName)}`,
+      "GET",
+    );
+    expect(
+      afterDelete.status,
+      `GET after DELETE must be 404 (got ${afterDelete.status}): ${afterDelete.text}`,
+    ).toBe(404);
+
+    await openDisplayFormatsCatalog(page);
+    await expect(createdRow(page, formatName)).toHaveCount(0, { timeout: 20_000 });
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1340,9 +1340,10 @@ The Design SPA **Create template** action uses POST; **Delete** uses this DELETE
 
 Content Explorer **display format** definitions (Developer **Display Formats**) are exposed
 under `/services/displayformats`. The REST layer is a thin contract over the UI **design**
-web service (`IPSUiDesignWs`) — create, update, and delete use the same
-`createDisplayFormats` / `loadDisplayFormats` / `saveDisplayFormats` /
-`deleteDisplayFormats` operations SOAP uses. There is no new SOAP surface. GET list/detail
+web service (`IPSUiDesignWs`) — create and update use the same
+`createDisplayFormats` / `loadDisplayFormats` / `saveDisplayFormats` operations SOAP uses.
+Admin delete loads the format and persists component XML (Workbench processor path) so
+`updateDisplayFormats` receives a document. There is no new SOAP surface. GET list/detail
 remain a catalog read.
 
 Responses include a nested `guid` object and a plain `guidString` (`host-type-uuid`) so
@@ -1354,7 +1355,7 @@ clients can load **Object ACL** via `GET /services/acls/object/{guid}`.
 | `GET` | `/services/displayformats/{idOrName}` | Load one format by internal name or GUID string |
 | `POST` | `/services/displayformats` | **Admin.** Create a format (`createDisplayFormats` then `saveDisplayFormats`) |
 | `PUT` | `/services/displayformats/{idOrName}` | **Admin.** Update `label`/`displayName` and/or `description` |
-| `DELETE` | `/services/displayformats/{idOrName}` | **Admin.** Delete a format (`deleteDisplayFormats`, `ignoreDependencies=false`) |
+| `DELETE` | `/services/displayformats/{idOrName}` | **Admin.** Delete a user format (loaded component XML persist; dependents `ignoreDependencies=false`) |
 
 JSON wraps the list as `DisplayFormatList` (`{"DisplayFormatList":[…]}`) including the empty
 catalog (`{"DisplayFormatList":[]}`, not a bare `[]`) and a single item as `DisplayFormat`.
@@ -1376,12 +1377,20 @@ Update (`PUT /services/displayformats/{idOrName}`) loads with a design lock
 `validForViewsAndSearches`, `validForRelatedContent`) are **derived from columns** the
 same way Workbench computes them — they are not independently persisted on PUT.
 
-Delete (`DELETE /services/displayformats/{idOrName}`) returns **204** when removed; a
-following `GET` is **404**. Unknown id/name is **404**. A format that still has dependents
-is **409**. Locked-by-another-user is **409** (the lock is not stolen). Non-Admin is **403**.
+Delete (`DELETE /services/displayformats/{idOrName}`) returns **204** when the format is
+removed from the catalog; a following `GET` is **404**. The REST adaptor loads the format
+with a design lock, marks it for deletion, and persists the **component XML** (the same
+Workbench objectstore path `updateDisplayFormats` expects). Locator-only SOAP
+`deleteDisplayFormats` is not used for this REST path — that request supplies no XML
+document and does not persist. Unknown id/name is **404**. A format that still has
+dependents is **409**. Locked-by-another-user is **409** (the lock is not stolen).
+Non-Admin is **403**. Do **not** delete packaged system formats (for example `By_Author`)
+to prove this path — create a uniquely named user format with `POST`, then `DELETE` that
+name.
 
 There is **no** Developer SPA display-format editor write in this slice — operators and
-integrators call the REST path (or Workbench).
+integrators call the REST path (or Workbench). The Developer **Display Formats** catalog
+lists user-created formats and omits a row after a successful REST delete.
 
 ### Object ACL save (display format and peers)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -20,10 +20,14 @@
 package com.percussion.apibridge;
 
 import com.percussion.cms.PSCmsException;
+import com.percussion.cms.objectstore.IPSDbComponent;
+import com.percussion.cms.objectstore.PSComponentProcessorProxy;
+import com.percussion.cms.objectstore.PSKey;
 import com.percussion.cms.objectstore.PSDFColumns;
 import com.percussion.cms.objectstore.PSDFProperties;
 import com.percussion.cms.objectstore.PSDisplayColumn;
 import com.percussion.cms.objectstore.PSDisplayFormat;
+import com.percussion.cms.objectstore.PSProcessorProxy;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
 import com.percussion.rest.Guid;
 import com.percussion.rest.displayformat.*;
@@ -34,12 +38,14 @@ import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.user.data.PSCurrentUser;
 import com.percussion.user.service.IPSUserService;
+import com.percussion.server.PSRequest;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
 import com.percussion.webservices.PSErrorsException;
 import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.PSWebserviceUtils;
 import com.percussion.webservices.ui.IPSUiDesignWs;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
@@ -61,9 +67,13 @@ import org.springframework.context.annotation.Lazy;
 /**
  * Provides the API implementation for the Display Format Resource.
  *
- * <p>GET catalog uses {@link IPSUiDesignWs#findDisplayFormats}. Admin create/update/delete persist
+ * <p>GET catalog uses {@link IPSUiDesignWs#findDisplayFormats}. Admin create/update persist
  * through the same design WS SOAP uses ({@code createDisplayFormats} / {@code loadDisplayFormats}
- * / {@code saveDisplayFormats} / {@code deleteDisplayFormats}). No new SOAP methods.
+ * / {@code saveDisplayFormats}). Admin delete loads with a design lock, marks the native format
+ * for deletion, and persists via the Workbench objectstore processor so {@code
+ * updateDisplayFormats} receives the XML document {@code PSTransactionSet} requires. Locator-only
+ * {@code deleteDisplayFormats} does not supply that document ({@code Xml Document Expected}). No
+ * new SOAP methods.
  */
 @PSSiteManageBean
 @Lazy
@@ -76,6 +86,7 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
 
   private final IPSUiDesignWs designWs;
   private final BooleanSupplier adminChecker;
+  private final LockedDisplayFormatXmlDeleter xmlDeleter;
 
   /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
   @Autowired(required = false)
@@ -83,13 +94,35 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
 
   @Autowired
   public DisplayFormatAdaptor(IPSUiDesignWs designWs) {
-    this(designWs, null);
+    this(designWs, null, null);
   }
 
   /** Package-visible for unit tests. */
   DisplayFormatAdaptor(IPSUiDesignWs designWs, BooleanSupplier adminChecker) {
+    this(designWs, adminChecker, null);
+  }
+
+  /**
+   * Package-visible for unit tests that stub XML persist (locator {@code deleteDisplayFormats}
+   * does not supply the update document).
+   */
+  DisplayFormatAdaptor(
+      IPSUiDesignWs designWs,
+      BooleanSupplier adminChecker,
+      LockedDisplayFormatXmlDeleter xmlDeleter) {
     this.designWs = designWs;
     this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
+    this.xmlDeleter = xmlDeleter != null ? xmlDeleter : this::deleteLockedViaComponentXml;
+  }
+
+  /**
+   * Persist a locked, loaded display format by supplying component XML (Workbench processor
+   * {@code delete(IPSDbComponent)}), then release the design lock.
+   */
+  @FunctionalInterface
+  interface LockedDisplayFormatXmlDeleter {
+    void delete(PSDisplayFormat nativeDf, IPSGuid id, String session, String user)
+        throws PSCmsException;
   }
 
   @Override
@@ -228,7 +261,10 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
         throw new WebApplicationException(
             "Could not delete display format; design lock required or held by another user", 409);
       }
-      designWs.deleteDisplayFormats(List.of(id), false, session, user);
+      PSDisplayFormat nativeDf =
+          nativeForDelete(locked.get(0), existing, idOrName);
+      nativeDf.markForDeletion();
+      xmlDeleter.delete(nativeDf, id, session, user);
       return true;
     } catch (WebApplicationException e) {
       throw e;
@@ -240,7 +276,132 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
           "Could not delete display format; design lock required or held by another user", 409);
     } catch (PSErrorsException e) {
       throw mapSaveOrDeleteFailure("delete", e);
+    } catch (PSCmsException e) {
+      throw mapSaveOrDeleteFailure(
+          "delete", wrapCmsDeleteFailure(id, e));
     }
+  }
+
+  /**
+   * Workbench path: dependency check, component XML save-delete, release lock. Locator-only {@code
+   * deleteDisplayFormats} posts {@code DBActionType=DELETE} with no input document; {@code
+   * updateDisplayFormats} is an XML datasource and throws {@code Xml Document Expected}. {@code
+   * saveDisplayFormats} of a marked object still locator-deletes first when a lock version is
+   * present, so this uses {@link PSComponentProcessorProxy#delete(com.percussion.cms.objectstore.IPSDbComponent)} instead.
+   */
+  void deleteLockedViaComponentXml(
+      PSDisplayFormat nativeDf, IPSGuid id, String session, String user) throws PSCmsException {
+    PSErrorException dep = PSWebserviceUtils.checkDependencies(id);
+    if (dep != null) {
+      throw new WebApplicationException(
+          "Display format has dependents and cannot be deleted", 409);
+    }
+    ensureMarkedForDeletion(nativeDf);
+    Object rawReq = PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
+    if (!(rawReq instanceof PSRequest req)) {
+      throw new WebApplicationException(
+          "Request session/user required for display format design write",
+          Response.Status.FORBIDDEN);
+    }
+    PSComponentProcessorProxy proxy =
+        new PSComponentProcessorProxy(PSProcessorProxy.PROCTYPE_SERVERLOCAL, req);
+    int deleted = proxy.delete(nativeDf);
+    log.info(
+        "Display format XML delete name={} displayId={} deletedRows={}",
+        nativeDf.getName(),
+        nativeDf.getDisplayId(),
+        deleted);
+    if (deleted <= 0) {
+      throw new PSCmsException(
+          0,
+          "Display format XML delete removed 0 rows for "
+              + nativeDf.getName()
+              + " (displayId="
+              + nativeDf.getDisplayId()
+              + ")");
+    }
+    try {
+      PSWebserviceUtils.releaseLocks(List.of(id), session, user);
+    } catch (RuntimeException e) {
+      log.debug("Could not release display-format lock after delete: {}", e.toString());
+    }
+  }
+
+  /**
+   * {@code loadDisplayFormats} can replay another catalog row (By_Type) with {@code displayId=-1}.
+   * Never persist-delete that object — build a persisted stub from the catalog identity.
+   */
+  static PSDisplayFormat nativeForDelete(
+      PSDisplayFormat loaded, DisplayFormat existing, String idOrName) throws PSCmsException {
+    String requested = firstNonBlank(idOrName, existing != null ? existing.getName() : null);
+    if (loaded != null
+        && loaded.getDisplayId() > 0
+        && namesMatchIgnoreCase(requested, loaded.getName())) {
+      return loaded;
+    }
+    return stubFromExisting(existing);
+  }
+
+  static PSDisplayFormat stubFromExisting(DisplayFormat existing) throws PSCmsException {
+    if (existing == null) {
+      throw new PSCmsException(0, "display format is required for XML delete");
+    }
+    int displayId = existing.getDisplayId();
+    if (displayId <= 0 && existing.getGuid() != null) {
+      displayId = existing.getGuid().getUuid();
+    }
+    if (displayId <= 0) {
+      throw new PSCmsException(
+          0, "Refusing XML delete of unpersisted display format " + existing.getName());
+    }
+    PSDisplayFormat stub = new PSDisplayFormat();
+    PSKey key = PSDisplayFormat.createKey(new String[] {String.valueOf(displayId)});
+    stub.setLocator(key);
+    String name = firstNonBlank(existing.getName(), existing.getInternalName());
+    if (name != null) {
+      stub.setName(name);
+      stub.setInternalName(name);
+    }
+    if (stub.getDisplayId() <= 0) {
+      throw new PSCmsException(0, "Delete stub displayId must be persisted");
+    }
+    return stub;
+  }
+
+  /**
+   * Loaded formats must be persisted before {@link PSDisplayFormat#markForDeletion()} will change
+   * state; otherwise {@code toDbXml} emits no DELETE action and the processor reports success with
+   * 0 rows removed.
+   */
+  static void ensureMarkedForDeletion(PSDisplayFormat nativeDf) throws PSCmsException {
+    if (nativeDf == null) {
+      throw new PSCmsException(0, "display format is required for XML delete");
+    }
+    if (!nativeDf.isPersisted()) {
+      PSKey loc = nativeDf.getLocator();
+      if (loc != null) {
+        loc.setPersisted(true);
+        nativeDf.setLocator(loc);
+      }
+    }
+    nativeDf.markForDeletion();
+    if (nativeDf.getState() != IPSDbComponent.DBSTATE_MARKEDFORDELETE) {
+      throw new PSCmsException(
+          0,
+          "Could not mark display format for deletion (state="
+              + nativeDf.getState()
+              + " persisted="
+              + nativeDf.isPersisted()
+              + " name="
+              + nativeDf.getName()
+              + ")");
+    }
+  }
+
+  private static PSErrorsException wrapCmsDeleteFailure(IPSGuid id, PSCmsException e) {
+    PSErrorsException errors = new PSErrorsException();
+    errors.addError(id, e);
+    return errors;
   }
 
   @Override
@@ -576,14 +737,24 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
     }
     String key = idOrName.trim();
     try {
-      return findDisplayFormat(key);
+      DisplayFormat byName = findDisplayFormat(key);
+      if (identityMatchesKey(byName, key)) {
+        return byName;
+      }
     } catch (PSCmsException | PSUnknownNodeTypeException e) {
-      // Expected miss → fall through to GUID parse / null
       log.debug("Display format not found by name {}: {}", key, e.toString());
+    }
+    DisplayFormat fromCatalog = findExactCatalogCopy(key);
+    if (fromCatalog != null) {
+      return fromCatalog;
     }
     try {
       var guid = new com.percussion.services.guidmgr.data.PSGuid(key);
-      return findDisplayFormat((IPSGuid) guid);
+      DisplayFormat byGuid = findDisplayFormat((IPSGuid) guid);
+      if (identityMatchesKey(byGuid, key)) {
+        return byGuid;
+      }
+      return null;
     } catch (IllegalArgumentException e) {
       log.debug("Invalid display format GUID syntax: {}", e.getMessage());
       return null;
@@ -611,17 +782,83 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
       throws PSCmsException, PSUnknownNodeTypeException {
     if (name != null && !name.isBlank()) {
       DisplayFormat byName = findDisplayFormat(name);
-      if (byName != null) {
+      if (identityMatchesKey(byName, name)) {
         return byName;
       }
     }
     if (saved != null && saved.getGUID() != null) {
       DisplayFormat byGuid = findDisplayFormat(saved.getGUID());
-      if (byGuid != null) {
+      if (byGuid != null
+          && (name == null || name.isBlank() || identityMatchesKey(byGuid, name))) {
         return byGuid;
       }
     }
-    return saved == null ? null : copyDisplayFormat(saved);
+    if (saved != null) {
+      return copyDisplayFormat(saved);
+    }
+    return name == null || name.isBlank() ? null : findExactCatalogCopy(name);
+  }
+
+  /**
+   * True when {@code df} is the catalog object for {@code key} (internal name or GUID string).
+   * Rejects bulk-load replay where a different name (e.g. By_Type) is returned for this key.
+   */
+  static boolean identityMatchesKey(DisplayFormat df, String key) {
+    if (df == null || key == null || key.isBlank()) {
+      return false;
+    }
+    String trimmed = key.trim();
+    String loadedName = firstNonBlank(df.getName(), df.getInternalName());
+    if (loadedName != null && !namesMatchIgnoreCase(trimmed, loadedName)) {
+      if (trimmed.equalsIgnoreCase(StringUtils.defaultString(df.getGuidString()))) {
+        return true;
+      }
+      Guid g = df.getGuid();
+      return g != null && trimmed.equalsIgnoreCase(StringUtils.defaultString(g.getStringValue()));
+    }
+    return loadedName != null;
+  }
+
+  /**
+   * Exact INTERNALNAME from catalog summaries, then {@link #copyUniqueSummary} (rejects
+   * replayed loads). Used when {@code findDisplayFormat(name)} returns the wrong object.
+   */
+  private DisplayFormat findExactCatalogCopy(String name) {
+    if (name == null || name.isBlank()) {
+      return null;
+    }
+    List<IPSCatalogSummary> summaries = catalogSummaries(name);
+    if (summaries == null) {
+      return null;
+    }
+    for (IPSCatalogSummary summary : summaries) {
+      if (summary != null && namesMatchIgnoreCase(name, summary.getName())) {
+        try {
+          return copyUniqueSummary(summary);
+        } catch (PSCmsException | PSUnknownNodeTypeException e) {
+          log.debug("Could not copy display format {}: {}", name, e.toString());
+          return copyFromCatalogSummary(summary);
+        }
+      }
+    }
+    return null;
+  }
+
+  private List<IPSCatalogSummary> catalogSummaries(String name) {
+    try {
+      List<IPSCatalogSummary> byName = designWs.findDisplayFormats(name, null);
+      if (byName != null) {
+        for (IPSCatalogSummary summary : byName) {
+          if (summary != null && namesMatchIgnoreCase(name, summary.getName())) {
+            return byName;
+          }
+        }
+      }
+      return designWs.findDisplayFormats(null, null);
+    } catch (RuntimeException e) {
+      log.debug("Could not catalog display formats for {}: {}", name, e.toString());
+      return null;
+    }
   }
 
   private static void applyWritableFields(PSDisplayFormat nativeDf, DisplayFormat body) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorSafeKeyTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -60,6 +61,8 @@ class DisplayFormatAdaptorSafeKeyTest {
     Method setKey = PSDbComponent.class.getDeclaredMethod("setKey", PSKey.class);
     setKey.setAccessible(true);
     setKey.invoke(nativeDf, key);
+    nativeDf.setName("By_Author");
+    nativeDf.setInternalName("By_Author");
     assertEquals(301, nativeDf.getDisplayId());
 
     when(designWs.findDisplayFormat(eq("By_Author"))).thenReturn(nativeDf);
@@ -182,7 +185,49 @@ class DisplayFormatAdaptorSafeKeyTest {
   void findDisplayFormatByKey_returnsNullWhenDesignWsMisses() throws Exception {
     IPSUiDesignWs designWs = mock(IPSUiDesignWs.class);
     when(designWs.findDisplayFormat(eq("Missing"))).thenReturn(null);
+    when(designWs.findDisplayFormats(eq("Missing"), nullable(String.class))).thenReturn(List.of());
+    when(designWs.findDisplayFormats(eq(null), nullable(String.class))).thenReturn(List.of());
     DisplayFormatAdaptor adaptor = new DisplayFormatAdaptor(designWs);
     assertNull(adaptor.findDisplayFormatByKey("Missing"));
+  }
+
+  @Test
+  void findDisplayFormatByKey_rejectsReplayAndUsesCatalogGuid() throws Exception {
+    IPSUiDesignWs designWs = mock(IPSUiDesignWs.class);
+    PSDisplayFormat replayed = nativeDisplayFormat(3, "By_Type");
+    PSDisplayFormat real = nativeDisplayFormat(42, "MyFmt");
+    IPSCatalogSummary myFmt = catalogSummary("MyFmt", "My Format", 42);
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(replayed);
+    when(designWs.findDisplayFormats(eq("MyFmt"), nullable(String.class))).thenReturn(List.of(myFmt));
+    when(designWs.findDisplayFormat(eq(myFmt.getGUID()))).thenReturn(real);
+
+    DisplayFormatAdaptor adaptor = new DisplayFormatAdaptor(designWs);
+    DisplayFormat out = adaptor.findDisplayFormatByKey("MyFmt");
+    assertNotNull(out);
+    assertEquals("MyFmt", out.getName());
+    assertEquals(42, out.getDisplayId());
+  }
+
+  @Test
+  void findDisplayFormatByKey_replayWithoutCatalogHit_isNull() throws Exception {
+    IPSUiDesignWs designWs = mock(IPSUiDesignWs.class);
+    PSDisplayFormat replayed = nativeDisplayFormat(3, "By_Type");
+    when(designWs.findDisplayFormat(eq("qa4091gone"))).thenReturn(replayed);
+    when(designWs.findDisplayFormats(eq("qa4091gone"), nullable(String.class))).thenReturn(List.of());
+    when(designWs.findDisplayFormats(eq(null), nullable(String.class))).thenReturn(List.of());
+    DisplayFormatAdaptor adaptor = new DisplayFormatAdaptor(designWs);
+    assertNull(adaptor.findDisplayFormatByKey("qa4091gone"));
+  }
+
+  @Test
+  void identityMatchesKey_rejectsDifferentName() {
+    DisplayFormat replayed = new DisplayFormat();
+    replayed.setName("By_Type");
+    replayed.setInternalName("By_Type");
+    assertFalse(DisplayFormatAdaptor.identityMatchesKey(replayed, "qa4091x"));
+    replayed.setName("qa4091x");
+    replayed.setInternalName("qa4091x");
+    assertTrue(DisplayFormatAdaptor.identityMatchesKey(replayed, "qa4091x"));
+    assertFalse(DisplayFormatAdaptor.identityMatchesKey(null, "qa4091x"));
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
@@ -27,12 +27,13 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.percussion.cms.PSCmsException;
+import com.percussion.cms.objectstore.IPSDbComponent;
 import com.percussion.cms.objectstore.PSDbComponent;
 import com.percussion.cms.objectstore.PSDisplayFormat;
 import com.percussion.cms.objectstore.PSKey;
@@ -50,6 +51,7 @@ import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.ui.IPSUiDesignWs;
 import jakarta.ws.rs.WebApplicationException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -61,7 +63,8 @@ import org.mockito.ArgumentCaptor;
 
 /**
  * UI-05 POST create / PUT update / DELETE persist via {@code createDisplayFormats}/{@code
- * saveDisplayFormats}/{@code deleteDisplayFormats}. Admin only; unique name; no lock steal.
+ * saveDisplayFormats} and XML component delete (not locator {@code deleteDisplayFormats}). Admin
+ * only; unique name; no lock steal.
  */
 @Tag("UnitTest")
 class DisplayFormatAdaptorWriteTest {
@@ -69,6 +72,7 @@ class DisplayFormatAdaptorWriteTest {
   private IPSUiDesignWs designWs;
   private DisplayFormatAdaptor adaptor;
   private IPSGuid guid;
+  private List<PSDisplayFormat> xmlDeleted;
 
   @BeforeEach
   void setUp() {
@@ -77,7 +81,12 @@ class DisplayFormatAdaptorWriteTest {
     PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
     PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
     designWs = mock(IPSUiDesignWs.class);
-    adaptor = new DisplayFormatAdaptor(designWs, () -> true);
+    xmlDeleted = new ArrayList<>();
+    adaptor =
+        new DisplayFormatAdaptor(
+            designWs,
+            () -> true,
+            (df, id, session, user) -> xmlDeleted.add(df));
     guid = new PSGuid(PSTypeEnum.DISPLAY_FORMAT, 42L);
     when(designWs.findDisplayFormats(any(), nullable(String.class)))
         .thenReturn(Collections.emptyList());
@@ -282,6 +291,39 @@ class DisplayFormatAdaptorWriteTest {
   }
 
   @Test
+  void nativeForDelete_rejectsReplayUnpersistedLoad() throws Exception {
+    PSDisplayFormat replayed = new PSDisplayFormat();
+    replayed.setName("By_Type");
+    replayed.setInternalName("By_Type");
+    assertTrue(replayed.getDisplayId() <= 0);
+    DisplayFormat existing = new DisplayFormat();
+    existing.setName("MyFmt");
+    existing.setDisplayId(42);
+    PSDisplayFormat out = DisplayFormatAdaptor.nativeForDelete(replayed, existing, "MyFmt");
+    assertEquals("MyFmt", out.getName());
+    assertEquals(42, out.getDisplayId());
+    assertTrue(out.getDisplayId() > 0);
+  }
+
+  @Test
+  void nativeForDelete_keepsMatchingPersistedLoad() throws Exception {
+    PSDisplayFormat loaded = nativeDisplayFormat(42, "MyFmt");
+    DisplayFormat existing = new DisplayFormat();
+    existing.setName("MyFmt");
+    existing.setDisplayId(42);
+    PSDisplayFormat out = DisplayFormatAdaptor.nativeForDelete(loaded, existing, "MyFmt");
+    assertEquals(42, out.getDisplayId());
+    assertEquals("MyFmt", out.getName());
+  }
+
+  @Test
+  void ensureMarkedForDeletion_setsMarkedStateOnPersistedKey() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    DisplayFormatAdaptor.ensureMarkedForDeletion(nativeDf);
+    assertEquals(IPSDbComponent.DBSTATE_MARKEDFORDELETE, nativeDf.getState());
+  }
+
+  @Test
   void delete_thenGetByName_isNotFound() throws Exception {
     PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
     when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
@@ -291,15 +333,20 @@ class DisplayFormatAdaptorWriteTest {
     assertTrue(adaptor.deleteDisplayFormat("MyFmt"));
     when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(null);
     assertNull(adaptor.findDisplayFormatByKey("MyFmt"));
-    verify(designWs)
-        .deleteDisplayFormats(anyList(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(1, xmlDeleted.size());
+    assertEquals("MyFmt", xmlDeleted.get(0).getName());
+    assertEquals(IPSDbComponent.DBSTATE_MARKEDFORDELETE, xmlDeleted.get(0).getState());
+    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).saveDisplayFormats(anyList(), anyBoolean(), any(), any());
   }
 
   @Test
-  void delete_unknown_returnsFalse() {
+  void delete_unknown_returnsFalse() throws Exception {
     when(designWs.findDisplayFormat(eq("missing"))).thenReturn(null);
     assertFalse(adaptor.deleteDisplayFormat("missing"));
+    assertTrue(xmlDeleted.isEmpty());
     verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadDisplayFormats(anyList(), anyBoolean(), anyBoolean(), any(), any());
   }
 
   @Test
@@ -312,6 +359,7 @@ class DisplayFormatAdaptorWriteTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
     assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(xmlDeleted.isEmpty());
     verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
   }
 
@@ -321,25 +369,50 @@ class DisplayFormatAdaptorWriteTest {
     when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
     when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
         .thenReturn(List.of(nativeDf));
-    PSErrorsException errors = new PSErrorsException();
-    errors.addError(guid, new PSErrorException("Object has dependents"));
-    doThrow(errors)
-        .when(designWs)
-        .deleteDisplayFormats(anyList(), eq(false), any(), any());
+    adaptor =
+        new DisplayFormatAdaptor(
+            designWs,
+            () -> true,
+            (df, id, session, user) -> {
+              throw new WebApplicationException(
+                  "Display format has dependents and cannot be deleted", 409);
+            });
 
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
     assertEquals(409, ex.getResponse().getStatus());
     assertTrue(ex.getMessage().toLowerCase().contains("depend"), ex.getMessage());
+    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
   }
 
   @Test
-  void delete_nonAdmin_is403() {
+  void delete_xmlPersistFailure_is500() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+    when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(nativeDf));
+    adaptor =
+        new DisplayFormatAdaptor(
+            designWs,
+            () -> true,
+            (df, id, session, user) -> {
+              throw new PSCmsException(0, "Xml Document Expected, none supplied");
+            });
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
+    assertTrue(ex.getMessage().toLowerCase().contains("delete"), ex.getMessage());
+    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_nonAdmin_is403() throws Exception {
     adaptor = new DisplayFormatAdaptor(designWs, () -> false);
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
     assertEquals(403, ex.getResponse().getStatus());
     verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadDisplayFormats(anyList(), anyBoolean(), anyBoolean(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Parent **#1690** / slice **#4086** residual **#4091**. Admin `DELETE /services/displayformats/{idOrName}` of a user format created via POST now persists: **204**, following GET is **404**, Developer Display Formats catalog omits the row.

Locator-only `IPSUiDesignWs.deleteDisplayFormats` posts `DBActionType=DELETE` with no XML document; `updateDisplayFormats` is an XML datasource (`Xml Document Expected`). `saveDisplayFormats` of a marked object still locator-deletes first when a lock version is present. This adaptor delete loads/locks, rejects By_Type load replay (`displayId=-1`), marks the catalog identity for deletion, and persists via `PSComponentProcessorProxy.delete` (Workbench component XML). Packaged system formats are not used as the delete proof.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2013 Failures: 0 Skipped: 125 (`DisplayFormatAdaptorWriteTest` 24, `DisplayFormatAdaptorSafeKeyTest` included).
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS; `npm run test:unit` 483 passed.
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993`; `qa-health`; docker cp `sitemanage-8.2.0-SNAPSHOT.jar` into WAR `WEB-INF/lib`; in-cell StopJetty/StartJetty; `qa-health` again.
4. Playwright: `npm run test:surface -- --path tests/developer-display-format-editor.spec.js` — **1 passed** (POST unique user format, catalog row, DELETE 204, GET 404, catalog omits; does not delete `By_Author` / system formats).
5. Do not claim column picker (UI-08).

## Checklist

- [x] **Product documentation** — `product-docs/8.2/developer/rest.md` Display formats DELETE persist notes
- [x] **Unit / module tests** — adaptor XML delete, replay rejection, stub-from-catalog `displayId`; sitemanage clean install green
- [x] **WebUI + Playwright** — `developer-display-format-editor.spec.js` (REST POST/DELETE + catalog omit; no SPA create re-implement)
- [x] **Build gates** — standalone sitemanage + perc-qa-automation clean install (no skipTests)
- [x] **Cross-platform** — N/A no new filesystem path joins (URL paths use `/`)

### C3 evidence

- `modules_built`: projects/sitemanage, modules/perc-qa-automation
- `build_evidence`: `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS Tests run: 2013 Failures: 0 Skipped: 125; `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` BUILD SUCCESS; frontend `npm run test:unit` 483 passed
- `downstream_checked`: none (no public type made final/sealed; package-visible adaptor helpers only)

### C5 UI proof

- qa cell `perc-matrix-cms-h2` `TEST_CMS_URL=http://127.0.0.1:9993`; qa-health HTTP:200 HEALTH:healthy (login + `/Rhythmyx/rest/mimetypes`)
- docker cp sitemanage jar; in-cell Jetty restart; qa-health again
- Playwright: `npm run test:surface -- --path tests/developer-display-format-editor.spec.js` — 1 passed
- console-clean: yes
- server.log-clean: yes (successful path `XML delete name=qa4091… deletedRows=1`; no new ERROR/FATAL for this DELETE)

Fixes #4091
Partial #4086
Parent: #1690

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
