### PR TITLE
feat(rest): Admin GET/PUT community new-search defaults (UI-09) (#4096)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-4096-community-new-search-defaults-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4096-community-new-search-defaults-erlang.md
@@ -1,0 +1,30 @@
+# Erlang review — issue #4096 community new-search defaults
+
+**Branch:** `feat/issue-4096-community-new-search-defaults`  
+**Scope:** uncommitted UI-09 Admin GET/PUT vs `origin/main`  
+**Date:** 2026-09-01  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (rest resource + IXxxAdaptor + sitemanage apibridge + Spring test stub + jaxrs serviceBeans ref); MainTest adaptor stub; Admin 403 / validation 400 behavioral tests; no WebUI Playwright required (no SPA)
+
+## Summary
+
+Adds Admin REST for Workbench UI-09 community CX new-search defaults. Persistence is the existing `PSSearch.cxNewSearch` property via `IPSUiDesignWs` load/save (same path as SOAP/Workbench). Does not create searches.
+
+Change-class companions present: resource, adaptor interface, wire DTOs, Spring `TestCommunityNewSearchDefaultsAdaptor`, sitemanage `CommunityNewSearchDefaultsAdaptor` + tests, `rest-jax-rs` bean ref + `CatalogRestJaxrsRegistrationTest`, product-docs 8.2 REST + admin note.
+
+## Cross-platform path checklist
+
+- No filesystem path construction. Community/search keys reject `/`, `\`, `..`, and NUL as identity tokens (URL keys, not OS paths).
+- Outcome: clean.
+
+## Issues
+
+None that block. Behavioral tests cover empty GET 200, unknown community 404, unknown/duplicate search 400, non-Admin 403, missing session 403, idempotent PUT (no save), replace/clear via design lock + save.
+
+## Tests / builds
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 951, Failures: 0 (`CommunityNewSearchDefaultsResourceTest` 10; `MainTest` 2)
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2102, Failures: 0, Errors: 0 (`CommunityNewSearchDefaultsAdaptorTest` 18)
+
+C5 Playwright: N/A (no WebUI/SPA this slice).

--- a/product-docs/8.2/admin/developer-searches.md
+++ b/product-docs/8.2/admin/developer-searches.md
@@ -65,3 +65,21 @@ The chrome calls:
 Writes lock the search for the request and release it on save.
 
 Integrator notes: [REST API — Searches](id:developer-rest).
+
+## Community new-search defaults
+
+Workbench could assign which searches are offered as **new search** for each
+community (`cxNewSearch`). Admins and integrators read and replace that set with:
+
+| Action | Request |
+|--------|---------|
+| Load | `GET /services/communities/{idOrName}/new-search-defaults` |
+| Replace | `PUT /services/communities/{idOrName}/new-search-defaults` |
+
+**Admin** only (**403** otherwise). An empty set is **200**, not 404. Unknown
+search in the PUT body is **400**; unknown community is **404**. This chrome does
+not yet include a community-defaults editor — use REST (or a later Developer
+screen). Search create/delete remains the table above and does not write these
+defaults.
+
+Contract: [REST API — Community new-search defaults](id:developer-rest).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1739,6 +1739,59 @@ Example create body:
 | `409` | Duplicate name, design lock held by another user, or dependents |
 | `500` | Design service or server failure |
 
+## Community new-search defaults (UI-09)
+
+Admin REST for **which Content Explorer searches are the “new search” defaults for a
+community**. This is the Workbench community-search assignment (`cxNewSearch` on the
+search definition), persisted through `IPSUiDesignWs` load/save searches — the same
+design path SOAP uses. It does **not** create or delete searches (see
+[Search write contract](#search-write-contract-admin) and sibling search persist).
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/communities/{idOrName}/new-search-defaults` | **Admin.** Current default-search set for the community |
+| `PUT` | `/services/communities/{idOrName}/new-search-defaults` | **Admin.** Replace the set (empty `searches` clears explicit defaults) |
+
+`{idOrName}` is numeric community id, GUID string, or exact name (same lookup as
+`GET /services/communities/{idOrName}`). GET of a community with **no** explicit
+defaults is **200** with `searches: []`, not 404.
+
+PUT body is `CommunityNewSearchDefaults`. Each `searches[]` entry may identify a
+search by `name`, numeric `id`, or `guid.stringValue` (same keys as
+`/services/searches/{idOrName}`). A second identical PUT is idempotent **200**.
+Unknown or duplicate search is **400**. Unknown community is **404**. Non-Admin is
+**403**. Design lock held by another user is **409**.
+
+JSON uses the `CommunityNewSearchDefaults` wire type (JAXB/Jackson
+UNWRAP_ROOT_VALUE). Prefer the generated OpenAPI schema as the integration source
+of truth.
+
+Example GET / PUT body:
+
+```json
+{
+  "CommunityNewSearchDefaults": {
+    "communityId": 10,
+    "communityName": "Default",
+    "searches": [
+      { "name": "SimpleSearch", "id": 42 }
+    ]
+  }
+}
+```
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | GET / PUT success (empty `searches` is a valid empty set) |
+| `400` | Invalid body, unknown search, or duplicate search in the PUT set |
+| `403` | Caller is not Admin, or the request has no session/user for PUT |
+| `404` | Community not found |
+| `409` | Design lock held by another user |
+| `500` | Design service or server failure |
+
+There is no Developer SPA for this assignment in this release; operators and
+integrators call the REST surface above.
+
 ### Search execute body
 
 Execute POST body is the JAXB envelope `{ "SearchExecuteRequest": { … } }` (flat

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/CommunityNewSearchDefaultsAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/CommunityNewSearchDefaultsAdaptor.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import com.percussion.cms.objectstore.PSSearch;
+import com.percussion.rest.Guid;
+import com.percussion.rest.communities.Community;
+import com.percussion.rest.communities.CommunityNewSearchDefaults;
+import com.percussion.rest.communities.CommunityNewSearchRef;
+import com.percussion.rest.communities.ICommunityAdaptor;
+import com.percussion.rest.communities.ICommunityNewSearchDefaultsAdaptor;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.share.service.exception.PSDataServiceException;
+import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.PSErrorException;
+import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * Community CX new-search defaults (UI-09). Reads and writes the Workbench {@code cxNewSearch}
+ * property on design searches through {@link IPSUiDesignWs} — the same path SOAP / Workbench uses.
+ * Does not create or delete searches.
+ */
+@PSSiteManageBean
+@Lazy
+public class CommunityNewSearchDefaultsAdaptor implements ICommunityNewSearchDefaultsAdaptor {
+
+  private static final Logger log = LogManager.getLogger(CommunityNewSearchDefaultsAdaptor.class);
+
+  static final String ADMIN_REQUIRED =
+      "Admin role required to read or update community new-search defaults";
+
+  private final IPSUiDesignWs designWs;
+  private final ICommunityAdaptor communityAdaptor;
+  private final BooleanSupplier adminChecker;
+
+  @Autowired(required = false)
+  private IPSUserService userService;
+
+  /**
+   * Production constructor. Admin checks use {@link IPSUserService} when injected.
+   *
+   * @param designWs UI design web service (search load/save)
+   * @param communityAdaptor community lookup by id/name/GUID
+   */
+  @Autowired
+  public CommunityNewSearchDefaultsAdaptor(
+      IPSUiDesignWs designWs, ICommunityAdaptor communityAdaptor) {
+    this(designWs, communityAdaptor, null);
+  }
+
+  /** Package-visible for unit tests. */
+  CommunityNewSearchDefaultsAdaptor(
+      IPSUiDesignWs designWs, ICommunityAdaptor communityAdaptor, BooleanSupplier adminChecker) {
+    this.designWs = designWs;
+    this.communityAdaptor = communityAdaptor;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
+  }
+
+  @Override
+  public CommunityNewSearchDefaults getDefaults(String communityIdOrName) {
+    requireAdmin();
+    Community community = resolveCommunity(communityIdOrName);
+    if (community == null) {
+      return null;
+    }
+    int communityId = communityNumericId(community);
+    try {
+      return toWire(community, filterAssigned(loadAllSearches(false), communityId));
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("Failed to load community new-search defaults for {}", communityIdOrName, e);
+      throw new IllegalStateException("Failed to load community new-search defaults", e);
+    }
+  }
+
+  @Override
+  public CommunityNewSearchDefaults replaceDefaults(
+      String communityIdOrName, CommunityNewSearchDefaults body) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    Community community = resolveCommunity(communityIdOrName);
+    if (community == null) {
+      return null;
+    }
+    int communityId = communityNumericId(community);
+    String session = currentSession();
+    String user = currentUser();
+    try {
+      List<PSSearch> catalog = loadAllSearches(false);
+      List<PSSearch> desired = resolveRequestedSearches(body.getSearches(), catalog);
+      List<PSSearch> current = filterAssigned(catalog, communityId);
+      Set<String> desiredKeys = identityKeys(desired);
+      Set<String> currentKeys = identityKeys(current);
+
+      List<PSSearch> toMutate = new ArrayList<>();
+      for (PSSearch search : catalog) {
+        if (search == null || search.getGUID() == null) {
+          continue;
+        }
+        String key = identityKey(search);
+        boolean want = desiredKeys.contains(key);
+        boolean have = currentKeys.contains(key);
+        if (want != have) {
+          toMutate.add(search);
+        }
+      }
+
+      if (!toMutate.isEmpty()) {
+        List<IPSGuid> ids = new ArrayList<>();
+        for (PSSearch s : toMutate) {
+          ids.add(s.getGUID());
+        }
+        List<PSSearch> locked = designWs.loadSearches(ids, true, false, session, user);
+        if (locked == null || locked.isEmpty()) {
+          throw new WebApplicationException(
+              "Could not update new-search defaults; design lock required or held by another user",
+              409);
+        }
+        for (PSSearch domain : locked) {
+          if (domain == null) {
+            continue;
+          }
+          boolean want = desiredKeys.contains(identityKey(domain));
+          applyCommunityAssignment(domain, communityId, want);
+        }
+        designWs.saveSearches(locked, true, session, user);
+        catalog = loadAllSearches(false);
+      }
+      return toWire(community, filterAssigned(catalog, communityId));
+    } catch (WebApplicationException | IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      throw new WebApplicationException(
+          "Could not update new-search defaults; design lock required or held by another user",
+          409);
+    } catch (PSErrorsException e) {
+      if (SearchAdaptor.isNotLockedError(e)) {
+        throw new WebApplicationException(
+            "Could not update new-search defaults; design lock required or held by another user",
+            409);
+      }
+      log.error("Failed to save community new-search defaults for {}", communityIdOrName, e);
+      throw new IllegalStateException("Failed to save community new-search defaults", e);
+    } catch (PSLockErrorException e) {
+      throw new WebApplicationException(
+          "Could not update new-search defaults; design lock required or held by another user",
+          409);
+    } catch (Exception e) {
+      log.error("Failed to replace community new-search defaults for {}", communityIdOrName, e);
+      throw new IllegalStateException("Failed to replace community new-search defaults", e);
+    }
+  }
+
+  Community resolveCommunity(String communityIdOrName) {
+    if (!isSafeCommunityKey(communityIdOrName)) {
+      return null;
+    }
+    return communityAdaptor.getCommunity(communityIdOrName.trim());
+  }
+
+  List<PSSearch> resolveRequestedSearches(List<CommunityNewSearchRef> refs, List<PSSearch> catalog) {
+    List<CommunityNewSearchRef> requested = refs != null ? refs : List.of();
+    List<PSSearch> resolved = new ArrayList<>();
+    Set<String> seen = new LinkedHashSet<>();
+    for (CommunityNewSearchRef ref : requested) {
+      if (ref == null) {
+        throw new IllegalArgumentException("search ref is required");
+      }
+      String key = searchRefKey(ref);
+      if (StringUtils.isBlank(key)) {
+        throw new IllegalArgumentException("search name, id, or guid is required");
+      }
+      if (!SearchAdaptor.isSafeSearchKey(key)) {
+        throw new IllegalArgumentException("Unknown search: " + key);
+      }
+      PSSearch found = SearchAdaptor.matchLoaded(catalog, key);
+      if (found == null) {
+        throw new IllegalArgumentException("Unknown search: " + key);
+      }
+      String identity = identityKey(found);
+      if (!seen.add(identity)) {
+        throw new IllegalArgumentException("Duplicate search: " + key);
+      }
+      resolved.add(found);
+    }
+    return resolved;
+  }
+
+  static void applyCommunityAssignment(PSSearch search, int communityId, boolean include) {
+    if (search == null) {
+      return;
+    }
+    int[] current = parseCommunityIds(search.getCXNewSearchCommunities());
+    LinkedHashSet<Integer> next = new LinkedHashSet<>();
+    for (int id : current) {
+      next.add(id);
+    }
+    if (include) {
+      next.add(communityId);
+    } else {
+      next.remove(communityId);
+    }
+    if (next.size() == current.length && include == containsId(current, communityId)) {
+      return;
+    }
+    search.clearCXNewSearch();
+    if (!next.isEmpty()) {
+      int[] ids = new int[next.size()];
+      int i = 0;
+      for (Integer id : next) {
+        ids[i++] = id;
+      }
+      search.setAsCXNewSearch(ids);
+    }
+  }
+
+  static List<PSSearch> filterAssigned(List<PSSearch> catalog, int communityId) {
+    List<PSSearch> out = new ArrayList<>();
+    if (catalog == null) {
+      return out;
+    }
+    String comm = String.valueOf(communityId);
+    for (PSSearch search : catalog) {
+      if (search != null && search.isCXNewSearch(comm)) {
+        out.add(search);
+      }
+    }
+    out.sort(
+        Comparator.comparing(
+            PSSearch::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
+    return out;
+  }
+
+  static CommunityNewSearchDefaults toWire(Community community, List<PSSearch> assigned) {
+    CommunityNewSearchDefaults out = new CommunityNewSearchDefaults();
+    if (community != null) {
+      out.setCommunityGuid(community.getGuid());
+      out.setCommunityId(community.getId());
+      out.setCommunityName(community.getName());
+    }
+    List<CommunityNewSearchRef> refs = new ArrayList<>();
+    if (assigned != null) {
+      for (PSSearch search : assigned) {
+        if (search != null) {
+          refs.add(toRef(search));
+        }
+      }
+    }
+    out.setSearches(refs);
+    return out;
+  }
+
+  static CommunityNewSearchRef toRef(PSSearch search) {
+    CommunityNewSearchRef ref = new CommunityNewSearchRef();
+    if (search.getGUID() != null) {
+      ref.setGuid(copyGuid(search.getGUID()));
+    }
+    ref.setId(search.getId());
+    ref.setName(search.getName());
+    ref.setLabel(search.getLabel());
+    return ref;
+  }
+
+  static int communityNumericId(Community community) {
+    if (community.getGuid() != null && community.getGuid().getUuid() != 0) {
+      return community.getGuid().getUuid();
+    }
+    long id = community.getId();
+    if (id < Integer.MIN_VALUE || id > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("community id is out of range");
+    }
+    return (int) id;
+  }
+
+  static boolean isSafeCommunityKey(String key) {
+    if (key == null || key.isBlank()) {
+      return false;
+    }
+    return !key.contains("..")
+        && key.indexOf('/') < 0
+        && key.indexOf('\\') < 0
+        && key.indexOf('\0') < 0;
+  }
+
+  static int[] parseCommunityIds(String[] raw) {
+    if (raw == null || raw.length == 0) {
+      return new int[0];
+    }
+    List<Integer> ids = new ArrayList<>();
+    for (String s : raw) {
+      if (StringUtils.isBlank(s)) {
+        continue;
+      }
+      String t = s.trim();
+      if ("n".equalsIgnoreCase(t)) {
+        continue;
+      }
+      if ("y".equalsIgnoreCase(t)) {
+        ids.add(PSSearch.ANY_COMMUNITY_ID);
+        continue;
+      }
+      try {
+        ids.add(Integer.parseInt(t));
+      } catch (NumberFormatException e) {
+        // skip non-numeric property leftovers
+      }
+    }
+    int[] out = new int[ids.size()];
+    for (int i = 0; i < ids.size(); i++) {
+      out[i] = ids.get(i);
+    }
+    return out;
+  }
+
+  private static boolean containsId(int[] ids, int communityId) {
+    for (int id : ids) {
+      if (id == communityId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static String searchRefKey(CommunityNewSearchRef ref) {
+    Guid g = ref.getGuid();
+    if (g != null) {
+      if (StringUtils.isNotBlank(g.getStringValue())) {
+        return g.getStringValue().trim();
+      }
+      if (StringUtils.isNotBlank(g.getUntypedString())) {
+        return g.getUntypedString().trim();
+      }
+      if (g.getUuid() != 0) {
+        return String.valueOf(g.getUuid());
+      }
+    }
+    if (StringUtils.isNotBlank(ref.getName())) {
+      return ref.getName().trim();
+    }
+    if (ref.getId() != 0) {
+      return String.valueOf(ref.getId());
+    }
+    return null;
+  }
+
+  private static Set<String> identityKeys(List<PSSearch> searches) {
+    Set<String> keys = new LinkedHashSet<>();
+    if (searches == null) {
+      return keys;
+    }
+    for (PSSearch s : searches) {
+      if (s != null) {
+        keys.add(identityKey(s));
+      }
+    }
+    return keys;
+  }
+
+  static String identityKey(PSSearch search) {
+    if (search.getGUID() != null && StringUtils.isNotBlank(search.getGUID().toString())) {
+      return search.getGUID().toString();
+    }
+    if (StringUtils.isNotBlank(search.getName())) {
+      return "name:" + search.getName().toLowerCase();
+    }
+    return "id:" + search.getId();
+  }
+
+  private List<PSSearch> loadAllSearches(boolean lock) throws PSErrorException, PSErrorResultsException {
+    List<IPSCatalogSummary> summaries = designWs.findSearches(null, null);
+    if (summaries == null || summaries.isEmpty()) {
+      return List.of();
+    }
+    List<IPSGuid> guids = new ArrayList<>();
+    for (IPSCatalogSummary sum : summaries) {
+      if (sum != null && sum.getGUID() != null) {
+        guids.add(sum.getGUID());
+      }
+    }
+    if (guids.isEmpty()) {
+      return List.of();
+    }
+    List<PSSearch> loaded =
+        designWs.loadSearches(guids, lock, false, currentSession(), currentUser());
+    return loaded != null ? loaded : List.of();
+  }
+
+  private static Guid copyGuid(IPSGuid guid) {
+    Guid g = new Guid();
+    g.setHostId(guid.getHostId());
+    g.setLongValue(guid.longValue());
+    g.setStringValue(guid.toString());
+    g.setType(guid.getType());
+    g.setUuid(guid.getUUID());
+    g.setUntypedString(guid.toStringUntyped());
+    return g;
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private static void requireSessionUserForWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for community new-search default write",
+          Response.Status.FORBIDDEN);
+    }
+  }
+
+  private static String currentSession() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+  }
+
+  private static String currentUser() {
+    return (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+  }
+}

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -76,6 +76,7 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="restAclResource" />
             <ref bean="restActionMenuResource" />
             <ref bean="restCommunityResource" />
+            <ref bean="restCommunityNewSearchDefaultsResource" />
             <ref bean="restDisplayFormatResource" />
             <ref bean="restFoldersResource" />
             <ref bean="restAssetResource" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/CommunityNewSearchDefaultsAdaptorTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/CommunityNewSearchDefaultsAdaptorTest.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSSearch;
+import com.percussion.rest.Guid;
+import com.percussion.rest.communities.Community;
+import com.percussion.rest.communities.CommunityNewSearchDefaults;
+import com.percussion.rest.communities.CommunityNewSearchRef;
+import com.percussion.rest.communities.ICommunityAdaptor;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * UI-09 Admin GET/PUT community CX new-search defaults via {@code cxNewSearch} and {@code
+ * IPSUiDesignWs} load/save. Empty set is 200; unknown search 400; unknown community 404;
+ * non-Admin 403. Does not create searches.
+ */
+@Tag("UnitTest")
+class CommunityNewSearchDefaultsAdaptorTest {
+
+  private IPSUiDesignWs designWs;
+  private ICommunityAdaptor communityAdaptor;
+  private CommunityNewSearchDefaultsAdaptor adaptor;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    designWs = mock(IPSUiDesignWs.class);
+    communityAdaptor = mock(ICommunityAdaptor.class);
+    adaptor = new CommunityNewSearchDefaultsAdaptor(designWs, communityAdaptor, () -> true);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void get_emptySetIsNot404() throws Exception {
+    when(communityAdaptor.getCommunity("Default")).thenReturn(community("Default", 10));
+    when(designWs.findSearches(isNull(), isNull())).thenReturn(List.of());
+
+    CommunityNewSearchDefaults out = adaptor.getDefaults("Default");
+    assertNotNull(out);
+    assertEquals("Default", out.getCommunityName());
+    assertEquals(10L, out.getCommunityId());
+    assertTrue(out.getSearches().isEmpty());
+  }
+
+  @Test
+  void get_returnsAssignedSearches() throws Exception {
+    when(communityAdaptor.getCommunity("10")).thenReturn(community("Default", 10));
+    PSSearch assigned = stubSearch("SimpleSearch", 42, "0-301-42");
+    when(assigned.isCXNewSearch("10")).thenReturn(true);
+    PSSearch other = stubSearch("Other", 43, "0-301-43");
+    when(other.isCXNewSearch("10")).thenReturn(false);
+    stubCatalog(assigned, other);
+
+    CommunityNewSearchDefaults out = adaptor.getDefaults("10");
+    assertEquals(1, out.getSearches().size());
+    assertEquals("SimpleSearch", out.getSearches().get(0).getName());
+  }
+
+  @Test
+  void get_unknownCommunityIsNull() {
+    when(communityAdaptor.getCommunity("missing")).thenReturn(null);
+    assertNull(adaptor.getDefaults("missing"));
+  }
+
+  @Test
+  void get_unsafeCommunityKeyIsNull() {
+    assertNull(adaptor.getDefaults("../etc"));
+    assertNull(adaptor.getDefaults("a/b"));
+  }
+
+  @Test
+  void get_nonAdminIs403() {
+    adaptor = new CommunityNewSearchDefaultsAdaptor(designWs, communityAdaptor, () -> false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.getDefaults("Default"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void put_replacesSetAndReloads() throws Exception {
+    when(communityAdaptor.getCommunity("Default")).thenReturn(community("Default", 10));
+    PSSearch current = stubSearch("OldSearch", 41, "0-301-41");
+    when(current.isCXNewSearch("10")).thenReturn(true);
+    when(current.getCXNewSearchCommunities()).thenReturn(new String[] {"10"});
+    PSSearch next = stubSearch("SimpleSearch", 42, "0-301-42");
+    when(next.isCXNewSearch("10")).thenReturn(false);
+    when(next.getCXNewSearchCommunities()).thenReturn(new String[0]);
+    stubCatalog(current, next);
+
+    PSSearch lockedOld = stubSearch("OldSearch", 41, "0-301-41");
+    when(lockedOld.getCXNewSearchCommunities()).thenReturn(new String[] {"10"});
+    PSSearch lockedNew = stubSearch("SimpleSearch", 42, "0-301-42");
+    when(lockedNew.getCXNewSearchCommunities()).thenReturn(new String[0]);
+    when(designWs.loadSearches(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(lockedOld, lockedNew));
+
+    // After save, catalog GET shows only SimpleSearch assigned
+    PSSearch afterOld = stubSearch("OldSearch", 41, "0-301-41");
+    when(afterOld.isCXNewSearch("10")).thenReturn(false);
+    PSSearch afterNew = stubSearch("SimpleSearch", 42, "0-301-42");
+    when(afterNew.isCXNewSearch("10")).thenReturn(true);
+    when(designWs.loadSearches(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(current, next))
+        .thenReturn(List.of(afterOld, afterNew));
+
+    CommunityNewSearchDefaults body = new CommunityNewSearchDefaults();
+    CommunityNewSearchRef ref = new CommunityNewSearchRef();
+    ref.setName("SimpleSearch");
+    body.setSearches(List.of(ref));
+
+    CommunityNewSearchDefaults out = adaptor.replaceDefaults("Default", body);
+    assertEquals(1, out.getSearches().size());
+    assertEquals("SimpleSearch", out.getSearches().get(0).getName());
+    verify(designWs).saveSearches(anyList(), eq(true), eq("test-session"), eq("Admin"));
+    verify(lockedOld).clearCXNewSearch();
+    verify(lockedNew).setAsCXNewSearch(org.mockito.ArgumentMatchers.any(int[].class));
+  }
+
+  @Test
+  void put_identicalSetIsIdempotentWithoutSave() throws Exception {
+    when(communityAdaptor.getCommunity("Default")).thenReturn(community("Default", 10));
+    PSSearch assigned = stubSearch("SimpleSearch", 42, "0-301-42");
+    when(assigned.isCXNewSearch("10")).thenReturn(true);
+    stubCatalog(assigned);
+
+    CommunityNewSearchDefaults body = new CommunityNewSearchDefaults();
+    CommunityNewSearchRef ref = new CommunityNewSearchRef();
+    ref.setName("SimpleSearch");
+    body.setSearches(List.of(ref));
+
+    CommunityNewSearchDefaults out = adaptor.replaceDefaults("Default", body);
+    assertEquals(1, out.getSearches().size());
+    verify(designWs, never()).saveSearches(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never())
+        .loadSearches(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void put_emptySetClearsAssignments() throws Exception {
+    when(communityAdaptor.getCommunity("Default")).thenReturn(community("Default", 10));
+    PSSearch current = stubSearch("SimpleSearch", 42, "0-301-42");
+    when(current.isCXNewSearch("10")).thenReturn(true);
+    when(current.getCXNewSearchCommunities()).thenReturn(new String[] {"10"});
+    stubCatalog(current);
+
+    PSSearch locked = stubSearch("SimpleSearch", 42, "0-301-42");
+    when(locked.getCXNewSearchCommunities()).thenReturn(new String[] {"10"});
+    when(designWs.loadSearches(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    PSSearch after = stubSearch("SimpleSearch", 42, "0-301-42");
+    when(after.isCXNewSearch("10")).thenReturn(false);
+    when(designWs.loadSearches(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(current))
+        .thenReturn(List.of(after));
+
+    CommunityNewSearchDefaults body = new CommunityNewSearchDefaults();
+    body.setSearches(List.of());
+    CommunityNewSearchDefaults out = adaptor.replaceDefaults("Default", body);
+    assertTrue(out.getSearches().isEmpty());
+    verify(locked).clearCXNewSearch();
+    verify(designWs).saveSearches(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void put_blankSearchRefIs400() throws Exception {
+    when(communityAdaptor.getCommunity("Default")).thenReturn(community("Default", 10));
+    stubCatalog();
+
+    CommunityNewSearchDefaults body = new CommunityNewSearchDefaults();
+    body.setSearches(List.of(new CommunityNewSearchRef()));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.replaceDefaults("Default", body));
+    assertTrue(ex.getMessage().contains("search name, id, or guid is required"));
+  }
+
+  @Test
+  void put_unknownSearchIs400() throws Exception {
+    when(communityAdaptor.getCommunity("Default")).thenReturn(community("Default", 10));
+    stubCatalog();
+
+    CommunityNewSearchDefaults body = new CommunityNewSearchDefaults();
+    CommunityNewSearchRef ref = new CommunityNewSearchRef();
+    ref.setName("Nope");
+    body.setSearches(List.of(ref));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.replaceDefaults("Default", body));
+    assertTrue(ex.getMessage().contains("Unknown search"));
+    verify(designWs, never()).saveSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void put_duplicateSearchIs400() throws Exception {
+    when(communityAdaptor.getCommunity("Default")).thenReturn(community("Default", 10));
+    PSSearch search = stubSearch("SimpleSearch", 42, "0-301-42");
+    when(search.isCXNewSearch("10")).thenReturn(false);
+    stubCatalog(search);
+
+    CommunityNewSearchDefaults body = new CommunityNewSearchDefaults();
+    CommunityNewSearchRef byName = new CommunityNewSearchRef();
+    byName.setName("SimpleSearch");
+    CommunityNewSearchRef byId = new CommunityNewSearchRef();
+    byId.setId(42);
+    body.setSearches(List.of(byName, byId));
+
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.replaceDefaults("Default", body));
+    assertTrue(ex.getMessage().contains("Duplicate search"));
+  }
+
+  @Test
+  void put_unknownCommunityIsNull() {
+    when(communityAdaptor.getCommunity("missing")).thenReturn(null);
+    assertNull(adaptor.replaceDefaults("missing", new CommunityNewSearchDefaults()));
+  }
+
+  @Test
+  void put_nonAdminIs403() {
+    adaptor = new CommunityNewSearchDefaultsAdaptor(designWs, communityAdaptor, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.replaceDefaults("Default", new CommunityNewSearchDefaults()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void put_missingSessionIs403() {
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.replaceDefaults("Default", new CommunityNewSearchDefaults()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void applyCommunityAssignment_addsWithoutDroppingOthers() {
+    PSSearch search = mock(PSSearch.class);
+    when(search.getCXNewSearchCommunities()).thenReturn(new String[] {"20"});
+    CommunityNewSearchDefaultsAdaptor.applyCommunityAssignment(search, 10, true);
+    verify(search).clearCXNewSearch();
+    ArgumentCaptor<int[]> cap = ArgumentCaptor.forClass(int[].class);
+    verify(search).setAsCXNewSearch(cap.capture());
+    int[] ids = cap.getValue();
+    assertEquals(2, ids.length);
+    assertTrue(ids[0] == 20 || ids[1] == 20);
+    assertTrue(ids[0] == 10 || ids[1] == 10);
+  }
+
+  @Test
+  void applyCommunityAssignment_clearsWhenLastCommunityRemoved() {
+    PSSearch search = mock(PSSearch.class);
+    when(search.getCXNewSearchCommunities()).thenReturn(new String[] {"10"});
+    CommunityNewSearchDefaultsAdaptor.applyCommunityAssignment(search, 10, false);
+    verify(search).clearCXNewSearch();
+    verify(search, never()).setAsCXNewSearch(org.mockito.ArgumentMatchers.any(int[].class));
+  }
+
+  @Test
+  void parseCommunityIds_mapsYesToAnyCommunity() {
+    int[] ids = CommunityNewSearchDefaultsAdaptor.parseCommunityIds(new String[] {"y"});
+    assertEquals(1, ids.length);
+    assertEquals(PSSearch.ANY_COMMUNITY_ID, ids[0]);
+  }
+
+  @Test
+  void communityNumericId_prefersGuidUuid() {
+    Community c = community("Default", 10);
+    assertEquals(10, CommunityNewSearchDefaultsAdaptor.communityNumericId(c));
+  }
+
+  private Community community(String name, int uuid) {
+    Guid g = new Guid();
+    g.setUuid(uuid);
+    g.setStringValue("0-13-" + uuid);
+    g.setLongValue(uuid);
+    g.setType((short) 13);
+    Community c = new Community();
+    c.setName(name);
+    c.setId(uuid);
+    c.setGuid(g);
+    return c;
+  }
+
+  private PSSearch stubSearch(String name, int id, String guidStr) {
+    IPSGuid guid = mock(IPSGuid.class);
+    when(guid.toString()).thenReturn(guidStr);
+    when(guid.toStringUntyped()).thenReturn(String.valueOf(id));
+    when(guid.getHostId()).thenReturn(0L);
+    when(guid.longValue()).thenReturn((long) id);
+    when(guid.getType()).thenReturn((short) 301);
+    when(guid.getUUID()).thenReturn(id);
+
+    PSSearch s = mock(PSSearch.class);
+    when(s.getName()).thenReturn(name);
+    when(s.getLabel()).thenReturn(name);
+    when(s.getId()).thenReturn(id);
+    when(s.getGUID()).thenReturn(guid);
+    when(s.isCXNewSearch("10")).thenReturn(false);
+    when(s.getCXNewSearchCommunities()).thenReturn(new String[0]);
+    return s;
+  }
+
+  private void stubCatalog(PSSearch... searches) throws Exception {
+    List<IPSCatalogSummary> sums = new java.util.ArrayList<>();
+    List<PSSearch> loaded = new java.util.ArrayList<>();
+    for (PSSearch s : searches) {
+      IPSGuid searchGuid = s.getGUID();
+      IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+      when(sum.getGUID()).thenReturn(searchGuid);
+      sums.add(sum);
+      loaded.add(s);
+    }
+    when(designWs.findSearches(isNull(), isNull())).thenReturn(sums);
+    when(designWs.loadSearches(anyList(), eq(false), eq(false), any(), any())).thenReturn(loaded);
+  }
+}

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -37,6 +37,8 @@ class CatalogRestJaxrsRegistrationTest {
   private static final String[] REQUIRED_REFS = {
     "restControlsResource",
     "restSearchResource",
+    // #4096 UI-09 community CX new-search defaults (nested under /communities/{id}/…)
+    "restCommunityNewSearchDefaultsResource",
     "restViewResource",
     "restServerConfigsResource",
     "restRelationshipTypeResource",

--- a/rest/README.md
+++ b/rest/README.md
@@ -37,6 +37,7 @@ The module provides 24+ REST resource endpoints organized by functional area:
 
 - **Contexts** (`ContextsResource`) - Manage publishing contexts
 - **Communities** (`CommunityResource`) - Define organizational units
+- **Community new-search defaults** (`CommunityNewSearchDefaultsResource`) - Admin GET/PUT of CX new-search defaults per community (UI-09)
 - **Roles** (`RolesResource`) - Manage user roles and permissions
 - **Users** (`UsersResource`) - User management and preferences
 - **ACLs** (`AclResource`) - Access control list management

--- a/rest/src/main/java/com/percussion/rest/communities/CommunityNewSearchDefaults.java
+++ b/rest/src/main/java/com/percussion/rest/communities/CommunityNewSearchDefaults.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.communities;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.percussion.rest.Guid;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Community Content Explorer new-search defaults (Workbench UI-09). GET returns the current set
+ * (empty list is 200). PUT replaces the set; {@code searches} may be empty to clear explicit
+ * defaults for that community.
+ */
+@XmlRootElement(name = "CommunityNewSearchDefaults")
+@JsonRootName("CommunityNewSearchDefaults")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Set of CX searches used as new-search defaults for one community")
+public class CommunityNewSearchDefaults {
+
+  @Schema(description = "Community design GUID")
+  private Guid communityGuid;
+
+  @Schema(description = "Numeric community id")
+  private long communityId;
+
+  @Schema(description = "Community name")
+  private String communityName;
+
+  @Schema(description = "Searches assigned as CX new-search defaults for this community")
+  private List<CommunityNewSearchRef> searches = new ArrayList<>();
+
+  public CommunityNewSearchDefaults() {}
+
+  public Guid getCommunityGuid() {
+    return communityGuid;
+  }
+
+  public void setCommunityGuid(Guid communityGuid) {
+    this.communityGuid = communityGuid;
+  }
+
+  public long getCommunityId() {
+    return communityId;
+  }
+
+  public void setCommunityId(long communityId) {
+    this.communityId = communityId;
+  }
+
+  public String getCommunityName() {
+    return communityName;
+  }
+
+  public void setCommunityName(String communityName) {
+    this.communityName = communityName;
+  }
+
+  public List<CommunityNewSearchRef> getSearches() {
+    return searches;
+  }
+
+  public void setSearches(List<CommunityNewSearchRef> searches) {
+    this.searches = searches != null ? searches : new ArrayList<>();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CommunityNewSearchDefaults that)) {
+      return false;
+    }
+    return communityId == that.communityId
+        && Objects.equals(communityGuid, that.communityGuid)
+        && Objects.equals(communityName, that.communityName)
+        && Objects.equals(searches, that.searches);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(communityGuid, communityId, communityName, searches);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/communities/CommunityNewSearchDefaultsResource.java
+++ b/rest/src/main/java/com/percussion/rest/communities/CommunityNewSearchDefaultsResource.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.communities;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Admin GET/PUT for community Content Explorer new-search defaults (Workbench UI-09).
+ *
+ * <p>Empty default set is 200 (not 404). Unknown community is 404. Unknown or duplicate search is
+ * 400. Non-Admin is 403. Persistence is the Workbench {@code cxNewSearch} property via {@code
+ * IPSUiDesignWs}; this resource does not create searches.
+ */
+@PSSiteManageBean(value = "restCommunityNewSearchDefaultsResource")
+@Path("/communities/{idOrName}/new-search-defaults")
+@XmlRootElement
+@Tag(
+    name = "Communities",
+    description = "Community operations including CX new-search defaults (UI-09)")
+public class CommunityNewSearchDefaultsResource {
+
+  private final ICommunityNewSearchDefaultsAdaptor adaptor;
+
+  public CommunityNewSearchDefaultsResource() {
+    this.adaptor = null;
+  }
+
+  @Autowired
+  public CommunityNewSearchDefaultsResource(ICommunityNewSearchDefaultsAdaptor adaptor) {
+    this.adaptor = adaptor;
+  }
+
+  @GET
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Get community new-search defaults",
+      description =
+          "Admin. Returns the Content Explorer searches marked as new-search defaults for the"
+              + " community (Workbench UI-09 / cxNewSearch). Lookup by numeric id, GUID string, or"
+              + " exact name. An empty set is 200, not 404.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "OK (empty searches array when none are assigned)",
+            content =
+                @Content(schema = @Schema(implementation = CommunityNewSearchDefaults.class))),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Community not found"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public CommunityNewSearchDefaults getDefaults(
+      @Parameter(description = "Community id, GUID string, or exact name", required = true)
+          @PathParam("idOrName")
+          String idOrName) {
+    try {
+      CommunityNewSearchDefaults out = requireAdaptor().getDefaults(idOrName);
+      if (out == null) {
+        throw new WebApplicationException("Community not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (RuntimeException e) {
+      throw mapFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Replace community new-search defaults",
+      description =
+          "Admin. Replaces the set of Content Explorer searches used as new-search defaults for"
+              + " the community. Body searches may be identified by name, numeric id, or GUID."
+              + " Empty searches clears explicit defaults for that community. A second identical"
+              + " PUT is idempotent 200. Does not create searches.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Replaced (idempotent when unchanged)",
+            content =
+                @Content(schema = @Schema(implementation = CommunityNewSearchDefaults.class))),
+        @ApiResponse(
+            responseCode = "400",
+            description = "Invalid input, unknown search, or duplicate search"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Community not found"),
+        @ApiResponse(responseCode = "409", description = "Design lock held by another user"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public CommunityNewSearchDefaults replaceDefaults(
+      @Parameter(description = "Community id, GUID string, or exact name", required = true)
+          @PathParam("idOrName")
+          String idOrName,
+      CommunityNewSearchDefaults body) {
+    try {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      CommunityNewSearchDefaults out = requireAdaptor().replaceDefaults(idOrName, body);
+      if (out == null) {
+        throw new WebApplicationException("Community not found: " + idOrName, 404);
+      }
+      return out;
+    } catch (RuntimeException e) {
+      throw mapFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  static WebApplicationException mapFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    if (e instanceof IllegalStateException) {
+      String msg = e.getMessage() != null ? e.getMessage() : "Conflict";
+      String lower = msg.toLowerCase();
+      if (lower.contains("lock") || lower.contains("depend")) {
+        return new WebApplicationException(msg, 409);
+      }
+      return new WebApplicationException(e, 500);
+    }
+    return new WebApplicationException(e, 500);
+  }
+
+  private ICommunityNewSearchDefaultsAdaptor requireAdaptor() {
+    if (adaptor == null) {
+      throw new WebApplicationException(
+          "Community new-search defaults adaptor not configured",
+          Response.Status.SERVICE_UNAVAILABLE);
+    }
+    return adaptor;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/communities/CommunityNewSearchRef.java
+++ b/rest/src/main/java/com/percussion/rest/communities/CommunityNewSearchRef.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.communities;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.percussion.rest.Guid;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.Objects;
+
+/**
+ * Search identity used in community new-search default GET/PUT (UI-09). PUT accepts {@code name},
+ * numeric {@code id}, or {@code guid} (same keys as {@code /services/searches/{idOrName}}).
+ */
+@XmlRootElement(name = "CommunityNewSearchRef")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Search assigned as a Content Explorer new-search default for a community")
+public class CommunityNewSearchRef {
+
+  @Schema(description = "Search design GUID")
+  private Guid guid;
+
+  @Schema(description = "Numeric search id (UUID portion)")
+  private int id;
+
+  @Schema(description = "Internal search name (catalog key)")
+  private String name;
+
+  @Schema(description = "Display label")
+  private String label;
+
+  public CommunityNewSearchRef() {}
+
+  public Guid getGuid() {
+    return guid;
+  }
+
+  public void setGuid(Guid guid) {
+    this.guid = guid;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public void setLabel(String label) {
+    this.label = label;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CommunityNewSearchRef that)) {
+      return false;
+    }
+    return id == that.id
+        && Objects.equals(guid, that.guid)
+        && Objects.equals(name, that.name)
+        && Objects.equals(label, that.label);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(guid, id, name, label);
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/communities/ICommunityNewSearchDefaultsAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/communities/ICommunityNewSearchDefaultsAdaptor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.communities;
+
+/**
+ * Admin adaptor for community Content Explorer new-search defaults (UI-09).
+ *
+ * <p>Persistence is the Workbench {@code cxNewSearch} property on design searches ({@code
+ * IPSUiDesignWs} load/save). An empty set is a valid GET/PUT result, not 404.
+ */
+public interface ICommunityNewSearchDefaultsAdaptor {
+
+  /**
+   * Admin. Return searches marked as CX new-search defaults for the community.
+   *
+   * @param communityIdOrName numeric id, GUID string, or exact name
+   * @return current set (possibly empty); {@code null} when the community is missing
+   */
+  CommunityNewSearchDefaults getDefaults(String communityIdOrName);
+
+  /**
+   * Admin. Replace the CX new-search default set for the community. Idempotent when the stored
+   * set already matches.
+   *
+   * @param communityIdOrName numeric id, GUID string, or exact name
+   * @param body required; {@code searches} may be empty to clear
+   * @return the stored set after replace; {@code null} when the community is missing
+   */
+  CommunityNewSearchDefaults replaceDefaults(String communityIdOrName, CommunityNewSearchDefaults body);
+}

--- a/rest/src/test/java/com/percussion/rest/communities/CommunityNewSearchDefaultsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/communities/CommunityNewSearchDefaultsResourceTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.communities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.WebApplicationException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("UnitTest")
+public class CommunityNewSearchDefaultsResourceTest {
+
+  private ICommunityNewSearchDefaultsAdaptor adaptor;
+  private CommunityNewSearchDefaultsResource resource;
+
+  @BeforeEach
+  public void setUp() {
+    adaptor = mock(ICommunityNewSearchDefaultsAdaptor.class);
+    resource = new CommunityNewSearchDefaultsResource(adaptor);
+  }
+
+  @Test
+  public void getDefaultsEmptyIs200() {
+    CommunityNewSearchDefaults empty = new CommunityNewSearchDefaults();
+    empty.setCommunityName("Default");
+    empty.setSearches(List.of());
+    when(adaptor.getDefaults(eq("Default"))).thenReturn(empty);
+
+    CommunityNewSearchDefaults out = resource.getDefaults("Default");
+    assertEquals("Default", out.getCommunityName());
+    assertTrue(out.getSearches().isEmpty());
+  }
+
+  @Test
+  public void getDefaultsUnknownCommunityIs404() {
+    when(adaptor.getDefaults(eq("missing"))).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getDefaults("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void getDefaultsRethrowsForbidden() {
+    WebApplicationException forbidden = new WebApplicationException("Admin role required", 403);
+    when(adaptor.getDefaults(eq("Default"))).thenThrow(forbidden);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.getDefaults("Default"));
+    assertEquals(403, ex.getResponse().getStatus());
+    assertSame(forbidden, ex);
+  }
+
+  @Test
+  public void missingAdaptorIs503OnGet() {
+    CommunityNewSearchDefaultsResource bare = new CommunityNewSearchDefaultsResource();
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> bare.getDefaults("Default"));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceDefaultsSuccess() {
+    CommunityNewSearchDefaults body = new CommunityNewSearchDefaults();
+    CommunityNewSearchRef ref = new CommunityNewSearchRef();
+    ref.setName("SimpleSearch");
+    body.setSearches(List.of(ref));
+    CommunityNewSearchDefaults stored = new CommunityNewSearchDefaults();
+    stored.setCommunityName("Default");
+    stored.setSearches(List.of(ref));
+    when(adaptor.replaceDefaults(eq("Default"), eq(body))).thenReturn(stored);
+
+    CommunityNewSearchDefaults out = resource.replaceDefaults("Default", body);
+    assertEquals(1, out.getSearches().size());
+    assertEquals("SimpleSearch", out.getSearches().get(0).getName());
+  }
+
+  @Test
+  public void replaceDefaultsNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.replaceDefaults("Default", null));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceDefaultsUnknownSearchIs400() {
+    when(adaptor.replaceDefaults(eq("Default"), org.mockito.ArgumentMatchers.any()))
+        .thenThrow(new IllegalArgumentException("Unknown search: Nope"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceDefaults("Default", new CommunityNewSearchDefaults()));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("Unknown search"));
+  }
+
+  @Test
+  public void replaceDefaultsUnknownCommunityIs404() {
+    when(adaptor.replaceDefaults(eq("missing"), org.mockito.ArgumentMatchers.any()))
+        .thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceDefaults("missing", new CommunityNewSearchDefaults()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void replaceDefaultsRethrowsForbidden() {
+    WebApplicationException forbidden = new WebApplicationException("Admin role required", 403);
+    when(adaptor.replaceDefaults(eq("Default"), org.mockito.ArgumentMatchers.any()))
+        .thenThrow(forbidden);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.replaceDefaults("Default", new CommunityNewSearchDefaults()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorIs503OnPut() {
+    CommunityNewSearchDefaultsResource bare = new CommunityNewSearchDefaultsResource();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> bare.replaceDefaults("Default", new CommunityNewSearchDefaults()));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestCommunityNewSearchDefaultsAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestCommunityNewSearchDefaultsAdaptor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.test.apibridge;
+
+import com.percussion.rest.communities.CommunityNewSearchDefaults;
+import com.percussion.rest.communities.ICommunityNewSearchDefaultsAdaptor;
+import java.util.List;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring test stub for {@link ICommunityNewSearchDefaultsAdaptor}. Required for ApplicationContext
+ * load.
+ */
+@Component
+@Lazy
+public class TestCommunityNewSearchDefaultsAdaptor implements ICommunityNewSearchDefaultsAdaptor {
+
+  @Override
+  public CommunityNewSearchDefaults getDefaults(String communityIdOrName) {
+    CommunityNewSearchDefaults empty = new CommunityNewSearchDefaults();
+    empty.setCommunityName(communityIdOrName);
+    empty.setSearches(List.of());
+    return empty;
+  }
+
+  @Override
+  public CommunityNewSearchDefaults replaceDefaults(
+      String communityIdOrName, CommunityNewSearchDefaults body) {
+    if (body == null) {
+      return getDefaults(communityIdOrName);
+    }
+    body.setCommunityName(communityIdOrName);
+    return body;
+  }
+}


### PR DESCRIPTION
## Summary

Admin REST for Workbench **UI-09** community Content Explorer new-search defaults (parent [#1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690)).

`GET`/`PUT` `/services/communities/{idOrName}/new-search-defaults` reads and replaces the set of searches marked `cxNewSearch` for that community through `IPSUiDesignWs` load/save — the same design path SOAP/Workbench uses. Empty set is **200**. Unknown search is **400**. Unknown community is **404**. Non-Admin is **403**. Identical PUT is idempotent. This slice does **not** create searches and has **no SPA**.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4096
Parent: #1690

## Test plan

1. Unit: `CommunityNewSearchDefaultsResourceTest` (HTTP 200/400/403/404/503) and `CommunityNewSearchDefaultsAdaptorTest` (empty GET, replace, idempotent PUT, duplicate/unknown search, Admin/session 403).
2. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 951, Failures: 0 (includes `MainTest` Spring stub).
3. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2102, Failures: 0, Errors: 0.
4. Confirm `rest-jax-rs` refs `restCommunityNewSearchDefaultsResource` (`CatalogRestJaxrsRegistrationTest`).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (contract, 403/404/400) and `product-docs/8.2/admin/developer-searches.md` (operator REST note)
- [x] **Unit / module tests** — behavioral tests for GET/PUT; rest + sitemanage standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen this slice)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests)
- [x] **Cross-platform** — no filesystem path I/O; identity keys reject `/` `\` `..` NUL

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 951, Failures: 0 (`CommunityNewSearchDefaultsResourceTest` 10; `MainTest` 2)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2102, Failures: 0, Errors: 0 (`CommunityNewSearchDefaultsAdaptorTest` 18)
- **downstream_checked:** `projects/sitemanage` (implements new `ICommunityNewSearchDefaultsAdaptor`); `CatalogRestJaxrsRegistrationTest` jaxrs bean ref. No existing type made `final` or signature-changed.

### C5 UI proof

N/A — REST-only; no SPA/Playwright this slice.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
