### PR TITLE
fix(system): H2 exclusive checkout single-winner harness (#4105)

### DIFF
--- a/docs/ai-generated/code-reviews/4105-h2-multiuser-lock-single-winner-erlang.md
+++ b/docs/ai-generated/code-reviews/4105-h2-multiuser-lock-single-winner-erlang.md
@@ -1,0 +1,49 @@
+# Erlang review: #4105 H2 multiuser lock harness single-winner checkout
+
+**Branch:** `fix/issue-4105-h2-multiuser-lock-single-winner`  
+**Base:** `origin/main`  
+**Scope:** uncommitted `PSH2MultiuserLockHarnessTest`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** tests.behavioral (CAS rowcount + hold-until-attempted latch); paths.hardcoded-sep false-positive (H2 JDBC URL `/`)
+
+## Summary
+
+Test-only harness fix for exclusive content checkout on file H2 (`FILE_LOCK=NO`). `SELECT FOR UPDATE` plus an unguarded `UPDATE` allowed two concurrent winners (and/or a serial handoff after check-in inflated the count). Checkout is now a compare-and-set `UPDATE … WHERE CHECKOUTUSER IS NULL` (rowcount == 1); the same-item test holds the winner's checkout until all editors have attempted. Serial handoff after check-in remains allowed and is covered separately.
+
+## Scope
+
+- Base: `origin/main` (`4f8c8dd957`)
+- Head: `fix/issue-4105-h2-multiuser-lock-single-winner` (uncommitted)
+- Files: 1 production-adjacent test + this review
+- Prior report: none
+- Memory patterns hit: tests.behavioral; paths JDBC URL `/` is not filesystem join
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Blocking bugs: 0
+- May commit/push: yes
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+Applied. Existing JDBC URL still uses `Path` + `toAbsolutePath()` and replaces `\` with `/` only for the H2 `file:` URL (URL path, not OS filesystem join). `@TempDir` is portable. No new hardcoded separators, Unix-only roots, or line-ending assertions.
+
+## Tests
+
+- `PSH2MultiuserLockHarnessTest`: 7 run, 0 fail (focused `mvnw -Dtest=…`)
+- `cd system && ../mvnw.cmd clean install`: BUILD SUCCESS; Tests run: 2692, Failures: 0, Errors: 0, Skipped: 247
+- Change-class companions: same-class CAS contention + serial-handoff tests; no production API / Spring context / product-docs / Playwright
+
+## Notes
+
+- C2 reverse-deps: N/A (test-only, no `final`/signature change)
+- C5 Playwright: N/A (no UI)
+- Product documentation: N/A (test-only harness)

--- a/system/src/test/java/com/percussion/services/datasource/PSH2MultiuserLockHarnessTest.java
+++ b/system/src/test/java/com/percussion/services/datasource/PSH2MultiuserLockHarnessTest.java
@@ -51,8 +51,8 @@ import org.junit.jupiter.api.io.TempDir;
  * without a full CMS Spring container:
  *
  * <ul>
- *   <li>Exclusive checkout via {@code SELECT … FOR UPDATE} then update of a checkout-user column
- *       (CONTENTSTATUS-style)
+ *   <li>Exclusive checkout via {@code SELECT … FOR UPDATE} then a compare-and-set update of a
+ *       checkout-user column ({@code WHERE CHECKOUTUSER IS NULL} / rowcount == 1, CONTENTSTATUS-style)
  *   <li>Design-object locks via row-level exclusive claim (PSObjectLock-style)
  *   <li>≥10 concurrent "editors" on distinct connections (FR-003 / SC-005 floor)
  *   <li>Same-item exclusive vs distinct-item parallel (T070)
@@ -225,6 +225,9 @@ public class PSH2MultiuserLockHarnessTest {
     final int itemId = 15;
     ExecutorService pool = Executors.newFixedThreadPool(EDITOR_COUNT);
     CountDownLatch start = new CountDownLatch(1);
+    // Hold the winner's checkout until every editor has attempted, so a legitimate serial
+    // handoff after check-in cannot inflate the exclusive-winner count (#4105).
+    CountDownLatch attemptsDone = new CountDownLatch(EDITOR_COUNT);
     AtomicInteger winners = new AtomicInteger();
     AtomicInteger losers = new AtomicInteger();
     List<Future<?>> futures = new ArrayList<>();
@@ -234,11 +237,22 @@ public class PSH2MultiuserLockHarnessTest {
       futures.add(
           pool.submit(
               () -> {
+                boolean won = false;
                 try {
-                  start.await(30, TimeUnit.SECONDS);
-                  if (checkoutItem(itemId, "editor-" + editor)) {
-                    // hold lock briefly then edit
-                    Thread.sleep(50);
+                  if (!start.await(30, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("start latch timeout");
+                  }
+                  won = checkoutItem(itemId, "editor-" + editor);
+                } catch (Exception ex) {
+                  throw new RuntimeException(ex);
+                } finally {
+                  attemptsDone.countDown();
+                }
+                try {
+                  if (won) {
+                    if (!attemptsDone.await(30, TimeUnit.SECONDS)) {
+                      throw new IllegalStateException("checkout-attempt latch timeout");
+                    }
                     updateBody(itemId, "editor-" + editor, "winner-body-" + editor);
                     checkinItem(itemId, "editor-" + editor);
                     winners.incrementAndGet();
@@ -272,6 +286,80 @@ public class PSH2MultiuserLockHarnessTest {
         assertNull(rs.getString(1));
         assertEquals(1, rs.getInt(2), "single edit applied");
         assertTrue(rs.getString(3).startsWith("winner-body-"));
+      }
+      c.commit();
+    }
+  }
+
+  @Test
+  @DisplayName("After exclusive check-in, a different editor may check out (serial handoff)")
+  void checkoutAfterCheckin_nextEditorWins() throws Exception {
+    final int itemId = 16;
+    assertTrue(checkoutItem(itemId, "editor-0"));
+    updateBody(itemId, "editor-0", "first-edit");
+    checkinItem(itemId, "editor-0");
+    assertTrue(checkoutItem(itemId, "editor-1"), "check-in must release exclusive checkout");
+    updateBody(itemId, "editor-1", "second-edit");
+    checkinItem(itemId, "editor-1");
+
+    try (Connection c = connect();
+        PreparedStatement ps =
+            c.prepareStatement(
+                "SELECT CHECKOUTUSER, VERSION, BODY FROM CONTENT_ITEM WHERE CONTENTID = ?")) {
+      ps.setInt(1, itemId);
+      try (ResultSet rs = ps.executeQuery()) {
+        assertTrue(rs.next());
+        assertNull(rs.getString(1));
+        assertEquals(2, rs.getInt(2), "two serial edits");
+        assertEquals("second-edit", rs.getString(3));
+      }
+      c.commit();
+    }
+  }
+
+  @Test
+  @DisplayName("Compare-and-set checkout UPDATE yields a single rowcount winner under contention")
+  void atomicCheckoutClaim_rowcountSingleWinner() throws Exception {
+    final int itemId = 17;
+    ExecutorService pool = Executors.newFixedThreadPool(EDITOR_COUNT);
+    CountDownLatch start = new CountDownLatch(1);
+    AtomicInteger claims = new AtomicInteger();
+    List<Future<?>> futures = new ArrayList<>();
+
+    for (int e = 0; e < EDITOR_COUNT; e++) {
+      final String user = "cas-" + e;
+      futures.add(
+          pool.submit(
+              () -> {
+                try {
+                  if (!start.await(30, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("start latch timeout");
+                  }
+                  if (claimFreeCheckout(itemId, user) == 1) {
+                    claims.incrementAndGet();
+                  }
+                } catch (Exception ex) {
+                  throw new RuntimeException(ex);
+                }
+              }));
+    }
+
+    start.countDown();
+    for (Future<?> f : futures) {
+      f.get(60, TimeUnit.SECONDS);
+    }
+    pool.shutdown();
+    assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS));
+
+    assertEquals(1, claims.get(), "exactly one CAS checkout claim");
+    try (Connection c = connect();
+        PreparedStatement ps =
+            c.prepareStatement("SELECT CHECKOUTUSER FROM CONTENT_ITEM WHERE CONTENTID = ?")) {
+      ps.setInt(1, itemId);
+      try (ResultSet rs = ps.executeQuery()) {
+        assertTrue(rs.next());
+        String holder = rs.getString(1);
+        assertTrue(holder != null && holder.startsWith("cas-"), holder);
       }
       c.commit();
     }
@@ -375,6 +463,9 @@ public class PSH2MultiuserLockHarnessTest {
   /**
    * Exclusive checkout: lock row, succeed only if free or already held by same user.
    *
+   * <p>H2 {@code SELECT … FOR UPDATE} is not a reliable exclusive barrier across connections in
+   * this FILE_LOCK=NO harness, so the claim is the compare-and-set {@code UPDATE} (rowcount == 1).
+   *
    * @return true if this editor holds the checkout after the call
    */
   private boolean checkoutItem(int contentId, String user) throws SQLException {
@@ -398,17 +489,46 @@ public class PSH2MultiuserLockHarnessTest {
           }
         }
       }
-      try (PreparedStatement upd =
-          c.prepareStatement("UPDATE CONTENT_ITEM SET CHECKOUTUSER = ? WHERE CONTENTID = ?")) {
-        upd.setString(1, user);
-        upd.setInt(2, contentId);
-        upd.executeUpdate();
+      int n = claimFreeCheckout(c, contentId, user);
+      if (n != 1) {
+        LAST_SQL_ERROR.set("claim lost (rowcount=" + n + ")");
+        c.rollback();
+        return false;
       }
       c.commit();
       return true;
     } catch (SQLException e) {
       LAST_SQL_ERROR.set(e.getSQLState() + " " + e.getMessage());
       return false;
+    }
+  }
+
+  /**
+   * Single-winner checkout claim: update only a free row (or a re-checkout by the same user).
+   *
+   * @return updated row count (1 = this connection won the claim)
+   */
+  private int claimFreeCheckout(int contentId, String user) throws SQLException {
+    try (Connection c = connect()) {
+      int n = claimFreeCheckout(c, contentId, user);
+      if (n == 1) {
+        c.commit();
+      } else {
+        c.rollback();
+      }
+      return n;
+    }
+  }
+
+  private int claimFreeCheckout(Connection c, int contentId, String user) throws SQLException {
+    try (PreparedStatement upd =
+        c.prepareStatement(
+            "UPDATE CONTENT_ITEM SET CHECKOUTUSER = ? WHERE CONTENTID = ? AND (CHECKOUTUSER IS NULL"
+                + " OR CHECKOUTUSER = '' OR CHECKOUTUSER = ?)")) {
+      upd.setString(1, user);
+      upd.setInt(2, contentId);
+      upd.setString(3, user);
+      return upd.executeUpdate();
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes exclusive-checkout flakiness in `PSH2MultiuserLockHarnessTest.concurrentSameItemCheckout_singleWinner` (#4105). On file H2 with `FILE_LOCK=NO`, `SELECT … FOR UPDATE` is not a reliable exclusive barrier across connections, and the test also counted a legitimate serial handoff after check-in as a second winner (`expected 1 but was 2`).

Checkout now claims with a compare-and-set `UPDATE … WHERE CHECKOUTUSER IS NULL` (rowcount == 1). The same-item test holds the winner's checkout until all editors have attempted, so the exclusive-winner count stays 1 without weakening product check-in/hand-off semantics. Serial handoff and CAS contention are covered by additional tests in the same class.

Fixes #4105

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` (JDK 21 via `JAVA_HOME`; no `-DskipTests`).
2. Confirm `PSH2MultiuserLockHarnessTest` (7 tests) is green, especially `concurrentSameItemCheckout_singleWinner`.
3. Confirm module Surefire: Tests run: 2692, Failures: 0, Errors: 0, Skipped: 247 and **BUILD SUCCESS**.

## Checklist

- [x] **Product documentation** — N/A (test-only H2 lock harness; no operator/admin/UI/API/config change)
- [x] **Unit / module tests** — behavioral tests in `PSH2MultiuserLockHarnessTest`; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` BUILD SUCCESS
- [x] **Cross-platform** — H2 JDBC `file:` URL still uses `Path` + `/` only as URL path; `@TempDir` portable

### C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Tests run: 2692, Failures: 0, Errors: 0, Skipped: 247; `PSH2MultiuserLockHarnessTest` Tests run: 7, Failures: 0
- **downstream_checked:** none (test-only; no `final`/public API shape change)

### C5 UI proof

N/A — no WebUI / Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
