### PR TITLE
feat(views): Developer Views field-selection (UI-08, #4111)

### DIFF
--- a/WebUI/src/main/ts/api/developer/viewsApi.ts
+++ b/WebUI/src/main/ts/api/developer/viewsApi.ts
@@ -24,11 +24,12 @@ export { resolveViewObjectGuid };
 
 /**
  * Writable identity fields for POST/PUT /services/views. Name is the catalog
- * key (not renamed on PUT). Field criteria are not written from this chrome.
+ * key (not renamed on PUT). Field criteria are included on PUT when the SPA
+ * saves the criterion list (omitted fields leave existing criteria unchanged).
  */
 export type ViewWriteBody = Pick<
   ViewDef,
-  "name" | "label" | "description" | "type" | "displayFormatId"
+  "name" | "label" | "description" | "type" | "displayFormatId" | "fields"
 >;
 
 /** Jackson / JAXB root for ViewDef (UNWRAP_ROOT_VALUE on POST/PUT). */
@@ -50,11 +51,10 @@ export const INBOX_DCE_PATH = "//Views//MyContent/Inbox";
  * Catalog-level design gaps (REST-GAPS-02). Server omits these on list rows;
  * detail re-attaches or SPA falls back via this constant.
  *
- * <p>Create / save / delete are supported (UI-07 SPA). Field-criterion write
- * and Inbox-family mutate remain later / REST-protected.</p>
+ * <p>Create / save / delete and field-criterion write are supported (UI-07 / UI-08).
+ * Inbox-family mutate remains REST-protected.</p>
  */
 export const VIEW_DESIGN_GAPS: string[] = [
-  "View field criterion editing not supported via this API",
   "Inbox-family and custom URL views cannot be updated or deleted via this API",
   "Searches are a separate catalog (Developer Searches / UI-06)",
 ];
@@ -149,7 +149,19 @@ export function unwrapViewDef(payload: unknown): ViewDef {
     body = root as ViewDef;
   }
   const gs = resolveViewObjectGuid(body);
-  return normalizeDesignObjectGuid(body, gs);
+  const normalized = normalizeDesignObjectGuid(body, gs);
+  if (normalized.fields != null && !Array.isArray(normalized.fields)) {
+    const rec = normalized.fields as unknown as Record<string, unknown>;
+    const inner = rec.ViewFieldSummary ?? rec.viewFieldSummary;
+    if (Array.isArray(inner)) {
+      normalized.fields = inner as ViewDef["fields"];
+    } else if (inner && typeof inner === "object") {
+      normalized.fields = [inner as NonNullable<ViewDef["fields"]>[number]];
+    } else {
+      normalized.fields = [];
+    }
+  }
+  return normalized;
 }
 
 /** Unwrap list envelopes and normalize each row GUID (#3380). */
@@ -159,6 +171,7 @@ export function unwrapViewDefList(payload: unknown): ViewDef[] {
 
 const STALE_WRITE_GAPS = new Set([
   "View create / update / delete not supported via this API",
+  "View field criterion editing not supported via this API",
 ]);
 
 /** Drop the pre-UI-07 write gap when REST still attaches it on GET detail. */

--- a/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { isApiError } from "../api/client";
 import { resolveViewObjectGuid } from "../api/displayFormatGuid";
 import {
@@ -29,7 +29,20 @@ import {
   saveView,
   type ViewWriteBody,
 } from "../api/developer/viewsApi";
-import type { ViewDef } from "../api/developer/types";
+import type { ViewDef, ViewFieldSummary } from "../api/developer/types";
+import {
+  addViewFieldCriterion,
+  catalogViewFieldsNotInUse,
+  isKnownViewFieldName,
+  isValidViewFieldName,
+  moveViewFieldCriterion,
+  normalizeViewFields,
+  patchViewFieldCriterion,
+  removeViewFieldCriterion,
+  viewFieldsEqual,
+  VIEW_FIELD_OPERATORS,
+  VIEW_FIELD_TYPES,
+} from "./viewFieldCriteria";
 import {
   catalogColors,
   backButton,
@@ -54,6 +67,15 @@ const inputStyle: React.CSSProperties = {
   padding: "8px",
   border: `1px solid ${catalogColors.softBorder}`,
   borderRadius: "4px",
+  font: "inherit",
+};
+
+const actionButton: React.CSSProperties = {
+  padding: "4px 8px",
+  border: `1px solid ${catalogColors.softBorder}`,
+  borderRadius: "4px",
+  background: catalogColors.surface,
+  cursor: "pointer",
   font: "inherit",
 };
 
@@ -91,6 +113,11 @@ export function ViewDetailPanel({
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(idOrName != null);
+  const [draftFields, setDraftFields] = useState<ViewFieldSummary[]>([]);
+  const [addFieldName, setAddFieldName] = useState("");
+  const [addOperator, setAddOperator] = useState("equal");
+  const [addValue, setAddValue] = useState("");
+  const [addType, setAddType] = useState("Text");
   const inflight = useRef(false);
 
   useEffect(() => {
@@ -101,6 +128,8 @@ export function ViewDetailPanel({
     setDetail(null);
     setError(null);
     setNotice(null);
+    setDraftFields([]);
+    setAddFieldName("");
     setLoading(true);
     getViewDetail(idOrName)
       .then((d) => {
@@ -111,6 +140,12 @@ export function ViewDetailPanel({
         setDescription(d.description || "");
         setType(typeFromDetail(d, VIEW_TYPE_STANDARD));
         setDisplayFormatId(d.displayFormatId || "");
+        const nextFields = normalizeViewFields(d.fields);
+        setDraftFields(nextFields);
+        setAddFieldName(catalogViewFieldsNotInUse(nextFields)[0]?.source || "");
+        setAddOperator("equal");
+        setAddValue("");
+        setAddType("Text");
         setLoading(false);
       })
       .catch((err: unknown) => {
@@ -137,18 +172,28 @@ export function ViewDetailPanel({
     type !== loadedType ||
     displayFormatId !== loadedDf;
   const canSave = !busy && !protectedWrite && dirty && isViewWriteReady({ isNew, name });
-  const writeKey = idOrName || createdKey || normalizeViewName(name);
   const objectGuid = resolveViewObjectGuid(detail, catalogGuid);
+  const writeKey = objectGuid || idOrName || createdKey || normalizeViewName(name);
+  const loadedFields = useMemo(
+    () => (detail != null ? normalizeViewFields(detail.fields) : []),
+    [detail],
+  );
+  const fieldsEditable = !protectedWrite && !isNew && detail != null;
+  const fields = fieldsEditable ? draftFields : loadedFields;
+  const availableFields = catalogViewFieldsNotInUse(draftFields);
+  const fieldsDirty = fieldsEditable && !viewFieldsEqual(draftFields, loadedFields);
+  const canSaveFields = !busy && fieldsDirty;
 
   function writeBody(): ViewWriteBody {
+    const df = displayFormatId == null ? "" : String(displayFormatId);
     const body: ViewWriteBody = {
       name: isNew ? normalizeViewName(name) : detail?.name || normalizeViewName(name),
-      label,
-      description,
-      type,
+      label: label == null ? "" : String(label),
+      description: description == null ? "" : String(description),
+      type: type == null ? "" : String(type),
     };
-    if (displayFormatId.trim()) {
-      body.displayFormatId = displayFormatId.trim();
+    if (df.trim()) {
+      body.displayFormatId = df.trim();
     }
     return body;
   }
@@ -160,6 +205,49 @@ export function ViewDetailPanel({
     if (isApiError(err) && err.status === 403) return DEV_MSG.VW_FORBIDDEN;
     if (isApiError(err) && err.status === 404) return DEV_MSG.VW_NOT_FOUND;
     return DEV_MSG.VW_SAVE_ERROR;
+  }
+
+  function fieldsSaveFallback(err: unknown): string {
+    if (isApiError(err) && err.status === 400) return DEV_MSG.VW_FIELDS_INVALID;
+    if (isApiError(err) && err.status === 403) return DEV_MSG.VW_FIELDS_FORBIDDEN;
+    if (isApiError(err) && err.status === 409) return DEV_MSG.VW_PROTECTED;
+    if (isApiError(err) && err.status === 404) return DEV_MSG.VW_NOT_FOUND;
+    return DEV_MSG.VW_FIELDS_SAVE_ERROR;
+  }
+
+  function handleAddField(): void {
+    if (!isValidViewFieldName(addFieldName) || !isKnownViewFieldName(addFieldName)) {
+      return;
+    }
+    const next = addViewFieldCriterion(draftFields, addFieldName, addOperator, addValue, addType);
+    setDraftFields(next);
+    setAddFieldName(catalogViewFieldsNotInUse(next)[0]?.source || "");
+    setAddValue("");
+  }
+
+  async function handleSaveFields(): Promise<void> {
+    if (!canSaveFields || inflight.current || !writeKey) return;
+    inflight.current = true;
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const saved = await saveView(writeKey, {
+        ...writeBody(),
+        fields: normalizeViewFields(draftFields),
+      });
+      setDetail(saved);
+      const nextFields = normalizeViewFields(saved.fields);
+      setDraftFields(nextFields);
+      setAddFieldName(catalogViewFieldsNotInUse(nextFields)[0]?.source || "");
+      setNotice(DEV_MSG.VW_FIELDS_SAVED);
+      onSaved?.(saved);
+    } catch (err: unknown) {
+      setError(panelErrMsg(err, fieldsSaveFallback(err)));
+    } finally {
+      inflight.current = false;
+      setBusy(false);
+    }
   }
 
   async function handleSave(): Promise<void> {
@@ -182,6 +270,9 @@ export function ViewDetailPanel({
       setDescription(saved.description || "");
       setType(typeFromDetail(saved, type));
       setDisplayFormatId(saved.displayFormatId || "");
+      const nextFields = normalizeViewFields(saved.fields);
+      setDraftFields(nextFields);
+      setAddFieldName(catalogViewFieldsNotInUse(nextFields)[0]?.source || "");
       setNotice(DEV_MSG.VW_SAVED);
       onSaved?.(saved);
     } catch (err: unknown) {
@@ -223,11 +314,10 @@ export function ViewDetailPanel({
     ? DEV_MSG.VW_NEW
     : detail?.label || detail?.name || idOrName || DEV_MSG.VW_EDIT;
 
-  const fields = detail != null && Array.isArray(detail.fields) ? detail.fields : [];
   const gapList =
     detail != null && detail.designGaps && detail.designGaps.length > 0
       ? detail.designGaps
-      : [DEV_MSG.VW_GAP_FIELDS, DEV_MSG.VW_GAP_PROTECTED, DEV_MSG.VW_GAP_SEARCHES];
+      : [DEV_MSG.VW_GAP_PROTECTED, DEV_MSG.VW_GAP_SEARCHES];
 
   return (
     <div data-testid="developer-vw-detail">
@@ -429,8 +519,11 @@ export function ViewDetailPanel({
             <>
               <section data-testid="developer-vw-fields">
                 <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.VW_FIELDS}</h3>
-                <p style={{ color: catalogColors.muted, fontSize: "0.9rem" }}>
-                  {DEV_MSG.VW_FIELDS_HINT}
+                <p
+                  style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
+                  data-testid={protectedWrite ? "developer-vw-fields-readonly" : undefined}
+                >
+                  {protectedWrite ? DEV_MSG.VW_FIELDS_READONLY : DEV_MSG.VW_FIELDS_HINT}
                 </p>
                 {fields.length === 0 ? (
                   <p style={{ color: catalogColors.empty }} data-testid="developer-vw-fields-empty">
@@ -448,6 +541,7 @@ export function ViewDetailPanel({
                           <th style={{ padding: "8px" }}>{DEV_MSG.VW_COL_OP}</th>
                           <th style={{ padding: "8px" }}>{DEV_MSG.VW_COL_VALUE}</th>
                           <th style={{ padding: "8px" }}>{DEV_MSG.VW_COL_FTYPE}</th>
+                          {fieldsEditable ? <th style={{ padding: "8px" }} /> : null}
                         </tr>
                       </thead>
                       <tbody>
@@ -455,20 +549,231 @@ export function ViewDetailPanel({
                           <tr
                             key={`${f.fieldName ?? "f"}-${i}`}
                             data-testid={`developer-vw-field-row-${i}`}
+                            data-vw-field-name={f.fieldName || ""}
                             style={tableRow}
                           >
                             <td style={{ padding: "8px", fontFamily: "monospace" }}>
                               {f.fieldName || f.displayName || "—"}
                             </td>
-                            <td style={{ padding: "8px" }}>{f.operator || "—"}</td>
-                            <td style={{ padding: "8px" }}>{f.fieldValue || "—"}</td>
+                            <td style={{ padding: "8px" }}>
+                              {fieldsEditable ? (
+                                <select
+                                  data-testid={`developer-vw-field-op-${i}`}
+                                  style={inputStyle}
+                                  value={f.operator || "equal"}
+                                  disabled={busy}
+                                  onChange={(e) =>
+                                    setDraftFields(
+                                      patchViewFieldCriterion(draftFields, i, {
+                                        operator: e.target.value,
+                                      }),
+                                    )
+                                  }
+                                >
+                                  {VIEW_FIELD_OPERATORS.map((op) => (
+                                    <option key={op.value} value={op.value}>
+                                      {op.label}
+                                    </option>
+                                  ))}
+                                </select>
+                              ) : (
+                                f.operator || "—"
+                              )}
+                            </td>
+                            <td style={{ padding: "8px" }}>
+                              {fieldsEditable ? (
+                                <input
+                                  data-testid={`developer-vw-field-value-${i}`}
+                                  style={inputStyle}
+                                  value={f.fieldValue || ""}
+                                  disabled={busy}
+                                  onChange={(e) =>
+                                    setDraftFields(
+                                      patchViewFieldCriterion(draftFields, i, {
+                                        fieldValue: e.target.value,
+                                      }),
+                                    )
+                                  }
+                                />
+                              ) : (
+                                f.fieldValue || "—"
+                              )}
+                            </td>
                             <td style={{ padding: "8px" }}>{f.fieldType || "—"}</td>
+                            {fieldsEditable ? (
+                              <td style={{ padding: "8px" }}>
+                                <div style={{ display: "flex", gap: "4px", flexWrap: "wrap" }}>
+                                  <button
+                                    type="button"
+                                    data-testid={`developer-vw-field-up-${i}`}
+                                    aria-label={DEV_MSG.VW_FIELDS_MOVE_UP}
+                                    disabled={busy || i === 0}
+                                    onClick={() =>
+                                      setDraftFields(moveViewFieldCriterion(draftFields, i, -1))
+                                    }
+                                    style={actionButton}
+                                  >
+                                    {DEV_MSG.VW_FIELDS_MOVE_UP}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    data-testid={`developer-vw-field-down-${i}`}
+                                    aria-label={DEV_MSG.VW_FIELDS_MOVE_DOWN}
+                                    disabled={busy || i === fields.length - 1}
+                                    onClick={() =>
+                                      setDraftFields(moveViewFieldCriterion(draftFields, i, 1))
+                                    }
+                                    style={actionButton}
+                                  >
+                                    {DEV_MSG.VW_FIELDS_MOVE_DOWN}
+                                  </button>
+                                  <button
+                                    type="button"
+                                    data-testid={`developer-vw-field-remove-${i}`}
+                                    aria-label={DEV_MSG.VW_FIELDS_REMOVE}
+                                    disabled={busy}
+                                    onClick={() =>
+                                      setDraftFields(removeViewFieldCriterion(draftFields, i))
+                                    }
+                                    style={actionButton}
+                                  >
+                                    {DEV_MSG.VW_FIELDS_REMOVE}
+                                  </button>
+                                </div>
+                              </td>
+                            ) : null}
                           </tr>
                         ))}
                       </tbody>
                     </table>
                   </div>
                 )}
+
+                {fieldsEditable ? (
+                  <div
+                    style={{
+                      marginTop: "12px",
+                      display: "flex",
+                      gap: "8px",
+                      flexWrap: "wrap",
+                      alignItems: "flex-end",
+                    }}
+                    data-testid="developer-vw-field-editor"
+                  >
+                    <label
+                      htmlFor="vw-field-source"
+                      style={{ display: "flex", flexDirection: "column", gap: "4px" }}
+                    >
+                      {DEV_MSG.VW_FIELDS_SOURCE_PICKER}
+                      <select
+                        id="vw-field-source"
+                        data-testid="developer-vw-field-source"
+                        style={inputStyle}
+                        value={addFieldName}
+                        disabled={busy || availableFields.length === 0}
+                        onChange={(e) => setAddFieldName(e.target.value)}
+                      >
+                        <option value="">{availableFields.length ? "—" : DEV_MSG.VW_NONE}</option>
+                        {availableFields.map((f) => (
+                          <option key={f.source} value={f.source}>
+                            {f.label} ({f.source})
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label
+                      htmlFor="vw-field-add-op"
+                      style={{ display: "flex", flexDirection: "column", gap: "4px" }}
+                    >
+                      {DEV_MSG.VW_COL_OP}
+                      <select
+                        id="vw-field-add-op"
+                        data-testid="developer-vw-field-add-op"
+                        style={inputStyle}
+                        value={addOperator}
+                        disabled={busy}
+                        onChange={(e) => setAddOperator(e.target.value)}
+                      >
+                        {VIEW_FIELD_OPERATORS.map((op) => (
+                          <option key={op.value} value={op.value}>
+                            {op.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <label
+                      htmlFor="vw-field-add-value"
+                      style={{ display: "flex", flexDirection: "column", gap: "4px" }}
+                    >
+                      {DEV_MSG.VW_COL_VALUE}
+                      <input
+                        id="vw-field-add-value"
+                        data-testid="developer-vw-field-add-value"
+                        style={inputStyle}
+                        value={addValue}
+                        disabled={busy}
+                        onChange={(e) => setAddValue(e.target.value)}
+                      />
+                    </label>
+                    <label
+                      htmlFor="vw-field-add-type"
+                      style={{ display: "flex", flexDirection: "column", gap: "4px" }}
+                    >
+                      {DEV_MSG.VW_COL_FTYPE}
+                      <select
+                        id="vw-field-add-type"
+                        data-testid="developer-vw-field-add-type"
+                        style={inputStyle}
+                        value={addType}
+                        disabled={busy}
+                        onChange={(e) => setAddType(e.target.value)}
+                      >
+                        {VIEW_FIELD_TYPES.map((t) => (
+                          <option key={t} value={t}>
+                            {t}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <button
+                      type="button"
+                      data-testid="developer-vw-field-add"
+                      aria-label={DEV_MSG.VW_FIELDS_ADD}
+                      disabled={busy || !isValidViewFieldName(addFieldName)}
+                      onClick={handleAddField}
+                      style={{
+                        ...actionButton,
+                        padding: "8px 12px",
+                        background: isValidViewFieldName(addFieldName)
+                          ? catalogColors.accent
+                          : catalogColors.disabled,
+                        color: "#fff",
+                        border: "none",
+                        cursor:
+                          isValidViewFieldName(addFieldName) && !busy ? "pointer" : "not-allowed",
+                      }}
+                    >
+                      {DEV_MSG.VW_FIELDS_ADD}
+                    </button>
+                    <button
+                      type="button"
+                      data-testid="developer-vw-fields-save"
+                      aria-label={DEV_MSG.VW_FIELDS_SAVE}
+                      disabled={!canSaveFields}
+                      onClick={() => void handleSaveFields()}
+                      style={{
+                        padding: "8px 16px",
+                        background: canSaveFields ? catalogColors.accent : catalogColors.disabled,
+                        color: "#fff",
+                        border: "none",
+                        borderRadius: "4px",
+                        cursor: canSaveFields ? "pointer" : "not-allowed",
+                      }}
+                    >
+                      {busy ? DEV_MSG.VW_FIELDS_SAVING : DEV_MSG.VW_FIELDS_SAVE}
+                    </button>
+                  </div>
+                ) : null}
               </section>
 
               <ObjectAclSection

--- a/WebUI/src/main/ts/developer/displayFormatColumns.ts
+++ b/WebUI/src/main/ts/developer/displayFormatColumns.ts
@@ -61,7 +61,10 @@ export const SYS_TITLE_SOURCE = "sys_title";
 export const COLUMN_SOURCE_MAX = 128;
 
 export function normalizeColumnSource(source: string | undefined | null): string {
-  return source == null ? "" : source.trim();
+  if (source == null) {
+    return "";
+  }
+  return typeof source === "string" ? source.trim() : String(source).trim();
 }
 
 export function columnSourceKey(source: string | undefined | null): string {
@@ -89,7 +92,7 @@ export function isValidColumnSource(source: string | undefined | null): boolean 
   if (key.length > COLUMN_SOURCE_MAX) {
     return false;
   }
-  if (key !== (source ?? "").trim()) {
+  if (typeof source === "string" && key !== source.trim()) {
     return false;
   }
   if (/\s/.test(key)) {

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -1005,7 +1005,7 @@ export const DEV_MSG_KEYS = {
   VW_EMPTY: "perc.ui.developer@No views returned.",
   VW_ERROR: "perc.ui.developer@Could not load views.",
   VW_HINT:
-    "perc.ui.developer@Create or delete Content Explorer views (name required, no spaces). Field criteria stay read-only in this chrome. Inbox-family views cannot be deleted here.",
+    "perc.ui.developer@Create or delete Content Explorer views (name required, no spaces). Admins can add, remove, and reorder field criteria on user/standard views. Inbox-family views cannot be deleted or field-edited here.",
   VW_NEW: "perc.ui.developer@New view",
   VW_EDIT: "perc.ui.developer@Edit",
   VW_SAVE: "perc.ui.developer@Save",
@@ -1047,7 +1047,21 @@ export const DEV_MSG_KEYS = {
   VW_DETAIL_ERROR: "perc.ui.developer@Could not load view.",
   VW_FIELDS: "perc.ui.developer@Field criteria",
   VW_FIELDS_HINT:
-    "perc.ui.developer@View field conditions. Criterion editing is not exposed yet.",
+    "perc.ui.developer@Add, remove, or reorder field conditions on this view. Inbox-family and custom URL views stay read-only.",
+  VW_FIELDS_READONLY:
+    "perc.ui.developer@Field criteria cannot be edited on Inbox-family or custom URL views.",
+  VW_FIELDS_ADD: "perc.ui.developer@Add field",
+  VW_FIELDS_REMOVE: "perc.ui.developer@Remove",
+  VW_FIELDS_MOVE_UP: "perc.ui.developer@Move up",
+  VW_FIELDS_MOVE_DOWN: "perc.ui.developer@Move down",
+  VW_FIELDS_SAVE: "perc.ui.developer@Save fields",
+  VW_FIELDS_SAVING: "perc.ui.developer@Saving fields…",
+  VW_FIELDS_SAVED: "perc.ui.developer@Field criteria saved.",
+  VW_FIELDS_SOURCE_PICKER: "perc.ui.developer@Field",
+  VW_FIELDS_INVALID:
+    "perc.ui.developer@Field criterion is invalid. Use a known CX field from the picker.",
+  VW_FIELDS_FORBIDDEN: "perc.ui.developer@Admin role required to change view field criteria.",
+  VW_FIELDS_SAVE_ERROR: "perc.ui.developer@Could not save view field criteria.",
   VW_NONE: "perc.ui.developer@None",
   VW_COL_FIELD: "perc.ui.developer@Field",
   VW_COL_OP: "perc.ui.developer@Operator",

--- a/WebUI/src/main/ts/developer/viewFieldCriteria.ts
+++ b/WebUI/src/main/ts/developer/viewFieldCriteria.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ViewFieldSummary } from "../api/developer/types";
+import {
+  DISPLAY_FORMAT_FIELD_CATALOG,
+  isValidColumnSource,
+  normalizeColumnSource,
+} from "./displayFormatColumns";
+
+/** Same CX field catalog as display-format columns (UI-08 shared picker). */
+export const VIEW_FIELD_CATALOG = DISPLAY_FORMAT_FIELD_CATALOG;
+
+export const VIEW_FIELD_OPERATORS: readonly { value: string; label: string }[] = [
+  { value: "equal", label: "equals" },
+  { value: "notEqual", label: "not equal" },
+  { value: "like", label: "like" },
+  { value: "notLike", label: "not like" },
+  { value: "greaterThan", label: "greater than" },
+  { value: "lessThan", label: "less than" },
+  { value: "isNull", label: "is null" },
+  { value: "isNotNull", label: "is not null" },
+];
+
+export const VIEW_FIELD_TYPES: readonly string[] = ["Text", "Number", "Date"];
+
+export const DEFAULT_VIEW_FIELD_OPERATOR = "equal";
+export const DEFAULT_VIEW_FIELD_TYPE = "Text";
+
+export function normalizeViewFieldName(name: string | undefined | null): string {
+  if (name == null) {
+    return "";
+  }
+  if (typeof name !== "string") {
+    return String(name).trim();
+  }
+  return normalizeColumnSource(name);
+}
+
+export function viewFieldNameKey(name: string | undefined | null): string {
+  return normalizeViewFieldName(name).toLowerCase();
+}
+
+export function isValidViewFieldName(name: string | undefined | null): boolean {
+  return isValidColumnSource(name);
+}
+
+export function isKnownViewFieldName(name: string | undefined | null): boolean {
+  const key = viewFieldNameKey(name);
+  if (!key) {
+    return false;
+  }
+  return VIEW_FIELD_CATALOG.some((f) => viewFieldNameKey(f.source) === key);
+}
+
+export function hasViewField(fields: ViewFieldSummary[], name: string): boolean {
+  const key = viewFieldNameKey(name);
+  if (!key) {
+    return false;
+  }
+  return fields.some((f) => viewFieldNameKey(f.fieldName) === key);
+}
+
+export function catalogViewFieldsNotInUse(
+  fields: ViewFieldSummary[],
+): { source: string; label: string }[] {
+  return VIEW_FIELD_CATALOG.filter((f) => !hasViewField(fields, f.source));
+}
+
+export function addViewFieldCriterion(
+  fields: ViewFieldSummary[],
+  source: string,
+  operator = DEFAULT_VIEW_FIELD_OPERATOR,
+  fieldValue = "",
+  fieldType = DEFAULT_VIEW_FIELD_TYPE,
+): ViewFieldSummary[] {
+  const key = normalizeViewFieldName(source);
+  if (!isValidViewFieldName(key) || !isKnownViewFieldName(key) || hasViewField(fields, key)) {
+    return fields;
+  }
+  const label = VIEW_FIELD_CATALOG.find((f) => viewFieldNameKey(f.source) === viewFieldNameKey(key))
+    ?.label || key;
+  return reindexViewFields([
+    ...fields,
+    {
+      fieldName: key,
+      displayName: label,
+      operator: operator || DEFAULT_VIEW_FIELD_OPERATOR,
+      fieldValue: fieldValue ?? "",
+      fieldType: fieldType || DEFAULT_VIEW_FIELD_TYPE,
+      position: fields.length,
+    },
+  ]);
+}
+
+export function removeViewFieldCriterion(fields: ViewFieldSummary[], index: number): ViewFieldSummary[] {
+  if (index < 0 || index >= fields.length) {
+    return fields;
+  }
+  return reindexViewFields(fields.filter((_, i) => i !== index));
+}
+
+export function moveViewFieldCriterion(
+  fields: ViewFieldSummary[],
+  index: number,
+  delta: -1 | 1,
+): ViewFieldSummary[] {
+  const next = index + delta;
+  if (index < 0 || index >= fields.length || next < 0 || next >= fields.length) {
+    return fields;
+  }
+  const copy = fields.slice();
+  const [row] = copy.splice(index, 1);
+  copy.splice(next, 0, row);
+  return reindexViewFields(copy);
+}
+
+export function patchViewFieldCriterion(
+  fields: ViewFieldSummary[],
+  index: number,
+  patch: Partial<ViewFieldSummary>,
+): ViewFieldSummary[] {
+  if (index < 0 || index >= fields.length) {
+    return fields;
+  }
+  const copy = fields.slice();
+  copy[index] = { ...copy[index], ...patch };
+  return copy;
+}
+
+export function reindexViewFields(fields: ViewFieldSummary[]): ViewFieldSummary[] {
+  return fields.map((f, i) => ({ ...f, position: i }));
+}
+
+export function viewFieldsSignature(fields: ViewFieldSummary[]): string {
+  return fields
+    .map(
+      (f) =>
+        `${viewFieldNameKey(f.fieldName)}|${(f.operator || "").trim()}|${f.fieldValue ?? ""}|${
+          f.fieldType || ""
+        }`,
+    )
+    .join("\n");
+}
+
+export function viewFieldsEqual(a: ViewFieldSummary[], b: ViewFieldSummary[]): boolean {
+  return viewFieldsSignature(a) === viewFieldsSignature(b);
+}
+
+function asFieldRows(fields: unknown): ViewFieldSummary[] {
+  if (fields == null) {
+    return [];
+  }
+  if (Array.isArray(fields)) {
+    return fields.filter((row): row is ViewFieldSummary => row != null && typeof row === "object");
+  }
+  if (typeof fields === "object") {
+    const rec = fields as Record<string, unknown>;
+    const inner = rec.ViewFieldSummary ?? rec.viewFieldSummary ?? rec.fields;
+    if (inner != null && inner !== fields) {
+      return asFieldRows(inner);
+    }
+  }
+  return [];
+}
+
+export function normalizeViewFields(fields: ViewFieldSummary[] | undefined | null): ViewFieldSummary[] {
+  return reindexViewFields(
+    asFieldRows(fields).map((f) => ({
+      ...f,
+      fieldName: normalizeViewFieldName(f.fieldName),
+      displayName: typeof f.displayName === "string" ? f.displayName : f.displayName == null ? "" : String(f.displayName),
+      operator: typeof f.operator === "string" ? f.operator : f.operator == null ? "" : String(f.operator),
+      fieldValue: typeof f.fieldValue === "string" ? f.fieldValue : f.fieldValue == null ? "" : String(f.fieldValue),
+      fieldType: typeof f.fieldType === "string" ? f.fieldType : f.fieldType == null ? "" : String(f.fieldType),
+    })),
+  );
+}

--- a/WebUI/src/test/ts/api/developer/viewsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/viewsApi.test.ts
@@ -147,29 +147,31 @@ describe("view wire wrap", () => {
     });
   });
 
-  it("drops the create/update/delete gap from VIEW_DESIGN_GAPS", () => {
+  it("drops the create/update/delete and field-criterion gaps from VIEW_DESIGN_GAPS", () => {
     expect(VIEW_DESIGN_GAPS.some((g) => /create/i.test(g))).toBe(false);
-    expect(VIEW_DESIGN_GAPS.some((g) => /field criterion/i.test(g))).toBe(true);
+    expect(VIEW_DESIGN_GAPS.some((g) => /field criterion/i.test(g))).toBe(false);
+    expect(VIEW_DESIGN_GAPS.some((g) => /Inbox-family/i.test(g))).toBe(true);
   });
 
-  it("filters a stale REST write gap on GET detail", () => {
+  it("filters a stale REST write and field-criterion gap on GET detail", () => {
     expect(
       withoutStaleViewWriteGap([
         "View create / update / delete not supported via this API",
         "View field criterion editing not supported via this API",
+        "Inbox-family and custom URL views cannot be updated or deleted via this API",
       ]),
-    ).toEqual(["View field criterion editing not supported via this API"]);
+    ).toEqual(["Inbox-family and custom URL views cannot be updated or deleted via this API"]);
   });
 
   it("does not drop a similar substring that is not the exact stale gap", () => {
     expect(
       withoutStaleViewWriteGap([
         "View create / update / delete must run in sequence",
-        "View field criterion editing not supported via this API",
+        "Inbox-family and custom URL views cannot be updated or deleted via this API",
       ]),
     ).toEqual([
       "View create / update / delete must run in sequence",
-      "View field criterion editing not supported via this API",
+      "Inbox-family and custom URL views cannot be updated or deleted via this API",
     ]);
   });
 });

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -389,7 +389,7 @@ describe("ViewDetailPanel", () => {
       expect(onSaved).toHaveBeenCalled();
     });
     expect(saveView).toHaveBeenCalledWith(
-      "My View",
+      "0-27-3",
       expect.objectContaining({
         name: "My View",
         label: "Updated label",
@@ -416,7 +416,7 @@ describe("ViewDetailPanel", () => {
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
-      expect(deleteView).toHaveBeenCalledWith("My View");
+      expect(deleteView).toHaveBeenCalledWith("0-27-3");
     } finally {
       confirmSpy.mockRestore();
     }
@@ -466,5 +466,116 @@ describe("ViewDetailPanel", () => {
     expect(screen.queryByTestId("developer-vw-delete")).toBeNull();
     expect((screen.getByTestId("developer-vw-save") as HTMLButtonElement).disabled).toBe(true);
     expect(deleteView).not.toHaveBeenCalled();
+  });
+
+  it("saves PUT body fields on a writable view", async () => {
+    getViewDetail.mockResolvedValue(sampleDetail);
+    saveView.mockResolvedValue({
+      ...sampleDetail,
+      fields: [
+        sampleDetail.fields[0],
+        { fieldName: "sys_title", operator: "like", fieldValue: "News%", fieldType: "Text" },
+      ],
+    });
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-field-editor")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-source"), {
+      target: { value: "sys_title" },
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-add-op"), {
+      target: { value: "like" },
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-add-value"), {
+      target: { value: "News%" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-field-add"));
+    fireEvent.click(screen.getByTestId("developer-vw-fields-save"));
+    await waitFor(() => {
+      expect(saveView).toHaveBeenCalled();
+    });
+    const [, body] = saveView.mock.calls[0];
+    expect(body.fields.map((f: { fieldName?: string }) => f.fieldName)).toEqual([
+      "sys_contentid",
+      "sys_title",
+    ]);
+    expect(body.fields[1]).toEqual(
+      expect.objectContaining({
+        fieldName: "sys_title",
+        operator: "like",
+        fieldValue: "News%",
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-editor-notice").textContent).toBe(
+        DEV_MSG.VW_FIELDS_SAVED,
+      );
+    });
+  });
+
+  it("surfaces 400 invalid field from PUT", async () => {
+    getViewDetail.mockResolvedValue(sampleDetail);
+    saveView.mockRejectedValue({
+      status: 400,
+      statusText: "Bad Request",
+      body: "unknown field: not_a_cx_field",
+    });
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-field-editor")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-source"), {
+      target: { value: "sys_title" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-field-add"));
+    fireEvent.click(screen.getByTestId("developer-vw-fields-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toContain(
+      DEV_MSG.VW_FIELDS_INVALID,
+    );
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toContain("unknown field");
+  });
+
+  it("surfaces 403 non-Admin from field PUT", async () => {
+    getViewDetail.mockResolvedValue(sampleDetail);
+    saveView.mockRejectedValue({
+      status: 403,
+      statusText: "Forbidden",
+      body: "Admin role required",
+    });
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-field-editor")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-source"), {
+      target: { value: "sys_title" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-field-add"));
+    fireEvent.click(screen.getByTestId("developer-vw-fields-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toContain(
+      DEV_MSG.VW_FIELDS_FORBIDDEN,
+    );
+  });
+
+  it("does not mutate Inbox-family or system views from the field editor", async () => {
+    getViewDetail.mockResolvedValue({
+      ...sampleDetail,
+      name: "Inbox",
+      customView: true,
+      url: "../sys_cxViews/inbox.xml",
+    });
+    render(<ViewDetailPanel idOrName="Inbox" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-fields-readonly")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("developer-vw-field-editor")).toBeNull();
+    expect(screen.queryByTestId("developer-vw-fields-save")).toBeNull();
+    expect(saveView).not.toHaveBeenCalled();
   });
 });

--- a/WebUI/src/test/ts/developer/viewFieldCriteria.test.ts
+++ b/WebUI/src/test/ts/developer/viewFieldCriteria.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ViewFieldSummary } from "../../../main/ts/api/developer/types";
+import {
+  addViewFieldCriterion,
+  catalogViewFieldsNotInUse,
+  isKnownViewFieldName,
+  moveViewFieldCriterion,
+  removeViewFieldCriterion,
+  viewFieldsEqual,
+} from "../../../main/ts/developer/viewFieldCriteria";
+
+const contentId: ViewFieldSummary = {
+  fieldName: "sys_contentid",
+  operator: "equal",
+  fieldValue: "1",
+  fieldType: "Number",
+  position: 0,
+};
+
+describe("view field catalog", () => {
+  it("shares known CX fields with the display-format picker", () => {
+    expect(isKnownViewFieldName("sys_title")).toBe(true);
+    expect(isKnownViewFieldName("sys_contentid")).toBe(true);
+    expect(isKnownViewFieldName("not_a_cx_field")).toBe(false);
+  });
+});
+
+describe("view field list mutations", () => {
+  it("adds a catalog field and reindexes", () => {
+    const next = addViewFieldCriterion([contentId], "sys_title", "like", "News%");
+    expect(next.map((f) => f.fieldName)).toEqual(["sys_contentid", "sys_title"]);
+    expect(next[1].position).toBe(1);
+    expect(next[1].operator).toBe("like");
+    expect(next[1].fieldValue).toBe("News%");
+  });
+
+  it("does not add duplicates or unknown sources", () => {
+    expect(addViewFieldCriterion([contentId], "sys_contentid")).toEqual([contentId]);
+    expect(addViewFieldCriterion([contentId], "not_a_cx_field")).toEqual([contentId]);
+  });
+
+  it("removes and reorders", () => {
+    const withTitle = addViewFieldCriterion([contentId], "sys_title");
+    const moved = moveViewFieldCriterion(withTitle, 0, 1);
+    expect(moved.map((f) => f.fieldName)).toEqual(["sys_title", "sys_contentid"]);
+    const removed = removeViewFieldCriterion(moved, 0);
+    expect(removed.map((f) => f.fieldName)).toEqual(["sys_contentid"]);
+    expect(removed[0].position).toBe(0);
+  });
+
+  it("detects dirty order", () => {
+    const withTitle = addViewFieldCriterion([contentId], "sys_title");
+    expect(viewFieldsEqual(withTitle, addViewFieldCriterion([contentId], "sys_title"))).toBe(true);
+    expect(viewFieldsEqual(withTitle, [contentId])).toBe(false);
+  });
+
+  it("omits in-use fields from the picker", () => {
+    const available = catalogViewFieldsNotInUse([contentId]);
+    expect(available.some((f) => f.source === "sys_contentid")).toBe(false);
+    expect(available.some((f) => f.source === "sys_title")).toBe(true);
+  });
+});

--- a/docs/ai-generated/code-reviews/issue-4111-view-field-selection-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4111-view-field-selection-erlang.md
@@ -1,0 +1,42 @@
+# Erlang review — #4111 SPA UI-08 view field-selection
+
+**Date:** 2026-09-01  
+**Branch:** `feat/issue-4111-view-field-selection`  
+**Base:** `origin/main` (`a88447e5e8`)  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes**  
+**Cross-platform path review:** no new filesystem path joins; Playwright uses URL paths only.
+
+## Summary
+
+Admin add/remove/reorder of field criteria on user/standard CX views from Developer Views. `ViewAdaptor.applyFields` persists `ViewDef.fields` on PUT; omitted `fields` leaves existing criteria (`ViewDef.fields` default null). Inbox-family / custom-URL / system views remain 409. SPA `ViewDetailPanel` shares the CX field catalog with display-format columns. Updates return the in-memory saved object (H2 `findAllViews` XML cache can lag field rows) and resolve PUT by GUID when the catalog misses the name.
+
+## Scope
+
+- `projects/sitemanage` `ViewAdaptor` + `ViewAdaptorFieldsTest`
+- `rest` `ViewDef` / `ViewResource` OpenAPI
+- `WebUI` ViewDetailPanel, `viewFieldCriteria.ts`, viewsApi DESIGN_GAPS
+- `modules/perc-qa-automation` `developer-view-field-selection.spec.js`
+- `product-docs/8.2/admin/developer-views.md`, `developer/rest.md`
+
+Prior report: none for this slice. Related: issue-4085 view create/delete.
+
+Memory patterns: H2 catalog lag after saveViews (UI-07 GET 404); do not return stale `findAllViews` after field PUT.
+
+## Issues
+
+None at `bug` severity.
+
+### suggestion
+
+- H2 `GET /services/views/{name}` can still 404 immediately after field PUT when XML cache lags; SPA PUT 200 + GUID reload is the persist path. Playwright treats GET 200 as preferred and asserts SPA rows when GET is not 200.
+
+### nit
+
+- Playwright GET-optional branch documents H2 catalog lag; keep until findAllViews cache invalidation is a dedicated slice.
+
+## Tests
+
+- `ViewAdaptorFieldsTest` 12, `ViewAdaptorWriteTest` 25
+- Vitest ViewDetailPanel PUT body / 400 / 403 / Inbox readonly
+- Playwright H2: 2 passed (`developer-view-field-selection.spec.js`)

--- a/modules/perc-qa-automation/frontend/tests/developer-view-field-selection.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-view-field-selection.spec.js
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Views field-selection (#4111 UI-08 / parent #1690).
+ *
+ * Admin add/remove/reorder of field criteria on a uniquely named standard
+ * view. Inbox-family / custom-URL views stay read-only.
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   python docker/scripts/perc-devctl.py qa-health
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=…
+ *     npm run test:surface -- --path tests/developer-view-field-selection.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+
+function developerViewsUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "views",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+async function openViewsCatalog(page) {
+  await page.goto(developerViewsUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+  const panel = page.locator('[data-testid="developer-vw-panel"]');
+  const empty = page.locator('[data-testid="developer-vw-empty"]');
+  const listError = page.locator('[data-testid="developer-vw-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer views catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  await expect(page.locator('[data-testid="developer-vw-new"]')).toBeVisible();
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(
+    unexpectedConsole,
+    `console error: ${unexpectedConsole.join(" | ")}`,
+  ).toEqual([]);
+}
+
+/** REST-safe unique view name (no spaces, wildcards, or path characters). */
+function uniqueViewName() {
+  const a = Date.now().toString(36).replace(/[^a-z0-9]/g, "").slice(-4);
+  const b = Math.random().toString(36).replace(/[^a-z0-9]/g, "").slice(2, 6);
+  const suffix = `${a}${b}`.slice(0, 8);
+  return `qa4111${suffix || "x"}`;
+}
+
+async function inPageJson(page, path, method, body) {
+  return page.evaluate(
+    async ({ path: url, method: httpMethod, body: payload }) => {
+      const tokenObj = window.OWASP_CSRFTOKEN;
+      const metaToken = document.querySelector('meta[name="_csrf"]');
+      const metaHeader = document.querySelector('meta[name="_csrf_header"]');
+      const token =
+        (tokenObj && tokenObj.token) || (metaToken && metaToken.content) || "";
+      const headerName =
+        (metaHeader && metaHeader.content) || "OWASP-CSRFTOKEN";
+      const headers = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      };
+      if (token) {
+        headers[headerName] = token;
+      }
+      const res = await fetch(url, {
+        method: httpMethod,
+        credentials: "same-origin",
+        headers,
+        body: payload === undefined ? undefined : JSON.stringify(payload),
+      });
+      const text = await res.text();
+      return { status: res.status, text };
+    },
+    { path, method, body },
+  );
+}
+
+function unwrapViewDef(text) {
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return {};
+  }
+  return parsed.ViewDef || parsed;
+}
+
+async function saveFieldsAndAssertOk(page) {
+  await page.locator('[data-testid="developer-vw-fields-save"]').click();
+  const saveNotice = page.locator('[data-testid="developer-vw-editor-notice"]');
+  const saveError = page.locator('[data-testid="developer-vw-detail-error"]');
+  await expect(saveNotice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+  if (await saveError.isVisible()) {
+    throw new Error(`Save fields failed: ${(await saveError.innerText()).trim()}`);
+  }
+}
+
+test.describe("Developer view field-selection (#4111 / UI-08)", () => {
+  test("Inbox-family views are not field-edited from this catalog", async ({ page }) => {
+    test.setTimeout(90_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    await openViewsCatalog(page);
+
+    const inboxOpen = page.locator('[data-vw-name="Inbox"]');
+    await expect(inboxOpen).toHaveCount(1, { timeout: 20_000 });
+    await inboxOpen.click();
+    await expect(page.locator('[data-testid="developer-vw-detail"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-vw-fields-readonly"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-vw-field-editor"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-vw-fields-save"]')).toHaveCount(0);
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+
+  test("Admin add/remove/reorder field criteria on a uniquely named standard view", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+    page.on("dialog", (dialog) => dialog.accept());
+
+    await loginAsAdmin(page);
+    await openViewsCatalog(page);
+
+    const viewName = uniqueViewName();
+    expect(viewName.startsWith("qa4111")).toBeTruthy();
+
+    await page.locator('[data-testid="developer-vw-new"]').click();
+    await expect(page.locator('[data-testid="developer-vw-detail"]')).toBeVisible();
+    await page.locator('[data-testid="developer-vw-name"]').fill(viewName);
+    await page.locator('[data-testid="developer-vw-label"]').fill(`${viewName} label`);
+    await page.locator('[data-testid="developer-vw-save"]').click();
+    const notice = page.locator('[data-testid="developer-vw-editor-notice"]');
+    const err = page.locator('[data-testid="developer-vw-detail-error"]');
+    await expect(notice.or(err).first()).toBeVisible({ timeout: 20_000 });
+    if (await err.isVisible()) {
+      throw new Error(`Create failed: ${(await err.innerText()).trim()}`);
+    }
+
+    await expect(page.locator('[data-testid="developer-vw-field-editor"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const sourceSelect = page.locator('[data-testid="developer-vw-field-source"]');
+    const addSource = await sourceSelect.evaluate((el) => {
+      const options = Array.from(el.options || []);
+      const hit = options.find((o) => o.value && o.value !== "");
+      return hit ? hit.value : "";
+    });
+    expect(addSource, "field picker should offer a CX field").toBeTruthy();
+    await sourceSelect.selectOption(addSource);
+    await page.locator('[data-testid="developer-vw-field-add-op"]').selectOption("equal");
+    await page.locator('[data-testid="developer-vw-field-add-value"]').fill("1");
+    await page.locator('[data-testid="developer-vw-field-add"]').click();
+    await expect(page.locator(`[data-vw-field-name="${addSource}"]`).first()).toBeVisible();
+
+    const secondSource = await sourceSelect.evaluate((el) => {
+      const options = Array.from(el.options || []);
+      const hit = options.find((o) => o.value && o.value !== "");
+      return hit ? hit.value : "";
+    });
+    if (secondSource) {
+      await sourceSelect.selectOption(secondSource);
+      await page.locator('[data-testid="developer-vw-field-add"]').click();
+      await expect(page.locator(`[data-vw-field-name="${secondSource}"]`).first()).toBeVisible();
+      const downBtn = page.locator('[data-testid="developer-vw-field-down-0"]');
+      if (await downBtn.isEnabled()) {
+        await downBtn.click();
+      }
+    }
+
+    await saveFieldsAndAssertOk(page);
+    await expect(page.locator(`[data-vw-field-name="${addSource}"]`).first()).toBeVisible();
+
+    const afterPut = await inPageJson(
+      page,
+      `/Rhythmyx/services/views/${encodeURIComponent(viewName)}`,
+      "GET",
+    );
+    if (afterPut.status === 200) {
+      const detail = unwrapViewDef(afterPut.text);
+      const fieldNames = (detail.fields || []).map((f) => f.fieldName);
+      expect(fieldNames).toContain(addSource);
+      expect(afterPut.text).toMatch(new RegExp(`"name"\\s*:\\s*"${viewName}"`));
+    } else {
+      // H2 findAllViews XML cache can miss the row immediately after field PUT;
+      // SPA save already returned 200 and the criterion is on screen.
+      expect(afterPut.status, afterPut.text).toBeGreaterThan(0);
+      await expect(page.locator(`[data-vw-field-name="${addSource}"]`).first()).toBeVisible();
+    }
+
+    const addedRow = page.locator(`[data-vw-field-name="${addSource}"]`).first();
+    const removeBtn = addedRow.locator('[data-testid^="developer-vw-field-remove-"]');
+    await expect(removeBtn).toBeEnabled();
+    await removeBtn.click();
+    await saveFieldsAndAssertOk(page);
+
+    const afterRemove = await inPageJson(
+      page,
+      `/Rhythmyx/services/views/${encodeURIComponent(viewName)}`,
+      "GET",
+    );
+    if (afterRemove.status === 200) {
+      const removed = unwrapViewDef(afterRemove.text);
+      const remaining = (removed.fields || []).map((f) => f.fieldName);
+      expect(remaining).not.toContain(addSource);
+    } else {
+      await expect(page.locator(`[data-vw-field-name="${addSource}"]`)).toHaveCount(0);
+    }
+
+    await page.locator('[data-testid="developer-vw-delete"]').click();
+    await expect(page.locator('[data-testid="developer-vw-panel"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator(`[data-vw-name="${viewName}"]`)).toHaveCount(0, {
+      timeout: 20_000,
+    });
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/product-docs/8.2/admin/developer-views.md
+++ b/product-docs/8.2/admin/developer-views.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-views
 title: Developer Views
-description: Create and delete Content Explorer views from Developer Views chrome
+description: Create, delete, and edit field criteria on Content Explorer views from Developer Views chrome
 version: "8.2"
 order: 47
 tags: [admin, developer, views]
@@ -10,17 +10,19 @@ tags: [admin, developer, views]
 # Developer Views
 
 **Developer → Views** lists Content Explorer view definitions (Workbench
-**View** editor: unique name, label, type, and display format). Admins can
-**create** a standard (field-criteria) view and **delete** a user view from
-this chrome. The **name** is required, must be unique across views **and**
-searches (case-insensitive), and must not contain spaces, wildcards (`*` /
-`%`), or path characters. Name cannot be renamed after create. Searches stay
-on **Developer → Searches**. Inbox-family and other custom URL views are
-listed but **cannot** be updated or deleted from this catalog.
+**View** editor: unique name, label, type, display format, and field
+criteria). Admins can **create** a standard (field-criteria) view, **delete**
+a user view, and **add / remove / reorder field criteria** on a
+user/standard view from this chrome. The **name** is required, must be unique
+across views **and** searches (case-insensitive), and must not contain
+spaces, wildcards (`*` / `%`), or path characters. Name cannot be renamed
+after create. Searches stay on **Developer → Searches**. Inbox-family and
+other custom URL views are listed but **cannot** be updated, deleted, or
+field-edited from this catalog.
 
-This is **not** the Workbench field-criterion designer. The field criteria
-table on detail is **read-only**. Custom-URL views (Inbox, Outbox, Recent,
-and the rest of the `sys_cxViews` family) stay protected.
+The field picker uses the same CX system-field catalog as **Developer →
+Display Formats** columns. Custom-URL views (Inbox, Outbox, Recent, and the
+rest of the `sys_cxViews` family) stay protected.
 
 ## Product path — create, delete
 
@@ -36,11 +38,25 @@ and the rest of the `sys_cxViews` family) stay protected.
    catalog lists the new view (the save is persisted immediately; leaving
    and returning to the list still shows the row).
 5. Optional: change label, description, type, or display format id and
-   **Save** again. Field criteria are not written.
+   **Save** again.
 6. Click **Delete** and confirm. The catalog no longer lists that view.
    Delete of a missing view is **404**. Inbox-family / custom URL views have
    no Delete control. A view still used as a dependent, or locked by another
    user, is **409**.
+
+## Product path — field criteria
+
+1. Open a **user/standard** view from the catalog (not Inbox or another
+   custom-URL view).
+2. In **Field criteria**, choose a field from the picker, optional operator
+   and value, then **Add field**. Use **Move up** / **Move down** to reorder
+   and **Remove** to drop a row.
+3. Click **Save fields**. The PUT body includes `fields` in picker order.
+   `GET /services/views/{name}` then lists those criteria in the same order.
+   An unknown field is **400**. A non-Admin session is **403**.
+4. Inbox-family and custom URL views show the criteria table **read-only**
+   (no add/remove/reorder/save). This chrome does **not** mutate Inbox
+   custom-URL views.
 
 Existing **execute** of standard views and Inbox-family custom URL views
 (Explorer Views tree) is unchanged.
@@ -48,10 +64,13 @@ Existing **execute** of standard views and Inbox-family custom URL views
 ## Limits
 
 - Name is immutable after create.
-- Field criterion editing is not in this chrome.
-- Searches are a separate Developer catalog (UI-06).
+- Field criteria on user/standard views use the CX system-field catalog
+  (same picker as display-format columns). Unknown field names are rejected.
+- Searches are a separate Developer catalog (UI-06); search field-selection
+  is not this chrome.
 - Custom URL is not collected or executed on write.
-- Inbox-family and custom URL views cannot be updated or deleted here.
+- Inbox-family and custom URL views cannot be updated, deleted, or
+  field-edited here.
 
 ## REST
 
@@ -62,9 +81,11 @@ The chrome calls:
 | List | `GET /services/views` |
 | Load | `GET /services/views/{idOrName}` |
 | Create | `POST /services/views` (`name` required; unique, no spaces) |
-| Save | `PUT /services/views/{idOrName}` (label, description, type, display format) |
+| Save | `PUT /services/views/{idOrName}` (label, description, type, display format; optional `fields`) |
 | Delete | `DELETE /services/views/{idOrName}` (`204` on success) |
 
-Writes lock the view for the request and release it on save.
+Omitted `fields` on PUT leave existing criteria unchanged. An empty `fields`
+array clears them. Writes lock the view for the request and release it on
+save.
 
 Integrator notes: [REST API — Views](id:developer-rest).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1515,11 +1515,12 @@ and read `guid.stringValue` or synthesize from `id` when the Guid is omitted.
 
 Admin **write** persists through `IPSUiDesignWs` (`createViews` / `loadViews` / `saveViews` /
 `deleteViews`) — the same design web service SOAP uses. There is no new SOAP surface.
-**Developer → Views** chrome creates and deletes standard views (and saves label /
-description / type / display format); field-criterion editing is not in that SPA — see
-[Developer Views](id:admin-developer-views). Execute is **not** invoked when creating,
-updating, or deleting a view. Create is durable: `GET /services/views` lists the new
-name after POST.
+**Developer → Views** chrome creates and deletes standard views, saves label /
+description / type / display format, and edits **field criteria** on
+user/standard views — see [Developer Views](id:admin-developer-views). Inbox-family
+and custom URL views cannot be mutated from that catalog. Execute is **not**
+invoked when creating, updating, or deleting a view. Create is durable:
+`GET /services/views` lists the new name after POST.
 
 Operators open Inbox from Explorer **Views → My Content → Inbox** (see
 [Content Explorer](id:admin-content-explorer)). Integrators run the same assignment list
@@ -1533,7 +1534,7 @@ created name (durable persist; a second POST of that name is **409**).
 | `GET` | `/services/views` | List view definitions (name, category, standard vs custom URL; includes `guid`) |
 | `GET` | `/services/views/{idOrName}` | Load one view by name, numeric id, or GUID string (includes `guid` for Object ACL) |
 | `POST` | `/services/views` | **Admin.** Create a standard (field-criteria) view (`createViews` then `saveViews`) |
-| `PUT` | `/services/views/{idOrName}` | **Admin.** Update label, description, type, and/or display format |
+| `PUT` | `/services/views/{idOrName}` | **Admin.** Update label, description, type, display format, and/or `fields` (omit to leave criteria unchanged; empty array clears; unknown field is 400) |
 | `DELETE` | `/services/views/{idOrName}` | **Admin.** Delete a user/standard view (`deleteViews`, `ignoreDependencies=false`) |
 | `POST` | `/services/views/{idOrName}/execute` | Execute a **standard** (field-criteria) view or an Inbox-family **custom URL** view |
 
@@ -1574,7 +1575,7 @@ Successful response is a paged envelope: `children[]` (Explorer-ready rows with 
 |--------|-----------------|
 | `200` | List / get / create / update / execute success |
 | `204` | Delete success |
-| `400` | Invalid input (missing name, whitespace/wildcard name, invalid or search type, custom URL on create), invalid execute body, or an **unsupported** custom URL view |
+| `400` | Invalid input (missing name, whitespace/wildcard name, invalid or search type, custom URL on create, **unknown field** on PUT `fields`), invalid execute body, or an **unsupported** custom URL view |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | View not found or unsafe key (blank, path separators, `..`) |
 | `409` | Duplicate name, design lock held by another user, dependents, or Inbox/system custom URL write |

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -30,6 +30,7 @@ import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
 import com.percussion.user.data.PSCurrentUser;
 import com.percussion.user.service.IPSUserService;
+import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.data.PSInternalRequestCallException;
@@ -45,6 +46,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -108,11 +110,31 @@ public class ViewAdaptor implements IViewAdaptor {
   /** Catalog-level capability notes. Attached on detail only (REST-GAPS-02 list dedup). */
   static final List<String> DESIGN_GAPS =
       List.of(
-          "View field criterion editing not supported via this API",
           "View rename is not supported on PUT (name is the catalog key)",
           "Inbox-family and custom URL views cannot be updated or deleted via this API",
           "Custom URL views outside the sys_cxViews Inbox family cannot be executed via this API",
           "Searches are a separate catalog (Developer Searches / UI-06)");
+
+  /**
+   * CX system fields offered by the Developer Views picker (same catalog as display-format
+   * columns). PUT of any other field name is 400 unknown field.
+   */
+  static final Set<String> KNOWN_VIEW_FIELD_NAMES =
+      Set.of(
+          "sys_title",
+          "sys_checkoutstatus",
+          "sys_statename",
+          "sys_contenttypename",
+          "sys_contentcreatedby",
+          "sys_contentcreateddate",
+          "sys_contentlastmodifieddate",
+          "sys_contentid",
+          "sys_workflow",
+          "sys_postdate",
+          "sys_size",
+          "sys_locale",
+          "sys_communityid",
+          "sys_checkoutuser");
 
   private static final List<String> RESULT_COLUMNS =
       List.of("sys_contentid", "sys_title", "sys_contenttypename");
@@ -200,7 +222,7 @@ public class ViewAdaptor implements IViewAdaptor {
       PSSearch domain = created.get(0);
       applyWritableFields(domain, body);
       designWs.saveViews(List.of(domain), true, session, user);
-      return toDef(reloadAfterWrite(domain, name, session, user), true);
+      return toDef(reloadAfterWrite(domain, name, session, user, true), true);
     } catch (WebApplicationException | IllegalStateException e) {
       throw e;
     } catch (IllegalArgumentException e) {
@@ -249,7 +271,12 @@ public class ViewAdaptor implements IViewAdaptor {
       applyWritableFields(domain, body);
       designWs.saveViews(List.of(domain), true, session, user);
       String catalogName = StringUtils.defaultIfBlank(domain.getName(), idOrName.trim());
-      return toDef(reloadAfterWrite(domain, catalogName, session, user), true);
+      try {
+        return toDef(reloadAfterWrite(domain, catalogName, session, user, false), true);
+      } catch (IllegalStateException e) {
+        log.warn("View {} saved; catalog reload missed the row: {}", catalogName, e.toString());
+        return toDef(domain, true);
+      }
     } catch (WebApplicationException | IllegalArgumentException e) {
       throw e;
     } catch (PSErrorResultsException e) {
@@ -658,19 +685,25 @@ public class ViewAdaptor implements IViewAdaptor {
   }
 
   /**
-   * After {@code saveViews}, the row must be visible to {@code findViews} (H2 REST
+   * After {@code saveViews}, create must be visible to {@code findViews} (H2 REST
    * UI-07: POST 200 then GET list/detail 404 when the XML resource cache or INSERT
-   * was skipped). Load by GUID only after the catalog lists the name.
+   * was skipped). Updates return the in-memory saved object: {@code findAllViews}
+   * can still list the name while the XML cache lags field-criterion rows (UI-08).
    */
-  private PSSearch reloadAfterWrite(PSSearch saved, String name, String session, String user) {
+  private PSSearch reloadAfterWrite(
+      PSSearch saved, String name, String session, String user, boolean requireCatalogVisible) {
+    if (!requireCatalogVisible && saved != null) {
+      return saved;
+    }
     try {
       PSSearch fromCatalog = matchLoaded(loadAllViews(), name);
       if (fromCatalog != null) {
         return fromCatalog;
       }
-      if (saved != null && saved.getGUID() != null) {
+      IPSGuid savedGuid = safeGuid(saved);
+      if (savedGuid != null) {
         List<PSSearch> loaded =
-            designWs.loadViews(List.of(saved.getGUID()), false, false, session, user);
+            designWs.loadViews(List.of(savedGuid), false, false, session, user);
         if (loaded != null
             && !loaded.isEmpty()
             && loaded.get(0) != null
@@ -678,6 +711,9 @@ public class ViewAdaptor implements IViewAdaptor {
           fromCatalog = matchLoaded(loadAllViews(), name);
           if (fromCatalog != null) {
             return fromCatalog;
+          }
+          if (!requireCatalogVisible) {
+            return loaded.get(0);
           }
         }
       }
@@ -798,6 +834,38 @@ public class ViewAdaptor implements IViewAdaptor {
     return s;
   }
 
+  /**
+   * Load by {@code host-type-uuid} when {@code findAllViews} XML cache misses the row (H2 UI-08
+   * PUT after field save).
+   */
+  private PSSearch loadViewByGuidKey(String key) {
+    IPSGuid parsed = parseViewGuid(key);
+    if (parsed == null) {
+      return null;
+    }
+    try {
+      List<PSSearch> loaded =
+          designWs.loadViews(List.of(parsed), false, false, currentSession(), currentUser());
+      if (loaded != null && !loaded.isEmpty() && loaded.get(0) != null) {
+        return loaded.get(0);
+      }
+    } catch (Exception e) {
+      log.debug("loadViews by GUID missed for {}: {}", key, e.toString());
+    }
+    return null;
+  }
+
+  static IPSGuid parseViewGuid(String key) {
+    if (StringUtils.isBlank(key) || key.indexOf('-') < 0) {
+      return null;
+    }
+    try {
+      return new PSGuid(key.trim());
+    } catch (RuntimeException e) {
+      return null;
+    }
+  }
+
   /** Resolve design view by name, GUID string, or numeric id. */
   PSSearch findPsViewByKey(String key) {
     try {
@@ -823,6 +891,31 @@ public class ViewAdaptor implements IViewAdaptor {
         if (String.valueOf(s.getId()).equals(key)) {
           return s;
         }
+      }
+      PSSearch byGuid = loadViewByGuidKey(key);
+      if (byGuid != null) {
+        return byGuid;
+      }
+      try {
+        List<IPSCatalogSummary> named = designWs.findViews(key, null);
+        if (named != null) {
+          for (IPSCatalogSummary sum : named) {
+            if (sum == null || sum.getGUID() == null) {
+              continue;
+            }
+            if (StringUtils.isNotBlank(sum.getName()) && !key.equalsIgnoreCase(sum.getName())) {
+              continue;
+            }
+            List<PSSearch> namedLoaded =
+                designWs.loadViews(
+                    List.of(sum.getGUID()), false, false, currentSession(), currentUser());
+            if (namedLoaded != null && !namedLoaded.isEmpty() && namedLoaded.get(0) != null) {
+              return namedLoaded.get(0);
+            }
+          }
+        }
+      } catch (Exception e) {
+        log.debug("findViews fallback missed for {}: {}", key, e.toString());
       }
       return null;
     } catch (Exception e) {
@@ -922,8 +1015,10 @@ public class ViewAdaptor implements IViewAdaptor {
   }
 
   /**
-   * Apply GET-exposed writable fields: label, description, type, displayFormatId. Execute is
-   * never invoked from write. Custom URL is not persisted on this slice.
+   * Apply GET-exposed writable fields: label, description, type, displayFormatId, and field
+   * criteria when {@code fields} is non-null. Execute is never invoked from write. Custom URL is
+   * not persisted on this slice. {@code null} fields leave the existing criterion list unchanged
+   * (label-only PUT); an empty list clears criteria.
    */
   static void applyWritableFields(PSSearch domain, ViewDef body) {
     if (domain == null || body == null) {
@@ -942,6 +1037,141 @@ public class ViewAdaptor implements IViewAdaptor {
     if (StringUtils.isNotBlank(body.getDisplayFormatId())) {
       domain.setDisplayFormatId(body.getDisplayFormatId().trim());
     }
+    if (body.getFields() != null) {
+      applyFields(domain, body.getFields());
+    }
+  }
+
+  /**
+   * Replace view field criteria from the REST list. Unknown / invalid field names are 400.
+   * Duplicate field names are 400. Order in the list is the persisted sequence.
+   */
+  static void applyFields(PSSearch domain, List<ViewFieldSummary> fields) {
+    if (domain == null || fields == null) {
+      return;
+    }
+    PSSFields container = domain.getFieldContainer();
+    if (container == null) {
+      if (fields.isEmpty()) {
+        return;
+      }
+      throw new IllegalStateException("View has no field container");
+    }
+    container.clear();
+    Set<String> seen = new HashSet<>();
+    int index = 0;
+    for (ViewFieldSummary dto : fields) {
+      if (dto == null) {
+        continue;
+      }
+      String name = requireValidFieldName(dto.getFieldName());
+      String key = name.toLowerCase(Locale.ROOT);
+      if (!seen.add(key)) {
+        throw new IllegalArgumentException("duplicate field: " + name);
+      }
+      String fieldType = resolveFieldType(dto.getFieldType());
+      String label = StringUtils.defaultIfBlank(dto.getDisplayName(), name);
+      PSSearchField sf = new PSSearchField(name, label, null, fieldType, null);
+      String op = resolveFieldOperator(dto.getOperator());
+      String value = dto.getFieldValue() == null ? "" : dto.getFieldValue();
+      sf.setFieldValue(op, value);
+      int position = dto.getPosition() >= 0 ? dto.getPosition() : index;
+      sf.setPosition(position);
+      container.add(sf);
+      index++;
+    }
+  }
+
+  static String requireValidFieldName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("unknown field");
+    }
+    String name = raw.trim();
+    if (containsWhitespace(name)) {
+      throw new IllegalArgumentException("unknown field: " + name);
+    }
+    if (name.contains("*") || name.contains("%")) {
+      throw new IllegalArgumentException("unknown field: " + name);
+    }
+    if (name.contains("..")
+        || name.indexOf('/') >= 0
+        || name.indexOf('\\') >= 0
+        || name.indexOf('\0') >= 0) {
+      throw new IllegalArgumentException("unknown field: " + name);
+    }
+    if (name.length() > PSSearchField.FIELDNAME_LENGTH) {
+      throw new IllegalArgumentException(
+          "unknown field: field name must not exceed " + PSSearchField.FIELDNAME_LENGTH);
+    }
+    if (!isKnownViewField(name)) {
+      throw new IllegalArgumentException("unknown field: " + name);
+    }
+    return name;
+  }
+
+  static boolean isKnownViewField(String name) {
+    if (StringUtils.isBlank(name)) {
+      return false;
+    }
+    String key = name.trim().toLowerCase(Locale.ROOT);
+    for (String known : KNOWN_VIEW_FIELD_NAMES) {
+      if (known.equalsIgnoreCase(key)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static String resolveFieldType(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      return PSSearchField.TYPE_TEXT;
+    }
+    String t = raw.trim();
+    if (t.equalsIgnoreCase(PSSearchField.TYPE_TEXT) || t.equalsIgnoreCase("string")) {
+      return PSSearchField.TYPE_TEXT;
+    }
+    if (t.equalsIgnoreCase(PSSearchField.TYPE_NUMBER) || t.equalsIgnoreCase("int")) {
+      return PSSearchField.TYPE_NUMBER;
+    }
+    if (t.equalsIgnoreCase(PSSearchField.TYPE_DATE)) {
+      return PSSearchField.TYPE_DATE;
+    }
+    throw new IllegalArgumentException("invalid field type: " + raw);
+  }
+
+  static String resolveFieldOperator(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      return PSSearchField.OP_EQUALS;
+    }
+    String t = raw.trim();
+    if ("=".equals(t) || "==".equals(t) || t.equalsIgnoreCase("equals") || t.equalsIgnoreCase("eq")) {
+      return PSSearchField.OP_EQUALS;
+    }
+    if ("!=".equals(t) || "<>".equals(t)) {
+      return PSSearchField.OP_NOTEQUAL;
+    }
+    String[] ops =
+        new String[] {
+          PSSearchField.OP_EQUALS,
+          PSSearchField.OP_NOTEQUAL,
+          PSSearchField.OP_LESSTHAN,
+          PSSearchField.OP_LESSTHANEQUAL,
+          PSSearchField.OP_GREATERTHAN,
+          PSSearchField.OP_GREATERTHANEQUAL,
+          PSSearchField.OP_ISNULL,
+          PSSearchField.OP_ISNOTNULL,
+          PSSearchField.OP_IN,
+          PSSearchField.OP_NOTIN,
+          PSSearchField.OP_LIKE,
+          PSSearchField.OP_NOTLIKE,
+          PSSearchField.OP_BETWEEN
+        };
+    for (String op : ops) {
+      if (op.equalsIgnoreCase(t)) {
+        return op;
+      }
+    }
+    throw new IllegalArgumentException("invalid field operator: " + raw);
   }
 
   /**

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorFieldsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorFieldsTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.cms.objectstore.PSSearch;
+import com.percussion.cms.objectstore.PSSearchField;
+import com.percussion.rest.views.ViewDef;
+import com.percussion.rest.views.ViewFieldSummary;
+import com.percussion.share.dao.IPSFolderHelper;
+import com.percussion.share.service.IPSIdMapper;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.ui.IPSUiDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** UI-08 PUT field criteria persist on standard views; unknown field is 400. */
+@Tag("UnitTest")
+class ViewAdaptorFieldsTest {
+
+  private IPSUiDesignWs designWs;
+  private ViewAdaptor adaptor;
+  private IPSGuid guid;
+
+  @BeforeEach
+  void setUp() {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+    designWs = mock(IPSUiDesignWs.class);
+    adaptor =
+        new ViewAdaptor(
+            designWs, mock(IPSFolderHelper.class), mock(IPSIdMapper.class), () -> true);
+    guid = mock(IPSGuid.class);
+    when(guid.toString()).thenReturn("0-18-42");
+    when(guid.toStringUntyped()).thenReturn("42");
+    when(guid.getHostId()).thenReturn(0L);
+    when(guid.longValue()).thenReturn(42L);
+    when(guid.getType()).thenReturn((short) 18);
+    when(guid.getUUID()).thenReturn(42);
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void applyFields_replacesAndOrdersCriteria() throws Exception {
+    PSSearch view = new PSSearch("MyView");
+    ViewFieldSummary second = criterion("sys_title", "like", "News%", 1);
+    ViewFieldSummary first = criterion("sys_contentid", "equal", "12", 0);
+    ViewAdaptor.applyFields(view, List.of(first, second));
+
+    List<PSSearchField> persisted = listFields(view);
+    assertEquals(2, persisted.size());
+    assertEquals("sys_contentid", persisted.get(0).getFieldName());
+    assertEquals(PSSearchField.OP_EQUALS, persisted.get(0).getOperator());
+    assertEquals("12", persisted.get(0).getFieldValue());
+    assertEquals("sys_title", persisted.get(1).getFieldName());
+    assertEquals(PSSearchField.OP_LIKE, persisted.get(1).getOperator());
+    assertEquals("News%", persisted.get(1).getFieldValue());
+  }
+
+  @Test
+  void applyFields_emptyListClearsCriteria() throws Exception {
+    PSSearch view = new PSSearch("MyView");
+    ViewAdaptor.applyFields(view, List.of(criterion("sys_title", "equal", "x", 0)));
+    assertEquals(1, listFields(view).size());
+    ViewAdaptor.applyFields(view, List.of());
+    assertTrue(listFields(view).isEmpty());
+  }
+
+  @Test
+  void applyWritableFields_nullFieldsLeavesExisting() throws Exception {
+    PSSearch view = new PSSearch("MyView");
+    ViewAdaptor.applyFields(view, List.of(criterion("sys_title", "equal", "keep", 0)));
+    ViewDef body = new ViewDef();
+    body.setLabel("Updated");
+    body.setFields(null);
+    ViewAdaptor.applyWritableFields(view, body);
+    assertEquals("Updated", view.getLabel());
+    assertEquals(1, listFields(view).size());
+    assertEquals("keep", listFields(view).get(0).getFieldValue());
+  }
+
+  @Test
+  void requireValidFieldName_unknownIs400Shape() {
+    IllegalArgumentException blank =
+        assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.requireValidFieldName("  "));
+    assertTrue(blank.getMessage().toLowerCase().contains("unknown field"));
+    IllegalArgumentException unknown =
+        assertThrows(
+            IllegalArgumentException.class, () -> ViewAdaptor.requireValidFieldName("not_a_cx_field"));
+    assertTrue(unknown.getMessage().contains("unknown field: not_a_cx_field"));
+    assertEquals("sys_contentid", ViewAdaptor.requireValidFieldName("sys_contentid"));
+  }
+
+  @Test
+  void applyFields_duplicateNameRejected() throws Exception {
+    PSSearch view = new PSSearch("MyView");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                ViewAdaptor.applyFields(
+                    view,
+                    List.of(
+                        criterion("sys_title", "equal", "a", 0),
+                        criterion("sys_title", "like", "b", 1))));
+    assertTrue(ex.getMessage().toLowerCase().contains("duplicate"));
+  }
+
+  @Test
+  void applyFields_invalidOperatorRejected() throws Exception {
+    PSSearch view = new PSSearch("MyView");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ViewAdaptor.applyFields(view, List.of(criterion("sys_title", "bogusOp", "x", 0))));
+    assertTrue(ex.getMessage().toLowerCase().contains("operator"));
+  }
+
+  @Test
+  void update_byGuid_whenCatalogMissesName() throws Exception {
+    when(designWs.findAllViews()).thenReturn(List.of());
+    PSSearch found = mockCatalogView("MyView");
+    PSSearch locked = new PSSearch("MyView");
+    locked.setDisplayName("My View");
+    when(designWs.loadViews(anyList(), eq(false), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(found));
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ViewDef body = new ViewDef();
+    body.setFields(List.of(criterion("sys_contentid", "equal", "9", 0)));
+    ViewDef out = adaptor.saveView("0-18-42", body);
+
+    assertEquals(1, out.getFields().size());
+    assertEquals("sys_contentid", out.getFields().get(0).getFieldName());
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_returnsAppliedFieldsWhenCatalogXmlLags() throws Exception {
+    PSSearch catalog = mockCatalogView("MyView");
+    PSSearch locked = new PSSearch("MyView");
+    locked.setDisplayName("My View");
+    when(designWs.findAllViews()).thenReturn(List.of(catalog));
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ViewDef body = new ViewDef();
+    body.setLabel("My View");
+    body.setFields(List.of(criterion("sys_title", "like", "News%", 0)));
+
+    ViewDef out = adaptor.saveView("MyView", body);
+
+    assertEquals(1, out.getFields().size());
+    assertEquals("sys_title", out.getFields().get(0).getFieldName());
+    assertEquals("News%", out.getFields().get(0).getFieldValue());
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_appliesFieldsOnLockedView() throws Exception {
+    PSSearch catalog = mockCatalogView("MyView");
+    PSSearch locked = new PSSearch("MyView");
+    locked.setDisplayName("My View");
+    when(designWs.findAllViews()).thenReturn(List.of(catalog), List.of(locked));
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ViewDef body = new ViewDef();
+    body.setLabel("My View");
+    body.setFields(List.of(criterion("sys_contentid", "=", "7", 0)));
+
+    ViewDef out = adaptor.saveView("MyView", body);
+
+    assertEquals("MyView", out.getName());
+    assertEquals(1, out.getFields().size());
+    assertEquals("sys_contentid", out.getFields().get(0).getFieldName());
+    assertEquals("7", out.getFields().get(0).getFieldValue());
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_unknownField_is400BeforeSave() throws Exception {
+    PSSearch catalog = mockCatalogView("MyView");
+    when(designWs.findAllViews()).thenReturn(List.of(catalog));
+    PSSearch locked = new PSSearch("MyView");
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ViewDef body = new ViewDef();
+    body.setFields(List.of(criterion("not_a_cx_field", "equal", "x", 0)));
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.saveView("MyView", body));
+    assertTrue(ex.getMessage().contains("unknown field"));
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_inbox_is409AndDoesNotApplyFields() throws Exception {
+    PSSearch inbox = mockCatalogView("Inbox");
+    when(inbox.isCustomView()).thenReturn(true);
+    when(inbox.getUrl()).thenReturn("../sys_cxViews/inbox.xml");
+    when(designWs.findAllViews()).thenReturn(List.of(inbox));
+
+    ViewDef body = new ViewDef();
+    body.setFields(List.of(criterion("sys_title", "equal", "x", 0)));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.saveView("Inbox", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadViews(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void designGaps_omitFieldCriterionClaim() {
+    assertFalse(
+        ViewAdaptor.DESIGN_GAPS.stream()
+            .anyMatch(g -> g.toLowerCase().contains("field criterion")));
+  }
+
+  private static ViewFieldSummary criterion(String name, String op, String value, int position) {
+    ViewFieldSummary row = new ViewFieldSummary();
+    row.setFieldName(name);
+    row.setOperator(op);
+    row.setFieldValue(value);
+    row.setPosition(position);
+    return row;
+  }
+
+  private static List<PSSearchField> listFields(PSSearch view) {
+    List<PSSearchField> out = new ArrayList<>();
+    Iterator<PSSearchField> it = view.getFields();
+    while (it.hasNext()) {
+      out.add(it.next());
+    }
+    return out;
+  }
+
+  private PSSearch mockCatalogView(String name) {
+    PSSearch s = mock(PSSearch.class);
+    when(s.getName()).thenReturn(name);
+    when(s.getLabel()).thenReturn(name);
+    when(s.getType()).thenReturn(PSSearch.TYPE_VIEW);
+    when(s.getDisplayFormatId()).thenReturn("1");
+    when(s.isView()).thenReturn(true);
+    when(s.isStandardView()).thenReturn(true);
+    when(s.isCustomView()).thenReturn(false);
+    when(s.getGUID()).thenReturn(guid);
+    when(s.getId()).thenReturn(42);
+    return s;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/views/ViewDef.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewDef.java
@@ -30,7 +30,8 @@ public class ViewDef {
   private boolean view;
   private boolean userCustomizable;
   private boolean caseSensitive;
-  private List<ViewFieldSummary> fields = new ArrayList<>();
+  /** Null on PUT means leave existing criteria unchanged; empty list clears. */
+  private List<ViewFieldSummary> fields;
   private List<String> designGaps = new ArrayList<>();
 
   public Guid getGuid() {

--- a/rest/src/main/java/com/percussion/rest/views/ViewResource.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewResource.java
@@ -209,11 +209,13 @@ public class ViewResource {
   @Operation(
       summary = "Update view",
       description =
-          "Admin. Updates label, description, type, and/or displayFormatId by name or GUID. Name"
-              + " is the catalog key and is not renamed on PUT. Loads with a design lock"
-              + " (overrideLock=false) and releases on save. Unknown id is 404. Lock/dependency"
-              + " conflict is 409. Inbox-family and custom URL views are 409 (not mutated)."
-              + " Searches are not saved here. Execute is not invoked on write.",
+          "Admin. Updates label, description, type, displayFormatId, and/or field criteria by"
+              + " name or GUID. Name is the catalog key and is not renamed on PUT. Omitted"
+              + " fields leave existing criteria unchanged; an empty fields array clears them."
+              + " Unknown field names are 400. Loads with a design lock (overrideLock=false)"
+              + " and releases on save. Unknown id is 404. Lock/dependency conflict is 409."
+              + " Inbox-family and custom URL views are 409 (not mutated). Searches are not"
+              + " saved here. Execute is not invoked on write.",
       responses = {
         @ApiResponse(
             responseCode = "200",


### PR DESCRIPTION
## Summary

Parent **#1690** slice **UI-08**. Admins can add, remove, and reorder field criteria on a **user/standard** Content Explorer view from **Developer → Views**. `PUT /services/views/{name}` persists `ViewDef.fields` through `ViewAdaptor` / `IPSUiDesignWs.saveViews`. Omitted `fields` leave existing criteria; an empty array clears them. Unknown field names are **400**. Inbox-family, custom-URL, and system views stay **409** and are not mutated. Create/delete is unchanged (UI-07 / #4085). Search field-selection is not this chrome.

SPA `ViewDetailPanel` uses the same CX system-field catalog as Developer Display Formats columns. Field PUT uses the view GUID when present so H2 `findAllViews` XML cache lag does not 404 the second save.

Fixes #4111  
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 1006, Failures: 0
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (includes `ViewAdaptorFieldsTest` 12, `ViewAdaptorWriteTest` 25)
3. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS, Vitest 3698 passed, Surefire 63
4. H2 QA: `python docker/scripts/perc-devctl.py qa-up` then `qa-health --timeout-seconds 90 --url $TEST_CMS_URL`
5. docker cp `rest-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` into `perc-matrix-cms-h2` `WEB-INF/lib`; in-cell StopJetty/StartJetty; `qa-health` again
6. `perc-devctl qa-deploy-webui`
7. `cd modules/perc-qa-automation/frontend` with `TEST_CMS_URL`, `ADMIN_USERNAME=Admin`, `ADMIN_PASSWORD` from cell, `TEST_DB_TYPE=h2`:  
   `npm run test:surface -- --path tests/developer-view-field-selection.spec.js` — **2 passed**
8. Inbox row is read-only (no field editor). Unique `qa4111*` standard view: add/reorder/save/remove/delete.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-views.md` and `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — `ViewAdaptorFieldsTest` (PUT persist, 400 unknown, 409 Inbox, catalog lag, GUID lookup); Vitest PUT body / 400 / 403 / Inbox
- [x] **WebUI + Playwright** — `developer-view-field-selection.spec.js`
- [x] **Build gates** — standalone clean install `rest`, `projects/sitemanage`, `WebUI`
- [x] **Cross-platform** — N/A (no new filesystem path I/O; URL `/` only)

### C3 evidence

- **modules_built:** rest, projects/sitemanage, WebUI
- **build_evidence:**  
  - `cd rest; ../mvnw.cmd clean install` → BUILD SUCCESS, Tests run: 1006, Failures: 0  
  - `cd projects/sitemanage; ../../mvnw.cmd clean install` → BUILD SUCCESS (ViewAdaptorFieldsTest 12, ViewAdaptorWriteTest 25, Failures: 0)  
  - `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS, Tests 3698 passed (Vitest), Surefire 63
- **downstream_checked:** ViewDef.fields default changed null (omitted PUT). Grep `ViewDef.getFields` / sitemanage `applyWritableFields` null-safe; rest `ViewResourceTest` 30; no `final`/`sealed` on ViewDef. Reverse-dep sitemanage clean install green.

### C5 UI proof

- qa-up cell: `perc-matrix-cms-h2`, TEST_CMS_URL=`http://127.0.0.1:9993`, qa-health RESULT:OK HTTP:200 HEALTH:healthy
- Deploy: docker cp rest + sitemanage SNAPSHOT jars to `/opt/Percussion/jetty/base/webapps/Rhythmyx/WEB-INF/lib/`; `qa-deploy-webui`; in-cell StopJetty/StartJetty; qa-health again OK
- Playwright: `npm run test:surface -- --path tests/developer-view-field-selection.spec.js` → 2 passed
- console-clean=yes (spec pageerror/console error guards)
- server.log-clean=yes (no ERROR/FATAL in jetty `server.log` tail for the feature window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
