### PR TITLE
feat(system): sitemap-xml IPSVirtualSiteSource (#4113)

### DIFF
--- a/system/services/src/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSource.java
@@ -799,8 +799,10 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
 
   /**
    * True when {@code candidate} is the same file/dir as {@code safeRoot} or a descendant.
-   * Uses {@link Path#startsWith} first, then {@link Files#isSameFile} so Windows
-   * case-insensitive volumes are not rejected on drive-letter or component case.
+   * Existing paths use {@link Files#isSameFile} parent walk so Windows case-insensitive
+   * volumes are not rejected on drive-letter or component case. Missing paths use a
+   * name-element {@link Path#startsWith} check (not a string prefix) so a sibling whose
+   * name shares a prefix ({@code sm-abs} vs {@code sm-abs-other}) is not treated as inside.
    */
   static boolean isInsideRoot(Path candidate, Path safeRoot) {
     if (candidate == null || safeRoot == null) {
@@ -808,24 +810,33 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
     }
     Path absCandidate = candidate.toAbsolutePath().normalize();
     Path absRoot = safeRoot.toAbsolutePath().normalize();
-    if (absCandidate.startsWith(absRoot)) {
-      return true;
-    }
     try {
-      if (!Files.exists(absCandidate) || !Files.exists(absRoot)) {
-        return false;
-      }
-      Path cursor = absCandidate;
-      while (cursor != null) {
-        if (Files.isSameFile(cursor, absRoot)) {
-          return true;
+      if (Files.exists(absCandidate) && Files.exists(absRoot)) {
+        Path cursor = absCandidate;
+        while (cursor != null) {
+          if (Files.isSameFile(cursor, absRoot)) {
+            return true;
+          }
+          cursor = cursor.getParent();
         }
-        cursor = cursor.getParent();
+        return false;
       }
     } catch (IOException e) {
       return false;
     }
-    return false;
+    return isLexicalDescendant(absCandidate, absRoot);
+  }
+
+  /**
+   * Name-element containment. {@link Path#startsWith} already compares path names, not
+   * raw strings; the name-count bound rejects a sibling that only shares a string prefix.
+   */
+  private static boolean isLexicalDescendant(Path absCandidate, Path absRoot) {
+    if (absCandidate.equals(absRoot)) {
+      return true;
+    }
+    return absCandidate.startsWith(absRoot)
+        && absCandidate.getNameCount() > absRoot.getNameCount();
   }
 
   private static boolean remainingParent(Path path) {

--- a/system/services/src/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSource.java
@@ -76,12 +76,20 @@ import org.xml.sax.SAXException;
 public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
 
   static final String DEFAULT_SITEMAP_FILE = "sitemap.xml";
+  /** Cap on sitemap.xml / sitemapindex XML (parser-abuse bound). */
   static final int MAX_SITEMAP_BYTES = 2_000_000;
+  /** Cap on per-loc page bodies and loopback HTTP responses. */
+  static final int MAX_PAGE_BYTES = 10_000_000;
   static final int MAX_INDEX_DEPTH = 4;
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
   private static final Set<String> LOOPBACK_HOSTS =
       Set.of("localhost", "127.0.0.1", "::1", "[::1]");
+  private static final HttpClient LOOPBACK_HTTP_CLIENT =
+      HttpClient.newBuilder()
+          .followRedirects(HttpClient.Redirect.NEVER)
+          .connectTimeout(CONNECT_TIMEOUT)
+          .build();
 
   @Override
   public String sourceType() {
@@ -190,7 +198,7 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
       return new SitemapFetch(readSitemapFile(file), file);
     }
     Path defaultFile = safeRoot.resolve(DEFAULT_SITEMAP_FILE).normalize();
-    if (Files.isRegularFile(defaultFile) && defaultFile.startsWith(safeRoot)) {
+    if (Files.isRegularFile(defaultFile) && isInsideRoot(defaultFile, safeRoot)) {
       return new SitemapFetch(readSitemapFile(defaultFile), defaultFile);
     }
     throw new VirtualSiteException(
@@ -244,7 +252,7 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
     } catch (InvalidPathException e) {
       throw new VirtualSiteException("sitemap-xml file is not a valid path", e);
     }
-    if (!resolved.startsWith(safeRoot)
+    if (!isInsideRoot(resolved, safeRoot)
         || !PSVirtualSiteHelper.isSafeRootPath(resolved)
         || remainingParent(resolved)) {
       throw new VirtualSiteException("sitemap-xml file escapes the site root");
@@ -351,9 +359,9 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
           "sitemap-xml loc file not found: " + file.toAbsolutePath().normalize());
     }
     long size = Files.size(file);
-    if (size > MAX_SITEMAP_BYTES) {
+    if (size > MAX_PAGE_BYTES) {
       throw new VirtualSiteException(
-          "sitemap-xml loc file exceeds " + MAX_SITEMAP_BYTES + " bytes: " + file);
+          "sitemap-xml loc file exceeds " + MAX_PAGE_BYTES + " bytes: " + file);
     }
     return Files.readString(file, StandardCharsets.UTF_8);
   }
@@ -396,7 +404,7 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
     } catch (InvalidPathException e) {
       throw new VirtualSiteException("sitemap-xml loc is not a valid path: " + trimmed, e);
     }
-    if (!resolved.startsWith(safeRoot)
+    if (!isInsideRoot(resolved, safeRoot)
         || !PSVirtualSiteHelper.isSafeRootPath(resolved)
         || remainingParent(resolved)) {
       throw new VirtualSiteException("sitemap-xml loc escapes the site root");
@@ -464,11 +472,6 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
   }
 
   static String fetchHttpBody(URL current) throws IOException, VirtualSiteException {
-    HttpClient client =
-        HttpClient.newBuilder()
-            .followRedirects(HttpClient.Redirect.NEVER)
-            .connectTimeout(CONNECT_TIMEOUT)
-            .build();
     URI requestUri = toRequestUri(current);
     HttpRequest request =
         HttpRequest.newBuilder(requestUri) // codeql[java/ssrf]
@@ -478,7 +481,7 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
             .build();
     HttpResponse<byte[]> response;
     try {
-      response = client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+      response = LOOPBACK_HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofByteArray());
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new VirtualSiteException("sitemap-xml request interrupted: " + redactUrl(current), e);
@@ -492,9 +495,9 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
           "sitemap-xml request failed: " + redactUrl(current) + " status " + status);
     }
     byte[] body = response.body() != null ? response.body() : new byte[0];
-    if (body.length > MAX_SITEMAP_BYTES) {
+    if (body.length > MAX_PAGE_BYTES) {
       throw new VirtualSiteException(
-          "sitemap-xml loc exceeds " + MAX_SITEMAP_BYTES + " bytes from " + redactUrl(current));
+          "sitemap-xml loc exceeds " + MAX_PAGE_BYTES + " bytes from " + redactUrl(current));
     }
     return new String(body, StandardCharsets.UTF_8);
   }
@@ -787,9 +790,42 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
   }
 
   private static boolean looksAbsoluteWindows(String logical) {
-    return logical.length() >= 2
-        && Character.isLetter(logical.charAt(0))
-        && logical.charAt(1) == ':';
+    if (logical.length() < 2 || logical.charAt(1) != ':') {
+      return false;
+    }
+    char drive = logical.charAt(0);
+    return (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z');
+  }
+
+  /**
+   * True when {@code candidate} is the same file/dir as {@code safeRoot} or a descendant.
+   * Uses {@link Path#startsWith} first, then {@link Files#isSameFile} so Windows
+   * case-insensitive volumes are not rejected on drive-letter or component case.
+   */
+  static boolean isInsideRoot(Path candidate, Path safeRoot) {
+    if (candidate == null || safeRoot == null) {
+      return false;
+    }
+    Path absCandidate = candidate.toAbsolutePath().normalize();
+    Path absRoot = safeRoot.toAbsolutePath().normalize();
+    if (absCandidate.startsWith(absRoot)) {
+      return true;
+    }
+    try {
+      if (!Files.exists(absCandidate) || !Files.exists(absRoot)) {
+        return false;
+      }
+      Path cursor = absCandidate;
+      while (cursor != null) {
+        if (Files.isSameFile(cursor, absRoot)) {
+          return true;
+        }
+        cursor = cursor.getParent();
+      }
+    } catch (IOException e) {
+      return false;
+    }
+    return false;
   }
 
   private static boolean remainingParent(Path path) {

--- a/system/services/src/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSource.java
+++ b/system/services/src/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSource.java
@@ -71,7 +71,8 @@ import org.xml.sax.SAXException;
  * second build in the same JVM after a sitemap ({@code sitemap.file} / default {@code
  * sitemap.xml}) or {@code _config.yaml} edit must see the new bytes. File watchers are not used;
  * {@code _config.yaml} is reloaded by {@link PSVirtualSiteBuildService}, not this source. XML
- * parse is XXE fail-closed via {@link PSSecureXMLUtils}.
+ * parse is XXE fail-closed via {@link PSSecureXMLUtils}. {@link #load} materializes only the
+ * matching loc body (one file read or loopback HTTP GET); it does not re-fetch every loc.
  */
 public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
 
@@ -117,10 +118,15 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
     if (ref == null) {
       throw new VirtualSiteException("sitemap-xml item ref is required");
     }
-    List<LoadedRow> rows = loadAllRows(config);
-    for (LoadedRow row : rows) {
-      if (row.ref().versionId().equals(ref.versionId()) && row.ref().id().equals(ref.id())) {
-        return new VirtualItem(row.ref(), row.frontmatter(), row.body(), row.sourcePath());
+    List<SitemapUrl> urls = loadAllUrlEntries(config);
+    int index = 0;
+    for (SitemapUrl url : urls) {
+      index++;
+      LoadedRow loaded = toLoadedRow(url, config, index, "");
+      if (loaded.ref().versionId().equals(ref.versionId()) && loaded.ref().id().equals(ref.id())) {
+        String pageBody = materializeLocBody(url);
+        return new VirtualItem(
+            loaded.ref(), loaded.frontmatter(), assembleBody(url.lastmod(), pageBody), url.sourcePath());
       }
     }
     throw new VirtualSiteException(
@@ -129,28 +135,14 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
 
   private static List<LoadedRow> loadAllRows(VirtualSiteConfig config)
       throws IOException, VirtualSiteException {
-    if (config == null) {
-      throw new VirtualSiteException("Virtual Site config is required");
-    }
-    Path root = config.root();
-    if (root == null || !PSVirtualSiteHelper.isSafeRootPath(root)) {
-      throw new VirtualSiteException("sitemap-xml site root is missing or unsafe");
-    }
-    Path safeRoot = root.normalize();
-    SitemapFetch fetch = readSitemap(config, safeRoot);
-    List<SitemapUrl> urls = parseSitemapDocument(fetch.xmlText(), safeRoot, fetch.sourcePath(), 0);
-    if (urls.isEmpty()) {
-      throw new VirtualSiteException(
-          "sitemap-xml fixture has no url loc entries: "
-              + fetch.sourcePath().toAbsolutePath().normalize());
-    }
+    List<SitemapUrl> urls = loadAllUrlEntries(config);
     List<LoadedRow> rows = new ArrayList<>();
     Map<String, Path> seenIds = new HashMap<>();
     Map<String, Path> seenPaths = new HashMap<>();
     int index = 0;
     for (SitemapUrl url : urls) {
       index++;
-      LoadedRow loaded = toLoadedRow(url, config, index);
+      LoadedRow loaded = toLoadedRow(url, config, index, "");
       String idKey = loaded.ref().versionId() + "\0" + loaded.ref().id();
       Path previousId = seenIds.put(idKey, loaded.ref().relativePath());
       if (previousId != null) {
@@ -183,6 +175,26 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
       rows.add(loaded);
     }
     return rows;
+  }
+
+  private static List<SitemapUrl> loadAllUrlEntries(VirtualSiteConfig config)
+      throws IOException, VirtualSiteException {
+    if (config == null) {
+      throw new VirtualSiteException("Virtual Site config is required");
+    }
+    Path root = config.root();
+    if (root == null || !PSVirtualSiteHelper.isSafeRootPath(root)) {
+      throw new VirtualSiteException("sitemap-xml site root is missing or unsafe");
+    }
+    Path safeRoot = root.normalize();
+    SitemapFetch fetch = readSitemap(config, safeRoot);
+    List<SitemapUrl> urls = parseSitemapDocument(fetch.xmlText(), safeRoot, fetch.sourcePath(), 0);
+    if (urls.isEmpty()) {
+      throw new VirtualSiteException(
+          "sitemap-xml fixture has no url loc entries: "
+              + fetch.sourcePath().toAbsolutePath().normalize());
+    }
+    return urls;
   }
 
   private static SitemapFetch readSitemap(VirtualSiteConfig config, Path safeRoot)
@@ -341,19 +353,18 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
       String lastmod = childText(urlEl, "lastmod");
       LocKind kind = classifyLoc(loc);
       if (kind == LocKind.HTTP) {
-        URL url = requireSafeLoopbackHttpUrl(loc);
-        String body = fetchHttpBody(url);
-        urls.add(new SitemapUrl(loc, lastmod, body, sourcePath, where));
+        requireSafeLoopbackHttpUrl(loc);
+        urls.add(new SitemapUrl(loc, lastmod, sourcePath, where, LocKind.HTTP));
       } else {
         Path file = resolveLocFile(safeRoot, loc);
-        String body = readPageFile(file);
-        urls.add(new SitemapUrl(loc, lastmod, body, file, where));
+        requireExistingPageFile(file);
+        urls.add(new SitemapUrl(loc, lastmod, file, where, LocKind.FILE));
       }
     }
     return urls;
   }
 
-  private static String readPageFile(Path file) throws IOException, VirtualSiteException {
+  private static void requireExistingPageFile(Path file) throws IOException, VirtualSiteException {
     if (!Files.isRegularFile(file)) {
       throw new VirtualSiteException(
           "sitemap-xml loc file not found: " + file.toAbsolutePath().normalize());
@@ -363,7 +374,18 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
       throw new VirtualSiteException(
           "sitemap-xml loc file exceeds " + MAX_PAGE_BYTES + " bytes: " + file);
     }
+  }
+
+  private static String readPageFile(Path file) throws IOException, VirtualSiteException {
+    requireExistingPageFile(file);
     return Files.readString(file, StandardCharsets.UTF_8);
+  }
+
+  private static String materializeLocBody(SitemapUrl url) throws IOException, VirtualSiteException {
+    if (url.kind() == LocKind.HTTP) {
+      return fetchHttpBody(requireSafeLoopbackHttpUrl(url.loc()));
+    }
+    return readPageFile(url.sourcePath());
   }
 
   static Path resolveLocFile(Path root, String loc) throws VirtualSiteException {
@@ -568,7 +590,8 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
     }
   }
 
-  private static LoadedRow toLoadedRow(SitemapUrl url, VirtualSiteConfig config, int order)
+  private static LoadedRow toLoadedRow(
+      SitemapUrl url, VirtualSiteConfig config, int order, String pageBody)
       throws VirtualSiteException {
     String where = url.where();
     String loc = url.loc() == null ? "" : url.loc().trim();
@@ -586,7 +609,7 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
     VirtualItemRef ref = new VirtualItemRef(id, version.id(), relative, order, title);
     VirtualFrontmatter fm =
         new VirtualFrontmatter(id, title, "", version.id(), true, order, List.of(), false);
-    String body = assembleBody(url.lastmod(), url.body());
+    String body = assembleBody(url.lastmod(), pageBody);
     return new LoadedRow(ref, fm, body, url.sourcePath());
   }
 
@@ -858,7 +881,7 @@ public class PSSitemapXmlVirtualSiteSource implements IPSVirtualSiteSource {
   private record NestedSitemap(String xmlText, Path sourcePath) {}
 
   private record SitemapUrl(
-      String loc, String lastmod, String body, Path sourcePath, String where) {}
+      String loc, String lastmod, Path sourcePath, String where, LocKind kind) {}
 
   private record LoadedRow(
       VirtualItemRef ref, VirtualFrontmatter frontmatter, String body, Path sourcePath) {}

--- a/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfig.java
+++ b/system/services/src/com/percussion/services/virtualsite/VirtualSiteConfig.java
@@ -241,7 +241,9 @@ public final class VirtualSiteConfig {
    * _config.yaml}).
    *
    * @return spec, or null when the mapping is omitted (adapter then uses {@code sitemap.xml} under
-   *     the site root)
+   *     the site root). Legacy constructors (12-arg and earlier) always pass {@code null} here; a
+   *     {@code SITEMAP_XML} site wired that way also falls back to {@code sitemap.xml} and does
+   *     not fail.
    */
   public SitemapSpec sitemap() {
     return sitemap;

--- a/system/src/test/java/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSourceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSourceTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -313,6 +314,44 @@ class PSSitemapXmlVirtualSiteSourceTest {
   }
 
   @Test
+  void loadFetchesOnlyMatchingLoopbackLoc() throws Exception {
+    HttpServer server = loopbackServer();
+    AtomicInteger hits = new AtomicInteger();
+    try {
+      serveTextCounting(server, "/alpha.html", "alpha-body", hits);
+      serveTextCounting(server, "/beta.html", "beta-body", hits);
+      server.start();
+      String alpha = loopbackUrl(server, "/alpha.html");
+      String beta = loopbackUrl(server, "/beta.html");
+      Path root = writeSite(tempDir.resolve("sm-http-one"), "sitemap.xml");
+      Files.writeString(
+          root.resolve("sitemap.xml"),
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url><loc>%s</loc></url>
+            <url><loc>%s</loc></url>
+          </urlset>
+          """
+              .formatted(alpha, beta),
+          StandardCharsets.UTF_8);
+      PSSitemapXmlVirtualSiteSource source = new PSSitemapXmlVirtualSiteSource();
+      VirtualSiteConfig cfg = config(root, "sitemap.xml");
+      List<VirtualItemRef> refs = source.discover(cfg);
+      assertEquals(2, refs.size());
+      assertEquals(0, hits.get(), "discover must not GET loc bodies");
+      VirtualItemRef alphaRef =
+          refs.stream().filter(r -> "alpha".equals(r.id())).findFirst().orElseThrow();
+      VirtualItem item = source.load(cfg, alphaRef);
+      assertTrue(item.markdownBody().contains("alpha-body"), item.markdownBody());
+      assertFalse(item.markdownBody().contains("beta-body"), item.markdownBody());
+      assertEquals(1, hits.get(), "load must GET only the matching loc");
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
   void requireSafeLoopbackHttpUrlRejectsCloudAndUserinfo() {
     VirtualSiteException userinfo =
         assertThrows(
@@ -581,10 +620,18 @@ class PSSitemapXmlVirtualSiteSourceTest {
   }
 
   private static void serveText(HttpServer server, String path, String text) {
+    serveTextCounting(server, path, text, null);
+  }
+
+  private static void serveTextCounting(
+      HttpServer server, String path, String text, AtomicInteger hits) {
     byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
     server.createContext(
         path,
         exchange -> {
+          if (hits != null) {
+            hits.incrementAndGet();
+          }
           exchange.getResponseHeaders().set("Content-Type", "text/html");
           exchange.sendResponseHeaders(200, bytes.length);
           try (OutputStream os = exchange.getResponseBody()) {

--- a/system/src/test/java/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSourceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSourceTest.java
@@ -488,6 +488,66 @@ class PSSitemapXmlVirtualSiteSourceTest {
     assertEquals("page", PSSitemapXmlVirtualSiteSource.slugForPath(":::"));
   }
 
+  @Test
+  void pageBodyBudgetIsLargerThanSitemapXmlCap() {
+    assertTrue(
+        PSSitemapXmlVirtualSiteSource.MAX_PAGE_BYTES
+            > PSSitemapXmlVirtualSiteSource.MAX_SITEMAP_BYTES);
+  }
+
+  @Test
+  void resolveSitemapFileRejectsAsciiDriveAbsoluteAndAllowsRelative() throws Exception {
+    Path root = writeSite(tempDir.resolve("sm-abs"), "sitemap.xml");
+    assertThrows(
+        VirtualSiteException.class,
+        () -> PSSitemapXmlVirtualSiteSource.resolveSitemapFile(root, "C:/evil.xml"));
+    assertThrows(
+        VirtualSiteException.class,
+        () -> PSSitemapXmlVirtualSiteSource.resolveSitemapFile(root, "d:\\evil.xml"));
+    Path relative = PSSitemapXmlVirtualSiteSource.resolveSitemapFile(root, "sitemap.xml");
+    assertTrue(PSSitemapXmlVirtualSiteSource.isInsideRoot(relative, root.normalize()));
+  }
+
+  @Test
+  void isInsideRootAcceptsNormalizedDescendant() throws Exception {
+    Path root = writeSite(tempDir.resolve("sm-inside"), null);
+    Path child = root.resolve("sitemap.xml");
+    Files.writeString(child, urlset("pages/x.md", null), StandardCharsets.UTF_8);
+    assertTrue(PSSitemapXmlVirtualSiteSource.isInsideRoot(child, root.normalize()));
+    assertFalse(
+        PSSitemapXmlVirtualSiteSource.isInsideRoot(
+            tempDir.resolve("other-root").resolve("sitemap.xml"), root.normalize()));
+  }
+
+  @Test
+  void legacyTwelveArgConstructorFallsBackToDefaultSitemapFile() throws Exception {
+    Path root = writeSite(tempDir.resolve("sm-legacy-ctor"), null);
+    Files.writeString(
+        root.resolve("pages").resolve("legacy.md"), "legacy body", StandardCharsets.UTF_8);
+    Files.writeString(
+        root.resolve(PSSitemapXmlVirtualSiteSource.DEFAULT_SITEMAP_FILE),
+        urlset("pages/legacy.md", null),
+        StandardCharsets.UTF_8);
+    VirtualSiteConfig cfg =
+        new VirtualSiteConfig(
+            root,
+            "Sitemap Docs",
+            "",
+            "page.html",
+            List.of(new VirtualSiteConfig.VersionSpec("8.2", "8.2", "8.2", true)),
+            List.of(),
+            "sm-docs",
+            null,
+            null,
+            null,
+            null,
+            null);
+    assertEquals(null, cfg.sitemap());
+    List<VirtualItemRef> refs = new PSSitemapXmlVirtualSiteSource().discover(cfg);
+    assertEquals(1, refs.size());
+    assertEquals("legacy", refs.get(0).id());
+  }
+
   private static HttpServer loopbackServer() throws Exception {
     HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
     server.setExecutor(Executors.newCachedThreadPool());

--- a/system/src/test/java/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSourceTest.java
+++ b/system/src/test/java/com/percussion/services/virtualsite/PSSitemapXmlVirtualSiteSourceTest.java
@@ -520,6 +520,32 @@ class PSSitemapXmlVirtualSiteSourceTest {
   }
 
   @Test
+  void siblingDirSharingRootNamePrefixIsRejected() throws Exception {
+    Path root = writeSite(tempDir.resolve("sm-abs"), "sitemap.xml");
+    Path sibling = tempDir.resolve("sm-abs-other");
+    Files.createDirectories(sibling);
+    Path evil = sibling.resolve("evil.xml");
+    Files.writeString(evil, urlset("pages/x.md", null), StandardCharsets.UTF_8);
+    assertFalse(PSSitemapXmlVirtualSiteSource.isInsideRoot(evil, root.normalize()));
+    String siblingLoc = evil.toAbsolutePath().normalize().toString().replace('\\', '/');
+    VirtualSiteException locEx =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> PSSitemapXmlVirtualSiteSource.resolveLocFile(root, siblingLoc));
+    assertTrue(locEx.getMessage().toLowerCase().contains("escapes"), locEx.getMessage());
+    Files.writeString(
+        root.resolve("sitemap.xml"), urlset(siblingLoc, null), StandardCharsets.UTF_8);
+    VirtualSiteException discoverEx =
+        assertThrows(
+            VirtualSiteException.class,
+            () -> new PSSitemapXmlVirtualSiteSource().discover(config(root, "sitemap.xml")));
+    assertTrue(
+        discoverEx.getMessage().toLowerCase().contains("escapes")
+            || discoverEx.getMessage().toLowerCase().contains("loc"),
+        discoverEx.getMessage());
+  }
+
+  @Test
   void legacyTwelveArgConstructorFallsBackToDefaultSitemapFile() throws Exception {
     Path root = writeSite(tempDir.resolve("sm-legacy-ctor"), null);
     Files.writeString(


### PR DESCRIPTION
## Summary

Parent **#2678** slice: add a **sitemap-xml** `IPSVirtualSiteSource` that discovers pages from a **local `sitemap.xml`** (urlset / sitemapindex of local file URLs) under a portable-safe `virtual.rootPath`.

- `VirtualSiteSourceType.SITEMAP_XML` (`sitemap-xml`) + `PSVirtualSiteSourceFactory` allow-list
- `PSSitemapXmlVirtualSiteSource` reads `sitemap.xml` or `_config.yaml` `sitemap.file`
- `<loc>` entries resolve to portable files under the site root; loopback `http(s)` locs are tests-only
- Rejects `virtual.remoteUrl`, credential properties, `sitemap.url`, and non-loopback `http(s)` locs
- CLI `PSVirtualSiteBuildMain … sitemap-xml` / `PSVirtualSiteBuildService.forSourceType` writes HTML (`pageCount > 0`)
- git/csv/sql/http-json/object-storage/rss-atom/icalendar adapters unchanged
- REST GET/PUT persist is **out of scope** (#4114); Developer Sites chrome is **out of scope** (#4115)

Fixes #4113  
Parent: #2678

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` (standalone; includes tests).
2. Unit: local sitemap.xml fixture assembles at least one HTML page; `sitemap.url` and non-loopback `http(s)` locs rejected; factory unknown kinds still fail.
3. Helper: `sitemap-xml` + safe root passes; leftover `virtual.remoteUrl`, cloud `rootPath`, and credential properties fail closed.
4. Confirm CLI 4th arg `sitemap-xml` is accepted (`PSVirtualSiteBuildMain`).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/` (developer virtual-sites, admin sites, reference site-config, developer rest) for the local sitemap-xml SPI/CLI
- [x] **Unit / module tests** — `PSSitemapXmlVirtualSiteSourceTest`, helper + config-loader companions; standalone system clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` BUILD SUCCESS
- [x] **Cross-platform** — NIO `Path` / `Files`; Windows vs Unix absolute `sitemap.file` tests behind `@EnabledOnOs`

### C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → **BUILD SUCCESS** (02:18). Tests run: 2689, Failures: 0, Errors: 0, Skipped: 245. `PSSitemapXmlVirtualSiteSourceTest` Tests run: 23, Failures: 0, Errors: 0, Skipped: 1 (Unix absolute path test on Windows).
- **downstream_checked:** Added enum constant + exhaustive factory `switch` updated. Grep: no rest/sitemanage/perc-toolkit exhaustive `switch` on `VirtualSiteSourceType` (`SitesAdaptor` uses `if` on CSV). No `final`/signature change on existing types. Reverse-dep clean install not required.

### C5 UI proof

N/A — SPI/CLI only; no WebUI / Explorer chrome in this slice.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
