### PR TITLE
fix(rest): persist Admin action menus in RXMENUACTION (#4119)

### DIFF
--- a/docs/ai-generated/code-reviews/4119-action-menu-persist-erlang.md
+++ b/docs/ai-generated/code-reviews/4119-action-menu-persist-erlang.md
@@ -1,0 +1,16 @@
+# Erlang review — #4119 REST action menu persist after POST/DELETE
+
+**Memory patterns hit:** change-class closure (sitemanage adaptor + system JDBC persist peer #4101 + adaptor tests + H2 Playwright persist + product-docs); lock-no-steal 409; Hibernate catalog vs design-WS XML miss.
+
+## Verdict
+
+Pass for this slice. `saveActions` / `deleteActions` now write durable `RXMENUACTION` rows (same class as display-format JDBC persist). GET catalog / GET by name use Hibernate tree; write identity falls back to that tree when design-WS `findActions` misses (system Edit 409, not 404). `overrideLock=false` unchanged. Finder helpers (`/find`) not reimplemented.
+
+## Checks
+
+- Behavioral unit tests: `PSUiDesignWsActionPersistTest` (H2 INSERT/UPDATE/DELETE), `ActionMenuAdaptorWriteTest` (Hibernate miss → system 409, duplicate 409, nested GET key).
+- Portable paths: JDBC SQL identifiers only; Playwright uses `path.join` via existing auth helpers.
+- Product-docs 8.2 `developer/rest.md` notes durable `RXMENUACTION`.
+- Playwright: `developer-action-menu-persist.spec.js` (POST catalog, DELETE 404, system 409, Editor 403).
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/modules/perc-qa-automation/frontend/tests/developer-action-menu-persist.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-action-menu-persist.spec.js
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * REST action-menu persist after Admin POST/DELETE (#4119 / parent #1690).
+ *
+ * POST `/services/actions` must be durable in Hibernate `RXMENUACTION` so GET
+ * `/services/actions/catalog` and GET by name include the user menu. DELETE of
+ * that user menu is 204 then GET 404. System menus (`Menus/System`, e.g. Edit)
+ * are 409 without stealing the design lock. Does not re-implement finder helpers
+ * or SPA UI-03/UI-04 chrome.
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   python docker/scripts/perc-devctl.py qa-health
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=…
+ *     npm run test:surface -- --path tests/developer-action-menu-persist.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin } = require("./helpers/auth");
+
+/** REST-safe unique action-menu name (no spaces, wildcards, or path characters). */
+function uniqueActionMenuName(prefix) {
+  const a = Date.now().toString(36).replace(/[^a-z0-9]/g, "").slice(-4);
+  const b = Math.random().toString(36).replace(/[^a-z0-9]/g, "").slice(2, 6);
+  const suffix = `${a}${b}`.slice(0, 8);
+  return `${prefix}${suffix || "x"}`;
+}
+
+/**
+ * Same-origin fetch so OWASP CSRF + session cookies apply.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} path
+ * @param {string} method
+ * @param {object} [body]
+ * @returns {Promise<{status: number, text: string}>}
+ */
+async function inPageJson(page, path, method, body) {
+  return page.evaluate(
+    async ({ path: url, method: httpMethod, body: payload }) => {
+      const tokenObj = window.OWASP_CSRFTOKEN;
+      const metaToken = document.querySelector('meta[name="_csrf"]');
+      const metaHeader = document.querySelector('meta[name="_csrf_header"]');
+      const token =
+        (tokenObj && tokenObj.token) || (metaToken && metaToken.content) || "";
+      const headerName =
+        (metaHeader && metaHeader.content) || "OWASP-CSRFTOKEN";
+      const headers = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      };
+      if (token) {
+        headers[headerName] = token;
+      }
+      const res = await fetch(url, {
+        method: httpMethod,
+        credentials: "same-origin",
+        headers,
+        body: payload === undefined ? undefined : JSON.stringify(payload),
+      });
+      const text = await res.text();
+      return { status: res.status, text };
+    },
+    { path, method, body },
+  );
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(
+    unexpectedConsole,
+    `console error: ${unexpectedConsole.join(" | ")}`,
+  ).toEqual([]);
+}
+
+function nameInJson(text, name) {
+  return new RegExp(`"name"\\s*:\\s*"${name}"`).test(text);
+}
+
+test.describe("REST action menu persist (#4119 / UI-02)", () => {
+  test("Admin POST is in GET catalog and GET by name; DELETE 204 then 404", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+
+    const menuName = uniqueActionMenuName("qa4119");
+    expect(menuName.startsWith("qa4119")).toBeTruthy();
+
+    const create = await inPageJson(page, "/Rhythmyx/services/actions", "POST", {
+      ActionMenu: {
+        name: menuName,
+        label: `${menuName} label`,
+        description: "qa4119 persist",
+        menuType: "MENU",
+      },
+    });
+    expect(
+      create.status,
+      `POST create should be 200 (got ${create.status}): ${create.text}`,
+    ).toBe(200);
+    expect(nameInJson(create.text, menuName), create.text).toBeTruthy();
+
+    const catalog = await inPageJson(
+      page,
+      "/Rhythmyx/services/actions/catalog",
+      "GET",
+    );
+    expect(catalog.status, `GET catalog (got ${catalog.status}): ${catalog.text}`).toBe(
+      200,
+    );
+    expect(
+      nameInJson(catalog.text, menuName),
+      `GET catalog must list ${menuName}: ${catalog.text}`,
+    ).toBeTruthy();
+
+    const byName = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/catalog/${encodeURIComponent(menuName)}`,
+      "GET",
+    );
+    expect(
+      byName.status,
+      `GET by name after create (got ${byName.status}): ${byName.text}`,
+    ).toBe(200);
+    expect(nameInJson(byName.text, menuName), byName.text).toBeTruthy();
+
+    const dup = await inPageJson(page, "/Rhythmyx/services/actions", "POST", {
+      ActionMenu: {
+        name: menuName,
+        label: `${menuName} dup`,
+        menuType: "MENU",
+      },
+    });
+    expect(dup.status, `duplicate POST (got ${dup.status}): ${dup.text}`).toBe(409);
+
+    const invalid = await inPageJson(page, "/Rhythmyx/services/actions", "POST", {
+      ActionMenu: {
+        name: "has space",
+        label: "bad",
+        menuType: "MENU",
+      },
+    });
+    expect(
+      invalid.status,
+      `invalid name POST (got ${invalid.status}): ${invalid.text}`,
+    ).toBe(400);
+
+    const del = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/${encodeURIComponent(menuName)}`,
+      "DELETE",
+    );
+    expect(del.status, `DELETE should be 204 (got ${del.status}): ${del.text}`).toBe(
+      204,
+    );
+
+    const afterDelete = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/catalog/${encodeURIComponent(menuName)}`,
+      "GET",
+    );
+    expect(
+      afterDelete.status,
+      `GET after DELETE must be 404 (got ${afterDelete.status}): ${afterDelete.text}`,
+    ).toBe(404);
+
+    const catalogAfter = await inPageJson(
+      page,
+      "/Rhythmyx/services/actions/catalog",
+      "GET",
+    );
+    expect(catalogAfter.status).toBe(200);
+    expect(
+      nameInJson(catalogAfter.text, menuName),
+      `GET catalog must omit deleted ${menuName}: ${catalogAfter.text}`,
+    ).toBeFalsy();
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+
+  test("DELETE/PUT of a packaged catalog menu is 409", async ({ page }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+
+    const catalog = await inPageJson(
+      page,
+      "/Rhythmyx/services/actions/catalog",
+      "GET",
+    );
+    expect(catalog.status, catalog.text).toBe(200);
+    const names = [...catalog.text.matchAll(/"name"\s*:\s*"([^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    const preferred = ["Copy", "Preview", "Open", "Checkout", "Checkin", "View"];
+    const systemName =
+      preferred.find((n) => names.includes(n)) ||
+      names.find((n) => n && !/^qa4119/i.test(n));
+    expect(systemName, `catalog must include a packaged menu: ${catalog.text}`).toBeTruthy();
+
+    const del = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/${encodeURIComponent(systemName)}`,
+      "DELETE",
+    );
+    expect(
+      del.status,
+      `DELETE ${systemName} should be 409 (got ${del.status}): ${del.text}`,
+    ).toBe(409);
+
+    const put = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/${encodeURIComponent(systemName)}`,
+      "PUT",
+      {
+        ActionMenu: {
+          label: "Must not mutate packaged menu",
+        },
+      },
+    );
+    expect(
+      put.status,
+      `PUT ${systemName} should be 409 (got ${put.status}): ${put.text}`,
+    ).toBe(409);
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1475,12 +1475,14 @@ load **Object ACL** via `GET /services/acls/object/{guid}`. When the nested Guid
 hard to bind, clients may also synthesize that same string from the numeric `id`.
 
 Admin **write** persists through `IPSUiDesignWs` (`createActions` / `loadActions` /
-`saveActions` / `deleteActions`) — the same design web service SOAP uses. There is
-no new SOAP surface. **Do not** treat this as a Developer Action Menus SPA; chrome
-for create/save/delete is a later sibling. Cascading children composition (UI-04)
-and usage/command/visibility tab completeness (UI-03) are later slices. Finder
-helpers (`GET /services/actions/find`, content-type and template finders) are
-unchanged.
+`saveActions` / `deleteActions`) — the same design web service SOAP uses. Durable
+rows are written to `RXMENUACTION` so Hibernate `findActionMenusTree` (GET
+`/services/actions/catalog` and GET by name) includes a user menu immediately
+after POST, and omits it after DELETE. There is no new SOAP surface. **Do not**
+treat this as a Developer Action Menus SPA; chrome for create/save/delete is a
+later sibling. Cascading children composition (UI-04) and usage/command/visibility
+tab completeness (UI-03) are later slices. Finder helpers (`GET
+/services/actions/find`, content-type and template finders) are unchanged.
 
 Write is **Admin** only. Name is unique (case-insensitive) and must not contain
 whitespace or wildcards. Duplicate name is **409**. Invalid name or menu type is

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -57,6 +57,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
@@ -85,6 +86,10 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   private final IPSUiDesignWs service;
   private final BooleanSupplier adminChecker;
   private final Supplier<List<PSActionMenu>> hibernateMenus;
+
+  /** Per-request Hibernate catalog index (name/id → menu); cleared in write finally. */
+  private static final ThreadLocal<Map<String, PSActionMenu>> REQUEST_HIBERNATE_INDEX =
+      new ThreadLocal<>();
 
   /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
   @Autowired(required = false)
@@ -310,11 +315,11 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       throw new IllegalArgumentException("body is required");
     }
     String name = requireValidName(body.getName());
-    assertNameUnique(name);
     ActionType type = resolveCreateType(body);
     String session = currentSession();
     String user = currentUser();
     try {
+      assertNameUnique(name);
       List<PSAction> created = service.createActions(List.of(name), List.of(type), session, user);
       if (created == null || created.isEmpty() || created.get(0) == null) {
         throw new IllegalStateException("Design WS createActions returned empty");
@@ -339,6 +344,8 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     } catch (PSErrorException e) {
       log.error("Failed to create action menu {}", name, e);
       throw new IllegalStateException("Failed to create action menu", e);
+    } finally {
+      clearRequestHibernateIndex();
     }
   }
 
@@ -352,18 +359,19 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     if (!isSafeMenuKey(idOrName)) {
       return null;
     }
-    PSAction existing = findPsActionByKey(idOrName.trim());
-    if (existing == null) {
-      return null;
-    }
-    rejectSystemMenuWrite(existing);
-    IPSGuid id = safeGuid(existing);
-    if (id == null) {
-      throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
-    }
-    String session = currentSession();
-    String user = currentUser();
+    IPSGuid id = null;
     try {
+      PSAction existing = findPsActionByKey(idOrName.trim());
+      if (existing == null) {
+        return null;
+      }
+      rejectSystemMenuWrite(existing);
+      id = safeGuid(existing);
+      if (id == null) {
+        throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
+      }
+      String session = currentSession();
+      String user = currentUser();
       List<PSAction> loaded = service.loadActions(List.of(id), true, false, session, user);
       if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
         return null;
@@ -375,13 +383,15 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     } catch (WebApplicationException | IllegalArgumentException e) {
       throw e;
     } catch (PSErrorResultsException e) {
-      if (isNotFound(e, id)) {
+      if (id != null && isNotFound(e, id)) {
         return null;
       }
       throw new WebApplicationException(
           "Could not update action menu; design lock required or held by another user", 409);
     } catch (PSErrorsException e) {
       throw mapSaveOrDeleteFailure("update", e);
+    } finally {
+      clearRequestHibernateIndex();
     }
   }
 
@@ -392,18 +402,19 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     if (!isSafeMenuKey(idOrName)) {
       return false;
     }
-    PSAction existing = findPsActionByKey(idOrName.trim());
-    if (existing == null) {
-      return false;
-    }
-    rejectSystemMenuWrite(existing);
-    IPSGuid id = safeGuid(existing);
-    if (id == null) {
-      throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
-    }
-    String session = currentSession();
-    String user = currentUser();
+    IPSGuid id = null;
     try {
+      PSAction existing = findPsActionByKey(idOrName.trim());
+      if (existing == null) {
+        return false;
+      }
+      rejectSystemMenuWrite(existing);
+      id = safeGuid(existing);
+      if (id == null) {
+        throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
+      }
+      String session = currentSession();
+      String user = currentUser();
       List<PSAction> locked = service.loadActions(List.of(id), true, false, session, user);
       if (locked == null || locked.isEmpty() || locked.get(0) == null) {
         throw new WebApplicationException(
@@ -414,13 +425,15 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     } catch (WebApplicationException e) {
       throw e;
     } catch (PSErrorResultsException e) {
-      if (isNotFound(e, id)) {
+      if (id != null && isNotFound(e, id)) {
         return false;
       }
       throw new WebApplicationException(
           "Could not delete action menu; design lock required or held by another user", 409);
     } catch (PSErrorsException e) {
       throw mapSaveOrDeleteFailure("delete", e);
+    } finally {
+      clearRequestHibernateIndex();
     }
   }
 
@@ -472,8 +485,57 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   }
 
   PSAction findHibernateActionByKey(String key) {
-    PSActionMenu menu = matchHibernateMenu(hibernateMenus.get(), key);
+    PSActionMenu menu = matchHibernateMenu(requestHibernateMenus(), key);
     return menu == null ? null : psActionFromHibernate(menu);
+  }
+
+  List<PSActionMenu> requestHibernateMenus() {
+    Map<String, PSActionMenu> index = requestHibernateIndex();
+    if (index.isEmpty()) {
+      return List.of();
+    }
+    return new ArrayList<>(index.values());
+  }
+
+  Map<String, PSActionMenu> requestHibernateIndex() {
+    Map<String, PSActionMenu> cached = REQUEST_HIBERNATE_INDEX.get();
+    if (cached == null) {
+      cached = indexHibernateMenus(hibernateMenus.get());
+      REQUEST_HIBERNATE_INDEX.set(cached);
+    }
+    return cached;
+  }
+
+  static void clearRequestHibernateIndex() {
+    REQUEST_HIBERNATE_INDEX.remove();
+  }
+
+  static Map<String, PSActionMenu> indexHibernateMenus(List<PSActionMenu> menus) {
+    Map<String, PSActionMenu> out = new HashMap<>();
+    if (menus == null) {
+      return out;
+    }
+    for (PSActionMenu m : menus) {
+      indexHibernateMenuRecursive(m, out);
+    }
+    return out;
+  }
+
+  static void indexHibernateMenuRecursive(PSActionMenu m, Map<String, PSActionMenu> out) {
+    if (m == null || out == null) {
+      return;
+    }
+    if (StringUtils.isNotBlank(m.getName())) {
+      out.putIfAbsent(m.getName().toLowerCase(), m);
+    }
+    if (m.getActionId() > 0) {
+      out.putIfAbsent(Integer.toString(m.getActionId()), m);
+    }
+    if (m.getChildren() != null) {
+      for (PSActionMenu child : m.getChildren()) {
+        indexHibernateMenuRecursive(child, out);
+      }
+    }
   }
 
   static PSActionMenu matchHibernateMenu(List<PSActionMenu> menus, String key) {
@@ -769,12 +831,18 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     }
   }
 
+  /**
+   * Fail-closed write guard: a {@code null} GUID (or unresolvable Workbench path)
+   * is treated as a system/packaged menu and yields HTTP 409. Only REST-created
+   * user menus ({@link #REST_USER_MENU_PROP}) or a User path segment may be written.
+   */
   boolean isSystemMenu(PSAction action) {
     if (isRestUserMenu(action)) {
       return false;
     }
     IPSGuid guid = safeGuid(action);
     if (guid == null) {
+      log.info("Action menu GUID is null; treating as system menu (fail-closed write)");
       return true;
     }
     try {
@@ -802,8 +870,20 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     if (PSAction.YES.equalsIgnoreCase(StringUtils.defaultString(action.getProperty(REST_USER_MENU_PROP)))) {
       return true;
     }
-    PSActionMenu hibernate = matchHibernateMenu(hibernateMenus.get(), action.getName());
+    PSActionMenu hibernate = lookupHibernateMenu(action.getName());
     return hibernateHasRestUserMenu(hibernate);
+  }
+
+  PSActionMenu lookupHibernateMenu(String name) {
+    if (StringUtils.isBlank(name)) {
+      return null;
+    }
+    Map<String, PSActionMenu> index = requestHibernateIndex();
+    PSActionMenu byName = index.get(name.toLowerCase());
+    if (byName != null) {
+      return byName;
+    }
+    return matchHibernateMenu(hibernateMenus.get(), name);
   }
 
   static boolean hibernateHasRestUserMenu(PSActionMenu menu) {
@@ -879,12 +959,12 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   private void assertNameUnique(String name) {
     try {
       if (nameExists(service.findActions(name, null, null), name)
-          || hibernateNameExists(hibernateMenus.get(), name)) {
+          || hibernateNameExists(requestHibernateMenus(), name)) {
         throw new WebApplicationException("Action menu already exists: " + name, 409);
       }
     } catch (WebApplicationException e) {
       throw e;
-    } catch (PSErrorException e) {
+    } catch (Exception e) {
       log.error("Failed to catalog action menus while checking uniqueness for {}", name, e);
       throw new IllegalStateException("Failed to catalog action menus", e);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -36,7 +36,9 @@ import com.percussion.rest.actions.IActionMenuAdaptor;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.legacy.IPSCmsObjectMgr;
 import com.percussion.services.legacy.PSCmsObjectMgrLocator;
+import com.percussion.services.menus.PSActionMenu;
 import com.percussion.services.menus.PSContentTypeActionMenuHelper;
 import com.percussion.services.menus.PSTemplateActionMenuHelper;
 import com.percussion.share.service.exception.PSDataServiceException;
@@ -58,6 +60,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -76,8 +79,12 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   static final String SYSTEM_MENU_WRITE =
       "System action menus cannot be updated or deleted via this API";
 
+  /** JDBC persist marker on REST-created user menus ({@code RXMENUACTIONPROPERTIES}). */
+  static final String REST_USER_MENU_PROP = "sys_restUserMenu";
+
   private final IPSUiDesignWs service;
   private final BooleanSupplier adminChecker;
+  private final Supplier<List<PSActionMenu>> hibernateMenus;
 
   /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
   @Autowired(required = false)
@@ -90,8 +97,20 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
 
   /** Package-visible for unit tests. */
   ActionMenuAdaptor(IPSUiDesignWs service, BooleanSupplier adminChecker) {
+    this(service, adminChecker, null);
+  }
+
+  /**
+   * Package-visible for unit tests that stub Hibernate {@code RXMENUACTION} catalog
+   * (design-WS {@code findActions} can miss rows that GET catalog lists).
+   */
+  ActionMenuAdaptor(
+      IPSUiDesignWs service,
+      BooleanSupplier adminChecker,
+      Supplier<List<PSActionMenu>> hibernateMenus) {
     this.service = service;
     this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
+    this.hibernateMenus = hibernateMenus != null ? hibernateMenus : this::loadHibernateMenus;
   }
 
   @Override
@@ -226,31 +245,61 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     String key = idOrName.trim();
     try {
       List<ActionMenu> all = findMenus(null, null, null, null, null);
-      if (all == null) {
-        return null;
-      }
-      for (ActionMenu m : all) {
-        if (m == null) {
-          continue;
-        }
-        if (key.equalsIgnoreCase(m.getName())) {
-          return m;
-        }
-        if (String.valueOf(m.getId()).equals(key)) {
-          return m;
-        }
-        if (m.getGuid() != null) {
-          String gsv = m.getGuid().getStringValue();
-          if (gsv != null && key.equalsIgnoreCase(gsv.trim())) {
-            return m;
-          }
-        }
-      }
-      return null;
+      return matchMenuInTree(all, key);
     } catch (PSErrorResultsException e) {
       log.debug("Action menu lookup failed for {}: {}", key, e.toString());
       return null;
     }
+  }
+
+  static ActionMenu matchMenuInTree(List<ActionMenu> menus, String key) {
+    if (menus == null || StringUtils.isBlank(key)) {
+      return null;
+    }
+    for (ActionMenu m : menus) {
+      ActionMenu hit = matchMenuRecursive(m, key);
+      if (hit != null) {
+        return hit;
+      }
+    }
+    return null;
+  }
+
+  static ActionMenu matchMenuRecursive(ActionMenu m, String key) {
+    if (m == null) {
+      return null;
+    }
+    if (menuKeyMatches(m, key)) {
+      return m;
+    }
+    if (m.getChildren() != null) {
+      for (ActionMenu child : m.getChildren()) {
+        ActionMenu hit = matchMenuRecursive(child, key);
+        if (hit != null) {
+          return hit;
+        }
+      }
+    }
+    return null;
+  }
+
+  static boolean menuKeyMatches(ActionMenu m, String key) {
+    if (m == null || StringUtils.isBlank(key)) {
+      return false;
+    }
+    if (key.equalsIgnoreCase(m.getName())) {
+      return true;
+    }
+    if (String.valueOf(m.getId()).equals(key)) {
+      return true;
+    }
+    if (m.getGuid() != null) {
+      String gsv = m.getGuid().getStringValue();
+      if (gsv != null && key.equalsIgnoreCase(gsv.trim())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
@@ -272,6 +321,7 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       }
       PSAction domain = created.get(0);
       applyWritableFields(domain, body);
+      domain.getProperties().setProperty(REST_USER_MENU_PROP, PSAction.YES);
       service.saveActions(List.of(domain), true, session, user);
       return toDto(domain);
     } catch (WebApplicationException | IllegalStateException e) {
@@ -398,20 +448,18 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       if (match == null) {
         match = parseActionGuid(key);
       }
-      if (match == null) {
-        return null;
+      if (match != null) {
+        List<PSAction> loaded =
+            service.loadActions(
+                List.of(match), false, false, currentSession(), currentUser());
+        if (loaded != null && !loaded.isEmpty() && loaded.get(0) != null) {
+          return loaded.get(0);
+        }
       }
-      List<PSAction> loaded =
-          service.loadActions(
-              List.of(match), false, false, currentSession(), currentUser());
-      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
-        return null;
-      }
-      return loaded.get(0);
     } catch (PSErrorResultsException e) {
       IPSGuid requested = parseActionGuid(key);
       if (requested != null && isNotFound(e, requested)) {
-        return null;
+        return findHibernateActionByKey(key);
       }
       log.debug("Action menu design load failed for {}: {}", key, e.toString());
       throw new WebApplicationException(
@@ -419,6 +467,111 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     } catch (PSErrorException e) {
       log.error("Failed to catalog action menus while resolving {}", key, e);
       throw new IllegalStateException("Failed to catalog action menus", e);
+    }
+    return findHibernateActionByKey(key);
+  }
+
+  PSAction findHibernateActionByKey(String key) {
+    PSActionMenu menu = matchHibernateMenu(hibernateMenus.get(), key);
+    return menu == null ? null : psActionFromHibernate(menu);
+  }
+
+  static PSActionMenu matchHibernateMenu(List<PSActionMenu> menus, String key) {
+    if (menus == null || StringUtils.isBlank(key)) {
+      return null;
+    }
+    for (PSActionMenu m : menus) {
+      PSActionMenu hit = matchHibernateMenuRecursive(m, key);
+      if (hit != null) {
+        return hit;
+      }
+    }
+    return null;
+  }
+
+  static PSActionMenu matchHibernateMenuRecursive(PSActionMenu m, String key) {
+    if (m == null) {
+      return null;
+    }
+    if (hibernateMenuKeyMatches(m, key)) {
+      return m;
+    }
+    if (m.getChildren() != null) {
+      for (PSActionMenu child : m.getChildren()) {
+        PSActionMenu hit = matchHibernateMenuRecursive(child, key);
+        if (hit != null) {
+          return hit;
+        }
+      }
+    }
+    return null;
+  }
+
+  static boolean hibernateMenuKeyMatches(PSActionMenu m, String key) {
+    if (m == null || StringUtils.isBlank(key)) {
+      return false;
+    }
+    if (key.equalsIgnoreCase(StringUtils.defaultString(m.getName()))) {
+      return true;
+    }
+    if (String.valueOf(m.getActionId()).equals(key)) {
+      return true;
+    }
+    try {
+      IPSGuid guid = PSAction.getGuidFromId(m.getActionId());
+      if (guid != null && key.equalsIgnoreCase(guid.toString())) {
+        return true;
+      }
+    } catch (RuntimeException e) {
+      return false;
+    }
+    return false;
+  }
+
+  static PSAction psActionFromHibernate(PSActionMenu menu) {
+    if (menu == null || StringUtils.isBlank(menu.getName()) || menu.getActionId() <= 0) {
+      return null;
+    }
+    String label = StringUtils.defaultIfBlank(menu.getDisplayName(), menu.getName());
+    String type = StringUtils.defaultIfBlank(menu.getType(), PSAction.TYPE_MENU);
+    if (!PSAction.TYPE_MENU.equalsIgnoreCase(type)
+        && !PSAction.TYPE_MENUITEM.equalsIgnoreCase(type)
+        && !PSAction.TYPE_CONTEXTMENU.equalsIgnoreCase(type)) {
+      type = PSAction.TYPE_MENU;
+    }
+    String handler =
+        PSAction.HANDLER_CLIENT.equalsIgnoreCase(menu.getHandler())
+            ? PSAction.HANDLER_CLIENT
+            : PSAction.HANDLER_SERVER;
+    PSAction action =
+        new PSAction(
+            menu.getName(),
+            label,
+            type,
+            StringUtils.defaultString(menu.getUrl()),
+            handler,
+            menu.getSortOrder());
+    action.setGUID(PSAction.getGuidFromId(menu.getActionId()));
+    if (menu.getDescription() != null) {
+      action.setDescription(menu.getDescription());
+    }
+    if (hibernateHasRestUserMenu(menu)) {
+      action.getProperties().setProperty(REST_USER_MENU_PROP, PSAction.YES);
+    }
+    return action;
+  }
+
+  List<PSActionMenu> loadHibernateMenus() {
+    try {
+      IPSCmsObjectMgr mgr = PSCmsObjectMgrLocator.getObjectManager();
+      if (mgr == null) {
+        return Collections.emptyList();
+      }
+      List<PSActionMenu> tree = mgr.findActionMenusTree();
+      return tree == null ? Collections.emptyList() : tree;
+    } catch (RuntimeException e) {
+      log.debug("Hibernate action menu catalog unavailable: {}", e.toString());
+      return Collections.emptyList();
     }
   }
 
@@ -617,13 +770,23 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   }
 
   boolean isSystemMenu(PSAction action) {
+    if (isRestUserMenu(action)) {
+      return false;
+    }
     IPSGuid guid = safeGuid(action);
     if (guid == null) {
-      return false;
+      return true;
     }
     try {
       String path = service.objectIdToPath(guid);
-      return isSystemMenuPath(path);
+      if (isSystemMenuPath(path)) {
+        return true;
+      }
+      if (isUserMenuPath(path)) {
+        return false;
+      }
+      // Blank/unknown Workbench path: fail closed (packaged Edit is 409, not 204).
+      return true;
     } catch (RuntimeException e) {
       // Fail closed: a lookup error must not skip system-menu protection.
       log.warn(
@@ -632,17 +795,55 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     }
   }
 
+  boolean isRestUserMenu(PSAction action) {
+    if (action == null) {
+      return false;
+    }
+    if (PSAction.YES.equalsIgnoreCase(StringUtils.defaultString(action.getProperty(REST_USER_MENU_PROP)))) {
+      return true;
+    }
+    PSActionMenu hibernate = matchHibernateMenu(hibernateMenus.get(), action.getName());
+    return hibernateHasRestUserMenu(hibernate);
+  }
+
+  static boolean hibernateHasRestUserMenu(PSActionMenu menu) {
+    if (menu == null || menu.getProperties() == null) {
+      return false;
+    }
+    for (com.percussion.services.menus.PSActionMenuProperty prop : menu.getProperties()) {
+      if (prop == null || prop.getPrimaryKey() == null) {
+        continue;
+      }
+      if (REST_USER_MENU_PROP.equalsIgnoreCase(prop.getPrimaryKey().getPropertyName())
+          && PSAction.YES.equalsIgnoreCase(StringUtils.defaultString(prop.getValue()))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Workbench UI Elements {@code Menus/System} (and Menu Entries {@code System}) path segment.
    * Package-visible for unit tests.
    */
   static boolean isSystemMenuPath(String path) {
-    if (StringUtils.isBlank(path)) {
+    return pathHasSegment(path, "system");
+  }
+
+  /**
+   * Workbench UI Elements {@code Menus/User} path segment for REST-created menus.
+   */
+  static boolean isUserMenuPath(String path) {
+    return pathHasSegment(path, "user");
+  }
+
+  static boolean pathHasSegment(String path, String segment) {
+    if (StringUtils.isBlank(path) || StringUtils.isBlank(segment)) {
       return false;
     }
     String[] parts = path.split("[/\\\\]+");
     for (String part : parts) {
-      if ("system".equalsIgnoreCase(part.trim())) {
+      if (segment.equalsIgnoreCase(part.trim())) {
         return true;
       }
     }
@@ -677,7 +878,8 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
 
   private void assertNameUnique(String name) {
     try {
-      if (nameExists(service.findActions(name, null, null), name)) {
+      if (nameExists(service.findActions(name, null, null), name)
+          || hibernateNameExists(hibernateMenus.get(), name)) {
         throw new WebApplicationException("Action menu already exists: " + name, 409);
       }
     } catch (WebApplicationException e) {
@@ -686,6 +888,10 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       log.error("Failed to catalog action menus while checking uniqueness for {}", name, e);
       throw new IllegalStateException("Failed to catalog action menus", e);
     }
+  }
+
+  static boolean hibernateNameExists(List<PSActionMenu> menus, String name) {
+    return matchHibernateMenu(menus, name) != null;
   }
 
   static boolean nameExists(List<IPSCatalogSummary> summaries, String name) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -50,6 +50,7 @@ import com.percussion.webservices.ui.data.ActionType;
 import jakarta.ws.rs.WebApplicationException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -82,6 +83,7 @@ class ActionMenuAdaptorWriteTest {
 
   @AfterEach
   void tearDown() {
+    ActionMenuAdaptor.clearRequestHibernateIndex();
     PSRequestInfo.resetRequestInfo();
   }
 
@@ -487,6 +489,48 @@ class ActionMenuAdaptorWriteTest {
     assertTrue(adaptor.deleteActionMenu("MyMenu"));
     verify(designWs)
         .deleteActions(eq(List.of(existing.getGUID())), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void isSystemMenu_nullGuid_isFailClosed() {
+    PSAction action = new PSAction("NoGuid", "NoGuid");
+    assertTrue(adaptor.isSystemMenu(action));
+  }
+
+  @Test
+  void create_catalogPsErrorsException_is500() throws Exception {
+    when(designWs.findActions(eq("DupMenu"), isNull(), isNull()))
+        .thenThrow(new PSErrorsException());
+    ActionMenu body = new ActionMenu();
+    body.setName("DupMenu");
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.createActionMenu(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("catalog"));
+  }
+
+  @Test
+  void create_catalogRuntimeFailure_is500() throws Exception {
+    when(designWs.findActions(eq("DupMenu"), isNull(), isNull()))
+        .thenThrow(new IllegalStateException("catalog exploded"));
+    ActionMenu body = new ActionMenu();
+    body.setName("DupMenu");
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.createActionMenu(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("catalog"));
+  }
+
+  @Test
+  void indexHibernateMenus_indexesNameAndChildId() {
+    PSActionMenu child = new PSActionMenu("Child", "c", "MENUITEM", "", "server", 0);
+    child.setActionId(8);
+    PSActionMenu root = new PSActionMenu("Root", "r", "MENU", "", "server", 0);
+    root.setActionId(7);
+    root.setChildren(List.of(child));
+    Map<String, PSActionMenu> index = ActionMenuAdaptor.indexHibernateMenus(List.of(root));
+    assertEquals(root, index.get("root"));
+    assertEquals(child, index.get("child"));
+    assertEquals(root, index.get("7"));
+    assertEquals(child, index.get("8"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -36,9 +36,11 @@ import static org.mockito.Mockito.when;
 
 import com.percussion.cms.objectstore.PSAction;
 import com.percussion.rest.actions.ActionMenu;
+import com.percussion.rest.actions.ActionMenuList;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.menus.PSActionMenu;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
@@ -338,6 +340,48 @@ class ActionMenuAdaptorWriteTest {
   }
 
   @Test
+  void delete_system_whenDesignWsMissesHibernateRow_is409() throws Exception {
+    PSActionMenu edit = new PSActionMenu("Edit", "Edit", PSAction.TYPE_MENUITEM, "", "SERVER", 0);
+    edit.setActionId(7);
+    adaptor = new ActionMenuAdaptor(designWs, () -> true, () -> List.of(edit));
+    when(designWs.objectIdToPath(any())).thenReturn("//ContentExplorer/Menus/System/Edit");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("Edit"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void create_duplicateName_fromHibernateCatalog_is409() {
+    PSActionMenu existing = new PSActionMenu("MyMenu", "My Menu", PSAction.TYPE_MENU, "", "SERVER", 0);
+    existing.setActionId(9);
+    adaptor = new ActionMenuAdaptor(designWs, () -> true, () -> List.of(existing));
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createActionMenu(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void matchMenuInTree_findsNestedChild() {
+    ActionMenu root = new ActionMenu();
+    root.setName("File");
+    root.setId(1);
+    ActionMenu child = new ActionMenu();
+    child.setName("MyMenu");
+    child.setId(42);
+    ActionMenuList kids = new ActionMenuList();
+    kids.add(child);
+    root.setChildren(kids);
+    assertEquals("MyMenu", ActionMenuAdaptor.matchMenuInTree(List.of(root), "MyMenu").getName());
+    assertEquals(42, ActionMenuAdaptor.matchMenuInTree(List.of(root), "42").getId());
+  }
+
+  @Test
   void delete_system_is409() throws Exception {
     PSAction system = stubAction("Edit", 42);
     stubCatalogLoad(system);
@@ -417,6 +461,32 @@ class ActionMenuAdaptorWriteTest {
     assertFalse(ActionMenuAdaptor.isSystemMenuPath("//ContentExplorer/Menus/User/MyMenu"));
     assertFalse(ActionMenuAdaptor.isSystemMenuPath(""));
     assertFalse(ActionMenuAdaptor.isSystemMenuPath(null));
+    assertTrue(ActionMenuAdaptor.isUserMenuPath("//ContentExplorer/Menus/User/MyMenu"));
+    assertFalse(ActionMenuAdaptor.isUserMenuPath("//ContentExplorer/Menus/System/Edit"));
+  }
+
+  @Test
+  void delete_blankPathWithoutRestMarker_is409() throws Exception {
+    PSAction existing = stubAction("Edit", 101);
+    stubCatalogLoad(existing);
+    when(designWs.objectIdToPath(any())).thenReturn("");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("Edit"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_blankPathWithRestMarker_succeeds() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    existing.getProperties().setProperty(ActionMenuAdaptor.REST_USER_MENU_PROP, PSAction.YES);
+    stubCatalogLoad(existing);
+    when(designWs.objectIdToPath(any())).thenReturn("");
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(existing));
+    assertTrue(adaptor.deleteActionMenu("MyMenu"));
+    verify(designWs)
+        .deleteActions(eq(List.of(existing.getGUID())), eq(false), eq("test-session"), eq("Admin"));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsActionPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsActionPersistTest.java
@@ -63,6 +63,16 @@ class PSUiDesignWsActionPersistTest {
 
     assertTrue(prepared.isPersisted());
     assertEquals(42, prepared.getId());
+    assertNotSame(source, prepared);
+  }
+
+  @Test
+  void prepareActionForSave_neverReturnsTheCallerInstance() {
+    PSAction source = newAction(7, "NoMutate");
+    PSAction prepared = PSUiDesignWs.prepareActionForSave(source);
+    assertNotSame(source, prepared);
+    assertEquals("NoMutate", source.getName());
+    assertEquals(7, source.getId());
   }
 
   @Test
@@ -127,16 +137,28 @@ class PSUiDesignWsActionPersistTest {
       PSUiDesignWs.ensureRestUserMenuProperty(conn, spec.actionId);
       assertTrue(PSUiDesignWs.actionRowExists(conn, spec.actionId, spec.name));
       assertTrue(PSUiDesignWs.actionRowExists(conn, spec.actionId, "otherName"));
+      assertFalse(PSUiDesignWs.actionRowExists(conn, 9999, "QaH2Am"));
 
-      PSAction updated = newAction(2048, "QaH2Am");
+      PSAction sibling = newAction(2049, "Victim");
+      sibling.setLabel("Victim label");
+      PSUiDesignWs.insertActionRow(conn, PSUiDesignWs.actionRowSpec(sibling));
+
+      PSAction updated = newAction(2048, "Victim");
       updated.setLabel("Updated label");
       updated.setDescription("updated");
       PSUiDesignWs.ActionRowSpec updatedSpec = PSUiDesignWs.actionRowSpec(updated);
       PSUiDesignWs.updateActionRow(conn, updatedSpec);
-      assertTrue(PSUiDesignWs.actionRowExists(conn, 2048, "QaH2Am"));
+      assertTrue(PSUiDesignWs.actionRowExists(conn, 2048, "Victim"));
+      try (var rs =
+          conn.prepareStatement("SELECT DISPLAYNAME FROM RXMENUACTION WHERE ACTIONID = 2049")
+              .executeQuery()) {
+        assertTrue(rs.next());
+        assertEquals("Victim label", rs.getString(1));
+      }
 
       PSUiDesignWs.deleteActionRow(conn, spec.actionId);
       assertFalse(PSUiDesignWs.actionRowExists(conn, spec.actionId, spec.name));
+      assertTrue(PSUiDesignWs.actionRowExists(conn, 2049, "Victim"));
     }
   }
 

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsActionPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsActionPersistTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.webservices.ui.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.objectstore.IPSDbComponent;
+import com.percussion.cms.objectstore.PSAction;
+import com.percussion.cms.objectstore.PSKey;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * UI-02 persist: createActions + saveActions must INSERT a row visible to
+ * Hibernate {@code RXMENUACTION} (H2 REST POST 200 then GET catalog miss).
+ */
+@Tag("UnitTest")
+class PSUiDesignWsActionPersistTest {
+
+  @Test
+  void prepareActionForSave_newForcesInsert() {
+    PSAction source = newAction(2048, "QaAm4119");
+    assertFalse(source.isPersisted());
+
+    PSAction prepared = PSUiDesignWs.prepareActionForSave(source);
+
+    assertNotSame(source, prepared);
+    assertFalse(prepared.isPersisted());
+    assertEquals(IPSDbComponent.DBSTATE_NEW, prepared.getState());
+    assertEquals("QaAm4119", prepared.getName());
+  }
+
+  @Test
+  void prepareActionForSave_persistedKeepsLocator() {
+    PSAction source = newAction(42, "MyMenu");
+    PSKey key = PSAction.createKey("42");
+    source.setLocator(key);
+    assertTrue(source.isPersisted());
+
+    PSAction prepared = PSUiDesignWs.prepareActionForSave(source);
+
+    assertTrue(prepared.isPersisted());
+    assertEquals(42, prepared.getId());
+  }
+
+  @Test
+  void actionRowSpec_mapsAssignedNewMenuForInsert() {
+    PSAction source = newAction(2048, "QaAm4119");
+    source.setLabel("QA AM label");
+    source.setDescription("issue 4119 persist");
+    source.setMenuType(PSAction.TYPE_MENU);
+    source.setClientAction(false);
+
+    PSUiDesignWs.ActionRowSpec spec =
+        PSUiDesignWs.actionRowSpec(PSUiDesignWs.prepareActionForSave(source));
+
+    assertEquals(2048, spec.actionId);
+    assertEquals("QaAm4119", spec.name);
+    assertEquals("QA AM label", spec.displayName);
+    assertEquals("issue 4119 persist", spec.description);
+    assertEquals(PSAction.TYPE_MENU, spec.type);
+    assertEquals(PSAction.HANDLER_SERVER, spec.handler);
+  }
+
+  @Test
+  void invalidateActionCatalog_doesNotThrowWhenCacheUnavailable() {
+    assertDoesNotThrow(PSUiDesignWs::invalidateActionCatalog);
+  }
+
+  @Test
+  void insertActionRow_isVisibleToSelectAndDeleteOnH2() throws Exception {
+    String url = "jdbc:h2:mem:issue4119actions" + System.nanoTime();
+    try (Connection conn = DriverManager.getConnection(url);
+        Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE RXMENUACTION ("
+              + "ACTIONID INTEGER NOT NULL PRIMARY KEY,"
+              + "NAME VARCHAR(50) NOT NULL,"
+              + "DISPLAYNAME VARCHAR(50) NOT NULL,"
+              + "DESCRIPTION VARCHAR(255),"
+              + "URL VARCHAR(4000),"
+              + "SORTORDER INTEGER,"
+              + "TYPE VARCHAR(50),"
+              + "HANDLER VARCHAR(50),"
+              + "VERSION INTEGER NOT NULL)");
+      st.execute(
+          "CREATE TABLE RXMENUACTIONPARAM (ACTIONID INTEGER NOT NULL, PARAMNAME VARCHAR(50) NOT NULL)");
+      st.execute(
+          "CREATE TABLE RXMENUACTIONPROPERTIES (ACTIONID INTEGER NOT NULL, PROPNAME VARCHAR(100) NOT NULL, PROPVALUE VARCHAR(4000), DESCRIPTION VARCHAR(255), PRIMARY KEY (ACTIONID, PROPNAME))");
+      st.execute(
+          "CREATE TABLE RXMENUVISIBILITY (ACTIONID INTEGER NOT NULL, VISIBILITYCONTEXT VARCHAR(50) NOT NULL, \"VALUE\" VARCHAR(100) NOT NULL)");
+      st.execute(
+          "CREATE TABLE RXMODEUICONTEXTACTION (MODEID INTEGER NOT NULL, UICONTEXTID INTEGER NOT NULL, ACTIONID INTEGER NOT NULL)");
+      st.execute(
+          "CREATE TABLE RXMENUACTIONRELATION (ACTIONID INTEGER NOT NULL, CHILDACTIONID INTEGER NOT NULL)");
+
+      PSAction source = newAction(2048, "QaH2Am");
+      source.setLabel("QA H2 AM");
+      source.setDescription("persist");
+      PSUiDesignWs.ActionRowSpec spec =
+          PSUiDesignWs.actionRowSpec(PSUiDesignWs.prepareActionForSave(source));
+      assertFalse(PSUiDesignWs.actionRowExists(conn, spec.actionId, spec.name));
+      PSUiDesignWs.insertActionRow(conn, spec);
+      assertTrue(spec.restUserMenu);
+      PSUiDesignWs.ensureRestUserMenuProperty(conn, spec.actionId);
+      assertTrue(PSUiDesignWs.actionRowExists(conn, spec.actionId, spec.name));
+      assertTrue(PSUiDesignWs.actionRowExists(conn, spec.actionId, "otherName"));
+
+      PSAction updated = newAction(2048, "QaH2Am");
+      updated.setLabel("Updated label");
+      updated.setDescription("updated");
+      PSUiDesignWs.ActionRowSpec updatedSpec = PSUiDesignWs.actionRowSpec(updated);
+      PSUiDesignWs.updateActionRow(conn, updatedSpec);
+      assertTrue(PSUiDesignWs.actionRowExists(conn, 2048, "QaH2Am"));
+
+      PSUiDesignWs.deleteActionRow(conn, spec.actionId);
+      assertFalse(PSUiDesignWs.actionRowExists(conn, spec.actionId, spec.name));
+    }
+  }
+
+  private static PSAction newAction(int actionId, String name) {
+    PSAction source = new PSAction(name, name, PSAction.TYPE_MENU, "", PSAction.HANDLER_SERVER, 0);
+    PSKey key = PSAction.createKey(String.valueOf(actionId));
+    key.setPersisted(false);
+    source.setLocator(key);
+    return source;
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -1074,13 +1074,26 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          if (prepared.getGUID() != null)
             releasedIds.add(prepared.getGUID());
       }
-      // Locator saveComponents posts updateActions with no XML document
-      // (PSTransactionSet: Xml Document Expected). Persist RXMENUACTION via
-      // JDBC so Hibernate findActionMenusTree / GET catalog round-trip (#4119).
+      // SOAP / locator saveComponents writes the full RXMENUACTION graph
+      // (params, visibility, relations). REST H2 can still post updateActions
+      // with no XML document (PSTransactionSet: Xml Document Expected) and
+      // leave 0 parent rows — JDBC then fills RXMENUACTION for GET catalog.
+      try
+      {
+         saveComponents(components, PSAction.class, false, session, user);
+      }
+      catch (PSErrorsException e)
+      {
+         log.debug("saveComponents(updateActions) missed RXMENUACTION; JDBC fallback", e);
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("saveComponents(updateActions) failed; JDBC fallback for REST H2", e);
+      }
       for (IPSDbComponent component : components)
       {
          if (component instanceof PSAction persisted)
-            ensureActionRowPersisted(persisted);
+            persistActionRowPreferringHibernate(persisted);
       }
       if (release && !releasedIds.isEmpty())
       {
@@ -2610,7 +2623,11 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       PSAction action = (PSAction) source.cloneFull();
       if (action.getId() <= 0 && source.getId() > 0)
       {
-         action = source;
+         PSKey sourceKey = source.getLocator();
+         PSKey copy = PSAction.createKey(String.valueOf(source.getId()));
+         if (sourceKey != null)
+            copy.setPersisted(sourceKey.isPersisted());
+         action.setLocator(copy);
       }
       if (!action.isPersisted())
       {
@@ -2689,7 +2706,67 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
    /**
     * If {@code updateActions} did not INSERT, write {@code RXMENUACTION} so
     * Hibernate {@code findActionMenusTree} / GET catalog can list the name.
+    * Prefer the Hibernate {@code Session} JDBC connection so the write enrolls
+    * in the Spring {@code @Transactional} on {@link #saveActions}.
     */
+   void persistActionRowPreferringHibernate(PSAction action)
+   {
+      SessionFactory factory = getSessionFactory();
+      if (factory != null)
+      {
+         try
+         {
+            factory.getCurrentSession().doWork(conn -> persistActionRowOn(conn, action));
+            return;
+         }
+         catch (IllegalStateException e)
+         {
+            throw e;
+         }
+         catch (org.hibernate.HibernateException e)
+         {
+            if (e.getCause() instanceof SQLException)
+            {
+               throw new IllegalStateException(
+                     "Action menu was saved but is not visible to findActionMenusTree: " + action.getName(),
+                     e);
+            }
+            log.debug("No Hibernate current session for RXMENUACTION persist; PSConnectionHelper fallback",
+                  e);
+         }
+         catch (RuntimeException e)
+         {
+            log.debug("No Hibernate current session for RXMENUACTION persist; PSConnectionHelper fallback",
+                  e);
+         }
+      }
+      ensureActionRowPersisted(action);
+   }
+
+   static void persistActionRowOn(Connection conn, PSAction action) throws SQLException
+   {
+      ActionRowSpec spec = actionRowSpec(action);
+      if (actionRowExists(conn, spec.actionId, spec.name))
+      {
+         updateActionRow(conn, spec);
+      }
+      else
+      {
+         try
+         {
+            insertActionRow(conn, spec);
+         }
+         catch (SQLException insertEx)
+         {
+            if (!actionRowExists(conn, spec.actionId, spec.name))
+               throw insertEx;
+            updateActionRow(conn, spec);
+         }
+      }
+      if (spec.restUserMenu)
+         ensureRestUserMenuProperty(conn, spec.actionId);
+   }
+
    static void ensureActionRowPersisted(PSAction action)
    {
       ActionRowSpec spec = actionRowSpec(action);
@@ -2697,25 +2774,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       try
       {
          conn = PSConnectionHelper.getDbConnection();
-         if (actionRowExists(conn, spec.actionId, spec.name))
-         {
-            updateActionRow(conn, spec);
-         }
-         else
-         {
-            try
-            {
-               insertActionRow(conn, spec);
-            }
-            catch (SQLException insertEx)
-            {
-               if (!actionRowExists(conn, spec.actionId, spec.name))
-                  throw insertEx;
-               updateActionRow(conn, spec);
-            }
-         }
-         if (spec.restUserMenu)
-            ensureRestUserMenuProperty(conn, spec.actionId);
+         persistActionRowOn(conn, action);
       }
       catch (NamingException | SQLException e)
       {
@@ -2730,11 +2789,10 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
 
    static boolean actionRowExists(Connection conn, int actionId, String name) throws SQLException
    {
-      String sql = "SELECT ACTIONID FROM RXMENUACTION WHERE ACTIONID = ? OR NAME = ?";
+      String sql = "SELECT ACTIONID FROM RXMENUACTION WHERE ACTIONID = ?";
       try (PreparedStatement ps = conn.prepareStatement(sql))
       {
          ps.setInt(1, actionId);
-         ps.setString(2, name);
          try (ResultSet rs = ps.executeQuery())
          {
             return rs.next();
@@ -2756,7 +2814,7 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
    static void updateActionRow(Connection conn, ActionRowSpec spec) throws SQLException
    {
       String sql = "UPDATE RXMENUACTION SET NAME = ?, DISPLAYNAME = ?, DESCRIPTION = ?, URL = ?, SORTORDER = ?, "
-            + "TYPE = ?, HANDLER = ?, VERSION = ? WHERE ACTIONID = ? OR NAME = ?";
+            + "TYPE = ?, HANDLER = ?, VERSION = ? WHERE ACTIONID = ?";
       try (PreparedStatement ps = conn.prepareStatement(sql))
       {
          bindActionRow(ps, spec, true);
@@ -2777,7 +2835,6 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          ps.setString(7, spec.handler);
          ps.setInt(8, spec.version);
          ps.setInt(9, spec.actionId);
-         ps.setString(10, spec.name);
       }
       else
       {
@@ -2811,23 +2868,37 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       }
    }
 
-   static void deleteActionRow(Connection conn, int actionId) throws SQLException
+   /** Bind count for {@link #deleteActionChildRows} (not inferred from SQL text). */
+   enum ActionSqlBinds
    {
-      deleteActionChildRows(conn, "DELETE FROM RXMENUACTIONPARAM WHERE ACTIONID = ?", actionId);
-      deleteActionChildRows(conn, "DELETE FROM RXMENUACTIONPROPERTIES WHERE ACTIONID = ?", actionId);
-      deleteActionChildRows(conn, "DELETE FROM RXMENUVISIBILITY WHERE ACTIONID = ?", actionId);
-      deleteActionChildRows(conn, "DELETE FROM RXMODEUICONTEXTACTION WHERE ACTIONID = ?", actionId);
-      deleteActionChildRows(conn,
-            "DELETE FROM RXMENUACTIONRELATION WHERE ACTIONID = ? OR CHILDACTIONID = ?", actionId);
-      deleteActionChildRows(conn, "DELETE FROM RXMENUACTION WHERE ACTIONID = ?", actionId);
+      ACTION_ID,
+      ACTION_ID_AND_CHILD
    }
 
-   static void deleteActionChildRows(Connection conn, String sql, int actionId) throws SQLException
+   static void deleteActionRow(Connection conn, int actionId) throws SQLException
+   {
+      deleteActionChildRows(conn, "DELETE FROM RXMENUACTIONPARAM WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+      deleteActionChildRows(conn, "DELETE FROM RXMENUACTIONPROPERTIES WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+      deleteActionChildRows(conn, "DELETE FROM RXMENUVISIBILITY WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+      deleteActionChildRows(conn, "DELETE FROM RXMODEUICONTEXTACTION WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+      deleteActionChildRows(conn,
+            "DELETE FROM RXMENUACTIONRELATION WHERE ACTIONID = ? OR CHILDACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID_AND_CHILD);
+      deleteActionChildRows(conn, "DELETE FROM RXMENUACTION WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+   }
+
+   static void deleteActionChildRows(Connection conn, String sql, int actionId, ActionSqlBinds binds)
+         throws SQLException
    {
       try (PreparedStatement ps = conn.prepareStatement(sql))
       {
          ps.setInt(1, actionId);
-         if (sql.contains("CHILDACTIONID"))
+         if (binds == ActionSqlBinds.ACTION_ID_AND_CHILD)
             ps.setInt(2, actionId);
          ps.executeUpdate();
       }

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -20,6 +20,7 @@ import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.IPSDbComponent;
 import com.percussion.cms.objectstore.PSAction;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
+import com.percussion.services.menus.PSActionMenu;
 import com.percussion.cms.objectstore.PSDisplayColumn;
 import com.percussion.cms.objectstore.PSDisplayFormat;
 import com.percussion.cms.objectstore.PSDFColumns;
@@ -67,6 +68,7 @@ import com.percussion.webservices.ui.IPSUiDesignWs;
 import com.percussion.webservices.ui.data.ActionType;
 import org.apache.commons.lang3.StringUtils;
 import com.percussion.webservices.ExceptionUtils;
+import org.hibernate.SessionFactory;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -282,6 +284,12 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
 
       deleteComponents(ids, PSAction.class, PSAction.getComponentType(PSAction.class), ignoreDependencies, session,
             user);
+      for (IPSGuid id : ids)
+      {
+         if (id != null)
+            ensureActionRowDeleted(id.getUUID());
+      }
+      invalidateActionCatalog();
    }
 
    /*
@@ -1057,8 +1065,35 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
    {
       PSWebserviceUtils.validateParameters(actions, "actions", true, session, user);
 
-      List<IPSDbComponent> components = new ArrayList<>(actions);
-      saveComponents(components, PSAction.class, release, session, user);
+      List<IPSDbComponent> components = new ArrayList<>();
+      List<IPSGuid> releasedIds = new ArrayList<>();
+      for (PSAction action : actions)
+      {
+         PSAction prepared = prepareActionForSave(action);
+         components.add(prepared);
+         if (prepared.getGUID() != null)
+            releasedIds.add(prepared.getGUID());
+      }
+      // Locator saveComponents posts updateActions with no XML document
+      // (PSTransactionSet: Xml Document Expected). Persist RXMENUACTION via
+      // JDBC so Hibernate findActionMenusTree / GET catalog round-trip (#4119).
+      for (IPSDbComponent component : components)
+      {
+         if (component instanceof PSAction persisted)
+            ensureActionRowPersisted(persisted);
+      }
+      if (release && !releasedIds.isEmpty())
+      {
+         IPSObjectLockService lockService = PSObjectLockServiceLocator.getLockingService();
+         List<PSObjectLock> locks = lockService.findLocksByObjectIds(releasedIds, session, user);
+         lockService.releaseLocks(locks);
+      }
+      invalidateActionCatalog();
+      for (IPSGuid id : releasedIds)
+      {
+         if (id != null)
+            evictActionMenuCache(id.getUUID());
+      }
    }
 
    /*
@@ -2522,6 +2557,303 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       catch (RuntimeException e)
       {
          log.debug("Could not flush sys_DisplayFormats resource cache: {}", e.toString());
+      }
+   }
+
+   /**
+    * Drop the XML resource cache for {@code sys_psxCms} so {@link #findActions}
+    * sees a row just saved or deleted in {@code RXMENUACTION}.
+    */
+   static void invalidateActionCatalog()
+   {
+      try
+      {
+         if (PSCacheManager.isAvailable())
+         {
+            PSCacheManager.getInstance().flushApplication("sys_psxCms");
+         }
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("Could not flush sys_psxCms action catalog cache: {}", e.toString());
+      }
+   }
+
+   void evictActionMenuCache(int actionId)
+   {
+      try
+      {
+         SessionFactory factory = getSessionFactory();
+         if (factory != null && factory.getCache() != null && actionId > 0)
+         {
+            factory.getCache().evictEntityData(PSActionMenu.class, Integer.valueOf(actionId));
+         }
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("Could not evict Hibernate RXMENUACTION cache for {}: {}", actionId, e.toString());
+      }
+   }
+
+   /**
+    * Prepare an action for {@link #saveActions}. Unpersisted objects are forced
+    * to {@code DBSTATE_NEW} so INSERT (not delete-then-insert) is the intent.
+    *
+    * @param source never {@code null}
+    * @return clone ready for JDBC persist, never {@code null}
+    */
+   static PSAction prepareActionForSave(PSAction source)
+   {
+      if (source == null)
+         throw new IllegalArgumentException("action cannot be null");
+
+      PSAction action = (PSAction) source.cloneFull();
+      if (action.getId() <= 0 && source.getId() > 0)
+      {
+         action = source;
+      }
+      if (!action.isPersisted())
+      {
+         PSKey key = action.getLocator();
+         if (key != null)
+         {
+            key.setPersisted(false);
+            action.setLocator(key);
+         }
+         if (action.getState() != IPSDbComponent.DBSTATE_NEW)
+         {
+            action.setState(IPSDbComponent.DBSTATE_NEW);
+         }
+      }
+      return action;
+   }
+
+   /**
+    * Column values for a durable {@code RXMENUACTION} INSERT/UPDATE when
+    * {@code updateActions} reports success with 0 rows (H2 REST #4119).
+    */
+   /** Property written on REST/JDBC-created user menus so DELETE can tell them from packaged rows. */
+   static final String REST_USER_MENU_PROP = "sys_restUserMenu";
+
+   static final class ActionRowSpec
+   {
+      final int actionId;
+      final String name;
+      final String displayName;
+      final String description;
+      final String url;
+      final int sortOrder;
+      final String type;
+      final String handler;
+      final int version;
+      final boolean restUserMenu;
+
+      ActionRowSpec(int actionId, String name, String displayName, String description, String url, int sortOrder,
+            String type, String handler, int version, boolean restUserMenu)
+      {
+         this.actionId = actionId;
+         this.name = name;
+         this.displayName = displayName;
+         this.description = description;
+         this.url = url;
+         this.sortOrder = sortOrder;
+         this.type = type;
+         this.handler = handler;
+         this.version = version;
+         this.restUserMenu = restUserMenu;
+      }
+   }
+
+   static ActionRowSpec actionRowSpec(PSAction action)
+   {
+      if (action == null)
+         throw new IllegalArgumentException("action cannot be null");
+      int id = action.getId();
+      if (id <= 0)
+         throw new IllegalArgumentException("action id must be assigned before persist");
+      String name = action.getName();
+      if (StringUtils.isBlank(name))
+         throw new IllegalArgumentException("action name is required");
+      String display = StringUtils.defaultIfBlank(action.getLabel(), name);
+      String description = StringUtils.trimToNull(action.getDescription());
+      String url = StringUtils.trimToNull(action.getURL());
+      String type = StringUtils.defaultIfBlank(action.getMenuType(), PSAction.TYPE_MENU);
+      String handler = action.isClientAction() ? PSAction.HANDLER_CLIENT : PSAction.HANDLER_SERVER;
+      int version = action.getVersion() != null ? action.getVersion().intValue() : 0;
+      boolean restUser = !action.isPersisted()
+            || StringUtils.equalsIgnoreCase(action.getProperty(REST_USER_MENU_PROP), PSAction.YES);
+      return new ActionRowSpec(id, name, display, description, url, action.getSortRank(), type, handler, version,
+            restUser);
+   }
+
+   /**
+    * If {@code updateActions} did not INSERT, write {@code RXMENUACTION} so
+    * Hibernate {@code findActionMenusTree} / GET catalog can list the name.
+    */
+   static void ensureActionRowPersisted(PSAction action)
+   {
+      ActionRowSpec spec = actionRowSpec(action);
+      Connection conn = null;
+      try
+      {
+         conn = PSConnectionHelper.getDbConnection();
+         if (actionRowExists(conn, spec.actionId, spec.name))
+         {
+            updateActionRow(conn, spec);
+         }
+         else
+         {
+            try
+            {
+               insertActionRow(conn, spec);
+            }
+            catch (SQLException insertEx)
+            {
+               if (!actionRowExists(conn, spec.actionId, spec.name))
+                  throw insertEx;
+               updateActionRow(conn, spec);
+            }
+         }
+         if (spec.restUserMenu)
+            ensureRestUserMenuProperty(conn, spec.actionId);
+      }
+      catch (NamingException | SQLException e)
+      {
+         throw new IllegalStateException(
+               "Action menu was saved but is not visible to findActionMenusTree: " + spec.name, e);
+      }
+      finally
+      {
+         PSConnectionHelper.releaseDbConnection(conn);
+      }
+   }
+
+   static boolean actionRowExists(Connection conn, int actionId, String name) throws SQLException
+   {
+      String sql = "SELECT ACTIONID FROM RXMENUACTION WHERE ACTIONID = ? OR NAME = ?";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setInt(1, actionId);
+         ps.setString(2, name);
+         try (ResultSet rs = ps.executeQuery())
+         {
+            return rs.next();
+         }
+      }
+   }
+
+   static void insertActionRow(Connection conn, ActionRowSpec spec) throws SQLException
+   {
+      String sql = "INSERT INTO RXMENUACTION (ACTIONID, NAME, DISPLAYNAME, DESCRIPTION, URL, SORTORDER, TYPE, "
+            + "HANDLER, VERSION) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         bindActionRow(ps, spec, false);
+         ps.executeUpdate();
+      }
+   }
+
+   static void updateActionRow(Connection conn, ActionRowSpec spec) throws SQLException
+   {
+      String sql = "UPDATE RXMENUACTION SET NAME = ?, DISPLAYNAME = ?, DESCRIPTION = ?, URL = ?, SORTORDER = ?, "
+            + "TYPE = ?, HANDLER = ?, VERSION = ? WHERE ACTIONID = ? OR NAME = ?";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         bindActionRow(ps, spec, true);
+         ps.executeUpdate();
+      }
+   }
+
+   static void bindActionRow(PreparedStatement ps, ActionRowSpec spec, boolean update) throws SQLException
+   {
+      if (update)
+      {
+         ps.setString(1, spec.name);
+         ps.setString(2, spec.displayName);
+         ps.setString(3, spec.description);
+         ps.setString(4, spec.url);
+         ps.setInt(5, spec.sortOrder);
+         ps.setString(6, spec.type);
+         ps.setString(7, spec.handler);
+         ps.setInt(8, spec.version);
+         ps.setInt(9, spec.actionId);
+         ps.setString(10, spec.name);
+      }
+      else
+      {
+         ps.setInt(1, spec.actionId);
+         ps.setString(2, spec.name);
+         ps.setString(3, spec.displayName);
+         ps.setString(4, spec.description);
+         ps.setString(5, spec.url);
+         ps.setInt(6, spec.sortOrder);
+         ps.setString(7, spec.type);
+         ps.setString(8, spec.handler);
+         ps.setInt(9, spec.version);
+      }
+   }
+
+   static void ensureActionRowDeleted(int actionId)
+   {
+      Connection conn = null;
+      try
+      {
+         conn = PSConnectionHelper.getDbConnection();
+         deleteActionRow(conn, actionId);
+      }
+      catch (NamingException | SQLException e)
+      {
+         log.debug("Could not JDBC-delete RXMENUACTION ACTIONID={}: {}", actionId, e.toString());
+      }
+      finally
+      {
+         PSConnectionHelper.releaseDbConnection(conn);
+      }
+   }
+
+   static void deleteActionRow(Connection conn, int actionId) throws SQLException
+   {
+      deleteActionChildRows(conn, "DELETE FROM RXMENUACTIONPARAM WHERE ACTIONID = ?", actionId);
+      deleteActionChildRows(conn, "DELETE FROM RXMENUACTIONPROPERTIES WHERE ACTIONID = ?", actionId);
+      deleteActionChildRows(conn, "DELETE FROM RXMENUVISIBILITY WHERE ACTIONID = ?", actionId);
+      deleteActionChildRows(conn, "DELETE FROM RXMODEUICONTEXTACTION WHERE ACTIONID = ?", actionId);
+      deleteActionChildRows(conn,
+            "DELETE FROM RXMENUACTIONRELATION WHERE ACTIONID = ? OR CHILDACTIONID = ?", actionId);
+      deleteActionChildRows(conn, "DELETE FROM RXMENUACTION WHERE ACTIONID = ?", actionId);
+   }
+
+   static void deleteActionChildRows(Connection conn, String sql, int actionId) throws SQLException
+   {
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setInt(1, actionId);
+         if (sql.contains("CHILDACTIONID"))
+            ps.setInt(2, actionId);
+         ps.executeUpdate();
+      }
+   }
+
+   static void ensureRestUserMenuProperty(Connection conn, int actionId) throws SQLException
+   {
+      String existsSql = "SELECT PROPNAME FROM RXMENUACTIONPROPERTIES WHERE ACTIONID = ? AND PROPNAME = ?";
+      try (PreparedStatement ps = conn.prepareStatement(existsSql))
+      {
+         ps.setInt(1, actionId);
+         ps.setString(2, REST_USER_MENU_PROP);
+         try (ResultSet rs = ps.executeQuery())
+         {
+            if (rs.next())
+               return;
+         }
+      }
+      String sql = "INSERT INTO RXMENUACTIONPROPERTIES (ACTIONID, PROPNAME, PROPVALUE, DESCRIPTION) VALUES (?, ?, ?, ?)";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setInt(1, actionId);
+         ps.setString(2, REST_USER_MENU_PROP);
+         ps.setString(3, PSAction.YES);
+         ps.setString(4, "Created via REST action menu persist");
+         ps.executeUpdate();
       }
    }
 


### PR DESCRIPTION
## Summary

Durable GET catalog after Admin action-menu POST/DELETE (issue #4119, parent #1690, slice of #4112).

`IPSUiDesignWs.saveActions` / `deleteActions` now persist `RXMENUACTION` via JDBC (same class as display-format persist #4101) so Hibernate `findActionMenusTree` used by `GET /services/actions/catalog` and GET by name includes a user menu after POST and omits it after DELETE. REST-created menus are marked `sys_restUserMenu`; packaged menus (blank or `Menus/System` Workbench path) mutate/delete **409** without stealing locks (`overrideLock=false`). Duplicate 409, invalid name 400, non-Admin 403 remain. Finder helpers and UI-03/UI-04 are unchanged. Coordinates with #4123 (JAXB POST mapping) by not changing the JAX-RS write resource.

Fixes #4119
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `system` / `sitemanage` / `perc-qa-automation` `mvnw clean install`.
2. `perc-devctl qa-up --skip-image-build` → hot-copy `perc-system` + `sitemanage` (+ matching `rest`) into the H2 WAR → in-cell StopJetty/StartJetty → `qa-health`.
3. `npm run test:surface -- --path tests/developer-action-menu-persist.spec.js` (2 passed).
4. Duplicate POST 409, invalid name 400 covered in adaptor unit tests; non-Admin 403 in `ActionMenuAdaptorWriteTest`.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (durable `RXMENUACTION` after POST/DELETE)
- [x] **Unit / module tests** — `PSUiDesignWsActionPersistTest`, `ActionMenuAdaptorWriteTest`; standalone clean install green
- [x] **WebUI + Playwright** — persist surface spec (no SPA chrome; REST from logged-in Admin)
- [x] **Build gates** — each changed Maven module standalone clean install (no skipTests)
- [x] **Cross-platform** — JDBC identifiers only; Playwright uses existing portable auth helpers

### C3 evidence

- **modules_built:** `system`, `projects/sitemanage`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2694, Failures: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS, Tests run: 2143, Failures: 0 (`ActionMenuAdaptorWriteTest` 29 tests)
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS (npm ci; no Surefire tests)
- **downstream_checked:** none (no `final`/signature change on existing public APIs). `sitemanage` standalone install consumed the new `perc-system` SNAPSHOT.

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER=perc-matrix-cms-h2`
- Hot-deploy: `perc-system-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar`, `rest-8.2.0-SNAPSHOT.jar` into `Rhythmyx/WEB-INF/lib`; in-cell StopJetty/StartJetty (not `docker restart`)
- `qa-health` RESULT:OK HTTP:200 HEALTH:healthy
- `npm run test:surface -- --path tests/developer-action-menu-persist.spec.js` — **2 passed**
- console-clean=yes
- server.log-clean=yes (no ERROR/FATAL in the test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
