### PR TITLE
fix(rest): persist Admin action menus in GET catalog (#4140)

### DIFF
--- a/docs/ai-generated/code-reviews/4140-action-menu-persist-erlang.md
+++ b/docs/ai-generated/code-reviews/4140-action-menu-persist-erlang.md
@@ -1,0 +1,16 @@
+# Erlang review — #4140 REST action-menu persist residual
+
+**Memory patterns hit:** change-class closure (rest JsonReader + sitemanage adaptor + system JDBC persist + adaptor tests + H2 Playwright persist spec + product-docs); lock-no-steal 409; Hibernate catalog vs design-WS XML miss; packaged Copy 404 vs 409.
+
+## Verdict
+
+Pass for this slice. Cluster persist (`ActionMenuJsonReader`, `RXMENUACTION` JDBC) is consumed from #4139 and tightened so GET catalog sees POST (own Hibernate session commit + `CacheMode.IGNORE` on `findActionMenus` + L2 region evict). Packaged `Copy` DELETE/PUT is 409 via Hibernate-first identity (design-WS miss no longer 404). REST user DELETE still JDBC-deletes when XML load misses. `overrideLock=false` unchanged. Finder helpers not reimplemented. SPA chrome not re-litigated.
+
+## Checks
+
+- Behavioral unit tests: `PSUiDesignWsActionPersistTest`, `ActionMenuAdaptorWriteTest` (Copy 409 when design-WS misses, rest-user DELETE still calls `deleteActions`), `ActionMenuJsonReaderTest`.
+- Portable paths: JDBC SQL identifiers only; Playwright uses existing auth helpers.
+- Product-docs 8.2 `developer/rest.md` + `admin/developer-action-menus.md`: durable catalog after POST; packaged Copy 409.
+- Playwright: `developer-action-menu-persist.spec.js`.
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/modules/perc-qa-automation/frontend/tests/developer-action-menu-persist.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-action-menu-persist.spec.js
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * REST action-menu persist after Admin POST/DELETE (#4119 / parent #1690).
+ *
+ * POST `/services/actions` must be durable in Hibernate `RXMENUACTION` so GET
+ * `/services/actions/catalog` and GET by name include the user menu. DELETE of
+ * that user menu is 204 then GET 404. System menus (`Menus/System`, e.g. Edit)
+ * are 409 without stealing the design lock. Does not re-implement finder helpers
+ * or SPA UI-03/UI-04 chrome.
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   python docker/scripts/perc-devctl.py qa-health
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=…
+ *     npm run test:surface -- --path tests/developer-action-menu-persist.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin } = require("./helpers/auth");
+
+/** REST-safe unique action-menu name (no spaces, wildcards, or path characters). */
+function uniqueActionMenuName(prefix) {
+  const a = Date.now().toString(36).replace(/[^a-z0-9]/g, "").slice(-4);
+  const b = Math.random().toString(36).replace(/[^a-z0-9]/g, "").slice(2, 6);
+  const suffix = `${a}${b}`.slice(0, 8);
+  return `${prefix}${suffix || "x"}`;
+}
+
+/**
+ * Same-origin fetch so OWASP CSRF + session cookies apply.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} path
+ * @param {string} method
+ * @param {object} [body]
+ * @returns {Promise<{status: number, text: string}>}
+ */
+async function inPageJson(page, path, method, body) {
+  return page.evaluate(
+    async ({ path: url, method: httpMethod, body: payload }) => {
+      const tokenObj = window.OWASP_CSRFTOKEN;
+      const metaToken = document.querySelector('meta[name="_csrf"]');
+      const metaHeader = document.querySelector('meta[name="_csrf_header"]');
+      const token =
+        (tokenObj && tokenObj.token) || (metaToken && metaToken.content) || "";
+      const headerName =
+        (metaHeader && metaHeader.content) || "OWASP-CSRFTOKEN";
+      const headers = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      };
+      if (token) {
+        headers[headerName] = token;
+      }
+      const res = await fetch(url, {
+        method: httpMethod,
+        credentials: "same-origin",
+        headers,
+        body: payload === undefined ? undefined : JSON.stringify(payload),
+      });
+      const text = await res.text();
+      return { status: res.status, text };
+    },
+    { path, method, body },
+  );
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(
+    unexpectedConsole,
+    `console error: ${unexpectedConsole.join(" | ")}`,
+  ).toEqual([]);
+}
+
+function nameInJson(text, name) {
+  return new RegExp(`"name"\\s*:\\s*"${name}"`).test(text);
+}
+
+test.describe("REST action menu persist (#4119 / UI-02)", () => {
+  test("Admin POST is in GET catalog and GET by name; DELETE 204 then 404", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+
+    const menuName = uniqueActionMenuName("qa4119");
+    expect(menuName.startsWith("qa4119")).toBeTruthy();
+
+    const create = await inPageJson(page, "/Rhythmyx/services/actions", "POST", {
+      ActionMenu: {
+        name: menuName,
+        label: `${menuName} label`,
+        description: "qa4119 persist",
+        menuType: "MENU",
+      },
+    });
+    expect(
+      create.status,
+      `POST create should be 200 (got ${create.status}): ${create.text}`,
+    ).toBe(200);
+    expect(nameInJson(create.text, menuName), create.text).toBeTruthy();
+
+    const catalog = await inPageJson(
+      page,
+      "/Rhythmyx/services/actions/catalog",
+      "GET",
+    );
+    expect(catalog.status, `GET catalog (got ${catalog.status}): ${catalog.text}`).toBe(
+      200,
+    );
+    expect(
+      nameInJson(catalog.text, menuName),
+      `GET catalog must list ${menuName}: ${catalog.text}`,
+    ).toBeTruthy();
+
+    const byName = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/catalog/${encodeURIComponent(menuName)}`,
+      "GET",
+    );
+    expect(
+      byName.status,
+      `GET by name after create (got ${byName.status}): ${byName.text}`,
+    ).toBe(200);
+    expect(nameInJson(byName.text, menuName), byName.text).toBeTruthy();
+
+    const dup = await inPageJson(page, "/Rhythmyx/services/actions", "POST", {
+      ActionMenu: {
+        name: menuName,
+        label: `${menuName} dup`,
+        menuType: "MENU",
+      },
+    });
+    expect(dup.status, `duplicate POST (got ${dup.status}): ${dup.text}`).toBe(409);
+
+    const invalid = await inPageJson(page, "/Rhythmyx/services/actions", "POST", {
+      ActionMenu: {
+        name: "has space",
+        label: "bad",
+        menuType: "MENU",
+      },
+    });
+    expect(
+      invalid.status,
+      `invalid name POST (got ${invalid.status}): ${invalid.text}`,
+    ).toBe(400);
+
+    const del = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/${encodeURIComponent(menuName)}`,
+      "DELETE",
+    );
+    expect(del.status, `DELETE should be 204 (got ${del.status}): ${del.text}`).toBe(
+      204,
+    );
+
+    const afterDelete = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/catalog/${encodeURIComponent(menuName)}`,
+      "GET",
+    );
+    expect(
+      afterDelete.status,
+      `GET after DELETE must be 404 (got ${afterDelete.status}): ${afterDelete.text}`,
+    ).toBe(404);
+
+    const catalogAfter = await inPageJson(
+      page,
+      "/Rhythmyx/services/actions/catalog",
+      "GET",
+    );
+    expect(catalogAfter.status).toBe(200);
+    expect(
+      nameInJson(catalogAfter.text, menuName),
+      `GET catalog must omit deleted ${menuName}: ${catalogAfter.text}`,
+    ).toBeFalsy();
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+
+  test("DELETE/PUT of a packaged catalog menu is 409", async ({ page }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+
+    const catalog = await inPageJson(
+      page,
+      "/Rhythmyx/services/actions/catalog",
+      "GET",
+    );
+    expect(catalog.status, catalog.text).toBe(200);
+    const names = [...catalog.text.matchAll(/"name"\s*:\s*"([^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    const preferred = ["Copy", "Preview", "Open", "Checkout", "Checkin", "View"];
+    const systemName =
+      preferred.find((n) => names.includes(n)) ||
+      names.find((n) => n && !/^qa4119/i.test(n));
+    expect(systemName, `catalog must include a packaged menu: ${catalog.text}`).toBeTruthy();
+
+    const del = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/${encodeURIComponent(systemName)}`,
+      "DELETE",
+    );
+    expect(
+      del.status,
+      `DELETE ${systemName} should be 409 (got ${del.status}): ${del.text}`,
+    ).toBe(409);
+
+    const put = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/${encodeURIComponent(systemName)}`,
+      "PUT",
+      {
+        ActionMenu: {
+          label: "Must not mutate packaged menu",
+        },
+      },
+    );
+    expect(
+      put.status,
+      `PUT ${systemName} should be 409 (got ${put.status}): ${put.text}`,
+    ).toBe(409);
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/product-docs/8.2/admin/developer-action-menus.md
+++ b/product-docs/8.2/admin/developer-action-menus.md
@@ -1,0 +1,73 @@
+---
+id: admin-developer-action-menus
+title: Developer Action Menus
+description: Create and delete Content Explorer action menus from Developer Action Menus chrome
+version: "8.2"
+order: 48
+tags: [admin, developer, action-menus]
+---
+
+# Developer Action Menus
+
+**Developer → Action Menus** lists Content Explorer action menu definitions
+(Workbench **Menus** editor: unique internal name, label, description, and
+menu type). Admins can **create** a user action menu and **delete** a selected
+user menu from this chrome. The **name** is required, must be unique
+(case-insensitive), and must not contain spaces, wildcards (`*` / `%`), or
+path characters. Name cannot be renamed after create.
+
+**System** menus (Workbench `Menus/System` hierarchy) are listed but **cannot**
+be updated or deleted from this catalog. A mutate or delete attempt is **409**;
+the product does not steal the design lock (`overrideLock=false`).
+
+This is **not** the Workbench cascading-children composer (UI-04) or the
+usage / command / visibility tabs (UI-03). Parameters and properties on
+detail stay **read-only**.
+
+## Product path — create, delete
+
+1. Sign in as **Admin** (write calls require the Admin role).
+2. Open **Developer → Action Menus**, or deep-link
+   `spa.jsp?entry=developer&section=action-menus`.
+3. Click **New action menu**. Enter a **name**. Save stays disabled until the
+   name is valid (no spaces, no `*` / `%`, no `/` or `..`). Optional: label,
+   description, menu type (`MENUITEM` default, `MENU`, `CONTEXTMENU`, or
+   `DYNAMICMENU`), and URL.
+4. Click **Save**. A duplicate name is **409** and the editor shows the server
+   conflict message (duplicate, system menu, or lock). An invalid name is
+   **400**. A non-Admin session is **403**. After a successful create, the name
+   field is read-only and the editor notice confirms the save. The catalog
+   lists the new name immediately (`GET /services/actions/catalog` and GET by
+   name); packaged menus such as **Copy** cannot be deleted (**409**).
+5. Optional: change label, description, menu type, or URL and **Save** again.
+   Child entries, parameters, properties, and visibility are not written.
+6. Click **Delete** and confirm. The catalog returns with a green **Action
+   menu deleted** notice and no longer lists that user menu. Delete of a
+   missing menu is **404**. Delete of a **system** menu is **409** and the row
+   remains. A menu still used as a dependent, or locked by another user, is
+   **409**. On **Save** in edit mode (name is read-only), a **400** shows the
+   server message rather than an invalid-name hint.
+
+## Limits
+
+- Name is immutable after create.
+- Cascading child menu composition is not in this chrome (UI-04).
+- Usage / command / visibility tab editing is not in this chrome (UI-03).
+- System menus cannot be updated or deleted here.
+
+## REST
+
+The chrome calls:
+
+| Action | Request |
+|--------|---------|
+| List | `GET /services/actions/catalog` |
+| Load | `GET /services/actions/catalog/{idOrName}` |
+| Create | `POST /services/actions` (`name` required; unique, no spaces) |
+| Save | `PUT /services/actions/{idOrName}` (label, description, menuType, url) |
+| Delete | `DELETE /services/actions/{idOrName}` (`204` on success) |
+
+Writes lock the menu for the request (`overrideLock=false`) and release it on
+save. System menus are **409**; the lock is not stolen.
+
+Integrator notes: [REST API — Action menus](id:developer-rest).

--- a/product-docs/8.2/admin/index.md
+++ b/product-docs/8.2/admin/index.md
@@ -117,6 +117,7 @@ Non-administrators never see the Admin top-nav item or these configuration surfa
 - [Developer Communities](id:admin-developer-communities)
 - [Developer Views](id:admin-developer-views)
 - [Developer Display Formats](id:admin-developer-display-formats)
+- [Developer Action Menus](id:admin-developer-action-menus)
 - [Object ACL & default template](id:admin-object-acl)
 - [Publishing](id:admin-publishing)
 - [Server operations](id:admin-server-ops)

--- a/product-docs/8.2/developer/index.md
+++ b/product-docs/8.2/developer/index.md
@@ -40,6 +40,8 @@ Operators using **Developer → Views** create/delete chrome: [Developer Views](
 
 Operators using **Developer → Display Formats** create/delete and column add/remove/reorder chrome: [Developer Display Formats](id:admin-developer-display-formats).
 
+Operators using **Developer → Action Menus** create/delete chrome: [Developer Action Menus](id:admin-developer-action-menus).
+
 ## Architecture snapshot
 
 ```text

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1475,12 +1475,17 @@ load **Object ACL** via `GET /services/acls/object/{guid}`. When the nested Guid
 hard to bind, clients may also synthesize that same string from the numeric `id`.
 
 Admin **write** persists through `IPSUiDesignWs` (`createActions` / `loadActions` /
-`saveActions` / `deleteActions`) — the same design web service SOAP uses. There is
-no new SOAP surface. **Do not** treat this as a Developer Action Menus SPA; chrome
-for create/save/delete is a later sibling. Cascading children composition (UI-04)
-and usage/command/visibility tab completeness (UI-03) are later slices. Finder
-helpers (`GET /services/actions/find`, content-type and template finders) are
-unchanged.
+`saveActions` / `deleteActions`) — the same design web service SOAP uses. Durable
+rows are written to `RXMENUACTION` so Hibernate `findActionMenusTree` (GET
+`/services/actions/catalog` and GET by name) includes a user menu immediately
+after POST, and omits it after DELETE. There is no new SOAP surface.
+**Developer → Action Menus** chrome creates and deletes user menus (and saves
+label / description / menuType / url); cascading children composition (UI-04)
+and usage/command/visibility tab completeness (UI-03) are later slices — see
+[Developer Action Menus](id:admin-developer-action-menus). Finder helpers
+(`GET /services/actions/find`, content-type and template finders) are unchanged.
+After POST the editor notice confirms the save. Packaged menus (for example
+**Copy**) are **409** on PUT/DELETE, not **404**.
 
 Write is **Admin** only. Name is unique (case-insensitive) and must not contain
 whitespace or wildcards. Duplicate name is **409**. Invalid name or menu type is
@@ -1500,9 +1505,12 @@ PUT round-trips GET detail fields already exposed (`label`, `description`,
 | `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, and/or url |
 | `DELETE` | `/services/actions/{idOrName}` | **Admin.** Delete a user action menu (`deleteActions`, `ignoreDependencies=false`) |
 
-JSON may wrap a single item as `ActionMenu`. Integrators should unwrap that
-envelope and read `guid.stringValue` (never assume the GUID is missing when `id`
-is present). See [Object ACL & default template](id:admin-object-acl).
+JSON may wrap a single item as `ActionMenu`. **Create** `POST /services/actions`
+sends that envelope (or a flat object with `name`). Do not post
+`allowedWorkflowTransitionsRequest` on the collection path — that finder lives at
+`POST /services/actions/find/transitions`. Integrators should unwrap the
+`ActionMenu` envelope and read `guid.stringValue` (never assume the GUID is
+missing when `id` is present). See [Object ACL & default template](id:admin-object-acl).
 
 ## Views (design catalog)
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -36,7 +36,10 @@ import com.percussion.rest.actions.IActionMenuAdaptor;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.legacy.IPSCmsObjectMgr;
 import com.percussion.services.legacy.PSCmsObjectMgrLocator;
+import com.percussion.services.menus.PSActionMenu;
+import com.percussion.services.menus.RxmActionMenuConstants;
 import com.percussion.services.menus.PSContentTypeActionMenuHelper;
 import com.percussion.services.menus.PSTemplateActionMenuHelper;
 import com.percussion.share.service.exception.PSDataServiceException;
@@ -55,9 +58,11 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -76,8 +81,16 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   static final String SYSTEM_MENU_WRITE =
       "System action menus cannot be updated or deleted via this API";
 
+  /** JDBC persist marker on REST-created user menus ({@code RXMENUACTIONPROPERTIES}). */
+  static final String REST_USER_MENU_PROP = RxmActionMenuConstants.REST_USER_MENU_PROP;
+
   private final IPSUiDesignWs service;
   private final BooleanSupplier adminChecker;
+  private final Supplier<List<PSActionMenu>> hibernateMenus;
+
+  /** Per-request Hibernate catalog index (name/id → menu); cleared in write finally. */
+  private static final ThreadLocal<Map<String, PSActionMenu>> REQUEST_HIBERNATE_INDEX =
+      new ThreadLocal<>();
 
   /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
   @Autowired(required = false)
@@ -90,19 +103,35 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
 
   /** Package-visible for unit tests. */
   ActionMenuAdaptor(IPSUiDesignWs service, BooleanSupplier adminChecker) {
+    this(service, adminChecker, null);
+  }
+
+  /**
+   * Package-visible for unit tests that stub Hibernate {@code RXMENUACTION} catalog
+   * (design-WS {@code findActions} can miss rows that GET catalog lists).
+   */
+  ActionMenuAdaptor(
+      IPSUiDesignWs service,
+      BooleanSupplier adminChecker,
+      Supplier<List<PSActionMenu>> hibernateMenus) {
     this.service = service;
     this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
+    this.hibernateMenus = hibernateMenus != null ? hibernateMenus : this::loadHibernateMenus;
   }
 
   @Override
   public List<ActionMenu> findMenus(
       String name, String label, Boolean item, Boolean dynamic, Boolean cascading)
       throws PSErrorResultsException {
-    var mgr = PSCmsObjectMgrLocator.getObjectManager();
-    // Nested tree (roots + children) so Explorer ActionToolbar can render
-    // cascading MENUs as dropdowns instead of a flat multi-row button dump (#2730).
-    List<ActionMenu> tree = ApiUtils.convertPSActionMenuList(mgr.findActionMenusTree());
-    return filterMenus(tree, name, label, item, dynamic, cascading);
+    try {
+      var mgr = PSCmsObjectMgrLocator.getObjectManager();
+      // Nested tree (roots + children) so Explorer ActionToolbar can render
+      // cascading MENUs as dropdowns instead of a flat multi-row button dump (#2730).
+      List<ActionMenu> tree = ApiUtils.convertPSActionMenuList(mgr.findActionMenusTree());
+      return filterMenus(tree, name, label, item, dynamic, cascading);
+    } finally {
+      clearRequestHibernateIndex();
+    }
   }
 
   /**
@@ -189,7 +218,11 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   @Override
   public List<ActionMenu> findAllowedTransitions(
       Integer[] contentIds, Integer[] assignmentTypeIds) {
-    return Collections.emptyList();
+    try {
+      return Collections.emptyList();
+    } finally {
+      clearRequestHibernateIndex();
+    }
   }
 
   @Override
@@ -200,57 +233,95 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     } catch (RuntimeException e) {
       log.error("Error finding allowed content-type menus: {}", e.getMessage(), e);
       return Collections.emptyList();
+    } finally {
+      clearRequestHibernateIndex();
     }
   }
 
   @Override
   public List<ActionMenu> findAllowedTemplates(Integer contentId, boolean isAA) {
-    if (contentId == null || contentId <= 0) {
-      return Collections.emptyList();
-    }
     try {
+      if (contentId == null || contentId <= 0) {
+        return Collections.emptyList();
+      }
       return ApiUtils.convertPSActionMenuList(
           PSTemplateActionMenuHelper.getInstance().getTemplateMenus(contentId, isAA, null));
     } catch (RuntimeException e) {
       log.error(
           "Error finding allowed templates for contentId {}: {}", contentId, e.getMessage(), e);
       return Collections.emptyList();
+    } finally {
+      clearRequestHibernateIndex();
     }
   }
 
   @Override
   public ActionMenu findMenuByKey(String idOrName) {
-    if (!isSafeMenuKey(idOrName)) {
-      return null;
-    }
-    String key = idOrName.trim();
     try {
-      List<ActionMenu> all = findMenus(null, null, null, null, null);
-      if (all == null) {
+      if (!isSafeMenuKey(idOrName)) {
         return null;
       }
-      for (ActionMenu m : all) {
-        if (m == null) {
-          continue;
-        }
-        if (key.equalsIgnoreCase(m.getName())) {
-          return m;
-        }
-        if (String.valueOf(m.getId()).equals(key)) {
-          return m;
-        }
-        if (m.getGuid() != null) {
-          String gsv = m.getGuid().getStringValue();
-          if (gsv != null && key.equalsIgnoreCase(gsv.trim())) {
-            return m;
-          }
-        }
+      String key = idOrName.trim();
+      try {
+        List<ActionMenu> all = findMenus(null, null, null, null, null);
+        return matchMenuInTree(all, key);
+      } catch (PSErrorResultsException e) {
+        log.debug("Action menu lookup failed for {}: {}", key, e.toString());
+        return null;
       }
-      return null;
-    } catch (PSErrorResultsException e) {
-      log.debug("Action menu lookup failed for {}: {}", key, e.toString());
+    } finally {
+      clearRequestHibernateIndex();
+    }
+  }
+
+  static ActionMenu matchMenuInTree(List<ActionMenu> menus, String key) {
+    if (menus == null || StringUtils.isBlank(key)) {
       return null;
     }
+    for (ActionMenu m : menus) {
+      ActionMenu hit = matchMenuRecursive(m, key);
+      if (hit != null) {
+        return hit;
+      }
+    }
+    return null;
+  }
+
+  static ActionMenu matchMenuRecursive(ActionMenu m, String key) {
+    if (m == null) {
+      return null;
+    }
+    if (menuKeyMatches(m, key)) {
+      return m;
+    }
+    if (m.getChildren() != null) {
+      for (ActionMenu child : m.getChildren()) {
+        ActionMenu hit = matchMenuRecursive(child, key);
+        if (hit != null) {
+          return hit;
+        }
+      }
+    }
+    return null;
+  }
+
+  static boolean menuKeyMatches(ActionMenu m, String key) {
+    if (m == null || StringUtils.isBlank(key)) {
+      return false;
+    }
+    if (key.equalsIgnoreCase(m.getName())) {
+      return true;
+    }
+    if (String.valueOf(m.getId()).equals(key)) {
+      return true;
+    }
+    if (m.getGuid() != null) {
+      String gsv = m.getGuid().getStringValue();
+      if (gsv != null && key.equalsIgnoreCase(gsv.trim())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
@@ -261,17 +332,18 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       throw new IllegalArgumentException("body is required");
     }
     String name = requireValidName(body.getName());
-    assertNameUnique(name);
     ActionType type = resolveCreateType(body);
     String session = currentSession();
     String user = currentUser();
     try {
+      assertNameUnique(name);
       List<PSAction> created = service.createActions(List.of(name), List.of(type), session, user);
       if (created == null || created.isEmpty() || created.get(0) == null) {
         throw new IllegalStateException("Design WS createActions returned empty");
       }
       PSAction domain = created.get(0);
       applyWritableFields(domain, body);
+      domain.getProperties().setProperty(REST_USER_MENU_PROP, PSAction.YES);
       service.saveActions(List.of(domain), true, session, user);
       return toDto(domain);
     } catch (WebApplicationException | IllegalStateException e) {
@@ -289,6 +361,8 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     } catch (PSErrorException e) {
       log.error("Failed to create action menu {}", name, e);
       throw new IllegalStateException("Failed to create action menu", e);
+    } finally {
+      clearRequestHibernateIndex();
     }
   }
 
@@ -302,18 +376,22 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     if (!isSafeMenuKey(idOrName)) {
       return null;
     }
-    PSAction existing = findPsActionByKey(idOrName.trim());
-    if (existing == null) {
-      return null;
-    }
-    rejectSystemMenuWrite(existing);
-    IPSGuid id = safeGuid(existing);
-    if (id == null) {
-      throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
-    }
-    String session = currentSession();
-    String user = currentUser();
+    IPSGuid id = null;
     try {
+      PSAction existing = findPsActionByKey(idOrName.trim());
+      if (existing == null) {
+        existing = findHibernateActionByKey(idOrName.trim());
+        if (existing == null) {
+          return null;
+        }
+      }
+      rejectSystemMenuWrite(existing);
+      id = safeGuid(existing);
+      if (id == null) {
+        throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
+      }
+      String session = currentSession();
+      String user = currentUser();
       List<PSAction> loaded = service.loadActions(List.of(id), true, false, session, user);
       if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
         return null;
@@ -325,13 +403,15 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     } catch (WebApplicationException | IllegalArgumentException e) {
       throw e;
     } catch (PSErrorResultsException e) {
-      if (isNotFound(e, id)) {
+      if (id != null && isNotFound(e, id)) {
         return null;
       }
       throw new WebApplicationException(
           "Could not update action menu; design lock required or held by another user", 409);
     } catch (PSErrorsException e) {
       throw mapSaveOrDeleteFailure("update", e);
+    } finally {
+      clearRequestHibernateIndex();
     }
   }
 
@@ -342,35 +422,43 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     if (!isSafeMenuKey(idOrName)) {
       return false;
     }
-    PSAction existing = findPsActionByKey(idOrName.trim());
-    if (existing == null) {
-      return false;
-    }
-    rejectSystemMenuWrite(existing);
-    IPSGuid id = safeGuid(existing);
-    if (id == null) {
-      throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
-    }
-    String session = currentSession();
-    String user = currentUser();
+    IPSGuid id = null;
     try {
-      List<PSAction> locked = service.loadActions(List.of(id), true, false, session, user);
-      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
-        throw new WebApplicationException(
-            "Could not delete action menu; design lock required or held by another user", 409);
+      PSAction existing = findPsActionByKey(idOrName.trim());
+      if (existing == null) {
+        existing = findHibernateActionByKey(idOrName.trim());
+        if (existing == null) {
+          return false;
+        }
+      }
+      rejectSystemMenuWrite(existing);
+      id = safeGuid(existing);
+      if (id == null) {
+        throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
+      }
+      String session = currentSession();
+      String user = currentUser();
+      boolean locked = false;
+      try {
+        List<PSAction> held = service.loadActions(List.of(id), true, false, session, user);
+        locked = held != null && !held.isEmpty() && held.get(0) != null;
+      } catch (PSErrorResultsException e) {
+        if (!(id != null && isNotFound(e, id))) {
+          throw new WebApplicationException(
+              "Could not delete action menu; design lock required or held by another user", 409);
+        }
+      }
+      if (!locked && !isRestUserMenu(existing)) {
+        return false;
       }
       service.deleteActions(List.of(id), false, session, user);
       return true;
     } catch (WebApplicationException e) {
       throw e;
-    } catch (PSErrorResultsException e) {
-      if (isNotFound(e, id)) {
-        return false;
-      }
-      throw new WebApplicationException(
-          "Could not delete action menu; design lock required or held by another user", 409);
     } catch (PSErrorsException e) {
       throw mapSaveOrDeleteFailure("delete", e);
+    } finally {
+      clearRequestHibernateIndex();
     }
   }
 
@@ -393,21 +481,23 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       return null;
     }
     String key = idOrName.trim();
+    PSAction fromHibernate = findHibernateActionByKey(key);
+    if (fromHibernate != null) {
+      return fromHibernate;
+    }
     try {
       IPSGuid match = matchSummaryGuid(service.findActions(null, null, null), key);
       if (match == null) {
         match = parseActionGuid(key);
       }
-      if (match == null) {
-        return null;
+      if (match != null) {
+        List<PSAction> loaded =
+            service.loadActions(
+                List.of(match), false, false, currentSession(), currentUser());
+        if (loaded != null && !loaded.isEmpty() && loaded.get(0) != null) {
+          return loaded.get(0);
+        }
       }
-      List<PSAction> loaded =
-          service.loadActions(
-              List.of(match), false, false, currentSession(), currentUser());
-      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
-        return null;
-      }
-      return loaded.get(0);
     } catch (PSErrorResultsException e) {
       IPSGuid requested = parseActionGuid(key);
       if (requested != null && isNotFound(e, requested)) {
@@ -419,6 +509,164 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     } catch (PSErrorException e) {
       log.error("Failed to catalog action menus while resolving {}", key, e);
       throw new IllegalStateException("Failed to catalog action menus", e);
+    }
+    return null;
+  }
+
+  PSAction findHibernateActionByKey(String key) {
+    PSActionMenu menu = matchHibernateMenu(requestHibernateMenus(), key);
+    return menu == null ? null : psActionFromHibernate(menu);
+  }
+
+  List<PSActionMenu> requestHibernateMenus() {
+    Map<String, PSActionMenu> index = requestHibernateIndex();
+    if (index.isEmpty()) {
+      return List.of();
+    }
+    return new ArrayList<>(index.values());
+  }
+
+  Map<String, PSActionMenu> requestHibernateIndex() {
+    Map<String, PSActionMenu> cached = REQUEST_HIBERNATE_INDEX.get();
+    if (cached == null) {
+      cached = indexHibernateMenus(hibernateMenus.get());
+      REQUEST_HIBERNATE_INDEX.set(cached);
+    }
+    return cached;
+  }
+
+  static void clearRequestHibernateIndex() {
+    REQUEST_HIBERNATE_INDEX.remove();
+  }
+
+  static boolean isRequestHibernateIndexBound() {
+    return REQUEST_HIBERNATE_INDEX.get() != null;
+  }
+
+  static Map<String, PSActionMenu> indexHibernateMenus(List<PSActionMenu> menus) {
+    Map<String, PSActionMenu> out = new HashMap<>();
+    if (menus == null) {
+      return out;
+    }
+    for (PSActionMenu m : menus) {
+      indexHibernateMenuRecursive(m, out);
+    }
+    return out;
+  }
+
+  static void indexHibernateMenuRecursive(PSActionMenu m, Map<String, PSActionMenu> out) {
+    if (m == null || out == null) {
+      return;
+    }
+    if (StringUtils.isNotBlank(m.getName())) {
+      out.putIfAbsent(m.getName().toLowerCase(), m);
+    }
+    if (m.getActionId() > 0) {
+      out.putIfAbsent(Integer.toString(m.getActionId()), m);
+    }
+    if (m.getChildren() != null) {
+      for (PSActionMenu child : m.getChildren()) {
+        indexHibernateMenuRecursive(child, out);
+      }
+    }
+  }
+
+  static PSActionMenu matchHibernateMenu(List<PSActionMenu> menus, String key) {
+    if (menus == null || StringUtils.isBlank(key)) {
+      return null;
+    }
+    for (PSActionMenu m : menus) {
+      PSActionMenu hit = matchHibernateMenuRecursive(m, key);
+      if (hit != null) {
+        return hit;
+      }
+    }
+    return null;
+  }
+
+  static PSActionMenu matchHibernateMenuRecursive(PSActionMenu m, String key) {
+    if (m == null) {
+      return null;
+    }
+    if (hibernateMenuKeyMatches(m, key)) {
+      return m;
+    }
+    if (m.getChildren() != null) {
+      for (PSActionMenu child : m.getChildren()) {
+        PSActionMenu hit = matchHibernateMenuRecursive(child, key);
+        if (hit != null) {
+          return hit;
+        }
+      }
+    }
+    return null;
+  }
+
+  static boolean hibernateMenuKeyMatches(PSActionMenu m, String key) {
+    if (m == null || StringUtils.isBlank(key)) {
+      return false;
+    }
+    if (key.equalsIgnoreCase(StringUtils.defaultString(m.getName()))) {
+      return true;
+    }
+    if (String.valueOf(m.getActionId()).equals(key)) {
+      return true;
+    }
+    try {
+      IPSGuid guid = PSAction.getGuidFromId(m.getActionId());
+      if (guid != null && key.equalsIgnoreCase(guid.toString())) {
+        return true;
+      }
+    } catch (RuntimeException e) {
+      return false;
+    }
+    return false;
+  }
+
+  static PSAction psActionFromHibernate(PSActionMenu menu) {
+    if (menu == null || StringUtils.isBlank(menu.getName()) || menu.getActionId() <= 0) {
+      return null;
+    }
+    String label = StringUtils.defaultIfBlank(menu.getDisplayName(), menu.getName());
+    String type = StringUtils.defaultIfBlank(menu.getType(), PSAction.TYPE_MENU);
+    if (!PSAction.TYPE_MENU.equalsIgnoreCase(type)
+        && !PSAction.TYPE_MENUITEM.equalsIgnoreCase(type)
+        && !PSAction.TYPE_CONTEXTMENU.equalsIgnoreCase(type)) {
+      type = PSAction.TYPE_MENU;
+    }
+    String handler =
+        PSAction.HANDLER_CLIENT.equalsIgnoreCase(menu.getHandler())
+            ? PSAction.HANDLER_CLIENT
+            : PSAction.HANDLER_SERVER;
+    PSAction action =
+        new PSAction(
+            menu.getName(),
+            label,
+            type,
+            StringUtils.defaultString(menu.getUrl()),
+            handler,
+            menu.getSortOrder());
+    action.setGUID(PSAction.getGuidFromId(menu.getActionId()));
+    if (menu.getDescription() != null) {
+      action.setDescription(menu.getDescription());
+    }
+    if (hibernateHasRestUserMenu(menu)) {
+      action.getProperties().setProperty(REST_USER_MENU_PROP, PSAction.YES);
+    }
+    return action;
+  }
+
+  List<PSActionMenu> loadHibernateMenus() {
+    try {
+      IPSCmsObjectMgr mgr = PSCmsObjectMgrLocator.getObjectManager();
+      if (mgr == null) {
+        return Collections.emptyList();
+      }
+      List<PSActionMenu> tree = mgr.findActionMenusTree();
+      return tree == null ? Collections.emptyList() : tree;
+    } catch (RuntimeException e) {
+      log.debug("Hibernate action menu catalog unavailable: {}", e.toString());
+      return Collections.emptyList();
     }
   }
 
@@ -616,14 +864,30 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     }
   }
 
+  /**
+   * Fail-closed write guard: a {@code null} GUID (or unresolvable Workbench path)
+   * is treated as a system/packaged menu and yields HTTP 409. Only REST-created
+   * user menus ({@link #REST_USER_MENU_PROP}) or a User path segment may be written.
+   */
   boolean isSystemMenu(PSAction action) {
+    if (isRestUserMenu(action)) {
+      return false;
+    }
     IPSGuid guid = safeGuid(action);
     if (guid == null) {
-      return false;
+      log.info("Action menu GUID is null; treating as system menu (fail-closed write)");
+      return true;
     }
     try {
       String path = service.objectIdToPath(guid);
-      return isSystemMenuPath(path);
+      if (isSystemMenuPath(path)) {
+        return true;
+      }
+      if (isUserMenuPath(path)) {
+        return false;
+      }
+      // Blank/unknown Workbench path: fail closed (packaged Edit is 409, not 204).
+      return true;
     } catch (RuntimeException e) {
       // Fail closed: a lookup error must not skip system-menu protection.
       log.warn(
@@ -632,17 +896,67 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     }
   }
 
+  boolean isRestUserMenu(PSAction action) {
+    if (action == null) {
+      return false;
+    }
+    if (PSAction.YES.equalsIgnoreCase(StringUtils.defaultString(action.getProperty(REST_USER_MENU_PROP)))) {
+      return true;
+    }
+    PSActionMenu hibernate = lookupHibernateMenu(action.getName());
+    return hibernateHasRestUserMenu(hibernate);
+  }
+
+  PSActionMenu lookupHibernateMenu(String name) {
+    if (StringUtils.isBlank(name)) {
+      return null;
+    }
+    Map<String, PSActionMenu> index = requestHibernateIndex();
+    PSActionMenu byName = index.get(name.toLowerCase());
+    if (byName != null) {
+      return byName;
+    }
+    return matchHibernateMenu(hibernateMenus.get(), name);
+  }
+
+  static boolean hibernateHasRestUserMenu(PSActionMenu menu) {
+    if (menu == null || menu.getProperties() == null) {
+      return false;
+    }
+    for (com.percussion.services.menus.PSActionMenuProperty prop : menu.getProperties()) {
+      if (prop == null || prop.getPrimaryKey() == null) {
+        continue;
+      }
+      if (REST_USER_MENU_PROP.equalsIgnoreCase(prop.getPrimaryKey().getPropertyName())
+          && PSAction.YES.equalsIgnoreCase(StringUtils.defaultString(prop.getValue()))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Workbench UI Elements {@code Menus/System} (and Menu Entries {@code System}) path segment.
    * Package-visible for unit tests.
    */
   static boolean isSystemMenuPath(String path) {
-    if (StringUtils.isBlank(path)) {
+    return pathHasSegment(path, "system");
+  }
+
+  /**
+   * Workbench UI Elements {@code Menus/User} path segment for REST-created menus.
+   */
+  static boolean isUserMenuPath(String path) {
+    return pathHasSegment(path, "user");
+  }
+
+  static boolean pathHasSegment(String path, String segment) {
+    if (StringUtils.isBlank(path) || StringUtils.isBlank(segment)) {
       return false;
     }
     String[] parts = path.split("[/\\\\]+");
     for (String part : parts) {
-      if ("system".equalsIgnoreCase(part.trim())) {
+      if (segment.equalsIgnoreCase(part.trim())) {
         return true;
       }
     }
@@ -677,15 +991,20 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
 
   private void assertNameUnique(String name) {
     try {
-      if (nameExists(service.findActions(name, null, null), name)) {
+      if (nameExists(service.findActions(name, null, null), name)
+          || hibernateNameExists(requestHibernateMenus(), name)) {
         throw new WebApplicationException("Action menu already exists: " + name, 409);
       }
     } catch (WebApplicationException e) {
       throw e;
-    } catch (PSErrorException e) {
+    } catch (Exception e) {
       log.error("Failed to catalog action menus while checking uniqueness for {}", name, e);
       throw new IllegalStateException("Failed to catalog action menus", e);
     }
+  }
+
+  static boolean hibernateNameExists(List<PSActionMenu> menus, String name) {
+    return matchHibernateMenu(menus, name) != null;
   }
 
   static boolean nameExists(List<IPSCatalogSummary> summaries, String name) {

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -142,6 +142,9 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
                  GUID last-segment tokens; JAXB / UNWRAP_ROOT_VALUE expects
                  AllowedContentTypeMenusRequest. Bind both envelopes. -->
             <ref bean="allowedContentTypeMenusRequestJsonReader" />
+            <!-- #4123: Admin POST /actions {ActionMenu:{…}} must not JAXB-bind as
+                 allowedWorkflowTransitionsRequest (finder is /find/transitions). -->
+            <ref bean="actionMenuJsonReader" />
             <!-- #3905 / #3895 CD-09: PUT /contenttypes/{id}/itemExits wrap can arrive empty
                  under CXF UNWRAP_ROOT_VALUE; bind wrap and flat before jacksonProvider. -->
             <ref bean="contentTypeItemExitsJsonReader" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -36,9 +36,12 @@ import static org.mockito.Mockito.when;
 
 import com.percussion.cms.objectstore.PSAction;
 import com.percussion.rest.actions.ActionMenu;
+import com.percussion.rest.actions.ActionMenuList;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.services.menus.PSActionMenu;
+import com.percussion.services.menus.RxmActionMenuConstants;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
@@ -48,6 +51,7 @@ import com.percussion.webservices.ui.data.ActionType;
 import jakarta.ws.rs.WebApplicationException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -80,6 +84,7 @@ class ActionMenuAdaptorWriteTest {
 
   @AfterEach
   void tearDown() {
+    ActionMenuAdaptor.clearRequestHibernateIndex();
     PSRequestInfo.resetRequestInfo();
   }
 
@@ -338,6 +343,77 @@ class ActionMenuAdaptorWriteTest {
   }
 
   @Test
+  void delete_system_whenDesignWsMissesHibernateRow_is409() throws Exception {
+    PSActionMenu edit = new PSActionMenu("Edit", "Edit", PSAction.TYPE_MENUITEM, "", "SERVER", 0);
+    edit.setActionId(7);
+    adaptor = new ActionMenuAdaptor(designWs, () -> true, () -> List.of(edit));
+    when(designWs.objectIdToPath(any())).thenReturn("//ContentExplorer/Menus/System/Edit");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("Edit"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void delete_packagedCopy_whenDesignWsMissesHibernateRow_is409() throws Exception {
+    PSActionMenu copy = new PSActionMenu("Copy", "Copy", PSAction.TYPE_MENUITEM, "", "SERVER", 0);
+    copy.setActionId(11);
+    adaptor = new ActionMenuAdaptor(designWs, () -> true, () -> List.of(copy));
+    when(designWs.objectIdToPath(any())).thenReturn("//ContentExplorer/Menus/System/Copy");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("Copy"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void delete_restUser_whenDesignWsLoadMisses_stillDeletes() throws Exception {
+    PSActionMenu user = new PSActionMenu("QaMenu", "QaMenu", PSAction.TYPE_MENU, "", "SERVER", 0);
+    user.setActionId(42);
+    user.addProperty(
+        new com.percussion.services.menus.PSActionMenuProperty(
+            42, ActionMenuAdaptor.REST_USER_MENU_PROP, PSAction.YES));
+    adaptor = new ActionMenuAdaptor(designWs, () -> true, () -> List.of(user));
+    when(designWs.loadActions(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of());
+
+    assertTrue(adaptor.deleteActionMenu("QaMenu"));
+    verify(designWs).deleteActions(anyList(), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void create_duplicateName_fromHibernateCatalog_is409() {
+    PSActionMenu existing = new PSActionMenu("MyMenu", "My Menu", PSAction.TYPE_MENU, "", "SERVER", 0);
+    existing.setActionId(9);
+    adaptor = new ActionMenuAdaptor(designWs, () -> true, () -> List.of(existing));
+    ActionMenu body = new ActionMenu();
+    body.setName("MyMenu");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createActionMenu(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void matchMenuInTree_findsNestedChild() {
+    ActionMenu root = new ActionMenu();
+    root.setName("File");
+    root.setId(1);
+    ActionMenu child = new ActionMenu();
+    child.setName("MyMenu");
+    child.setId(42);
+    ActionMenuList kids = new ActionMenuList();
+    kids.add(child);
+    root.setChildren(kids);
+    assertEquals("MyMenu", ActionMenuAdaptor.matchMenuInTree(List.of(root), "MyMenu").getName());
+    assertEquals(42, ActionMenuAdaptor.matchMenuInTree(List.of(root), "42").getId());
+  }
+
+  @Test
   void delete_system_is409() throws Exception {
     PSAction system = stubAction("Edit", 42);
     stubCatalogLoad(system);
@@ -417,6 +493,74 @@ class ActionMenuAdaptorWriteTest {
     assertFalse(ActionMenuAdaptor.isSystemMenuPath("//ContentExplorer/Menus/User/MyMenu"));
     assertFalse(ActionMenuAdaptor.isSystemMenuPath(""));
     assertFalse(ActionMenuAdaptor.isSystemMenuPath(null));
+    assertTrue(ActionMenuAdaptor.isUserMenuPath("//ContentExplorer/Menus/User/MyMenu"));
+    assertFalse(ActionMenuAdaptor.isUserMenuPath("//ContentExplorer/Menus/System/Edit"));
+  }
+
+  @Test
+  void delete_blankPathWithoutRestMarker_is409() throws Exception {
+    PSAction existing = stubAction("Edit", 101);
+    stubCatalogLoad(existing);
+    when(designWs.objectIdToPath(any())).thenReturn("");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteActionMenu("Edit"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_blankPathWithRestMarker_succeeds() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    existing.getProperties().setProperty(ActionMenuAdaptor.REST_USER_MENU_PROP, PSAction.YES);
+    stubCatalogLoad(existing);
+    when(designWs.objectIdToPath(any())).thenReturn("");
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(existing));
+    assertTrue(adaptor.deleteActionMenu("MyMenu"));
+    verify(designWs)
+        .deleteActions(eq(List.of(existing.getGUID())), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void isSystemMenu_nullGuid_isFailClosed() {
+    PSAction action = new PSAction("NoGuid", "NoGuid");
+    assertTrue(adaptor.isSystemMenu(action));
+  }
+
+  @Test
+  void create_catalogPsErrorsException_is500() throws Exception {
+    when(designWs.findActions(eq("DupMenu"), isNull(), isNull()))
+        .thenThrow(new PSErrorsException());
+    ActionMenu body = new ActionMenu();
+    body.setName("DupMenu");
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.createActionMenu(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("catalog"));
+  }
+
+  @Test
+  void create_catalogRuntimeFailure_is500() throws Exception {
+    when(designWs.findActions(eq("DupMenu"), isNull(), isNull()))
+        .thenThrow(new IllegalStateException("catalog exploded"));
+    ActionMenu body = new ActionMenu();
+    body.setName("DupMenu");
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.createActionMenu(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("catalog"));
+  }
+
+  @Test
+  void indexHibernateMenus_indexesNameAndChildId() {
+    PSActionMenu child = new PSActionMenu("Child", "c", "MENUITEM", "", "server", 0);
+    child.setActionId(8);
+    PSActionMenu root = new PSActionMenu("Root", "r", "MENU", "", "server", 0);
+    root.setActionId(7);
+    root.setChildren(List.of(child));
+    Map<String, PSActionMenu> index = ActionMenuAdaptor.indexHibernateMenus(List.of(root));
+    assertEquals(root, index.get("root"));
+    assertEquals(child, index.get("child"));
+    assertEquals(root, index.get("7"));
+    assertEquals(child, index.get("8"));
   }
 
   @Test
@@ -435,6 +579,32 @@ class ActionMenuAdaptorWriteTest {
     ActionMenu bad = new ActionMenu();
     bad.setMenuType("nope");
     assertThrows(IllegalArgumentException.class, () -> ActionMenuAdaptor.resolveCreateType(bad));
+  }
+
+  @Test
+  void restUserMenuProperty_matchesSharedConstant() {
+    assertEquals(RxmActionMenuConstants.REST_USER_MENU_PROP, ActionMenuAdaptor.REST_USER_MENU_PROP);
+    assertEquals("sys_restUserMenu", RxmActionMenuConstants.REST_USER_MENU_PROP);
+  }
+
+  @Test
+  void findMenuByKey_clearsRequestHibernateIndexOnUnsafeKey() {
+    ActionMenuAdaptor indexed =
+        new ActionMenuAdaptor(designWs, () -> true, () -> List.of());
+    indexed.requestHibernateIndex();
+    assertTrue(ActionMenuAdaptor.isRequestHibernateIndexBound());
+    assertNull(indexed.findMenuByKey("../escape"));
+    assertFalse(ActionMenuAdaptor.isRequestHibernateIndexBound());
+  }
+
+  @Test
+  void findAllowedTransitions_clearsRequestHibernateIndex() {
+    ActionMenuAdaptor indexed =
+        new ActionMenuAdaptor(designWs, () -> true, () -> List.of());
+    indexed.requestHibernateIndex();
+    assertTrue(ActionMenuAdaptor.isRequestHibernateIndexBound());
+    assertTrue(indexed.findAllowedTransitions(null, null).isEmpty());
+    assertFalse(ActionMenuAdaptor.isRequestHibernateIndexBound());
   }
 
   private PSAction stubAction(String name, int id) {

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -78,6 +78,9 @@ class CatalogRestJaxrsRegistrationTest {
   private static final String FIND_TYPES_JSON_READER =
       "allowedContentTypeMenusRequestJsonReader";
 
+  /** Admin action-menu create POST #4123 — must precede jacksonProvider. */
+  private static final String ACTION_MENU_JSON_READER = "actionMenuJsonReader";
+
   /** CD-18 auto-translation PUT wrap / bare array (#4028) — must precede jacksonProvider. */
   private static final String AUTO_TRANSLATION_ROWS_JSON_READER =
       "autoTranslationRowsJsonReader";
@@ -136,6 +139,7 @@ class CatalogRestJaxrsRegistrationTest {
     int guidListReader = providerBlock.indexOf("bean=\"" + GUID_LIST_JSON_READER + "\"");
     int addFolderReader = providerBlock.indexOf("bean=\"" + ADD_FOLDER_JSON_READER + "\"");
     int findTypesReader = providerBlock.indexOf("bean=\"" + FIND_TYPES_JSON_READER + "\"");
+    int actionMenuReader = providerBlock.indexOf("bean=\"" + ACTION_MENU_JSON_READER + "\"");
     int autoTranslationReader =
         providerBlock.indexOf("bean=\"" + AUTO_TRANSLATION_ROWS_JSON_READER + "\"");
     int displayFormatReader =
@@ -177,6 +181,11 @@ class CatalogRestJaxrsRegistrationTest {
             + FIND_TYPES_JSON_READER
             + " (missing → Explorer find/types flat contentIds / GUID 400)");
     assertTrue(
+        actionMenuReader >= 0,
+        "rest-jax-rs providers must ref "
+            + ACTION_MENU_JSON_READER
+            + " (missing → Admin POST /actions JAXB allowedWorkflowTransitionsRequest)");
+    assertTrue(
         autoTranslationReader >= 0,
         "rest-jax-rs providers must ref "
             + AUTO_TRANSLATION_ROWS_JSON_READER
@@ -208,6 +217,9 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(
         findTypesReader < jackson,
         FIND_TYPES_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        actionMenuReader < jackson,
+        ACTION_MENU_JSON_READER + " must be listed before jacksonProvider");
     assertTrue(
         autoTranslationReader < jackson,
         AUTO_TRANSLATION_ROWS_JSON_READER + " must be listed before jacksonProvider");

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenu.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenu.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.actions;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.percussion.cms.objectstore.PSAction;
 import com.percussion.rest.Guid;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,6 +27,7 @@ import java.util.Objects;
 
 /** Represents an Action Menu in Percussion CMS. */
 @XmlRootElement(name = "ActionMenu")
+@JsonRootName("ActionMenu")
 @Schema(description = "Represents an Action Menu")
 public class ActionMenu {
 

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.actions;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for Admin {@code POST /actions} and {@code PUT /actions/{id}} ({@link ActionMenu}).
+ *
+ * <p>CXF JAXB / {@code UNWRAP_ROOT_VALUE} can bind collection POST to {@link
+ * AllowedWorkflowTransitionsRequest} ({@code allowedWorkflowTransitionsRequest}) when the
+ * finder still shares the resource. The SPA posts {@code {"ActionMenu":{…}}} (#4123 / #4112).
+ * This reader binds wrap and flat shapes before {@code jacksonProvider}.
+ *
+ * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code jacksonProvider}.
+ */
+@Provider
+@Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("actionMenuJsonReader")
+public class ActionMenuJsonReader implements MessageBodyReader<ActionMenu> {
+
+  /** Mapper without UNWRAP_ROOT_VALUE so wrap vs flat is inspected explicitly. */
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  /** Logger for malformed JSON (details stay off the 400 body). */
+  private static final Logger log = LogManager.getLogger(ActionMenuJsonReader.class);
+
+  /** Client 400 for malformed JSON; Jackson parse details stay server-side. */
+  static final String INVALID_JSON = "Invalid ActionMenu JSON";
+
+  /** No-op constructor. */
+  public ActionMenuJsonReader() {}
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    if (type == null || !ActionMenu.class.isAssignableFrom(type)) {
+      return false;
+    }
+    if (ActionMenuList.class.isAssignableFrom(type)) {
+      return false;
+    }
+    return mediaType == null || isJsonCompatible(mediaType);
+  }
+
+  static boolean isJsonCompatible(MediaType mediaType) {
+    if (mediaType == null || mediaType.isWildcardType() || mediaType.isWildcardSubtype()) {
+      return true;
+    }
+    String subtype = mediaType.getSubtype();
+    if (subtype == null) {
+      return false;
+    }
+    String lower = subtype.toLowerCase();
+    return "json".equals(lower) || lower.endsWith("+json");
+  }
+
+  @Override
+  public ActionMenu readFrom(
+      Class<ActionMenu> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new ActionMenu();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new ActionMenu();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Bind create/update JSON. Empty / whitespace is an empty DTO (adaptor rejects blank name).
+   *
+   * @param json request body; may be null
+   * @return non-null menu
+   */
+  public static ActionMenu parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new ActionMenu();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      log.debug(INVALID_JSON, e);
+      throw new WebApplicationException(INVALID_JSON, 400);
+    }
+    return parseNode(root);
+  }
+
+  /**
+   * Bind a parsed JSON tree to {@link ActionMenu}.
+   *
+   * @param root parsed body; may be null
+   * @return non-null menu
+   */
+  public static ActionMenu parseNode(JsonNode root) {
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new ActionMenu();
+    }
+    if (!root.isObject()) {
+      throw new WebApplicationException("ActionMenu body must be a JSON object", 400);
+    }
+    JsonNode nested = firstObject(root, "ActionMenu", "actionMenu");
+    JsonNode fields = nested != null ? nested : root;
+    ActionMenu out = new ActionMenu();
+    out.setName(textField(fields, "name"));
+    out.setLabel(textField(fields, "label"));
+    out.setDescription(textField(fields, "description"));
+    out.setMenuType(textField(fields, "menuType"));
+    out.setUrl(textField(fields, "url"));
+    out.setHandler(textField(fields, "handler"));
+    Integer id = intField(fields, "id");
+    if (id != null) {
+      out.setId(id);
+    }
+    return out;
+  }
+
+  private static String textField(JsonNode node, String name) {
+    JsonNode n = node.get(name);
+    if (n == null || n.isNull() || n.isMissingNode()) {
+      return null;
+    }
+    if (n.isObject() || n.isArray()) {
+      return null;
+    }
+    String s = n.asString();
+    return s != null && !s.isBlank() ? s : null;
+  }
+
+  private static Integer intField(JsonNode node, String name) {
+    JsonNode n = node.get(name);
+    if (n == null || n.isNull() || n.isMissingNode() || !n.isNumber()) {
+      return null;
+    }
+    return n.asInt();
+  }
+
+  private static JsonNode firstObject(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && n.isObject()) {
+        return n;
+      }
+    }
+    return null;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -208,12 +208,13 @@ public class ActionMenuResource {
       summary = "Create action menu",
       description =
           "Admin. Creates and persists a user action menu via IPSUiDesignWs.createActions then"
-              + " saveActions (Workbench Finish, held design lock released on save). Name is"
-              + " required, unique (case-insensitive), and must not contain whitespace or"
-              + " wildcards. Optional label, description, menuType, and url (GET detail fields)"
-              + " are applied before save. Duplicate name is 409. System menus are not created"
-              + " here. Cascading children composition is a later slice. This is not Developer"
-              + " Action Menus SPA chrome.",
+              + " saveActions (Workbench Finish, held design lock released on save). JSON body"
+              + " is ActionMenu (wrap {\"ActionMenu\":{…}} or flat). Collection POST is create;"
+              + " allowedWorkflowTransitionsRequest belongs on POST /actions/find/transitions"
+              + " (#4123). Name is required, unique (case-insensitive), and must not contain"
+              + " whitespace or wildcards. Optional label, description, menuType, and url (GET"
+              + " detail fields) are applied before save. Duplicate name is 409. System menus"
+              + " are not created here. Cascading children composition is a later slice.",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.rest.JacksonContextResolver;
+import com.percussion.rest.errors.WebApplicationExceptionMapper;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import java.io.ByteArrayInputStream;
+import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.cxf.endpoint.Server;
+import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
+import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
+import org.apache.cxf.message.MessageImpl;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
+
+/**
+ * CXF pipeline for Admin {@code POST /actions} (#4123).
+ *
+ * <p>JAXB / a stale collection POST used {@code AllowedWorkflowTransitionsRequest} and rejected
+ * {@code ActionMenu}. With {@link ActionMenuJsonReader}, wrapped and flat create bodies bind
+ * and call {@code createActionMenu}.
+ */
+@Tag("UnitTest")
+public class ActionMenuCreateCxfUnmarshallTest {
+
+  private static final String WRAPPED =
+      "{\"ActionMenu\":{\"name\":\"cxfN1\",\"label\":\"Create me\",\"menuType\":\"MENUITEM\"}}";
+  private static final String FLAT = "{\"name\":\"cxfFlat\",\"label\":\"Flat\"}";
+
+  private Server server;
+
+  @AfterEach
+  public void stopServer() {
+    if (server != null) {
+      server.stop();
+      server.destroy();
+      server = null;
+    }
+  }
+
+  @Test
+  public void cxfFactorySelectsActionMenuJsonReader() throws Exception {
+    ServerProviderFactory factory = ServerProviderFactory.createInstance(null);
+    ActionMenuJsonReader custom = new ActionMenuJsonReader();
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(ActionMenu.class));
+    factory.setUserProviders(Arrays.asList(custom, jackson, new JacksonContextResolver()));
+
+    MessageImpl message = new MessageImpl();
+    MessageBodyReader<ActionMenu> selected =
+        factory.createMessageBodyReader(
+            ActionMenu.class,
+            ActionMenu.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            message);
+    assertNotNull(selected, "CXF must find a MessageBodyReader for ActionMenu");
+    assertTrue(
+        selected.isReadable(
+            ActionMenu.class,
+            ActionMenu.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE),
+        selected.getClass().getName());
+
+    ActionMenu menu =
+        selected.readFrom(
+            ActionMenu.class,
+            ActionMenu.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(WRAPPED.getBytes(StandardCharsets.UTF_8)));
+    assertEquals("cxfN1", menu.getName());
+  }
+
+  @Test
+  public void cxfPostWrappedActionMenuInvokesCreate() throws Exception {
+    assertCreatePost(WRAPPED, "cxfN1", "local://issue-4123-actions-wrap");
+  }
+
+  @Test
+  public void cxfPostFlatActionMenuInvokesCreate() throws Exception {
+    assertCreatePost(FLAT, "cxfFlat", "local://issue-4123-actions-flat");
+  }
+
+  private void assertCreatePost(String json, String expectedName, String address) throws Exception {
+    AtomicReference<ActionMenu> captured = new AtomicReference<>();
+    IActionMenuAdaptor adaptor = mock(IActionMenuAdaptor.class);
+    when(adaptor.createActionMenu(any()))
+        .thenAnswer(
+            inv -> {
+              ActionMenu in = inv.getArgument(0);
+              captured.set(in);
+              ActionMenu created = new ActionMenu();
+              created.setName(in.getName());
+              created.setLabel(in.getLabel());
+              created.setId(42);
+              return created;
+            });
+
+    ActionMenuResource resource = new ActionMenuResource();
+    var field = ActionMenuResource.class.getDeclaredField("adaptor");
+    field.setAccessible(true);
+    field.set(resource, adaptor);
+
+    server = startServer(resource, address);
+
+    WebClient client =
+        WebClient.create(address)
+            .accept(MediaType.APPLICATION_JSON)
+            .type(MediaType.APPLICATION_JSON)
+            .path("/actions");
+    Response response = client.post(json);
+    assertEquals(
+        200, response.getStatus(), () -> "POST /actions must be HTTP 200 (status=" + response.getStatus() + ")");
+    ActionMenu saved = captured.get();
+    assertNotNull(saved, "adaptor.createActionMenu must be invoked");
+    assertEquals(expectedName, saved.getName());
+    verify(adaptor).createActionMenu(any());
+  }
+
+  private static Server startServer(ActionMenuResource resource, String address) {
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(ActionMenu.class));
+    JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
+    sf.setAddress(address);
+    sf.setServiceBean(resource);
+    sf.setProviders(
+        List.of(
+            new ActionMenuJsonReader(),
+            new AllowedContentTypeMenusRequestJsonReader(),
+            jackson,
+            new JacksonContextResolver(),
+            new WebApplicationExceptionMapper()));
+    Server created = sf.create();
+    assertNotNull(created, "CXF local server must start");
+    return created;
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuJsonReaderTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+/** #4123: wrap and flat ActionMenu JSON for Admin create POST. */
+class ActionMenuJsonReaderTest {
+
+  @Test
+  void parse_wrappedSpaEnvelope() {
+    ActionMenu menu =
+        ActionMenuJsonReader.parse(
+            "{\"ActionMenu\":{\"name\":\"n1\",\"label\":\"L\",\"description\":\"d\","
+                + "\"menuType\":\"MENUITEM\",\"url\":\"/app\"}}");
+    assertEquals("n1", menu.getName());
+    assertEquals("L", menu.getLabel());
+    assertEquals("d", menu.getDescription());
+    assertEquals("MENUITEM", menu.getMenuType());
+    assertEquals("/app", menu.getUrl());
+  }
+
+  @Test
+  void parse_flatBody() {
+    ActionMenu menu = ActionMenuJsonReader.parse("{\"name\":\"flatName\",\"label\":\"x\"}");
+    assertEquals("flatName", menu.getName());
+    assertEquals("x", menu.getLabel());
+  }
+
+  @Test
+  void parse_emptyIsEmptyDto() {
+    ActionMenu menu = ActionMenuJsonReader.parse("  ");
+    assertNull(menu.getName());
+  }
+
+  @Test
+  void parse_invalidJsonIs400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> ActionMenuJsonReader.parse("{"));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertEquals(ActionMenuJsonReader.INVALID_JSON, ex.getMessage());
+    String jacksonHint = ex.getMessage() == null ? "" : ex.getMessage().toLowerCase();
+    assertFalse(jacksonHint.contains("unexpected"));
+    assertFalse(jacksonHint.contains("offset"));
+    assertFalse(jacksonHint.contains("token"));
+  }
+
+  @Test
+  void parse_nonObjectIs400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> ActionMenuJsonReader.parse("[1]"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void isReadable_actionMenuJsonOnly() {
+    ActionMenuJsonReader reader = new ActionMenuJsonReader();
+    assertTrue(
+        reader.isReadable(
+            ActionMenu.class, ActionMenu.class, null, MediaType.APPLICATION_JSON_TYPE));
+    assertFalse(
+        reader.isReadable(
+            ActionMenuList.class, ActionMenuList.class, null, MediaType.APPLICATION_JSON_TYPE));
+    assertFalse(
+        reader.isReadable(
+            AllowedWorkflowTransitionsRequest.class,
+            AllowedWorkflowTransitionsRequest.class,
+            null,
+            MediaType.APPLICATION_JSON_TYPE));
+  }
+}

--- a/system/services/src/com/percussion/services/legacy/impl/PSCmsObjectMgr.java
+++ b/system/services/src/com/percussion/services/legacy/impl/PSCmsObjectMgr.java
@@ -285,12 +285,19 @@ public class PSCmsObjectMgr
 
     public List<PSActionMenu> findActionMenus() {
         Session session = getSession();
-
+        CacheMode previous = session.getCacheMode();
         try {
-            return session.createQuery("from PSActionMenu m order by m.sortOrder asc", PSActionMenu.class).list();
+            // REST POST writes RXMENUACTION via JDBC; the entity region is
+            // READ_WRITE and can hide a just-committed row from GET catalog.
+            session.setCacheMode(CacheMode.IGNORE);
+            return session.createQuery("from PSActionMenu m order by m.sortOrder asc", PSActionMenu.class)
+                    .setCacheable(false)
+                    .list();
         } catch (Exception e) {
             logger.warn("An error occurred while listing action menus: {}" , PSExceptionUtils.getMessageForLog(e));
             return new ArrayList<>();
+        } finally {
+            session.setCacheMode(previous);
         }
     }
 

--- a/system/services/src/com/percussion/services/menus/RxmActionMenuConstants.java
+++ b/system/services/src/com/percussion/services/menus/RxmActionMenuConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.services.menus;
+
+/**
+ * Shared RXMENUACTION property names used by design-WS JDBC persist and the REST
+ * action-menu adaptor. Keep a single spelling so DELETE fail-closed system-menu
+ * detection cannot drift from create-time writes.
+ */
+public final class RxmActionMenuConstants {
+
+  /**
+   * Marker on REST/JDBC-created user menus ({@code RXMENUACTIONPROPERTIES}).
+   */
+  public static final String REST_USER_MENU_PROP = "sys_restUserMenu";
+
+  private RxmActionMenuConstants() {}
+}

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsActionPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsActionPersistTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.webservices.ui.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.percussion.cms.objectstore.IPSDbComponent;
+import com.percussion.cms.objectstore.PSAction;
+import com.percussion.cms.objectstore.PSKey;
+import com.percussion.services.menus.RxmActionMenuConstants;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * UI-02 persist: createActions + saveActions must INSERT a row visible to
+ * Hibernate {@code RXMENUACTION} (H2 REST POST 200 then GET catalog miss).
+ */
+@Tag("UnitTest")
+class PSUiDesignWsActionPersistTest {
+
+  @Test
+  void prepareActionForSave_newForcesInsert() {
+    PSAction source = newAction(2048, "QaAm4119");
+    assertFalse(source.isPersisted());
+
+    PSAction prepared = PSUiDesignWs.prepareActionForSave(source);
+
+    assertNotSame(source, prepared);
+    assertFalse(prepared.isPersisted());
+    assertEquals(IPSDbComponent.DBSTATE_NEW, prepared.getState());
+    assertEquals("QaAm4119", prepared.getName());
+  }
+
+  @Test
+  void prepareActionForSave_persistedKeepsLocator() {
+    PSAction source = newAction(42, "MyMenu");
+    PSKey key = PSAction.createKey("42");
+    source.setLocator(key);
+    assertTrue(source.isPersisted());
+
+    PSAction prepared = PSUiDesignWs.prepareActionForSave(source);
+
+    assertTrue(prepared.isPersisted());
+    assertEquals(42, prepared.getId());
+    assertNotSame(source, prepared);
+  }
+
+  @Test
+  void prepareActionForSave_neverReturnsTheCallerInstance() {
+    PSAction source = newAction(7, "NoMutate");
+    PSAction prepared = PSUiDesignWs.prepareActionForSave(source);
+    assertNotSame(source, prepared);
+    assertEquals("NoMutate", source.getName());
+    assertEquals(7, source.getId());
+  }
+
+  @Test
+  void actionRowSpec_mapsAssignedNewMenuForInsert() {
+    PSAction source = newAction(2048, "QaAm4119");
+    source.setLabel("QA AM label");
+    source.setDescription("issue 4119 persist");
+    source.setMenuType(PSAction.TYPE_MENU);
+    source.setClientAction(false);
+
+    PSUiDesignWs.ActionRowSpec spec =
+        PSUiDesignWs.actionRowSpec(PSUiDesignWs.prepareActionForSave(source));
+
+    assertEquals(2048, spec.actionId);
+    assertEquals("QaAm4119", spec.name);
+    assertEquals("QA AM label", spec.displayName);
+    assertEquals("issue 4119 persist", spec.description);
+    assertEquals(PSAction.TYPE_MENU, spec.type);
+    assertEquals(PSAction.HANDLER_SERVER, spec.handler);
+  }
+
+  @Test
+  void invalidateActionCatalog_doesNotThrowWhenCacheUnavailable() {
+    assertDoesNotThrow(PSUiDesignWs::invalidateActionCatalog);
+  }
+
+  @Test
+  void evictActionMenuRegion_doesNotThrowWhenFactoryMissing() {
+    PSUiDesignWs ws = new PSUiDesignWs();
+    assertDoesNotThrow(ws::evictActionMenuRegion);
+  }
+
+  @Test
+  void insertActionRow_isVisibleToSelectAndDeleteOnH2() throws Exception {
+    String url = "jdbc:h2:mem:issue4119actions" + System.nanoTime();
+    try (Connection conn = DriverManager.getConnection(url);
+        Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE RXMENUACTION ("
+              + "ACTIONID INTEGER NOT NULL PRIMARY KEY,"
+              + "NAME VARCHAR(50) NOT NULL,"
+              + "DISPLAYNAME VARCHAR(50) NOT NULL,"
+              + "DESCRIPTION VARCHAR(255),"
+              + "URL VARCHAR(4000),"
+              + "SORTORDER INTEGER,"
+              + "TYPE VARCHAR(50),"
+              + "HANDLER VARCHAR(50),"
+              + "VERSION INTEGER NOT NULL)");
+      st.execute(
+          "CREATE TABLE RXMENUACTIONPARAM (ACTIONID INTEGER NOT NULL, PARAMNAME VARCHAR(50) NOT NULL)");
+      st.execute(
+          "CREATE TABLE RXMENUACTIONPROPERTIES (ACTIONID INTEGER NOT NULL, PROPNAME VARCHAR(100) NOT NULL, PROPVALUE VARCHAR(4000), DESCRIPTION VARCHAR(255), PRIMARY KEY (ACTIONID, PROPNAME))");
+      st.execute(
+          "CREATE TABLE RXMENUVISIBILITY (ACTIONID INTEGER NOT NULL, VISIBILITYCONTEXT VARCHAR(50) NOT NULL, \"VALUE\" VARCHAR(100) NOT NULL)");
+      st.execute(
+          "CREATE TABLE RXMODEUICONTEXTACTION (MODEID INTEGER NOT NULL, UICONTEXTID INTEGER NOT NULL, ACTIONID INTEGER NOT NULL)");
+      st.execute(
+          "CREATE TABLE RXMENUACTIONRELATION (ACTIONID INTEGER NOT NULL, CHILDACTIONID INTEGER NOT NULL)");
+
+      PSAction source = newAction(2048, "QaH2Am");
+      source.setLabel("QA H2 AM");
+      source.setDescription("persist");
+      PSUiDesignWs.ActionRowSpec spec =
+          PSUiDesignWs.actionRowSpec(PSUiDesignWs.prepareActionForSave(source));
+      assertFalse(PSUiDesignWs.actionRowExists(conn, spec.actionId, spec.name));
+      PSUiDesignWs.insertActionRow(conn, spec);
+      assertTrue(spec.restUserMenu);
+      PSUiDesignWs.ensureRestUserMenuProperty(conn, spec.actionId);
+      assertTrue(PSUiDesignWs.actionRowExists(conn, spec.actionId, spec.name));
+      assertTrue(PSUiDesignWs.actionRowExists(conn, spec.actionId, "otherName"));
+      assertFalse(PSUiDesignWs.actionRowExists(conn, 9999, "QaH2Am"));
+
+      PSAction sibling = newAction(2049, "Victim");
+      sibling.setLabel("Victim label");
+      PSUiDesignWs.insertActionRow(conn, PSUiDesignWs.actionRowSpec(sibling));
+
+      PSAction updated = newAction(2048, "Victim");
+      updated.setLabel("Updated label");
+      updated.setDescription("updated");
+      PSUiDesignWs.ActionRowSpec updatedSpec = PSUiDesignWs.actionRowSpec(updated);
+      PSUiDesignWs.updateActionRow(conn, updatedSpec);
+      assertTrue(PSUiDesignWs.actionRowExists(conn, 2048, "Victim"));
+      try (var rs =
+          conn.prepareStatement("SELECT DISPLAYNAME FROM RXMENUACTION WHERE ACTIONID = 2049")
+              .executeQuery()) {
+        assertTrue(rs.next());
+        assertEquals("Victim label", rs.getString(1));
+      }
+
+      try (var ins =
+          conn.prepareStatement("INSERT INTO RXMENUACTIONPARAM (ACTIONID, PARAMNAME) VALUES (?, ?)")) {
+        ins.setInt(1, spec.actionId);
+        ins.setString(2, "sys_contentid");
+        ins.executeUpdate();
+      }
+      PSUiDesignWs.deleteActionRow(conn, spec.actionId);
+      assertFalse(PSUiDesignWs.actionRowExists(conn, spec.actionId, spec.name));
+      assertTrue(PSUiDesignWs.actionRowExists(conn, 2049, "Victim"));
+      try (var rs = conn.prepareStatement("SELECT COUNT(*) FROM RXMENUACTIONPARAM").executeQuery()) {
+        assertTrue(rs.next());
+        assertEquals(0, rs.getInt(1));
+      }
+    }
+  }
+
+  @Test
+  void restUserMenuProperty_matchesSharedConstant() {
+    assertEquals(RxmActionMenuConstants.REST_USER_MENU_PROP, PSUiDesignWs.REST_USER_MENU_PROP);
+  }
+
+  private static PSAction newAction(int actionId, String name) {
+    PSAction source = new PSAction(name, name, PSAction.TYPE_MENU, "", PSAction.HANDLER_SERVER, 0);
+    PSKey key = PSAction.createKey(String.valueOf(actionId));
+    key.setPersisted(false);
+    source.setLocator(key);
+    return source;
+  }
+}

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -20,6 +20,8 @@ import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.IPSDbComponent;
 import com.percussion.cms.objectstore.PSAction;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
+import com.percussion.services.menus.PSActionMenu;
+import com.percussion.services.menus.RxmActionMenuConstants;
 import com.percussion.cms.objectstore.PSDisplayColumn;
 import com.percussion.cms.objectstore.PSDisplayFormat;
 import com.percussion.cms.objectstore.PSDFColumns;
@@ -67,6 +69,9 @@ import com.percussion.webservices.ui.IPSUiDesignWs;
 import com.percussion.webservices.ui.data.ActionType;
 import org.apache.commons.lang3.StringUtils;
 import com.percussion.webservices.ExceptionUtils;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -280,8 +285,24 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
    {
       PSWebserviceUtils.validateParameters(ids, "ids", true, session, user);
 
-      deleteComponents(ids, PSAction.class, PSAction.getComponentType(PSAction.class), ignoreDependencies, session,
-            user);
+      try
+      {
+         deleteComponents(ids, PSAction.class, PSAction.getComponentType(PSAction.class), ignoreDependencies, session,
+               user);
+      }
+      catch (PSErrorsException e)
+      {
+         // REST H2 often has RXMENUACTION without the XML design document.
+         // JDBC still removes the catalog row so GET-by-name is 404.
+         log.debug("deleteComponents missed XML action; JDBC RXMENUACTION delete continues", e);
+      }
+      for (IPSGuid id : ids)
+      {
+         if (id != null)
+            deleteActionRowPreferringHibernate(id.getUUID());
+      }
+      invalidateActionCatalog();
+      evictActionMenuRegion();
    }
 
    /*
@@ -1057,8 +1078,44 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
    {
       PSWebserviceUtils.validateParameters(actions, "actions", true, session, user);
 
-      List<IPSDbComponent> components = new ArrayList<>(actions);
-      saveComponents(components, PSAction.class, release, session, user);
+      List<IPSDbComponent> components = new ArrayList<>();
+      List<IPSGuid> releasedIds = new ArrayList<>();
+      for (PSAction action : actions)
+      {
+         PSAction prepared = prepareActionForSave(action);
+         components.add(prepared);
+         if (prepared.getGUID() != null)
+            releasedIds.add(prepared.getGUID());
+      }
+      // SOAP / locator saveComponents writes the full RXMENUACTION graph
+      // (params, visibility, relations). REST H2 can still post updateActions
+      // with no XML document (PSTransactionSet: Xml Document Expected) and
+      // leave 0 parent rows — JDBC then fills RXMENUACTION for GET catalog.
+      try
+      {
+         saveComponents(components, PSAction.class, false, session, user);
+      }
+      catch (PSErrorsException e)
+      {
+         log.debug("saveComponents(updateActions) missed RXMENUACTION; JDBC fallback", e);
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("saveComponents(updateActions) failed; JDBC fallback for REST H2", e);
+      }
+      for (IPSDbComponent component : components)
+      {
+         if (component instanceof PSAction persisted)
+            persistActionRowPreferringHibernate(persisted);
+      }
+      if (release && !releasedIds.isEmpty())
+      {
+         IPSObjectLockService lockService = PSObjectLockServiceLocator.getLockingService();
+         List<PSObjectLock> locks = lockService.findLocksByObjectIds(releasedIds, session, user);
+         lockService.releaseLocks(locks);
+      }
+      invalidateActionCatalog();
+      evictActionMenuRegion();
    }
 
    /*
@@ -2522,6 +2579,450 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       catch (RuntimeException e)
       {
          log.debug("Could not flush sys_DisplayFormats resource cache: {}", e.toString());
+      }
+   }
+
+   /**
+    * Drop the XML resource cache for {@code sys_psxCms} so {@link #findActions}
+    * sees a row just saved or deleted in {@code RXMENUACTION}.
+    */
+   static void invalidateActionCatalog()
+   {
+      try
+      {
+         if (PSCacheManager.isAvailable())
+         {
+            PSCacheManager.getInstance().flushApplication("sys_psxCms");
+         }
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("Could not flush sys_psxCms action catalog cache: {}", e.toString());
+      }
+   }
+
+   void evictActionMenuCache(int actionId)
+   {
+      evictActionMenuRegion();
+      try
+      {
+         SessionFactory factory = getSessionFactory();
+         if (factory != null && factory.getCache() != null && actionId > 0)
+         {
+            factory.getCache().evictEntityData(PSActionMenu.class, Integer.valueOf(actionId));
+         }
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("Could not evict Hibernate RXMENUACTION cache for {}: {}", actionId, e.toString());
+      }
+   }
+
+   /**
+    * Drop the whole {@code PSActionMenu} L2 region so GET catalog does not
+    * reuse a READ_WRITE snapshot from before the JDBC INSERT/DELETE.
+    */
+   void evictActionMenuRegion()
+   {
+      try
+      {
+         SessionFactory factory = getSessionFactory();
+         if (factory != null && factory.getCache() != null)
+         {
+            factory.getCache().evictEntityData(PSActionMenu.class);
+         }
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("Could not evict Hibernate RXMENUACTION region: {}", e.toString());
+      }
+   }
+
+   /**
+    * Prepare an action for {@link #saveActions}. Unpersisted objects are forced
+    * to {@code DBSTATE_NEW} so INSERT (not delete-then-insert) is the intent.
+    *
+    * @param source never {@code null}
+    * @return clone ready for JDBC persist, never {@code null}
+    */
+   static PSAction prepareActionForSave(PSAction source)
+   {
+      if (source == null)
+         throw new IllegalArgumentException("action cannot be null");
+
+      PSAction action = (PSAction) source.cloneFull();
+      if (action.getId() <= 0 && source.getId() > 0)
+      {
+         PSKey sourceKey = source.getLocator();
+         PSKey copy = PSAction.createKey(String.valueOf(source.getId()));
+         if (sourceKey != null)
+            copy.setPersisted(sourceKey.isPersisted());
+         action.setLocator(copy);
+      }
+      if (!action.isPersisted())
+      {
+         PSKey key = action.getLocator();
+         if (key != null)
+         {
+            key.setPersisted(false);
+            action.setLocator(key);
+         }
+         if (action.getState() != IPSDbComponent.DBSTATE_NEW)
+         {
+            action.setState(IPSDbComponent.DBSTATE_NEW);
+         }
+      }
+      return action;
+   }
+
+   /**
+    * Column values for a durable {@code RXMENUACTION} INSERT/UPDATE when
+    * {@code updateActions} reports success with 0 rows (H2 REST #4119).
+    */
+   /** Property written on REST/JDBC-created user menus so DELETE can tell them from packaged rows. */
+   static final String REST_USER_MENU_PROP = RxmActionMenuConstants.REST_USER_MENU_PROP;
+
+   static final class ActionRowSpec
+   {
+      final int actionId;
+      final String name;
+      final String displayName;
+      final String description;
+      final String url;
+      final int sortOrder;
+      final String type;
+      final String handler;
+      final int version;
+      final boolean restUserMenu;
+
+      ActionRowSpec(int actionId, String name, String displayName, String description, String url, int sortOrder,
+            String type, String handler, int version, boolean restUserMenu)
+      {
+         this.actionId = actionId;
+         this.name = name;
+         this.displayName = displayName;
+         this.description = description;
+         this.url = url;
+         this.sortOrder = sortOrder;
+         this.type = type;
+         this.handler = handler;
+         this.version = version;
+         this.restUserMenu = restUserMenu;
+      }
+   }
+
+   static ActionRowSpec actionRowSpec(PSAction action)
+   {
+      if (action == null)
+         throw new IllegalArgumentException("action cannot be null");
+      int id = action.getId();
+      if (id <= 0)
+         throw new IllegalArgumentException("action id must be assigned before persist");
+      String name = action.getName();
+      if (StringUtils.isBlank(name))
+         throw new IllegalArgumentException("action name is required");
+      String display = StringUtils.defaultIfBlank(action.getLabel(), name);
+      String description = StringUtils.trimToNull(action.getDescription());
+      String url = StringUtils.trimToNull(action.getURL());
+      String type = StringUtils.defaultIfBlank(action.getMenuType(), PSAction.TYPE_MENU);
+      String handler = action.isClientAction() ? PSAction.HANDLER_CLIENT : PSAction.HANDLER_SERVER;
+      int version = action.getVersion() != null ? action.getVersion().intValue() : 0;
+      boolean restUser = !action.isPersisted()
+            || StringUtils.equalsIgnoreCase(action.getProperty(REST_USER_MENU_PROP), PSAction.YES);
+      return new ActionRowSpec(id, name, display, description, url, action.getSortRank(), type, handler, version,
+            restUser);
+   }
+
+   /**
+    * If {@code updateActions} did not INSERT, write {@code RXMENUACTION} so
+    * Hibernate {@code findActionMenusTree} / GET catalog can list the name.
+    * Prefer the Hibernate {@code Session} JDBC connection so the write enrolls
+    * in the Spring {@code @Transactional} on {@link #saveActions}.
+    */
+   void persistActionRowPreferringHibernate(PSAction action)
+   {
+      SessionFactory factory = getSessionFactory();
+      if (factory != null)
+      {
+         if (runActionJdbcOnCurrentSession(factory, conn -> persistActionRowOn(conn, action),
+               action.getName()))
+         {
+            return;
+         }
+         runActionJdbcOnOwnSession(factory, conn -> persistActionRowOn(conn, action), action.getName());
+         return;
+      }
+      ensureActionRowPersisted(action);
+   }
+
+   @FunctionalInterface
+   interface ActionJdbcWork
+   {
+      void accept(Connection conn) throws SQLException;
+   }
+
+   /**
+    * @return {@code true} when the current Hibernate session ran the work
+    */
+   boolean runActionJdbcOnCurrentSession(SessionFactory factory, ActionJdbcWork work, String actionName)
+   {
+      try
+      {
+         Session session = factory.getCurrentSession();
+         session.doWork(conn -> work.accept(conn));
+         session.flush();
+         return true;
+      }
+      catch (IllegalStateException e)
+      {
+         throw e;
+      }
+      catch (org.hibernate.HibernateException e)
+      {
+         if (e.getCause() instanceof SQLException)
+         {
+            throw new IllegalStateException(
+                  "Action menu was saved but is not visible to findActionMenusTree: " + actionName, e);
+         }
+         log.debug("No Hibernate current session for RXMENUACTION JDBC; own session", e);
+         return false;
+      }
+      catch (RuntimeException e)
+      {
+         log.debug("No Hibernate current session for RXMENUACTION JDBC; own session", e);
+         return false;
+      }
+   }
+
+   /**
+    * Independent Hibernate session that commits so GET catalog sees the row
+    * when Spring did not bind {@code SessionFactory.getCurrentSession()}.
+    */
+   void runActionJdbcOnOwnSession(SessionFactory factory, ActionJdbcWork work, String actionName)
+   {
+      Session session = factory.openSession();
+      Transaction tx = session.beginTransaction();
+      try
+      {
+         session.doWork(conn -> work.accept(conn));
+         tx.commit();
+      }
+      catch (RuntimeException e)
+      {
+         if (tx.isActive())
+            tx.rollback();
+         throw new IllegalStateException(
+               "Action menu was saved but is not visible to findActionMenusTree: " + actionName, e);
+      }
+      finally
+      {
+         session.close();
+      }
+   }
+
+   static void persistActionRowOn(Connection conn, PSAction action) throws SQLException
+   {
+      ActionRowSpec spec = actionRowSpec(action);
+      if (actionRowExists(conn, spec.actionId, spec.name))
+      {
+         updateActionRow(conn, spec);
+      }
+      else
+      {
+         try
+         {
+            insertActionRow(conn, spec);
+         }
+         catch (SQLException insertEx)
+         {
+            if (!actionRowExists(conn, spec.actionId, spec.name))
+               throw insertEx;
+            updateActionRow(conn, spec);
+         }
+      }
+      if (spec.restUserMenu)
+         ensureRestUserMenuProperty(conn, spec.actionId);
+   }
+
+   static void ensureActionRowPersisted(PSAction action)
+   {
+      ActionRowSpec spec = actionRowSpec(action);
+      Connection conn = null;
+      try
+      {
+         conn = PSConnectionHelper.getDbConnection();
+         persistActionRowOn(conn, action);
+      }
+      catch (NamingException | SQLException e)
+      {
+         throw new IllegalStateException(
+               "Action menu was saved but is not visible to findActionMenusTree: " + spec.name, e);
+      }
+      finally
+      {
+         PSConnectionHelper.releaseDbConnection(conn);
+      }
+   }
+
+   static boolean actionRowExists(Connection conn, int actionId, String name) throws SQLException
+   {
+      String sql = "SELECT ACTIONID FROM RXMENUACTION WHERE ACTIONID = ?";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setInt(1, actionId);
+         try (ResultSet rs = ps.executeQuery())
+         {
+            return rs.next();
+         }
+      }
+   }
+
+   static void insertActionRow(Connection conn, ActionRowSpec spec) throws SQLException
+   {
+      String sql = "INSERT INTO RXMENUACTION (ACTIONID, NAME, DISPLAYNAME, DESCRIPTION, URL, SORTORDER, TYPE, "
+            + "HANDLER, VERSION) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         bindActionRow(ps, spec, false);
+         ps.executeUpdate();
+      }
+   }
+
+   static void updateActionRow(Connection conn, ActionRowSpec spec) throws SQLException
+   {
+      String sql = "UPDATE RXMENUACTION SET NAME = ?, DISPLAYNAME = ?, DESCRIPTION = ?, URL = ?, SORTORDER = ?, "
+            + "TYPE = ?, HANDLER = ?, VERSION = ? WHERE ACTIONID = ?";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         bindActionRow(ps, spec, true);
+         ps.executeUpdate();
+      }
+   }
+
+   static void bindActionRow(PreparedStatement ps, ActionRowSpec spec, boolean update) throws SQLException
+   {
+      if (update)
+      {
+         ps.setString(1, spec.name);
+         ps.setString(2, spec.displayName);
+         ps.setString(3, spec.description);
+         ps.setString(4, spec.url);
+         ps.setInt(5, spec.sortOrder);
+         ps.setString(6, spec.type);
+         ps.setString(7, spec.handler);
+         ps.setInt(8, spec.version);
+         ps.setInt(9, spec.actionId);
+      }
+      else
+      {
+         ps.setInt(1, spec.actionId);
+         ps.setString(2, spec.name);
+         ps.setString(3, spec.displayName);
+         ps.setString(4, spec.description);
+         ps.setString(5, spec.url);
+         ps.setInt(6, spec.sortOrder);
+         ps.setString(7, spec.type);
+         ps.setString(8, spec.handler);
+         ps.setInt(9, spec.version);
+      }
+   }
+
+   /**
+    * Prefer the Hibernate {@code Session} JDBC connection so child-row DELETEs
+    * enroll in the Spring {@code @Transactional} on {@link #deleteActions}.
+    */
+   void deleteActionRowPreferringHibernate(int actionId)
+   {
+      SessionFactory factory = getSessionFactory();
+      String label = String.valueOf(actionId);
+      if (factory != null)
+      {
+         if (runActionJdbcOnCurrentSession(factory, conn -> deleteActionRow(conn, actionId), label))
+         {
+            return;
+         }
+         runActionJdbcOnOwnSession(factory, conn -> deleteActionRow(conn, actionId), label);
+         return;
+      }
+      ensureActionRowDeleted(actionId);
+   }
+
+   static void ensureActionRowDeleted(int actionId)
+   {
+      Connection conn = null;
+      try
+      {
+         conn = PSConnectionHelper.getDbConnection();
+         deleteActionRow(conn, actionId);
+      }
+      catch (NamingException | SQLException e)
+      {
+         throw new IllegalStateException(
+               "Action menu child rows could not be deleted for ACTIONID=" + actionId, e);
+      }
+      finally
+      {
+         PSConnectionHelper.releaseDbConnection(conn);
+      }
+   }
+
+   /** Bind count for {@link #deleteActionChildRows} (not inferred from SQL text). */
+   enum ActionSqlBinds
+   {
+      ACTION_ID,
+      ACTION_ID_AND_CHILD
+   }
+
+   static void deleteActionRow(Connection conn, int actionId) throws SQLException
+   {
+      deleteActionChildRows(conn, "DELETE FROM RXMENUACTIONPARAM WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+      deleteActionChildRows(conn, "DELETE FROM RXMENUACTIONPROPERTIES WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+      deleteActionChildRows(conn, "DELETE FROM RXMENUVISIBILITY WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+      deleteActionChildRows(conn, "DELETE FROM RXMODEUICONTEXTACTION WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+      deleteActionChildRows(conn,
+            "DELETE FROM RXMENUACTIONRELATION WHERE ACTIONID = ? OR CHILDACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID_AND_CHILD);
+      deleteActionChildRows(conn, "DELETE FROM RXMENUACTION WHERE ACTIONID = ?", actionId,
+            ActionSqlBinds.ACTION_ID);
+   }
+
+   static void deleteActionChildRows(Connection conn, String sql, int actionId, ActionSqlBinds binds)
+         throws SQLException
+   {
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setInt(1, actionId);
+         if (binds == ActionSqlBinds.ACTION_ID_AND_CHILD)
+            ps.setInt(2, actionId);
+         ps.executeUpdate();
+      }
+   }
+
+   static void ensureRestUserMenuProperty(Connection conn, int actionId) throws SQLException
+   {
+      String existsSql = "SELECT PROPNAME FROM RXMENUACTIONPROPERTIES WHERE ACTIONID = ? AND PROPNAME = ?";
+      try (PreparedStatement ps = conn.prepareStatement(existsSql))
+      {
+         ps.setInt(1, actionId);
+         ps.setString(2, REST_USER_MENU_PROP);
+         try (ResultSet rs = ps.executeQuery())
+         {
+            if (rs.next())
+               return;
+         }
+      }
+      String sql = "INSERT INTO RXMENUACTIONPROPERTIES (ACTIONID, PROPNAME, PROPVALUE, DESCRIPTION) VALUES (?, ?, ?, ?)";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setInt(1, actionId);
+         ps.setString(2, REST_USER_MENU_PROP);
+         ps.setString(3, PSAction.YES);
+         ps.setString(4, "Created via REST action menu persist");
+         ps.executeUpdate();
       }
    }
 


### PR DESCRIPTION
## Summary

Cycle Verify residual for REST action-menu persist (parent [#1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690), persist [#4119](https://github.com/intersoftdatalabs-in/percussioncms/issues/4119)). Consumes cluster `ActionMenuJsonReader` and `RXMENUACTION` JDBC persist from [#4139](https://github.com/intersoftdatalabs-in/percussioncms/pull/4139) without re-litigating SPA chrome.

Admin `POST /services/actions` is durable in Hibernate `findActionMenusTree` so `GET /services/actions/catalog` and GET by name list the new user menu. JDBC persist commits on an owned Hibernate session when Spring has no current session; GET catalog uses `CacheMode.IGNORE` and evicts the `PSActionMenu` L2 region. Packaged catalog menus (e.g. **Copy**) are **409** on DELETE/PUT (Hibernate-first identity; not 404). User DELETE is 204 then GET 404 (JDBC delete continues if XML design load misses). `overrideLock=false` unchanged.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4140
Parent: #1690

## Test plan

1. Standalone `mvnw clean install` in `rest`, `system`, `projects/sitemanage` (no skipTests).
2. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → docker cp rest/sitemanage/perc-system jars + `sitemanage-beans.xml` into WAR `WEB-INF/lib` (not `jetty/base/lib`) → in-cell StopJetty/StartJetty → `qa-health --url $TEST_CMS_URL/Rhythmyx/rest/mimetypes`.
3. `cd modules/perc-qa-automation/frontend && npm run test:surface -- --path tests/developer-action-menu-persist.spec.js` (Admin POST in catalog; DELETE 204/404; Copy 409).
4. `qa-down` when done.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/developer/rest.md` (durable catalog after POST; packaged Copy 409) and `product-docs/8.2/admin/developer-action-menus.md`
- [x] **Unit / module tests** — `ActionMenuJsonReaderTest`, `ActionMenuAdaptorWriteTest` (Copy 409 when design-WS misses), `PSUiDesignWsActionPersistTest`
- [x] **WebUI + Playwright** — persist spec only (no SPA chrome); `developer-action-menu-persist.spec.js` 2 passed on H2 QA
- [x] **Build gates** — standalone clean install rest, system, sitemanage
- [x] **Cross-platform** — JDBC identifiers only; no OS path joins

### C3 evidence

- **modules_built:** rest, system, projects/sitemanage
- **build_evidence:** `cd rest && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 1023, Failures: 0; `cd system && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 2749, Failures: 0, Skipped: 248; `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS Tests run: 2226, Failures: 0, Skipped: 125
- **downstream_checked:** sitemanage standalone install against new rest + perc-system SNAPSHOTs; no `final`/`sealed` public API change (C2 N/A for type sealing)

### C5 UI / REST live proof

- qa-up `--skip-image-build` RESULT:OK `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- docker cp `rest-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar`, `perc-system-8.2.0-SNAPSHOT.jar` + `sitemanage-beans.xml` (`actionMenuJsonReader`); in-cell StopJetty/StartJetty (not docker restart)
- qa-health RESULT:OK HTTP:200 HEALTH:healthy `http://127.0.0.1:9993/Rhythmyx/rest/mimetypes`
- Playwright: `npm run test:surface -- --path tests/developer-action-menu-persist.spec.js` — **2 passed** (2.8s)
- console-clean=yes (spec `pageerror` / console error guards)
- server.log-clean=yes (no action-menu ERROR/FATAL in the test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
