### PR TITLE
fix(system): retype managednav leftovers to NavigationErrorCodes (#4144)

### DIFF
--- a/docs/ai-generated/code-reviews/4144-managednav-navigation-error-codes-erlang.md
+++ b/docs/ai-generated/code-reviews/4144-managednav-navigation-error-codes-erlang.md
@@ -1,0 +1,34 @@
+# Erlang review: #4144 managednav NavigationErrorCodes leftover
+
+- **Branch:** `fix/issue-4144-managednav-navigation-error-codes`
+- **Base:** `origin/main`
+- **Scope:** uncommitted managednav leftover retype vs `HEAD` / `origin/main`
+- **Date:** 2026-09-02
+- **Memory patterns hit:** incomplete change-class closure (leftover typed-code companions); missing behavioral tests; public API shape (`PSNavException` ctor overloads)
+
+## Summary
+
+`PSManagedNavService` production throw sites now construct `PSNavException` with `NavigationErrorCodes` instead of bare `IPSNavigationErrors` ints. Typed constructors were added on `PSNavException` matching existing int overloads (including `(code, Object)` so `Exception` remains a message argument, not a cause). `IPSNavigationErrors` stays as the compile-time numeric bridge. Dual-write skip is covered because every `NavigationErrorCodes` constant is non-auditable.
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Cross-platform path checklist
+
+N/A — no filesystem path / I/O changes.
+
+## Issues
+
+None (hard-gate).
+
+### Notes (not blocking)
+
+- `system/Tools/RxFix/.../PSFixNavigation.java` still uses `IPSNavigationErrors.NAVIGATION_SERVICE_CANNOT_FIND_ANY_NAVONS` (out of scope per issue).
+- Added `PSNavException(IPSErrorCode, …)` overloads; no `final`/`sealed`; no subclasses or anonymous subclasses found. Existing int constructors unchanged so reverse-deps keep compiling.
+- Product-docs N/A (internal error-catalog retype, not operator-facing).
+- Playwright N/A (no UI).

--- a/system/src/main/java/com/percussion/fastforward/managednav/IPSNavigationErrors.java
+++ b/system/src/main/java/com/percussion/fastforward/managednav/IPSNavigationErrors.java
@@ -17,6 +17,13 @@
 
 package com.percussion.fastforward.managednav;
 
+/**
+ * Numeric bridge for managed-navigation error codes (18001–18009; category base 18000).
+ *
+ * <p>Prefer {@code com.intsof.percussioncms.auditlog.codes.NavigationErrorCodes} (and typed {@link
+ * PSNavException} constructors) at production throw sites. These ints remain for legacy callers and
+ * message lookup; they match {@code NavigationErrorCodes#numericCode()}.
+ */
 public interface IPSNavigationErrors {
 
   int NAVIGATION_SERVICE_CATEGORY = 18000; // through 18250

--- a/system/src/main/java/com/percussion/fastforward/managednav/PSManagedNavService.java
+++ b/system/src/main/java/com/percussion/fastforward/managednav/PSManagedNavService.java
@@ -27,6 +27,7 @@ import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.Validate.notEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
 
+import com.intsof.percussioncms.auditlog.codes.NavigationErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSAaRelationship;
@@ -206,7 +207,7 @@ public class PSManagedNavService implements IPSManagedNavService {
     PSComponentSummary folder = getParentFolder(getRequestCtx(), navon);
     if (folder == null) {
       throw new PSNavException(
-          IPSNavigationErrors.NAVIGATION_SERVICE_CANT_FIND_RELATED_FOLDER_FOR_NAVON, navonId);
+          NavigationErrorCodes.NAVIGATION_SERVICE_CANT_FIND_RELATED_FOLDER_FOR_NAVON, navonId);
     }
 
     return folder;
@@ -257,7 +258,7 @@ public class PSManagedNavService implements IPSManagedNavService {
     } catch (PSErrorResultsException e) {
       PSNavException ne =
           new PSNavException(
-              IPSNavigationErrors.NAVIGATION_SERVICE_FAILED_TO_MOVE_SOURCE_NAVON_TO_TARGET,
+              NavigationErrorCodes.NAVIGATION_SERVICE_FAILED_TO_MOVE_SOURCE_NAVON_TO_TARGET,
               new Object[] {srcId, targetId},
               e);
       log.error(PSExceptionUtils.getMessageForLog(e));
@@ -408,7 +409,7 @@ public class PSManagedNavService implements IPSManagedNavService {
     } catch (Exception ex) {
       PSNavException ne =
           new PSNavException(
-              IPSNavigationErrors.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER, ex);
+              NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER, ex);
       if (ex instanceof PSNavException) {
         ne = (PSNavException) ex;
       } else if (ex instanceof PSErrorException) {
@@ -463,7 +464,7 @@ public class PSManagedNavService implements IPSManagedNavService {
     if (id != null) {
       PSNavException e =
           new PSNavException(
-              IPSNavigationErrors
+              NavigationErrorCodes
                   .NAVIGATION_SERVICE_FAILED_TO_MOVE_SECTION_BECAUSE_TARGET_ALREADY_HAS_ITEM,
               new Object[] {targetFolder.getName(), srcFolder.getName()});
       log.warn(PSExceptionUtils.getMessageForLog(e));
@@ -491,10 +492,10 @@ public class PSManagedNavService implements IPSManagedNavService {
     if (navSummary != null) {
       if (getNavonContentTypeIds().contains(navSummary.getContentTypeId())) {
         throw new PSNavException(
-            IPSNavigationErrors.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVON);
+            NavigationErrorCodes.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVON);
       } else {
         throw new PSNavException(
-            IPSNavigationErrors.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE);
+            NavigationErrorCodes.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE);
       }
     }
 
@@ -502,7 +503,7 @@ public class PSManagedNavService implements IPSManagedNavService {
       List<String> typeNames = getNavTreeContentTypeNames();
       if (typeNames == null || typeNames.isEmpty()) {
         throw new PSNavException(
-            IPSNavigationErrors.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER);
+            NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER);
       }
       PSCoreItem coreItem = contentWs.createItems(typeNames.get(0), 1).get(0);
       coreItem.setTextField("sys_title", navTreeName);
@@ -527,7 +528,7 @@ public class PSManagedNavService implements IPSManagedNavService {
       List<IPSGuid> guids = contentWs.saveItems(Collections.singletonList(coreItem), false, false);
       if (guids == null || guids.isEmpty() || guids.get(0) == null) {
         throw new PSNavException(
-            IPSNavigationErrors.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER);
+            NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER);
       }
       contentWs.addFolderChildren(path, guids);
 
@@ -537,7 +538,7 @@ public class PSManagedNavService implements IPSManagedNavService {
     } catch (Exception ex) {
       PSNavException ne =
           new PSNavException(
-              IPSNavigationErrors.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER,
+              NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER,
               new Object[] {path, navTreeName},
               ex);
       if (ex instanceof PSErrorException) {
@@ -903,7 +904,7 @@ public class PSManagedNavService implements IPSManagedNavService {
       if (id == -1) {
         PSNavException e =
             new PSNavException(
-                IPSNavigationErrors.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH, folderPath);
+                NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH, folderPath);
         log.error(PSExceptionUtils.getMessageForLog(e));
         log.debug(PSExceptionUtils.getDebugMessageForLog(e));
         throw (e);
@@ -913,7 +914,7 @@ public class PSManagedNavService implements IPSManagedNavService {
     } catch (PSCmsException e) {
       PSNavException ne =
           new PSNavException(
-              IPSNavigationErrors.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH,
+              NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH,
               new Object[] {folderPath},
               e);
       log.error(PSExceptionUtils.getMessageForLog(e));

--- a/system/src/main/java/com/percussion/fastforward/managednav/PSNavException.java
+++ b/system/src/main/java/com/percussion/fastforward/managednav/PSNavException.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.fastforward.managednav;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSRuntimeException;
 import com.percussion.security.error.PSExceptionUtils;
 
@@ -128,6 +129,49 @@ public class PSNavException extends PSRuntimeException {
    */
   public PSNavException(int code, Object arg) {
     super(code, arg);
+  }
+
+  /**
+   * Typed construction from a catalogued {@link IPSErrorCode} (e.g. {@code NavigationErrorCodes}).
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSNavException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single message argument.
+   *
+   * <p>Do not add a two-arg {@code (IPSErrorCode, Throwable)} overload: existing call sites pass an
+   * {@code Exception} as the message argument via {@link #PSNavException(int, Object)}.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arg sole message argument; may be {@code null}
+   */
+  public PSNavException(IPSErrorCode code, Object arg) {
+    super(code, arg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSNavException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
+   * Typed construction with message arguments and a cause.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   * @param cause the underlying cause; may be {@code null}
+   */
+  public PSNavException(IPSErrorCode code, Object[] arrayArgs, Throwable cause) {
+    super(code, arrayArgs, cause);
   }
 
   /** The underlying exception that caused this exception. */

--- a/system/src/test/java/com/percussion/fastforward/managednav/PSManagedNavLeftoverErrorCodesSliceTest.java
+++ b/system/src/test/java/com/percussion/fastforward/managednav/PSManagedNavLeftoverErrorCodesSliceTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.fastforward.managednav;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.AuditContext;
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.codes.NavigationErrorCodes;
+import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.services.audit.PSSystemAuditLogger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #4144 (parent #2616): leftover managednav production sites throw typed {@code
+ * NavigationErrorCodes} (not bare {@code IPSNavigationErrors} ints). Dual-write is skipped because
+ * the catalog is non-auditable. {@link IPSNavigationErrors} remains the numeric bridge.
+ */
+@Tag("UnitTest")
+class PSManagedNavLeftoverErrorCodesSliceTest {
+
+  @BeforeEach
+  void setUp() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @AfterEach
+  void tearDown() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWrite() {
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH,
+        NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH.numericCode());
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_CANT_FIND_RELATED_FOLDER_FOR_NAVON,
+        NavigationErrorCodes.NAVIGATION_SERVICE_CANT_FIND_RELATED_FOLDER_FOR_NAVON.numericCode());
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_FAILED_TO_MOVE_SOURCE_NAVON_TO_TARGET,
+        NavigationErrorCodes.NAVIGATION_SERVICE_FAILED_TO_MOVE_SOURCE_NAVON_TO_TARGET
+            .numericCode());
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_FAILED_TO_MOVE_SECTION_BECAUSE_TARGET_ALREADY_HAS_ITEM,
+        NavigationErrorCodes.NAVIGATION_SERVICE_FAILED_TO_MOVE_SECTION_BECAUSE_TARGET_ALREADY_HAS_ITEM
+            .numericCode());
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVON,
+        NavigationErrorCodes.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVON
+            .numericCode());
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE,
+        NavigationErrorCodes.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE
+            .numericCode());
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER,
+        NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER.numericCode());
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_CANNOT_FIND_ANY_NAVONS,
+        NavigationErrorCodes.NAVIGATION_SERVICE_CANNOT_FIND_ANY_NAVONS.numericCode());
+    assertEquals(
+        IPSNavigationErrors.NAVIGATION_SERVICE_CANNOT_FIND_NAVTREE_FOR_SITE,
+        NavigationErrorCodes.NAVIGATION_SERVICE_CANNOT_FIND_NAVTREE_FOR_SITE.numericCode());
+
+    for (NavigationErrorCodes code : NavigationErrorCodes.values()) {
+      leftoverNonAuditable(code);
+    }
+  }
+
+  @Test
+  void leftoverProductionExceptionTypeRetainsTypedCodeAndSkipsDualWrite() {
+    RuntimeException cause = new RuntimeException("wrap");
+    PSNavException folderMissing =
+        new PSNavException(
+            NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH, "//Sites/x");
+    assertSame(
+        NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH,
+        folderMissing.getTypedErrorCode());
+    assertEquals(
+        NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH.numericCode(),
+        folderMissing.getErrorCode());
+    assertFalse(folderMissing.isAuditable());
+
+    PSNavException moveFailed =
+        new PSNavException(
+            NavigationErrorCodes.NAVIGATION_SERVICE_FAILED_TO_MOVE_SOURCE_NAVON_TO_TARGET,
+            new Object[] {"src", "tgt"},
+            cause);
+    assertSame(
+        NavigationErrorCodes.NAVIGATION_SERVICE_FAILED_TO_MOVE_SOURCE_NAVON_TO_TARGET,
+        moveFailed.getTypedErrorCode());
+    assertSame(cause, moveFailed.getCause());
+    assertFalse(moveFailed.isAuditable());
+
+    PSNavException addFailed =
+        new PSNavException(
+            NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER, cause);
+    assertSame(
+        NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER,
+        addFailed.getTypedErrorCode());
+    assertFalse(addFailed.isAuditable());
+    assertNull(addFailed.getCause());
+
+    var skipped =
+        PSSystemAuditLogger.logLegacyIfAuditable(
+            NavigationErrorCodes.NAVIGATION_SERVICE_FOLDER_ID_NOT_FOUND_FOR_PATH.numericCode(),
+            AuditContext.builder().actor("jdoe").build(),
+            "//Sites/x");
+    assertEquals(LegacyErrorCodeRegistry.SKIPPED, skipped);
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  void typedNavExceptionCtorRejectsNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSNavException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSNavException((IPSErrorCode) null, "arg"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PSNavException((IPSErrorCode) null, new Object[] {"a"}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new PSNavException(
+                (IPSErrorCode) null, new Object[] {"a"}, new RuntimeException("c")));
+  }
+
+  @Test
+  void legacyIntCtorRemainsNumericBridgeWithoutTypedCode() {
+    PSNavException legacy =
+        new PSNavException(IPSNavigationErrors.NAVIGATION_SERVICE_CANNOT_FIND_ANY_NAVONS);
+    assertNull(legacy.getTypedErrorCode());
+    assertEquals(
+        NavigationErrorCodes.NAVIGATION_SERVICE_CANNOT_FIND_ANY_NAVONS.numericCode(),
+        legacy.getErrorCode());
+    assertFalse(legacy.isAuditable());
+  }
+
+  private static void leftoverNonAuditable(NavigationErrorCodes code) {
+    assertFalse(code.isAuditable(), code.toString());
+    PSNavException ex = new PSNavException(code);
+    assertSame(code, ex.getTypedErrorCode());
+    assertEquals(code.numericCode(), ex.getErrorCode());
+    assertFalse(ex.isAuditable(), code.toString());
+  }
+}

--- a/system/src/test/java/com/percussion/fastforward/managednav/PSManagedNavServiceAddNavTreeToFolderTest.java
+++ b/system/src/test/java/com/percussion/fastforward/managednav/PSManagedNavServiceAddNavTreeToFolderTest.java
@@ -18,6 +18,7 @@
 package com.percussion.fastforward.managednav;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.intsof.percussioncms.auditlog.codes.NavigationErrorCodes;
 import com.percussion.cms.objectstore.PSComponentSummary;
 import com.percussion.cms.objectstore.PSCoreItem;
 import com.percussion.services.assembly.IPSAssemblyService;
@@ -118,9 +120,14 @@ class PSManagedNavServiceAddNavTreeToFolderTest {
             () ->
                 service.addNavTreeToFolder(
                     "//Sites/QaSite3364", "QaSite3364-NavTree", "Home", -1));
+    assertSame(
+        NavigationErrorCodes.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE,
+        thrown.getTypedErrorCode());
     assertEquals(
-        IPSNavigationErrors.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE,
+        NavigationErrorCodes.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVTREE
+            .numericCode(),
         thrown.getErrorCode());
+    assertFalse(thrown.isAuditable());
   }
 
   @Test
@@ -136,9 +143,14 @@ class PSManagedNavServiceAddNavTreeToFolderTest {
             () ->
                 service.addNavTreeToFolder(
                     "//Sites/QaSite3364", "QaSite3364-NavTree", "Home", -1));
+    assertSame(
+        NavigationErrorCodes.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVON,
+        thrown.getTypedErrorCode());
     assertEquals(
-        IPSNavigationErrors.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVON,
+        NavigationErrorCodes.NAVIGATION_SERVICE_NAVTREE_CANNOT_BE_ADDED_TO_FOLDER_WITH_NAVON
+            .numericCode(),
         thrown.getErrorCode());
+    assertFalse(thrown.isAuditable());
   }
 
   @Test
@@ -152,9 +164,13 @@ class PSManagedNavServiceAddNavTreeToFolderTest {
             () ->
                 service.addNavTreeToFolder(
                     "//Sites/QaSite3364", "QaSite3364-NavTree", "Home", -1));
+    assertSame(
+        NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER,
+        thrown.getTypedErrorCode());
     assertEquals(
-        IPSNavigationErrors.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER,
+        NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER.numericCode(),
         thrown.getErrorCode());
+    assertFalse(thrown.isAuditable());
     assertEquals(PSErrorResultsException.class, thrown.getCause().getClass());
     verify(contentWs, never()).addFolderChildren(anyString(), any());
   }
@@ -169,8 +185,12 @@ class PSManagedNavServiceAddNavTreeToFolderTest {
             () ->
                 service.addNavTreeToFolder(
                     "//Sites/QaSite3364", "QaSite3364-NavTree", "Home", -1));
+    assertSame(
+        NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER,
+        thrown.getTypedErrorCode());
     assertEquals(
-        IPSNavigationErrors.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER,
+        NavigationErrorCodes.NAVIGATION_SERVICE_ERROR_ADDING_NAVTREE_TO_FOLDER.numericCode(),
         thrown.getErrorCode());
+    assertFalse(thrown.isAuditable());
   }
 }


### PR DESCRIPTION
## Summary

Parent leftover slice of #2616 / Fixes #4144. Production `PSManagedNavService` throw sites now use typed `NavigationErrorCodes` and `PSNavException(IPSErrorCode, …)` constructors instead of bare `IPSNavigationErrors` ints. `IPSNavigationErrors` remains the numeric bridge (ints 18001–18009 unchanged). Navigation catalog codes are non-auditable, so dual-write is skipped.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` (JDK 21) — BUILD SUCCESS.
2. Confirm leftover slice tests: `PSManagedNavLeftoverErrorCodesSliceTest` (catalog ints match, typed ctors, dual-write skip).
3. Confirm `PSManagedNavServiceAddNavTreeToFolderTest` asserts `getTypedErrorCode()` and `isAuditable() == false`.
4. No UI / Playwright (internal error-catalog retype).

## Checklist

- [x] **Product documentation** — **N/A** (not product-facing): internal leftover error-catalog retype; no operator/admin/UX/REST contract change
- [x] **Unit / module tests** — leftover dual-write skip + addNavTree typed-code assertions; `system` standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — **N/A** (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` BUILD SUCCESS; Tests run: 2745, Failures: 0, Errors: 0, Skipped: 248
- [x] **Cross-platform** — **N/A** (no path/file I/O)

### C3 evidence

- `modules_built=system`
- `build_evidence=cd system && ../mvnw.cmd clean install` (JAVA_HOME=JDK 21) → BUILD SUCCESS in 01:44; Tests run: 2745, Failures: 0, Errors: 0, Skipped: 248; `PSManagedNavLeftoverErrorCodesSliceTest` Tests run: 4; `PSManagedNavServiceAddNavTreeToFolderTest` Tests run: 6
- `downstream_checked=grep extends PSNavException (none); grep new PSNavException() { (none). Added typed constructor overloads only; existing int/String ctors unchanged. sitemanage still compares numeric getErrorCode() which is preserved.`

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
