### PR TITLE
fix(system): retype job handler throws to JobErrorCodes (#4143)

### DIFF
--- a/docs/ai-generated/code-reviews/4143-job-error-codes-erlang.md
+++ b/docs/ai-generated/code-reviews/4143-job-error-codes-erlang.md
@@ -1,0 +1,25 @@
+# Erlang review — issue #4143 (parent #2616 leftover)
+
+**Branch:** `fix/issue-4143-job-error-codes`  
+**Scope:** uncommitted `system` job-handler retype vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** pass  
+**May commit/push:** yes  
+**Memory patterns hit:** leftover `IPS*Errors` int throw sites → typed `*ErrorCodes`; dual-write skip via `isAuditable()==false`; keep numeric bridge interface.
+
+## Summary
+
+Production `PSJobException` throws in `com.percussion.server.job` (`PSJobHandler`, `PSJobHandlerConfiguration`, `PSJobRunnerFactory`) now use `JobErrorCodes` / typed `PSJobException` constructors. `IPSJobErrors` remains as the int bridge. Behavioral tests cover missing job definition, factory class-not-found, missing runJob params, malformed/unknown job id, already-running lock, and catalog dual-write skip (`DefaultAuditLogService.log` → `SKIPPED`, empty repository). Numeric codes match `IPSJobErrors`. No public signature change; no path I/O.
+
+## Cross-platform path checklist
+
+N/A — no filesystem path construction. Config XML is an in-memory string.
+
+## Issues
+
+None.
+
+## Tests / build
+
+- `cd system && ../mvnw.cmd "-Dtest=PSJobHandlerTypedErrorCodeSliceTest" test` — Tests run: 7, Failures: 0
+- `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2696, Failures: 0, Errors: 0, Skipped: 245

--- a/system/src/main/java/com/percussion/server/job/IPSJobErrors.java
+++ b/system/src/main/java/com/percussion/server/job/IPSJobErrors.java
@@ -18,8 +18,9 @@
 package com.percussion.server.job;
 
 /**
- * The IPSJobErrors interface is provided as a convenient mechanism for accessing the various
- * deployent related error codes.
+ * Legacy numeric bridge for server job error codes. Production throw sites should use typed {@link
+ * com.intsof.percussioncms.auditlog.codes.JobErrorCodes} constructors on {@link PSJobException}.
+ * Constant values here remain the source of the historic int codes (1–11).
  */
 public interface IPSJobErrors {
   /**

--- a/system/src/main/java/com/percussion/server/job/PSJobHandler.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobHandler.java
@@ -17,8 +17,9 @@
 
 package com.percussion.server.job;
 
-import com.percussion.conn.PSServerException;
+import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
+import com.percussion.conn.PSServerException;
 import com.percussion.design.objectstore.PSAclEntry;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -118,13 +119,13 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
     String subReqType;
     try {
       if (reqType == null || !reqType.startsWith("job-")) {
-        throw new PSJobException(IPSJobErrors.INVALID_REQUEST_TYPE, reqType == null ? "" : reqType);
+        throw new PSJobException(JobErrorCodes.INVALID_REQUEST_TYPE, reqType == null ? "" : reqType);
       } else {
         subReqType = reqType.substring("job-".length());
       }
 
       Document inDoc = request.getInputDocument();
-      if (inDoc == null) throw new PSJobException(IPSJobErrors.NULL_INPUT_DOC);
+      if (inDoc == null) throw new PSJobException(JobErrorCodes.NULL_INPUT_DOC);
 
       // all requests have security checked by default - must have admin
       // access
@@ -134,7 +135,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
       else if (subReqType.equals("cancelJob")) respDoc = cancelJob(inDoc, request);
       else if (subReqType.equals("getJobStatus")) respDoc = getJobStatus(inDoc, request);
       else {
-        throw new PSJobException(IPSJobErrors.INVALID_REQUEST_TYPE, reqType);
+        throw new PSJobException(JobErrorCodes.INVALID_REQUEST_TYPE, reqType);
       }
     } catch (Exception e) {
       // Convert to xml response
@@ -142,7 +143,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
       if (e instanceof PSJobException) je = (PSJobException) e;
       else if (e instanceof PSException) je = new PSJobException((PSException) e);
       else {
-        je = new PSJobException(IPSJobErrors.UNEXPECTED_ERROR, e.getLocalizedMessage());
+        je = new PSJobException(JobErrorCodes.UNEXPECTED_ERROR, e.getLocalizedMessage());
       }
 
       respDoc = PSXmlDocumentBuilder.createXmlDocument();
@@ -190,13 +191,13 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
     String category = req.getParameter("sys_jobCategory");
     if (category == null || category.trim().length() == 0) {
       Object[] args = {"sys_jobCategory", category == null ? "null" : category};
-      throw new PSJobException(IPSJobErrors.SERVER_REQUEST_PARAM_INVALID, args);
+      throw new PSJobException(JobErrorCodes.SERVER_REQUEST_PARAM_INVALID, args);
     }
 
     String jobType = req.getParameter("sys_jobType");
     if (jobType == null || jobType.trim().length() == 0) {
       Object[] args = {"sys_jobType", jobType == null ? "null" : jobType};
-      throw new PSJobException(IPSJobErrors.SERVER_REQUEST_PARAM_INVALID, args);
+      throw new PSJobException(JobErrorCodes.SERVER_REQUEST_PARAM_INVALID, args);
     }
 
     // create the job
@@ -269,11 +270,11 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
           new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {reqRoot.getTagName(), une.getLocalizedMessage()};
-      throw new PSJobException(IPSJobErrors.SERVER_REQUEST_MALFORMED, args);
+      throw new PSJobException(JobErrorCodes.SERVER_REQUEST_MALFORMED, args);
     }
 
     PSJobRunner job = m_jobRunners.get(jobId);
-    if (job == null) throw new PSJobException(IPSJobErrors.INVALID_JOB_ID, jobId.toString());
+    if (job == null) throw new PSJobException(JobErrorCodes.INVALID_JOB_ID, jobId.toString());
 
     // prepare response
     Document respDoc = PSXmlDocumentBuilder.createXmlDocument();
@@ -325,11 +326,11 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
           new PSUnknownNodeTypeException(ObjectStoreErrorCodes.XML_ELEMENT_INVALID_ATTR, msgArgs);
 
       Object[] args = {reqRoot.getTagName(), une.getLocalizedMessage()};
-      throw new PSJobException(IPSJobErrors.SERVER_REQUEST_MALFORMED, args);
+      throw new PSJobException(JobErrorCodes.SERVER_REQUEST_MALFORMED, args);
     }
 
     PSJobRunner job = m_jobRunners.get(jobId);
-    if (job == null) throw new PSJobException(IPSJobErrors.INVALID_JOB_ID, jobId.toString());
+    if (job == null) throw new PSJobException(JobErrorCodes.INVALID_JOB_ID, jobId.toString());
 
     int resultCode = doCancelJob(job);
 
@@ -426,7 +427,7 @@ public class PSJobHandler implements IPSLoadableRequestHandler, IPSJobListener {
   private void lockJobHandler(PSJobRunner job) throws PSJobException {
     synchronized (m_jobMonitor) {
       if (m_currentJob != null && m_currentJob.isAlive())
-        throw new PSJobException(IPSJobErrors.JOB_ALREADY_RUNNING);
+        throw new PSJobException(JobErrorCodes.JOB_ALREADY_RUNNING);
       else m_currentJob = job;
     }
   }

--- a/system/src/main/java/com/percussion/server/job/PSJobHandlerConfiguration.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobHandlerConfiguration.java
@@ -17,6 +17,7 @@
 
 package com.percussion.server.job;
 
+import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
 import com.intsof.percussioncms.auditlog.codes.ObjectStoreErrorCodes;
 import com.percussion.design.objectstore.PSUnknownDocTypeException;
 import com.percussion.design.objectstore.PSUnknownNodeTypeException;
@@ -202,7 +203,7 @@ public class PSJobHandlerConfiguration {
 
     if (className == null) {
       Object[] args = {category, jobType};
-      throw new PSJobException(IPSJobErrors.JOB_DEFINITION_NOT_FOUND, args);
+      throw new PSJobException(JobErrorCodes.JOB_DEFINITION_NOT_FOUND, args);
     }
 
     return className;
@@ -242,7 +243,7 @@ public class PSJobHandlerConfiguration {
 
     if (props == null) {
       Object[] args = {category, jobType};
-      throw new PSJobException(IPSJobErrors.JOB_DEFINITION_NOT_FOUND, args);
+      throw new PSJobException(JobErrorCodes.JOB_DEFINITION_NOT_FOUND, args);
     }
 
     return props;

--- a/system/src/main/java/com/percussion/server/job/PSJobRunnerFactory.java
+++ b/system/src/main/java/com/percussion/server/job/PSJobRunnerFactory.java
@@ -17,6 +17,8 @@
 
 package com.percussion.server.job;
 
+import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
+
 /**
  * Class for creating classes implementing PSJobRunner based on the type and category of job. Types
  * are paired with class names in the {@link PSJobHandlerConfiguration}. Any class that will be
@@ -63,13 +65,13 @@ public class PSJobRunnerFactory {
       runner = (PSJobRunner) Class.forName(className).newInstance();
     } catch (ClassNotFoundException e) {
       Object[] args = {className, e.getLocalizedMessage()};
-      throw new PSJobException(IPSJobErrors.FACTORY_GET_RUNNER, args);
+      throw new PSJobException(JobErrorCodes.FACTORY_GET_RUNNER, args);
     } catch (InstantiationException e) {
       Object[] args = {className, e.getLocalizedMessage()};
-      throw new PSJobException(IPSJobErrors.FACTORY_GET_RUNNER, args);
+      throw new PSJobException(JobErrorCodes.FACTORY_GET_RUNNER, args);
     } catch (IllegalAccessException e) {
       Object[] args = {className, e.getLocalizedMessage()};
-      throw new PSJobException(IPSJobErrors.FACTORY_GET_RUNNER, args);
+      throw new PSJobException(JobErrorCodes.FACTORY_GET_RUNNER, args);
     }
 
     return runner;

--- a/system/src/test/java/com/percussion/server/job/PSJobHandlerTypedErrorCodeSliceTest.java
+++ b/system/src/test/java/com/percussion/server/job/PSJobHandlerTypedErrorCodeSliceTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.server.job;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.AuditContext;
+import com.intsof.percussioncms.auditlog.AuditLogId;
+import com.intsof.percussioncms.auditlog.DefaultAuditLogService;
+import com.intsof.percussioncms.auditlog.LegacyErrorCodeRegistry;
+import com.intsof.percussioncms.auditlog.codes.JobErrorCodes;
+import com.intsof.percussioncms.auditlog.spi.ConcurrentMemoryAuditLogRepository;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.server.PSRequest;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #4143 (parent #2616 leftover): {@code com.percussion.server.job} production throw sites use
+ * typed {@link JobErrorCodes} via IPSErrorCode-aware {@link PSJobException} constructors — not
+ * bare {@code IPSJobErrors} ints. Job catalog codes are non-auditable and skip dual-write.
+ */
+@Tag("UnitTest")
+public class PSJobHandlerTypedErrorCodeSliceTest {
+
+  @BeforeEach
+  void setUp() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @AfterEach
+  void tearDown() {
+    ConcurrentMemoryAuditLogRepository.INSTANCE.clear();
+    DefaultAuditLogService.Holder.resetToDefault();
+  }
+
+  @Test
+  public void leftoverJobCodesMatchLegacyIntsAndSkipDualWrite() {
+    assertEquals(
+        IPSJobErrors.JOB_DEFINITION_NOT_FOUND,
+        JobErrorCodes.JOB_DEFINITION_NOT_FOUND.numericCode());
+    assertEquals(IPSJobErrors.FACTORY_GET_RUNNER, JobErrorCodes.FACTORY_GET_RUNNER.numericCode());
+    assertEquals(
+        IPSJobErrors.INVALID_REQUEST_TYPE, JobErrorCodes.INVALID_REQUEST_TYPE.numericCode());
+    assertEquals(IPSJobErrors.UNEXPECTED_ERROR, JobErrorCodes.UNEXPECTED_ERROR.numericCode());
+    assertEquals(IPSJobErrors.NULL_INPUT_DOC, JobErrorCodes.NULL_INPUT_DOC.numericCode());
+    assertEquals(
+        IPSJobErrors.SERVER_REQUEST_PARAM_INVALID,
+        JobErrorCodes.SERVER_REQUEST_PARAM_INVALID.numericCode());
+    assertEquals(
+        IPSJobErrors.JOB_ALREADY_RUNNING, JobErrorCodes.JOB_ALREADY_RUNNING.numericCode());
+    assertEquals(
+        IPSJobErrors.SERVER_REQUEST_MALFORMED,
+        JobErrorCodes.SERVER_REQUEST_MALFORMED.numericCode());
+    assertEquals(IPSJobErrors.INVALID_JOB_ID, JobErrorCodes.INVALID_JOB_ID.numericCode());
+    assertEquals(
+        IPSJobErrors.INVALID_JOB_DESCRIPTOR,
+        JobErrorCodes.INVALID_JOB_DESCRIPTOR.numericCode());
+    assertEquals(
+        IPSJobErrors.CONFIG_FILE_NOT_FOUND, JobErrorCodes.CONFIG_FILE_NOT_FOUND.numericCode());
+
+    leftoverNonAuditable(
+        new PSJobException(JobErrorCodes.JOB_DEFINITION_NOT_FOUND, new Object[] {"cat", "type"}),
+        JobErrorCodes.JOB_DEFINITION_NOT_FOUND);
+    leftoverNonAuditable(
+        new PSJobException(JobErrorCodes.FACTORY_GET_RUNNER, new Object[] {"cls", "err"}),
+        JobErrorCodes.FACTORY_GET_RUNNER);
+    leftoverNonAuditable(
+        new PSJobException(JobErrorCodes.INVALID_REQUEST_TYPE, "job-foo"),
+        JobErrorCodes.INVALID_REQUEST_TYPE);
+    leftoverNonAuditable(
+        new PSJobException(JobErrorCodes.UNEXPECTED_ERROR, "boom"),
+        JobErrorCodes.UNEXPECTED_ERROR);
+    leftoverNonAuditable(
+        new PSJobException(JobErrorCodes.NULL_INPUT_DOC), JobErrorCodes.NULL_INPUT_DOC);
+    leftoverNonAuditable(
+        new PSJobException(
+            JobErrorCodes.SERVER_REQUEST_PARAM_INVALID, new Object[] {"sys_jobType", "null"}),
+        JobErrorCodes.SERVER_REQUEST_PARAM_INVALID);
+    leftoverNonAuditable(
+        new PSJobException(JobErrorCodes.JOB_ALREADY_RUNNING), JobErrorCodes.JOB_ALREADY_RUNNING);
+    leftoverNonAuditable(
+        new PSJobException(
+            JobErrorCodes.SERVER_REQUEST_MALFORMED, new Object[] {"PSXJobGetStatus", "bad"}),
+        JobErrorCodes.SERVER_REQUEST_MALFORMED);
+    leftoverNonAuditable(
+        new PSJobException(JobErrorCodes.INVALID_JOB_ID, "99"), JobErrorCodes.INVALID_JOB_ID);
+
+    for (JobErrorCodes code : JobErrorCodes.values()) {
+      assertFalse(code.isAuditable(), code.name());
+      AuditLogId id = DefaultAuditLogService.Holder.get().log(code, AuditContext.empty());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED, id, code.name());
+    }
+    assertEquals(0, ConcurrentMemoryAuditLogRepository.INSTANCE.size());
+  }
+
+  @Test
+  public void missingJobDefinitionThrowsTypedNonAuditableCode() throws Exception {
+    PSJobHandlerConfiguration cfg = configWithJob("cat1", "jt1", "com.example.JobRunner");
+    PSJobException missingClass =
+        assertThrows(PSJobException.class, () -> cfg.getJobClassName("cat1", "missing"));
+    leftoverNonAuditable(missingClass, JobErrorCodes.JOB_DEFINITION_NOT_FOUND);
+
+    PSJobException missingParams =
+        assertThrows(PSJobException.class, () -> cfg.getJobInitParams("nope", "jt1"));
+    leftoverNonAuditable(missingParams, JobErrorCodes.JOB_DEFINITION_NOT_FOUND);
+  }
+
+  @Test
+  public void factoryMissingRunnerClassThrowsTypedNonAuditableCode() throws Exception {
+    PSJobHandlerConfiguration cfg =
+        configWithJob("cat1", "jt1", "com.percussion.server.job.DoesNotExistJobRunner");
+    PSJobRunnerFactory factory = new PSJobRunnerFactory(cfg);
+    PSJobException ex = assertThrows(PSJobException.class, () -> factory.getJobRunner("cat1", "jt1"));
+    leftoverNonAuditable(ex, JobErrorCodes.FACTORY_GET_RUNNER);
+  }
+
+  @Test
+  public void runJobMissingParamsThrowsTypedNonAuditableCode() throws Exception {
+    PSJobHandler handler = new PSJobHandler();
+    Document inDoc = PSXmlDocumentBuilder.createXmlDocument();
+    PSXmlDocumentBuilder.createRoot(inDoc, "PSXJobRun");
+    PSRequest req = new PSRequest(null, null, null, null);
+
+    PSJobException missingCategory =
+        assertThrows(PSJobException.class, () -> handler.runJob(inDoc, req));
+    leftoverNonAuditable(missingCategory, JobErrorCodes.SERVER_REQUEST_PARAM_INVALID);
+
+    req.setParameter("sys_jobCategory", "deployer");
+    PSJobException missingType =
+        assertThrows(PSJobException.class, () -> handler.runJob(inDoc, req));
+    leftoverNonAuditable(missingType, JobErrorCodes.SERVER_REQUEST_PARAM_INVALID);
+  }
+
+  @Test
+  public void getStatusAndCancelThrowTypedCodesForMalformedAndUnknownJobId() throws Exception {
+    PSJobHandler handler = new PSJobHandler();
+    PSRequest req = new PSRequest(null, null, null, null);
+
+    PSJobException malformedStatus =
+        assertThrows(
+            PSJobException.class, () -> handler.getJobStatus(jobIdDoc("PSXJobGetStatus", "x"), req));
+    leftoverNonAuditable(malformedStatus, JobErrorCodes.SERVER_REQUEST_MALFORMED);
+
+    PSJobException unknownStatus =
+        assertThrows(
+            PSJobException.class, () -> handler.getJobStatus(jobIdDoc("PSXJobGetStatus", "7"), req));
+    leftoverNonAuditable(unknownStatus, JobErrorCodes.INVALID_JOB_ID);
+
+    PSJobException malformedCancel =
+        assertThrows(
+            PSJobException.class, () -> handler.cancelJob(jobIdDoc("PSXJobCancel", "bad"), req));
+    leftoverNonAuditable(malformedCancel, JobErrorCodes.SERVER_REQUEST_MALFORMED);
+
+    PSJobException unknownCancel =
+        assertThrows(
+            PSJobException.class, () -> handler.cancelJob(jobIdDoc("PSXJobCancel", "8"), req));
+    leftoverNonAuditable(unknownCancel, JobErrorCodes.INVALID_JOB_ID);
+  }
+
+  @Test
+  public void lockJobHandlerThrowsTypedAlreadyRunningWhenJobAlive() throws Exception {
+    CountDownLatch hold = new CountDownLatch(1);
+    ParkingJobRunner first = new ParkingJobRunner(hold);
+    first.start();
+    assertTrue(first.awaitStarted(2, TimeUnit.SECONDS));
+    try {
+      PSJobHandler handler = new PSJobHandler();
+      Method lock = PSJobHandler.class.getDeclaredMethod("lockJobHandler", PSJobRunner.class);
+      lock.setAccessible(true);
+      lock.invoke(handler, first);
+
+      ParkingJobRunner second = new ParkingJobRunner(new CountDownLatch(1));
+      InvocationTargetException wrapped =
+          assertThrows(InvocationTargetException.class, () -> lock.invoke(handler, second));
+      assertTrue(wrapped.getCause() instanceof PSJobException);
+      leftoverNonAuditable((PSJobException) wrapped.getCause(), JobErrorCodes.JOB_ALREADY_RUNNING);
+    } finally {
+      hold.countDown();
+      first.interrupt();
+      first.join(2000);
+    }
+  }
+
+  @Test
+  public void typedConstructorRejectsNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSJobException((IPSErrorCode) null));
+  }
+
+  private static void leftoverNonAuditable(PSJobException ex, JobErrorCodes expected) {
+    assertEquals(expected.numericCode(), ex.getErrorCode(), expected.toString());
+    assertSame(expected, ex.getTypedErrorCode(), expected.toString());
+    assertFalse(ex.isAuditable(), expected.toString());
+    assertFalse(expected.isAuditable(), expected.toString());
+  }
+
+  private static Document jobIdDoc(String rootName, String id) {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element root = PSXmlDocumentBuilder.createRoot(doc, rootName);
+    root.setAttribute("id", id);
+    return doc;
+  }
+
+  private static PSJobHandlerConfiguration configWithJob(
+      String category, String jobType, String className) throws Exception {
+    String xml =
+        """
+        <PSXJobHandlerConfiguration>
+          <InitParams>
+            <InitParam name="h1" value="v1"/>
+          </InitParams>
+          <Categories>
+            <Category name="%s">
+              <InitParams/>
+              <Jobs>
+                <Job jobType="%s" className="%s">
+                  <InitParams/>
+                </Job>
+              </Jobs>
+            </Category>
+          </Categories>
+        </PSXJobHandlerConfiguration>
+        """
+            .formatted(category, jobType, className);
+    Document doc =
+        PSXmlDocumentBuilder.createXmlDocument(
+            new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), false);
+    return new PSJobHandlerConfiguration(doc);
+  }
+
+  /** Job runner that stays alive until the hold latch is released. */
+  private static final class ParkingJobRunner extends PSJobRunner {
+    private final CountDownLatch hold;
+    private final CountDownLatch started = new CountDownLatch(1);
+
+    ParkingJobRunner(CountDownLatch hold) {
+      this.hold = hold;
+    }
+
+    @Override
+    public void init(int id, Document descriptor, PSRequest req, Properties initParams) {
+      m_id = id;
+    }
+
+    @Override
+    public void doRun() {
+      // unused — run() is overridden to avoid PSRequestInfo init
+    }
+
+    @Override
+    public void run() {
+      started.countDown();
+      try {
+        hold.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    boolean awaitStarted(long timeout, TimeUnit unit) throws InterruptedException {
+      return started.await(timeout, unit);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Parent leftover of #2616: remaining production `IPSJobErrors` throw sites in `com.percussion.server.job` now use typed `JobErrorCodes` via `PSJobException` constructors. `IPSJobErrors` is kept as the numeric bridge (1–11).

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4143
Partial #2616

## Test plan

1. `cd system && ../mvnw.cmd "-Dtest=PSJobHandlerTypedErrorCodeSliceTest" test`
2. `cd system && ../mvnw.cmd clean install`
3. Confirm production throws retain legacy numeric codes and `isAuditable()==false`; dual-write `DefaultAuditLogService.log(JobErrorCodes.*)` returns SKIPPED.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal typed error-code leftover; no operator/UI/API/config change
- [x] **Unit / module tests** — `PSJobHandlerTypedErrorCodeSliceTest` (7 tests); `system` standalone clean install green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` BUILD SUCCESS
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- `modules_built=system`
- `build_evidence=cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2696, Failures: 0, Errors: 0, Skipped: 245; slice Tests run: 7, Failures: 0
- `downstream_checked=none` (no public/protected signature change; existing `PSJobException(IPSErrorCode)` overloads reused)

### C5 UI proof

N/A — Java backend leftover retype only.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
