### PR TITLE
fix(system): leftover search IPSSearchErrors typed SearchErrorCodes (#4155)

### DIFF
--- a/docs/ai-generated/code-reviews/4155-system-search-errorcodes-erlang.md
+++ b/docs/ai-generated/code-reviews/4155-system-search-errorcodes-erlang.md
@@ -1,0 +1,26 @@
+# Erlang review: #4155 system search IPSSearchErrors typed SearchErrorCodes
+
+**Scope:** uncommitted work on `fix/issue-4155-search-error-codes` vs `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Date:** 2026-09-02
+
+## Summary
+
+Parent #2616 leftover slice. Production `com.percussion.search` throw sites (`PSSearchEngine`, `PSGenerateSearchResultsExit`, `PSAdminLockedException`, lucene `PSSearchQueryImpl` / `PSSearchEngineImpl` / `PSSearchIndexerImpl`) plus `PSSearchHandler` search-engine required now construct typed `SearchErrorCodes` / `LuceneErrorCodes` / `ServerErrorCodes.RAW_DUMP` via additive `PSSearchException(IPSErrorCode…)` constructors. `IPSSearchErrors` remains the numeric bridge. Dual-write skip tests cover leftover non-auditable search/lucene codes; `SEARCH_ENGINE_AUTHENTICATION_FAILED` remains auditable. Allow-list shrunk for fully converted paths only. `PSServer` / other handler families left for #4150 / #4153. No product UI/config surface.
+
+Memory patterns hit: change-class closure (typed ctors + production throws + dual-write skip + allow-list shrink + freeze-gate pytest); no signature-breaking API changes (additive ctors; no `(String, IPSErrorCode)` overload).
+
+## Gate
+
+No bugs. Behavioral tests cover typed construction, production `PSAdminLockedException` / `PSSearchQueryImpl` throws, dual-write skip vs AUTH dual-write. Freeze gate `python scripts/verify-no-bare-ipserrors.py` PASS. Pytest `scripts/test_verify_no_bare_ipserrors.py` 23 passed. Standalone `cd modules/perc-auditlog && ../../mvnw.cmd clean install` BUILD SUCCESS, Tests run: 315, Failures: 0. Standalone `cd system && ../mvnw.cmd clean install` BUILD SUCCESS, Tests run: 2700, Failures: 0, Skipped: 245. Cross-platform path checklist: N/A (no new filesystem path construction).
+
+## Issues
+
+None.
+
+## Cross-platform path checklist
+
+- [x] No new `".../" +` or `"...\\" +` filesystem path construction
+- [x] New tests do not assert Unix-only absolute path shapes
+- [x] N/A for product scripts / installers (allow-list paths stay posix `/` as required by the freeze gate)

--- a/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
+++ b/modules/perc-auditlog/src/test/java/com/intsof/percussioncms/auditlog/LegacyErrorCodeRegistryTest.java
@@ -826,6 +826,48 @@ class LegacyErrorCodeRegistryTest {
   }
 
   @Test
+  void leftoverSearchProductionCodesSkipDualWrite() {
+    SearchErrorCodes[] skip =
+        new SearchErrorCodes[] {
+          SearchErrorCodes.ADMIN_HANDLER_LOCKED,
+          SearchErrorCodes.SEARCH_ENGINE_FAILED_INIT,
+          SearchErrorCodes.SEARCH_ENGINE_REQUIRED,
+          SearchErrorCodes.USE_GET_INSTANCE,
+          SearchErrorCodes.INVALID_INDEX_CONTENTTYPE,
+          SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER,
+        };
+    LuceneErrorCodes[] luceneSkip =
+        new LuceneErrorCodes[] {
+          LuceneErrorCodes.INDEX_DIR_PARAM_INVALID_MISSING,
+          LuceneErrorCodes.HITS_IOEXCEPTION,
+          LuceneErrorCodes.SEARCH_QUERY_PARSEEXCEPTION,
+          LuceneErrorCodes.INDEX_IO_EXCEPTION_SEARCHING,
+          LuceneErrorCodes.INDEX_OPTIMIZATION_ERROR,
+        };
+
+    for (SearchErrorCodes code : skip) {
+      CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+      DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+      AuditLogId id =
+          LegacyErrorCodeRegistry.logIfAuditable(
+              svc, code.numericCode(), AuditContext.builder().actor("jdoe").build());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED, id, code.name());
+      assertTrue(sink.records().isEmpty(), code.name());
+      assertFalse(code.isAuditable(), code.name());
+    }
+    for (LuceneErrorCodes code : luceneSkip) {
+      CapturingAuditLogSink sink = new CapturingAuditLogSink("cap");
+      DefaultAuditLogService svc = DefaultAuditLogService.builder().addSink(sink).build();
+      AuditLogId id =
+          LegacyErrorCodeRegistry.logIfAuditable(
+              svc, code.numericCode(), AuditContext.builder().actor("jdoe").build());
+      assertEquals(LegacyErrorCodeRegistry.SKIPPED, id, code.name());
+      assertTrue(sink.records().isEmpty(), code.name());
+      assertFalse(code.isAuditable(), code.name());
+    }
+  }
+
+  @Test
   void localeCodesAreRegisteredButNotAuditable() {
     assertFalse(LegacyErrorCodeRegistry.isAuditable(1801));
     assertSame(

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -21,10 +21,15 @@
 #   #3971 leftover system/src/main com.percussion.error call sites
 #   #3969 leftover system/src/main design.catalog call sites
 #   #4013 leftover system/src/main com.percussion.cx call sites
+#   #4155 leftover system search IPSSearchErrors / lucene peers
 # Converted (no longer listed): extensions-main #3756/#3938 (allow-list)
 # shrink after #3793 re-listed already-typed production paths);
 # design.catalog leftover #3969; system/src/main com.percussion.mail leftover
-# #4017; cx leftover #4013 (PSFont, PSOption, PSOptions, PSUserOptions).
+# #4017; cx leftover #4013 (PSFont, PSOption, PSOptions, PSUserOptions);
+# system search leftover #4155 (PSAdminLockedException, PSGenerateSearchResultsExit,
+# PSSearchEngine, lucene PSSearchEngineImpl / PSSearchIndexerImpl / PSSearchQueryImpl).
+# Remaining search package: PSAddThumbnailURL, PSBaseExecutableSearch (IPSCmsErrors);
+# PSSearchHandler keeps other IPS*Errors families (#4150/#4153).
 #
 # Always-allow (not listed here): files named IPS*Errors.java (interfaces)
 # and *ErrorCodes.java / *ErrorCode.java (typed bridges).
@@ -71,13 +76,7 @@ system/src/main/java/com/percussion/relationship/effect/PSPublishUnpublishMandat
 system/src/main/java/com/percussion/relationship/effect/PSUnpublishMandatory.java
 system/src/main/java/com/percussion/relationship/effect/PSValidate.java
 system/src/main/java/com/percussion/search/PSAddThumbnailURL.java
-system/src/main/java/com/percussion/search/PSAdminLockedException.java
 system/src/main/java/com/percussion/search/PSBaseExecutableSearch.java
-system/src/main/java/com/percussion/search/PSGenerateSearchResultsExit.java
-system/src/main/java/com/percussion/search/PSSearchEngine.java
-system/src/main/java/com/percussion/search/lucene/PSSearchEngineImpl.java
-system/src/main/java/com/percussion/search/lucene/PSSearchIndexerImpl.java
-system/src/main/java/com/percussion/search/lucene/PSSearchQueryImpl.java
 system/src/main/java/com/percussion/server/PSApplicationHandler.java
 system/src/main/java/com/percussion/server/PSBaseResponse.java
 system/src/main/java/com/percussion/server/PSConsole.java

--- a/scripts/test_verify_no_bare_ipserrors.py
+++ b/scripts/test_verify_no_bare_ipserrors.py
@@ -485,6 +485,26 @@ def test_system_cx_converted_paths_not_allowlisted() -> None:
     assert resurrected == [], resurrected
 
 
+def test_system_search_converted_paths_not_allowlisted() -> None:
+    """#4155 typed leftover com.percussion.search IPSSearchErrors / lucene peers."""
+    converted = (
+        "system/src/main/java/com/percussion/search/PSAdminLockedException.java",
+        "system/src/main/java/com/percussion/search/PSGenerateSearchResultsExit.java",
+        "system/src/main/java/com/percussion/search/PSSearchEngine.java",
+        "system/src/main/java/com/percussion/search/lucene/PSSearchEngineImpl.java",
+        "system/src/main/java/com/percussion/search/lucene/PSSearchIndexerImpl.java",
+        "system/src/main/java/com/percussion/search/lucene/PSSearchQueryImpl.java",
+    )
+    text = ALLOWLIST.read_text(encoding="utf-8")
+    entries = {
+        ln.strip()
+        for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    }
+    resurrected = [p for p in converted if p in entries]
+    assert resurrected == [], resurrected
+
+
 def test_empty_allowlist_fails_on_real_residuals(tmp_path: Path) -> None:
     """Without the residual file, current production leftovers must fail."""
     empty = tmp_path / "empty-allowlist.txt"

--- a/system/src/main/java/com/percussion/search/PSAdminLockedException.java
+++ b/system/src/main/java/com/percussion/search/PSAdminLockedException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.search;
 
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
 import com.percussion.error.PSException;
 
 /**
@@ -27,6 +28,6 @@ import com.percussion.error.PSException;
 public class PSAdminLockedException extends PSException {
   /** Ctor */
   public PSAdminLockedException() {
-    super(IPSSearchErrors.ADMIN_HANDLER_LOCKED);
+    super(SearchErrorCodes.ADMIN_HANDLER_LOCKED);
   }
 }

--- a/system/src/main/java/com/percussion/search/PSGenerateSearchResultsExit.java
+++ b/system/src/main/java/com/percussion/search/PSGenerateSearchResultsExit.java
@@ -17,6 +17,8 @@
 
 package com.percussion.search;
 
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSComponentProcessorProxy;
@@ -37,7 +39,6 @@ import com.percussion.extension.PSParameterMismatchException;
 import com.percussion.i18n.PSI18nUtils;
 import com.percussion.search.objectstore.PSWSSearchRequest;
 import com.percussion.server.IPSRequestContext;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSRequest;
 import com.percussion.server.PSServer;
 import com.percussion.system.utils.IPSHtmlParameters;
@@ -93,7 +94,7 @@ public class PSGenerateSearchResultsExit extends PSDefaultExtension
         Object[] args = {"HTML", IPSHtmlParameters.SYS_SEARCHID};
 
         throw new PSExtensionProcessingException(
-            IPSSearchErrors.HTML_SEARCH_MISSING_PARAMETER, args);
+            SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER, args);
       }
 
       PSSearch search = loadSearch(processor, searchId);
@@ -153,7 +154,7 @@ public class PSGenerateSearchResultsExit extends PSDefaultExtension
           // validate length etc.
           String msg = PSCommonSearchUtils.validateFTSSearchQuery(fullTextQuery, null, locale);
           if (msg != null) {
-            throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, msg);
+            throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, msg);
           }
 
           search.setProperty(PSSearch.PROP_FULLTEXTQUERY, fullTextQuery);
@@ -184,7 +185,7 @@ public class PSGenerateSearchResultsExit extends PSDefaultExtension
           field.setFieldValues(op, values);
           String msg = PSSearchFieldOperators.validateSearchFieldValue(field, null, locale);
           if (msg != null) {
-            throw new PSExtensionProcessingException(IPSServerErrors.RAW_DUMP, msg);
+            throw new PSExtensionProcessingException(ServerErrorCodes.RAW_DUMP, msg);
           }
         }
       }

--- a/system/src/main/java/com/percussion/search/PSSearchEngine.java
+++ b/system/src/main/java/com/percussion/search/PSSearchEngine.java
@@ -16,10 +16,11 @@
  */
 package com.percussion.search;
 
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.search.lucene.PSSearchQueryImpl;
 import com.percussion.security.error.PSExceptionUtils;
-import com.percussion.server.IPSServerErrors;
 import com.percussion.server.PSConsole;
 import com.percussion.server.PSServer;
 import java.util.Enumeration;
@@ -206,13 +207,14 @@ public abstract class PSSearchEngine {
                 + "kill the execd process(es) before attempting to restart "
                 + "the Rhythmyx server.");
         throw new PSSearchException(
-            IPSServerErrors.RAW_DUMP,
+            ServerErrorCodes.RAW_DUMP,
             "Can't start search engine due to previously reported errors.");
       }
     } catch (ExceptionInInitializerError eie) {
       String[] args = {className, eie.getException().getLocalizedMessage()};
       // remap to search exception
-      PSSearchException se = new PSSearchException(IPSSearchErrors.SEARCH_ENGINE_FAILED_INIT, args);
+      PSSearchException se =
+          new PSSearchException(SearchErrorCodes.SEARCH_ENGINE_FAILED_INIT, args);
       throw se;
     } catch (Exception e) {
       /*because many exceptions can be thrown and they are treated basically
@@ -221,7 +223,8 @@ public abstract class PSSearchEngine {
 
       String[] args = {className, e.getLocalizedMessage()};
       // remap to search exception
-      PSSearchException se = new PSSearchException(IPSSearchErrors.SEARCH_ENGINE_FAILED_INIT, args);
+      PSSearchException se =
+          new PSSearchException(SearchErrorCodes.SEARCH_ENGINE_FAILED_INIT, args);
       throw se;
     } finally {
       // unblock calls to getInstance();
@@ -800,7 +803,7 @@ public abstract class PSSearchEngine {
       try {
         if (m_pausedCount > 0) m_pauseMonitor.wait(60000);
         if (m_pausedCount > 0) {
-          throw new PSSearchException(IPSServerErrors.RAW_DUMP, m_pauseMessage);
+          throw new PSSearchException(ServerErrorCodes.RAW_DUMP, m_pauseMessage);
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();

--- a/system/src/main/java/com/percussion/search/PSSearchException.java
+++ b/system/src/main/java/com/percussion/search/PSSearchException.java
@@ -17,6 +17,7 @@
 
 package com.percussion.search;
 
+import com.percussion.error.IPSErrorCode;
 import com.percussion.error.PSException;
 
 /**
@@ -29,6 +30,48 @@ public class PSSearchException extends PSException {
   // see base class
   public PSSearchException(int msgCode, Object singleArg) {
     super(msgCode, singleArg);
+  }
+
+  /**
+   * Typed construction with no message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   */
+  public PSSearchException(IPSErrorCode code) {
+    super(code);
+  }
+
+  /**
+   * Typed construction with a single string argument. Prefer this over {@code (IPSErrorCode,
+   * Object)} so {@code (code, throwable)} is not ambiguous with {@link #PSSearchException(IPSErrorCode,
+   * Throwable, Object...)}.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param singleArg sole message argument; may be {@code null}
+   */
+  public PSSearchException(IPSErrorCode code, String singleArg) {
+    super(code, singleArg);
+  }
+
+  /**
+   * Typed construction with message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param arrayArgs message arguments; may be {@code null}
+   */
+  public PSSearchException(IPSErrorCode code, Object[] arrayArgs) {
+    super(code, arrayArgs);
+  }
+
+  /**
+   * Typed construction with a cause and optional message arguments.
+   *
+   * @param code catalogued error code, never {@code null}
+   * @param cause causal throwable; may be {@code null}
+   * @param arrayArgs message arguments
+   */
+  public PSSearchException(IPSErrorCode code, Throwable cause, Object... arrayArgs) {
+    super(code, arrayArgs, cause);
   }
 
   // see base class

--- a/system/src/main/java/com/percussion/search/lucene/PSSearchEngineImpl.java
+++ b/system/src/main/java/com/percussion/search/lucene/PSSearchEngineImpl.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.search.lucene;
 
+import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.design.objectstore.PSSearchConfig;
 import com.percussion.search.PSSearchAdmin;
@@ -69,14 +70,14 @@ public class PSSearchEngineImpl extends PSSearchEngine {
     String indexRoot = cfg.getIndexDirectory();
     if (StringUtils.isBlank(indexRoot)) {
       throw new PSSearchException(
-          IPSLuceneErrors.INDEX_DIR_PARAM_INVALID_MISSING,
+          LuceneErrorCodes.INDEX_DIR_PARAM_INVALID_MISSING,
           IPSLuceneConstants.REQPROP_INDEX_ROOT_DIR);
     }
     File irDir = new File(indexRoot);
     if (irDir.exists() && !irDir.isDirectory()) {
       if (StringUtils.isBlank(indexRoot)) {
         throw new PSSearchException(
-            IPSLuceneErrors.INDEX_DIR_PARAM_INVALID_MISSING,
+            LuceneErrorCodes.INDEX_DIR_PARAM_INVALID_MISSING,
             IPSLuceneConstants.REQPROP_INDEX_ROOT_DIR);
       }
     }

--- a/system/src/main/java/com/percussion/search/lucene/PSSearchIndexerImpl.java
+++ b/system/src/main/java/com/percussion/search/lucene/PSSearchIndexerImpl.java
@@ -16,6 +16,7 @@
  */
 package com.percussion.search.lucene;
 
+import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.objectstore.PSInvalidContentTypeException;
@@ -110,7 +111,7 @@ public class PSSearchIndexerImpl extends PSSearchIndexer {
     }
     if (!errors.isEmpty()) {
       Object[] args = {errors.toString()};
-      throw new PSSearchException(IPSLuceneErrors.INDEX_OPTIMIZATION_ERROR, args);
+      throw new PSSearchException(LuceneErrorCodes.INDEX_OPTIMIZATION_ERROR, args);
     }
     for (long id : committedids) {
       m_indexesNotCommitted.remove(id);
@@ -140,7 +141,7 @@ public class PSSearchIndexerImpl extends PSSearchIndexer {
     }
     if (!errors.isEmpty()) {
       Object[] args = {errors.toString()};
-      throw new PSSearchException(IPSLuceneErrors.INDEX_OPTIMIZATION_ERROR, args);
+      throw new PSSearchException(LuceneErrorCodes.INDEX_OPTIMIZATION_ERROR, args);
     }
   }
 
@@ -172,7 +173,7 @@ public class PSSearchIndexerImpl extends PSSearchIndexer {
       }
       if (!errors.isEmpty()) {
         Object[] args = {errors.toString()};
-        throw new PSSearchException(IPSLuceneErrors.INDEX_OPTIMIZATION_ERROR, args);
+        throw new PSSearchException(LuceneErrorCodes.INDEX_OPTIMIZATION_ERROR, args);
       }
     } finally {
       ms_indexWriters.clear();

--- a/system/src/main/java/com/percussion/search/lucene/PSSearchQueryImpl.java
+++ b/system/src/main/java/com/percussion/search/lucene/PSSearchQueryImpl.java
@@ -16,12 +16,13 @@
  */
 package com.percussion.search.lucene;
 
+import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.objectstore.PSContentType;
 import com.percussion.cms.objectstore.PSKey;
 import com.percussion.cms.objectstore.server.PSItemDefManager;
 import com.percussion.design.objectstore.PSLocator;
-import com.percussion.search.IPSSearchErrors;
 import com.percussion.search.PSSearchException;
 import com.percussion.search.PSSearchQuery;
 import com.percussion.search.PSSearchResult;
@@ -71,7 +72,7 @@ public class PSSearchQueryImpl extends PSSearchQuery implements Closeable {
   private PSSearchQueryImpl() throws PSSearchException {
     // Prevent from the reflection api.
     if (instance != null) {
-      throw new PSSearchException(IPSSearchErrors.USE_GET_INSTANCE);
+      throw new PSSearchException(SearchErrorCodes.USE_GET_INSTANCE);
     }
   }
 
@@ -141,9 +142,9 @@ public class PSSearchQueryImpl extends PSSearchQuery implements Closeable {
       }
       searcher.getIndexReader().close();
     } catch (IOException e) {
-      throw new PSSearchException(IPSLuceneErrors.HITS_IOEXCEPTION, e);
+      throw new PSSearchException(LuceneErrorCodes.HITS_IOEXCEPTION, e);
     } catch (ParseException e) {
-      throw new PSSearchException(IPSLuceneErrors.SEARCH_QUERY_PARSEEXCEPTION, e);
+      throw new PSSearchException(LuceneErrorCodes.SEARCH_QUERY_PARSEEXCEPTION, e);
     }
 
     return searchResults;
@@ -251,7 +252,7 @@ public class PSSearchQueryImpl extends PSSearchQuery implements Closeable {
         searcher = new MultiReader(isList.toArray(new IndexReader[0]));
     } catch (IOException e) {
       Object[] args = {String.valueOf(ctypeIds)};
-      throw new PSSearchException(IPSLuceneErrors.INDEX_IO_EXCEPTION_SEARCHING, e, args);
+      throw new PSSearchException(LuceneErrorCodes.INDEX_IO_EXCEPTION_SEARCHING, e, args);
     }
     return searcher;
   }
@@ -269,7 +270,7 @@ public class PSSearchQueryImpl extends PSSearchQuery implements Closeable {
   private IndexReader getIndexReader(String ctypeId) throws IOException, PSSearchException {
 
     if (!StringUtils.isNumeric(ctypeId))
-      throw new PSSearchException(IPSSearchErrors.INVALID_INDEX_CONTENTTYPE);
+      throw new PSSearchException(SearchErrorCodes.INVALID_INDEX_CONTENTTYPE);
 
     File f = new File(PSSearchEngineImpl.getLuceneIndexRootPath() + ctypeId);
     if (!f.exists() || !f.isDirectory()) {

--- a/system/src/main/java/com/percussion/server/webservices/PSSearchHandler.java
+++ b/system/src/main/java/com/percussion/server/webservices/PSSearchHandler.java
@@ -19,6 +19,7 @@ package com.percussion.server.webservices;
 
 import static com.percussion.cms.objectstore.PSProcessorProxy.RELATIONSHIP_COMPTYPE;
 
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
 import com.percussion.cms.IPSConstants;
 import com.percussion.cms.PSCmsException;
 import com.percussion.cms.PSCmsObjectNameLookupUtils;
@@ -64,7 +65,6 @@ import com.percussion.extension.IPSExtensionManager;
 import com.percussion.extension.PSExtensionException;
 import com.percussion.extension.PSExtensionProcessingException;
 import com.percussion.i18n.PSI18nUtils;
-import com.percussion.search.IPSSearchErrors;
 import com.percussion.search.IPSSearchResultRow;
 import com.percussion.search.IPSSearchResultsProcessor;
 import com.percussion.search.PSSearchEngine;
@@ -450,7 +450,7 @@ public class PSSearchHandler extends PSWebServicesBaseHandler implements IPSSear
     boolean isExtQuery =
         ftsQuery != null || !extSearchFields.isEmpty() || searchReq.useExternalSearchEngine();
     if (!useSearchEngine && isExtQuery) {
-      throw new PSSearchException(IPSSearchErrors.SEARCH_ENGINE_REQUIRED);
+      throw new PSSearchException(SearchErrorCodes.SEARCH_ENGINE_REQUIRED);
     }
 
     // do ext search only if fts query or external params supplied

--- a/system/src/test/java/com/percussion/search/PSSearchTypedErrorCodeSliceTest.java
+++ b/system/src/test/java/com/percussion/search/PSSearchTypedErrorCodeSliceTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.intsof.percussioncms.auditlog.codes.LuceneErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.SearchErrorCodes;
+import com.intsof.percussioncms.auditlog.codes.ServerErrorCodes;
+import com.percussion.error.IPSErrorCode;
+import com.percussion.extension.PSExtensionProcessingException;
+import com.percussion.search.lucene.PSSearchQueryImpl;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Issue #4155 (parent #2616): leftover search production call-sites use typed {@link
+ * SearchErrorCodes} / {@link LuceneErrorCodes} (not bare {@code IPSSearchErrors} ints). Operational
+ * codes skip dual-write; authentication failure remains auditable.
+ */
+@Tag("UnitTest")
+public class PSSearchTypedErrorCodeSliceTest {
+
+  @Test
+  public void adminLockedUsesTypedNonAuditableCode() {
+    PSAdminLockedException ex = new PSAdminLockedException();
+    assertEquals(SearchErrorCodes.ADMIN_HANDLER_LOCKED.numericCode(), ex.getErrorCode());
+    assertSame(SearchErrorCodes.ADMIN_HANDLER_LOCKED, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+    assertFalse(SearchErrorCodes.ADMIN_HANDLER_LOCKED.isAuditable());
+  }
+
+  @Test
+  public void searchEngineRequiredUsesTypedNonAuditableCode() {
+    PSSearchException ex = new PSSearchException(SearchErrorCodes.SEARCH_ENGINE_REQUIRED);
+    assertEquals(SearchErrorCodes.SEARCH_ENGINE_REQUIRED.numericCode(), ex.getErrorCode());
+    assertSame(SearchErrorCodes.SEARCH_ENGINE_REQUIRED, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void failedInitUsesTypedNonAuditableCode() {
+    String[] args = {"com.example.Engine", "boom"};
+    PSSearchException ex = new PSSearchException(SearchErrorCodes.SEARCH_ENGINE_FAILED_INIT, args);
+    assertEquals(SearchErrorCodes.SEARCH_ENGINE_FAILED_INIT.numericCode(), ex.getErrorCode());
+    assertSame(SearchErrorCodes.SEARCH_ENGINE_FAILED_INIT, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void htmlSearchMissingParameterUsesTypedNonAuditableCode() {
+    Object[] args = {"HTML", "sys_searchid"};
+    PSExtensionProcessingException ex =
+        new PSExtensionProcessingException(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER, args);
+    assertEquals(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER.numericCode(), ex.getErrorCode());
+    assertSame(SearchErrorCodes.HTML_SEARCH_MISSING_PARAMETER, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void rawDumpPauseMessageUsesTypedNonAuditableCode() {
+    PSSearchException ex =
+        new PSSearchException(ServerErrorCodes.RAW_DUMP, "Search server unavailable");
+    assertEquals(ServerErrorCodes.RAW_DUMP.numericCode(), ex.getErrorCode());
+    assertSame(ServerErrorCodes.RAW_DUMP, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void luceneHitsIoExceptionUsesTypedNonAuditableCode() {
+    IOException cause = new IOException("hits");
+    PSSearchException ex = new PSSearchException(LuceneErrorCodes.HITS_IOEXCEPTION, cause);
+    assertEquals(LuceneErrorCodes.HITS_IOEXCEPTION.numericCode(), ex.getErrorCode());
+    assertSame(LuceneErrorCodes.HITS_IOEXCEPTION, ex.getTypedErrorCode());
+    assertSame(cause, ex.getCause());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void luceneIndexIoSearchingUsesTypedNonAuditableCode() {
+    IOException cause = new IOException("index");
+    Object[] args = {"[301]"};
+    PSSearchException ex =
+        new PSSearchException(LuceneErrorCodes.INDEX_IO_EXCEPTION_SEARCHING, cause, args);
+    assertEquals(LuceneErrorCodes.INDEX_IO_EXCEPTION_SEARCHING.numericCode(), ex.getErrorCode());
+    assertSame(LuceneErrorCodes.INDEX_IO_EXCEPTION_SEARCHING, ex.getTypedErrorCode());
+    assertFalse(ex.isAuditable());
+  }
+
+  @Test
+  public void authenticationFailedRemainsAuditableForDualWrite() {
+    PSSearchException ex =
+        new PSSearchException(SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED);
+    assertEquals(
+        SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED.numericCode(), ex.getErrorCode());
+    assertSame(SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED, ex.getTypedErrorCode());
+    assertTrue(ex.isAuditable());
+    assertTrue(SearchErrorCodes.SEARCH_ENGINE_AUTHENTICATION_FAILED.isAuditable());
+  }
+
+  @Test
+  public void typedConstructorsRejectNullCode() {
+    assertThrows(IllegalArgumentException.class, () -> new PSSearchException((IPSErrorCode) null));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PSSearchException((IPSErrorCode) null, "x"));
+  }
+
+  @Test
+  public void secondQueryImplConstructionUsesTypedUseGetInstance() throws Exception {
+    PSSearchQueryImpl.getInstance();
+    Constructor<PSSearchQueryImpl> ctor = PSSearchQueryImpl.class.getDeclaredConstructor();
+    ctor.setAccessible(true);
+    InvocationTargetException wrapped =
+        assertThrows(InvocationTargetException.class, ctor::newInstance);
+    PSSearchException se = (PSSearchException) wrapped.getCause();
+    assertSame(SearchErrorCodes.USE_GET_INSTANCE, se.getTypedErrorCode());
+    assertFalse(se.isAuditable());
+  }
+
+  @Test
+  public void nonNumericContentTypeUsesTypedInvalidIndexContentType() throws Exception {
+    PSSearchQueryImpl query = PSSearchQueryImpl.getInstance();
+    Method reader = PSSearchQueryImpl.class.getDeclaredMethod("getIndexReader", String.class);
+    reader.setAccessible(true);
+    InvocationTargetException wrapped =
+        assertThrows(
+            InvocationTargetException.class, () -> reader.invoke(query, "not-a-type-id"));
+    PSSearchException se = (PSSearchException) wrapped.getCause();
+    assertSame(SearchErrorCodes.INVALID_INDEX_CONTENTTYPE, se.getTypedErrorCode());
+    assertFalse(se.isAuditable());
+  }
+}


### PR DESCRIPTION
## Summary

Parent leftover slice of [#2616](https://github.com/intersoftdatalabs-in/percussioncms/issues/2616): retype remaining production `IPSSearchErrors` throw sites under `com.percussion.search` plus `PSSearchHandler` search-engine-required to typed `SearchErrorCodes` / `LuceneErrorCodes` (and `ServerErrorCodes.RAW_DUMP` on the same files so they can leave the residual allow-list).

`IPSSearchErrors` stays as the numeric bridge. `PSServer` / other handler `IPS*Errors` leftovers remain owned by #4150 / #4153.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4155  
Parent: #2616

## Test plan

1. `python scripts/verify-no-bare-ipserrors.py` → PASS
2. `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` → 23 passed
3. `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS
4. `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS
5. Confirm operational search/lucene codes skip dual-write; `SEARCH_ENGINE_AUTHENTICATION_FAILED` remains auditable

## Checklist

- [x] **Product documentation** — N/A (not product-facing): typed error-code leftover retype; no operator/UI/API/config change
- [x] **Unit / module tests** — `PSSearchTypedErrorCodeSliceTest` plus leftover dual-write skip in `LegacyErrorCodeRegistryTest`; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests); reverse-deps N/A (additive constructors, type not `final`)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `modules/perc-auditlog`, `system`
- **build_evidence:**
  - `cd modules/perc-auditlog && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 315, Failures: 0
  - `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2700, Failures: 0, Skipped: 245
  - `python scripts/verify-no-bare-ipserrors.py` → PASS
  - `python -m pytest scripts/test_verify_no_bare_ipserrors.py -q` → 23 passed
- **downstream_checked:** grep `extends PSSearchException` / `new PSSearchException() {` — none; additive `IPSErrorCode` constructors only (C2 did not apply)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
