### PR TITLE
fix(system): retype install JDBC IPSTableFactoryErrors (#4157)

### DIFF
--- a/docs/ai-generated/code-reviews/4157-install-tablefactory-error-codes-erlang.md
+++ b/docs/ai-generated/code-reviews/4157-install-tablefactory-error-codes-erlang.md
@@ -1,0 +1,45 @@
+# Erlang review: #4157 install IPSTableFactoryErrors typed TableFactoryErrorCodes
+
+- **Branch:** `fix/issue-4157-install-tablefactory-error-codes`
+- **Parent:** #2616
+- **Date:** 2026-09-02
+- **Recommendation:** approve
+- **Gate:** pass
+- **May commit/push:** yes
+- **Memory patterns hit:** leftover IPS*Errors retype + dual-write skip tests; shrink residual allow-list; behavioral XML/init throw coverage (not token grep only)
+
+## Summary
+
+Retype remaining production `IPSTableFactoryErrors` throw sites in `system/.../install` JDBC helpers (`PSJdbcNextNumberColumn`, `PSJdbcTableMapper`, `PSJdbcTransitionRoles`, `PSJdbcUniqueColumn`) to existing `TableFactoryErrorCodes` / typed `PSJdbcTableFactoryException` constructors. Numeric codes stay bridged via `IPSTableFactoryErrors`. All leftover catalog codes are non-auditable (`isAuditable()==false`), so dual-write skip is asserted; there is no auditable code in this catalog to dual-write. Allow-list shrinks by those four paths. Behavioral tests cover `fromXml` wrong-type/null/invalid-attr, `init` missing column, and private `getRequiredColumnValue` missing/null column.
+
+## Issues
+
+None (hard-gate).
+
+### Suggestions (non-blocking)
+
+- `PSJdbcNextNumberColumn` still throws `new PSJdbcTableFactoryException(0, e)` on generic execute/next-number SQL failures (pre-existing; not `IPSTableFactoryErrors`). Out of this slice.
+
+## Cross-platform path checklist
+
+N/A — no new filesystem path construction or path assertions.
+
+## Change-class companions
+
+- Production throw-site retype (peer: TableFactory `PSJdbcTableSchema` / #3741)
+- Dual-write skip tests on typed exceptions
+- `scripts/ipserrors-residual-allowlist.txt` shrink
+- Module standalone `mvnw clean install` (system)
+
+## Product documentation
+
+N/A — internal error-catalog retype; no operator/admin/REST/UI surface change.
+
+## C2 API shape
+
+Did not apply: no `final`/`sealed` types; no public/protected signature changes.
+
+## Build
+
+- `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS
+- Focused: `PSInstallJdbcTypedErrorCodeSliceTest` Tests run: 16, Failures: 0

--- a/scripts/ipserrors-residual-allowlist.txt
+++ b/scripts/ipserrors-residual-allowlist.txt
@@ -21,6 +21,9 @@
 #   #3971 leftover system/src/main com.percussion.error call sites
 #   #3969 leftover system/src/main design.catalog call sites
 #   #4013 leftover system/src/main com.percussion.cx call sites
+#   #4157 leftover system/src/main com.percussion.install JDBC table-factory
+#     helpers (PSJdbcNextNumberColumn, PSJdbcTableMapper,
+#     PSJdbcTransitionRoles, PSJdbcUniqueColumn)
 # Converted (no longer listed): extensions-main #3756/#3938 (allow-list)
 # shrink after #3793 re-listed already-typed production paths);
 # design.catalog leftover #3969; system/src/main com.percussion.mail leftover
@@ -58,10 +61,6 @@ system/src/main/java/com/percussion/fastforward/managednav/PSManagedNavService.j
 system/src/main/java/com/percussion/fastforward/utils/PSUtils.java
 system/src/main/java/com/percussion/i18n/PSLocale.java
 system/src/main/java/com/percussion/i18n/PSLocaleManager.java
-system/src/main/java/com/percussion/install/PSJdbcNextNumberColumn.java
-system/src/main/java/com/percussion/install/PSJdbcTableMapper.java
-system/src/main/java/com/percussion/install/PSJdbcTransitionRoles.java
-system/src/main/java/com/percussion/install/PSJdbcUniqueColumn.java
 system/src/main/java/com/percussion/publisher/server/PSPubTimeStatistics.java
 system/src/main/java/com/percussion/relationship/effect/PSEffectUtils.java
 system/src/main/java/com/percussion/relationship/effect/PSIsCloneExists.java

--- a/system/src/main/java/com/percussion/install/PSJdbcNextNumberColumn.java
+++ b/system/src/main/java/com/percussion/install/PSJdbcNextNumberColumn.java
@@ -18,9 +18,9 @@ package com.percussion.install;
 
 // java
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.data.PSIdGenerator;
 import com.percussion.tablefactory.IPSJdbcTableDataHandler;
-import com.percussion.tablefactory.IPSTableFactoryErrors;
 import com.percussion.tablefactory.PSJdbcColumnData;
 import com.percussion.tablefactory.PSJdbcColumnDef;
 import com.percussion.tablefactory.PSJdbcDbmsDef;
@@ -63,7 +63,7 @@ public class PSJdbcNextNumberColumn implements IPSJdbcTableDataHandler {
     PSJdbcColumnDef colDef = m_tblSchema.getColumn(m_column);
     if (colDef == null) {
       Object args[] = {m_tblSchema.getName(), m_column};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.COLUMN_NOT_FOUND, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.COLUMN_NOT_FOUND, args);
     }
   }
 
@@ -147,7 +147,7 @@ public class PSJdbcNextNumberColumn implements IPSJdbcTableDataHandler {
 
     if (!sourceNode.getNodeName().equals(IPSJdbcTableDataHandler.NODE_NAME)) {
       Object[] args = {IPSJdbcTableDataHandler.NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -158,14 +158,14 @@ public class PSJdbcNextNumberColumn implements IPSJdbcTableDataHandler {
 
     Element columnEl = walker.getNextElement(COLUMN_EL, firstFlags);
     if (columnEl == null) {
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, COLUMN_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, COLUMN_EL);
     }
 
     // get the name attribute
     String sTemp = columnEl.getAttribute(COLUMN_NAME_ATTR);
     if (sTemp == null || sTemp.trim().length() == 0) {
       Object[] args = {COLUMN_EL, COLUMN_NAME_ATTR, sTemp == null ? "null" : sTemp};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_column = sTemp;
@@ -174,7 +174,7 @@ public class PSJdbcNextNumberColumn implements IPSJdbcTableDataHandler {
     sTemp = columnEl.getAttribute(NEXT_NUMBER_KEY_ATTR);
     if (sTemp == null || sTemp.trim().length() == 0) {
       Object[] args = {COLUMN_EL, NEXT_NUMBER_KEY_ATTR, sTemp == null ? "null" : sTemp};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
 
     m_nextNumberKey = sTemp;

--- a/system/src/main/java/com/percussion/install/PSJdbcTableMapper.java
+++ b/system/src/main/java/com/percussion/install/PSJdbcTableMapper.java
@@ -16,8 +16,8 @@
  */
 package com.percussion.install;
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.tablefactory.IPSJdbcTableDataHandler;
-import com.percussion.tablefactory.IPSTableFactoryErrors;
 import com.percussion.tablefactory.PSJdbcDataTypeMap;
 import com.percussion.tablefactory.PSJdbcDbmsDef;
 import com.percussion.tablefactory.PSJdbcExecutionStep;
@@ -68,7 +68,7 @@ public class PSJdbcTableMapper implements IPSJdbcTableDataHandler {
       dataTypeMap = new PSJdbcDataTypeMap(m_dbmsDef.getBackEndDB(), m_dbmsDef.getDriver(), null);
     } catch (Exception e) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
+          TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
     }
 
     // check if the source table exists
@@ -131,7 +131,7 @@ public class PSJdbcTableMapper implements IPSJdbcTableDataHandler {
       }
     } catch (SQLException e) {
       Object[] args = {m_destTable, PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.DATA_PROCESS_ERROR, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.DATA_PROCESS_ERROR, args, e);
     } finally {
       if (step != null) step.close();
     }
@@ -150,7 +150,7 @@ public class PSJdbcTableMapper implements IPSJdbcTableDataHandler {
 
     if (!sourceNode.getNodeName().equals(IPSJdbcTableDataHandler.NODE_NAME)) {
       Object[] args = {IPSJdbcTableDataHandler.NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -163,7 +163,7 @@ public class PSJdbcTableMapper implements IPSJdbcTableDataHandler {
 
     if (tableMapEl == null) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.XML_ELEMENT_NULL, PSJdbcTableMapping.NODE_NAME);
+          TableFactoryErrorCodes.XML_ELEMENT_NULL, PSJdbcTableMapping.NODE_NAME);
     }
     m_tableMapEl = tableMapEl;
 
@@ -173,7 +173,7 @@ public class PSJdbcTableMapper implements IPSJdbcTableDataHandler {
       Object[] args = {
         PSJdbcTableMapping.NODE_NAME, DEST_TABLE_ATTR, sTemp == null ? "null" : sTemp
       };
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_destTable = sTemp;
 
@@ -183,7 +183,7 @@ public class PSJdbcTableMapper implements IPSJdbcTableDataHandler {
       Object[] args = {
         PSJdbcTableMapping.NODE_NAME, SRC_TABLE_ATTR, sTemp == null ? "null" : sTemp
       };
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_srcTable = sTemp;
   }

--- a/system/src/main/java/com/percussion/install/PSJdbcTransitionRoles.java
+++ b/system/src/main/java/com/percussion/install/PSJdbcTransitionRoles.java
@@ -18,8 +18,8 @@ package com.percussion.install;
 
 // java
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.tablefactory.IPSJdbcTableDataHandler;
-import com.percussion.tablefactory.IPSTableFactoryErrors;
 import com.percussion.tablefactory.PSJdbcColumnData;
 import com.percussion.tablefactory.PSJdbcDataTypeMap;
 import com.percussion.tablefactory.PSJdbcDbmsDef;
@@ -109,7 +109,7 @@ public class PSJdbcTransitionRoles implements IPSJdbcTableDataHandler {
       dataTypeMap = new PSJdbcDataTypeMap(m_dbmsDef.getBackEndDB(), m_dbmsDef.getDriver(), null);
     } catch (Exception e) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
+          TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
     }
 
     // get the schema of "TRANSITIONS" table
@@ -211,7 +211,7 @@ public class PSJdbcTransitionRoles implements IPSJdbcTableDataHandler {
       plan.execute(conn);
     } catch (SQLException e) {
       Object args[] = {TBL_TRANSITIONS, PSJdbcTableFactoryException.formatSqlException(e)};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.SQL_CATALOG_DATA, args, e);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.SQL_CATALOG_DATA, args, e);
     } finally {
       if (transTblStep != null) transTblStep.close();
     }
@@ -236,12 +236,12 @@ public class PSJdbcTransitionRoles implements IPSJdbcTableDataHandler {
     PSJdbcColumnData colData = row.getColumn(colName);
     if (colData == null) {
       Object args[] = {tableName, colName};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.COLUMN_NOT_FOUND, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.COLUMN_NOT_FOUND, args);
     }
     String colValue = colData.getValue();
     if (colValue == null) {
       Object args[] = {tableName, "Column (" + colName + ") has null value"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.CHECK_EXISTING_DATA, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.CHECK_EXISTING_DATA, args);
     }
     return colValue;
   }
@@ -259,7 +259,7 @@ public class PSJdbcTransitionRoles implements IPSJdbcTableDataHandler {
 
     if (!sourceNode.getNodeName().equals(IPSJdbcTableDataHandler.NODE_NAME)) {
       Object[] args = {IPSJdbcTableDataHandler.NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
   }
 

--- a/system/src/main/java/com/percussion/install/PSJdbcUniqueColumn.java
+++ b/system/src/main/java/com/percussion/install/PSJdbcUniqueColumn.java
@@ -18,8 +18,8 @@ package com.percussion.install;
 
 // java
 
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
 import com.percussion.tablefactory.IPSJdbcTableDataHandler;
-import com.percussion.tablefactory.IPSTableFactoryErrors;
 import com.percussion.tablefactory.PSJdbcColumnData;
 import com.percussion.tablefactory.PSJdbcColumnDef;
 import com.percussion.tablefactory.PSJdbcDataTypeMap;
@@ -75,7 +75,7 @@ public class PSJdbcUniqueColumn implements IPSJdbcTableDataHandler {
     PSJdbcColumnDef colDef = m_tblSchema.getColumn(m_column);
     if (colDef == null) {
       Object args[] = {m_tblSchema.getName(), m_column};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.COLUMN_NOT_FOUND, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.COLUMN_NOT_FOUND, args);
     }
   }
 
@@ -93,7 +93,7 @@ public class PSJdbcUniqueColumn implements IPSJdbcTableDataHandler {
       dataTypeMap = new PSJdbcDataTypeMap(m_dbmsDef.getBackEndDB(), m_dbmsDef.getDriver(), null);
     } catch (Exception e) {
       throw new PSJdbcTableFactoryException(
-          IPSTableFactoryErrors.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
+          TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP, e.toString(), e);
     }
 
     // add the column value to the <code>m_colValues</code>
@@ -168,7 +168,7 @@ public class PSJdbcUniqueColumn implements IPSJdbcTableDataHandler {
 
     if (!sourceNode.getNodeName().equals(IPSJdbcTableDataHandler.NODE_NAME)) {
       Object[] args = {IPSJdbcTableDataHandler.NODE_NAME, sourceNode.getNodeName()};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, args);
     }
 
     PSXmlTreeWalker walker = new PSXmlTreeWalker(sourceNode);
@@ -179,14 +179,14 @@ public class PSJdbcUniqueColumn implements IPSJdbcTableDataHandler {
 
     Element columnEl = walker.getNextElement(COLUMN_EL, firstFlags);
     if (columnEl == null) {
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_NULL, COLUMN_EL);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, COLUMN_EL);
     }
 
     // get the name attribute
     String sTemp = columnEl.getAttribute(COLUMN_NAME_ATTR);
     if (sTemp == null || sTemp.trim().length() == 0) {
       Object[] args = {COLUMN_EL, COLUMN_NAME_ATTR, sTemp == null ? "null" : sTemp};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_column = sTemp;
 
@@ -194,7 +194,7 @@ public class PSJdbcUniqueColumn implements IPSJdbcTableDataHandler {
     sTemp = columnEl.getAttribute(COLUMN_VALUE_ATTR);
     if (sTemp == null) {
       Object[] args = {COLUMN_EL, COLUMN_VALUE_ATTR, "null"};
-      throw new PSJdbcTableFactoryException(IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR, args);
+      throw new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR, args);
     }
     m_value = sTemp;
   }

--- a/system/src/test/java/com/percussion/install/PSInstallJdbcTypedErrorCodeSliceTest.java
+++ b/system/src/test/java/com/percussion/install/PSInstallJdbcTypedErrorCodeSliceTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.percussion.install;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.intsof.percussioncms.auditlog.codes.TableFactoryErrorCodes;
+import com.percussion.tablefactory.IPSJdbcTableDataHandler;
+import com.percussion.tablefactory.IPSTableFactoryErrors;
+import com.percussion.tablefactory.PSJdbcColumnData;
+import com.percussion.tablefactory.PSJdbcColumnDef;
+import com.percussion.tablefactory.PSJdbcDataTypeMap;
+import com.percussion.tablefactory.PSJdbcDbmsDef;
+import com.percussion.tablefactory.PSJdbcRowData;
+import com.percussion.tablefactory.PSJdbcTableComponent;
+import com.percussion.tablefactory.PSJdbcTableFactoryException;
+import com.percussion.tablefactory.PSJdbcTableMapping;
+import com.percussion.tablefactory.PSJdbcTableSchema;
+import com.percussion.xml.PSXmlDocumentBuilder;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.Types;
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/**
+ * Issue #4157 (parent #2616 leftover): install JDBC table-factory helpers throw typed {@link
+ * TableFactoryErrorCodes} rather than bare {@code IPSTableFactoryErrors} ints. All leftover catalog
+ * codes are non-auditable (dual-write skip).
+ */
+@Tag("UnitTest")
+class PSInstallJdbcTypedErrorCodeSliceTest {
+
+  @Test
+  void leftoverCatalogsMatchLegacyIntsAndSkipDualWrite() {
+    assertEquals(
+        IPSTableFactoryErrors.XML_ELEMENT_NULL,
+        TableFactoryErrorCodes.XML_ELEMENT_NULL.numericCode());
+    assertEquals(
+        IPSTableFactoryErrors.XML_ELEMENT_WRONG_TYPE,
+        TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.numericCode());
+    assertEquals(
+        IPSTableFactoryErrors.XML_ELEMENT_INVALID_ATTR,
+        TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR.numericCode());
+    assertEquals(
+        IPSTableFactoryErrors.COLUMN_NOT_FOUND,
+        TableFactoryErrorCodes.COLUMN_NOT_FOUND.numericCode());
+    assertEquals(
+        IPSTableFactoryErrors.LOAD_DEFAULT_DATATYPE_MAP,
+        TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP.numericCode());
+    assertEquals(
+        IPSTableFactoryErrors.SQL_CATALOG_DATA,
+        TableFactoryErrorCodes.SQL_CATALOG_DATA.numericCode());
+    assertEquals(
+        IPSTableFactoryErrors.CHECK_EXISTING_DATA,
+        TableFactoryErrorCodes.CHECK_EXISTING_DATA.numericCode());
+    assertEquals(
+        IPSTableFactoryErrors.DATA_PROCESS_ERROR,
+        TableFactoryErrorCodes.DATA_PROCESS_ERROR.numericCode());
+
+    assertFalse(TableFactoryErrorCodes.XML_ELEMENT_NULL.isAuditable());
+    assertFalse(TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE.isAuditable());
+    assertFalse(TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR.isAuditable());
+    assertFalse(TableFactoryErrorCodes.COLUMN_NOT_FOUND.isAuditable());
+    assertFalse(TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP.isAuditable());
+    assertFalse(TableFactoryErrorCodes.SQL_CATALOG_DATA.isAuditable());
+    assertFalse(TableFactoryErrorCodes.CHECK_EXISTING_DATA.isAuditable());
+    assertFalse(TableFactoryErrorCodes.DATA_PROCESS_ERROR.isAuditable());
+  }
+
+  @Test
+  void typedConstructionRetainsCatalogAndSkipsDualWrite() {
+    leftoverNonAuditable(
+        new PSJdbcTableFactoryException(
+            TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE, new Object[] {"dataHandler", "row"}),
+        TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE);
+    leftoverNonAuditable(
+        new PSJdbcTableFactoryException(TableFactoryErrorCodes.XML_ELEMENT_NULL, "column"),
+        TableFactoryErrorCodes.XML_ELEMENT_NULL);
+    leftoverNonAuditable(
+        new PSJdbcTableFactoryException(
+            TableFactoryErrorCodes.COLUMN_NOT_FOUND, new Object[] {"t", "c"}),
+        TableFactoryErrorCodes.COLUMN_NOT_FOUND);
+    leftoverNonAuditable(
+        new PSJdbcTableFactoryException(
+            TableFactoryErrorCodes.DATA_PROCESS_ERROR,
+            new Object[] {"dest", "sql"},
+            new RuntimeException("cause")),
+        TableFactoryErrorCodes.DATA_PROCESS_ERROR);
+    leftoverNonAuditable(
+        new PSJdbcTableFactoryException(
+            TableFactoryErrorCodes.SQL_CATALOG_DATA,
+            new Object[] {"TRANSITIONS", "sql"},
+            new RuntimeException("cause")),
+        TableFactoryErrorCodes.SQL_CATALOG_DATA);
+    leftoverNonAuditable(
+        new PSJdbcTableFactoryException(
+            TableFactoryErrorCodes.CHECK_EXISTING_DATA, new Object[] {"t", "null col"}),
+        TableFactoryErrorCodes.CHECK_EXISTING_DATA);
+    leftoverNonAuditable(
+        new PSJdbcTableFactoryException(
+            TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP, "boom", new RuntimeException("cause")),
+        TableFactoryErrorCodes.LOAD_DEFAULT_DATATYPE_MAP);
+  }
+
+  @Test
+  void uniqueColumnWrongXmlElementThrowsTypedWrongType() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element wrong = doc.createElement("row");
+
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class, () -> new PSJdbcUniqueColumn().fromXml(wrong)),
+        TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE);
+  }
+
+  @Test
+  void uniqueColumnMissingColumnElementThrowsTypedNull() {
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class,
+            () -> new PSJdbcUniqueColumn().fromXml(emptyHandler(PSXmlDocumentBuilder.createXmlDocument()))),
+        TableFactoryErrorCodes.XML_ELEMENT_NULL);
+  }
+
+  @Test
+  void uniqueColumnMissingNameAttrThrowsTypedInvalidAttr() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element handler = emptyHandler(doc);
+    Element column = doc.createElement("column");
+    column.setAttribute("value", "BASE");
+    handler.appendChild(column);
+
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class, () -> new PSJdbcUniqueColumn().fromXml(handler)),
+        TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR);
+  }
+
+  @Test
+  void uniqueColumnInitMissingColumnThrowsTypedNotFound() throws Exception {
+    PSJdbcUniqueColumn handler = new PSJdbcUniqueColumn();
+    handler.fromXml(uniqueColumnXml("targetCol", "BASE"));
+
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class,
+            () ->
+                handler.init(
+                    new PSJdbcDbmsDef(), null, null, schemaWithColumn("otherCol"))),
+        TableFactoryErrorCodes.COLUMN_NOT_FOUND);
+  }
+
+  @Test
+  void nextNumberColumnWrongXmlElementThrowsTypedWrongType() {
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class,
+            () ->
+                new PSJdbcNextNumberColumn()
+                    .fromXml(PSXmlDocumentBuilder.createXmlDocument().createElement("row"))),
+        TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE);
+  }
+
+  @Test
+  void nextNumberColumnMissingColumnElementThrowsTypedNull() {
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class,
+            () ->
+                new PSJdbcNextNumberColumn()
+                    .fromXml(emptyHandler(PSXmlDocumentBuilder.createXmlDocument()))),
+        TableFactoryErrorCodes.XML_ELEMENT_NULL);
+  }
+
+  @Test
+  void nextNumberColumnMissingNextNumberKeyThrowsTypedInvalidAttr() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element handler = emptyHandler(doc);
+    Element column = doc.createElement("column");
+    column.setAttribute("name", "id");
+    handler.appendChild(column);
+
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class,
+            () -> new PSJdbcNextNumberColumn().fromXml(handler)),
+        TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR);
+  }
+
+  @Test
+  void nextNumberColumnInitMissingColumnThrowsTypedNotFound() throws Exception {
+    PSJdbcNextNumberColumn handler = new PSJdbcNextNumberColumn();
+    handler.fromXml(nextNumberColumnXml("targetCol", "CONTENTTYPES"));
+
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class,
+            () ->
+                handler.init(
+                    new PSJdbcDbmsDef(), null, null, schemaWithColumn("otherCol"))),
+        TableFactoryErrorCodes.COLUMN_NOT_FOUND);
+  }
+
+  @Test
+  void tableMapperWrongXmlElementThrowsTypedWrongType() {
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class,
+            () ->
+                new PSJdbcTableMapper()
+                    .fromXml(PSXmlDocumentBuilder.createXmlDocument().createElement("row"))),
+        TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE);
+  }
+
+  @Test
+  void tableMapperMissingTableMapThrowsTypedNull() {
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class,
+            () ->
+                new PSJdbcTableMapper()
+                    .fromXml(emptyHandler(PSXmlDocumentBuilder.createXmlDocument()))),
+        TableFactoryErrorCodes.XML_ELEMENT_NULL);
+  }
+
+  @Test
+  void tableMapperMissingDestTableThrowsTypedInvalidAttr() {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element handler = emptyHandler(doc);
+    Element tableMap = doc.createElement(PSJdbcTableMapping.NODE_NAME);
+    tableMap.setAttribute("srcTable", "SRC");
+    handler.appendChild(tableMap);
+
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class, () -> new PSJdbcTableMapper().fromXml(handler)),
+        TableFactoryErrorCodes.XML_ELEMENT_INVALID_ATTR);
+  }
+
+  @Test
+  void transitionRolesWrongXmlElementThrowsTypedWrongType() {
+    leftoverNonAuditable(
+        assertThrows(
+            PSJdbcTableFactoryException.class,
+            () ->
+                new PSJdbcTransitionRoles()
+                    .fromXml(PSXmlDocumentBuilder.createXmlDocument().createElement("row"))),
+        TableFactoryErrorCodes.XML_ELEMENT_WRONG_TYPE);
+  }
+
+  @Test
+  void transitionRolesMissingColumnThrowsTypedNotFound() throws Exception {
+    leftoverNonAuditable(
+        invokeRequiredColumnValue(
+            rowWithColumns(new PSJdbcColumnData("OTHER", "1")), "TRANSITIONS", "TRANSITIONID"),
+        TableFactoryErrorCodes.COLUMN_NOT_FOUND);
+  }
+
+  @Test
+  void transitionRolesNullColumnValueThrowsTypedCheckExistingData() throws Exception {
+    leftoverNonAuditable(
+        invokeRequiredColumnValue(
+            rowWithColumns(new PSJdbcColumnData("TRANSITIONID", null)),
+            "TRANSITIONS",
+            "TRANSITIONID"),
+        TableFactoryErrorCodes.CHECK_EXISTING_DATA);
+  }
+
+  private static void leftoverNonAuditable(
+      PSJdbcTableFactoryException ex, TableFactoryErrorCodes expected) {
+    assertEquals(expected.numericCode(), ex.getErrorCode());
+    assertSame(expected, ex.getTypedErrorCode());
+    assertFalse(expected.isAuditable());
+    assertFalse(ex.isAuditable());
+  }
+
+  private static Element emptyHandler(Document doc) {
+    Element handler = doc.createElement(IPSJdbcTableDataHandler.NODE_NAME);
+    handler.setAttribute(IPSJdbcTableDataHandler.CLASS_ATTR, "com.percussion.install.Test");
+    return handler;
+  }
+
+  private static Element uniqueColumnXml(String columnName, String value) {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element handler = emptyHandler(doc);
+    Element column = doc.createElement("column");
+    column.setAttribute("name", columnName);
+    column.setAttribute("value", value);
+    handler.appendChild(column);
+    return handler;
+  }
+
+  private static Element nextNumberColumnXml(String columnName, String key) {
+    Document doc = PSXmlDocumentBuilder.createXmlDocument();
+    Element handler = emptyHandler(doc);
+    Element column = doc.createElement("column");
+    column.setAttribute("name", columnName);
+    column.setAttribute("nextNumberKey", key);
+    handler.appendChild(column);
+    return handler;
+  }
+
+  private static PSJdbcTableSchema schemaWithColumn(String columnName) throws Exception {
+    PSJdbcDataTypeMap map = new PSJdbcDataTypeMap("MSSQL", "sqlserver", null);
+    PSJdbcColumnDef col =
+        new PSJdbcColumnDef(
+            map, columnName, PSJdbcTableComponent.ACTION_CREATE, Types.VARCHAR, "50", true, null);
+    return new PSJdbcTableSchema("myTable", List.of(col).iterator());
+  }
+
+  private static PSJdbcRowData rowWithColumns(PSJdbcColumnData... columns) {
+    return new PSJdbcRowData(List.of(columns).iterator(), PSJdbcRowData.ACTION_UPDATE);
+  }
+
+  private static PSJdbcTableFactoryException invokeRequiredColumnValue(
+      PSJdbcRowData row, String tableName, String colName) throws Exception {
+    Method method =
+        PSJdbcTransitionRoles.class.getDeclaredMethod(
+            "getRequiredColumnValue", PSJdbcRowData.class, String.class, String.class);
+    method.setAccessible(true);
+    try {
+      method.invoke(new PSJdbcTransitionRoles(), row, tableName, colName);
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof PSJdbcTableFactoryException ex) {
+        return ex;
+      }
+      throw e;
+    }
+    throw new AssertionError("expected PSJdbcTableFactoryException");
+  }
+}


### PR DESCRIPTION
## Summary

Retypes leftover production `IPSTableFactoryErrors` throw sites in system install JDBC helpers (`PSJdbcNextNumberColumn`, `PSJdbcTableMapper`, `PSJdbcTransitionRoles`, `PSJdbcUniqueColumn`) to `TableFactoryErrorCodes` / typed `PSJdbcTableFactoryException` constructors. `IPSTableFactoryErrors` remains the numeric bridge.

Parent tracker: #2616. Fixes #4157.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `python scripts/verify-no-bare-ipserrors.py` → PASS (four install paths removed from residual allow-list).
2. `cd system && ../mvnw.cmd -Dtest=PSInstallJdbcTypedErrorCodeSliceTest test` — Tests run: 16, Failures: 0.
3. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2705, Failures: 0, Errors: 0, Skipped: 245).
4. Confirm XML `fromXml` wrong-type / missing child / invalid attr and `init` missing-column paths throw typed non-auditable codes (`isAuditable()==false`, dual-write skip). Catalog has no auditable codes in this slice.

## Checklist

- [x] **Product documentation** — N/A (not product-facing): internal error-catalog retype; no operator/admin/REST/UI/install-procedure change
- [x] **Unit / module tests** — `PSInstallJdbcTypedErrorCodeSliceTest` plus standalone `system` `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change)
- [x] **Build gates** — `cd system && ../mvnw.cmd clean install` BUILD SUCCESS; no skipTests
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `system`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` → BUILD SUCCESS (Total time 01:29 min). Tests run: 2705, Failures: 0, Errors: 0, Skipped: 245. Slice test `PSInstallJdbcTypedErrorCodeSliceTest` Tests run: 16, Failures: 0. `python scripts/verify-no-bare-ipserrors.py` PASS.
- **downstream_checked:** none (C2 did not apply — no `final`/`sealed` types and no public/protected signature changes)

### C5 UI proof

N/A — Java backend typed-error leftover; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
