### PR TITLE
fix(WebUI): Developer catalog in-app delete confirm (#4122)

### DIFF
--- a/WebUI/src/main/ts/developer/ActionMenuDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ActionMenuDetailPanel.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { extractRestErrorMessage, isApiError } from "../api/client";
 import {
   ACTION_MENU_TYPE_ITEM,
@@ -39,6 +40,7 @@ import {
   tableHeaderRow,
   tableRow,
 } from "./catalogStyles";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 import { ObjectAclSection } from "./ObjectAclSection";
@@ -88,6 +90,7 @@ export function ActionMenuDetailPanel({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [loading, setLoading] = useState(idOrName != null);
   const inflight = useRef(false);
 
@@ -205,9 +208,15 @@ export function ActionMenuDetailPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (isNew || !writeKey || inflight.current) return;
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete(): Promise<void> {
     if (isNew || !writeKey || inflight.current) return;
-    if (!window.confirm(DEV_MSG.AM_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -420,7 +429,7 @@ export function ActionMenuDetailPanel({
                 data-testid="developer-am-delete"
                 aria-label={DEV_MSG.AM_DELETE}
                 disabled={busy}
-                onClick={() => void handleDelete()}
+                onClick={requestDelete}
                 style={{
                   padding: "8px 16px",
                   background: "#c53030",
@@ -531,6 +540,13 @@ export function ActionMenuDetailPanel({
           ) : null}
         </>
       ) : null}
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.AM_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/CatalogConfirmDialog.tsx
+++ b/WebUI/src/main/ts/developer/CatalogConfirmDialog.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { useDialogEscape } from "../architecture/useDialogEscape";
+import { catalogColors } from "./catalogStyles";
+import { DEV_MSG } from "./messages";
+
+export interface CatalogConfirmDialogProps {
+  open: boolean;
+  busy: boolean;
+  /** Destructive confirm sentence (catalog-specific). */
+  message: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(15, 23, 42, 0.45)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+  padding: 16,
+};
+
+const panelStyle: React.CSSProperties = {
+  background: "#fff",
+  borderRadius: 8,
+  border: `1px solid ${catalogColors.headerBorder}`,
+  maxWidth: 480,
+  width: "100%",
+  padding: "1.25rem 1.5rem",
+  boxShadow: "0 8px 24px rgba(0,0,0,0.12)",
+};
+
+/**
+ * In-app confirm for Developer catalog deletes (508/WCAG).
+ * Peer: Design {@code DeleteTemplateDialog} + {@code useDialogEscape}.
+ */
+export function CatalogConfirmDialog({
+  open,
+  busy,
+  message,
+  onCancel,
+  onConfirm,
+}: CatalogConfirmDialogProps): React.ReactElement | null {
+  useDialogEscape(open, busy, onCancel);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      style={overlayStyle}
+      data-testid="developer-catalog-confirm-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="developer-catalog-confirm-title"
+      aria-describedby="developer-catalog-confirm-hint developer-catalog-confirm-body"
+    >
+      <div style={panelStyle}>
+        <h2 id="developer-catalog-confirm-title" style={{ marginTop: 0 }}>
+          {DEV_MSG.CATALOG_CONFIRM_TITLE}
+        </h2>
+        <p
+          id="developer-catalog-confirm-hint"
+          style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
+        >
+          {DEV_MSG.CATALOG_CONFIRM_HINT}
+        </p>
+        <p id="developer-catalog-confirm-body" data-testid="developer-catalog-confirm-body">
+          {message}
+        </p>
+        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+          <button
+            type="button"
+            data-testid="developer-catalog-confirm-cancel"
+            disabled={busy}
+            onClick={onCancel}
+          >
+            {DEV_MSG.CATALOG_CONFIRM_CANCEL}
+          </button>
+          <button
+            type="button"
+            data-testid="developer-catalog-confirm-submit"
+            disabled={busy}
+            onClick={onConfirm}
+            style={{
+              background: catalogColors.error,
+              color: "#fff",
+              border: "none",
+              borderRadius: 4,
+              padding: "6px 12px",
+              cursor: busy ? "not-allowed" : "pointer",
+              font: "inherit",
+            }}
+          >
+            {DEV_MSG.CATALOG_CONFIRM_SUBMIT}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/WebUI/src/main/ts/developer/CommunityDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/CommunityDetailPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import {
   communityGuidForWrite,
@@ -49,6 +50,7 @@ import {
   visibilityEmptyKind,
   visibilitySummaryCounts,
 } from "./communityVisibilityFilters";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
@@ -167,6 +169,7 @@ export function CommunityDetailPanel({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [visibleObjects, setVisibleObjects] = useState<CommunityVisibleObject[]>([]);
   const [visibilityLoading, setVisibilityLoading] = useState(false);
   const [visibilityError, setVisibilityError] = useState<string | null>(null);
@@ -362,6 +365,17 @@ export function CommunityDetailPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (isNew || inflight.current) return;
+    const guid = resolveCommunityGuid(detail, communityGuid);
+    if (!guid) {
+      setError(DEV_MSG.COMM_DELETE_NO_GUID);
+      return;
+    }
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete(): Promise<void> {
     if (isNew || inflight.current) return;
     const guid = resolveCommunityGuid(detail, communityGuid);
@@ -369,7 +383,7 @@ export function CommunityDetailPanel({
       setError(DEV_MSG.COMM_DELETE_NO_GUID);
       return;
     }
-    if (!window.confirm(DEV_MSG.COMM_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -535,7 +549,7 @@ export function CommunityDetailPanel({
                 data-testid="developer-comm-delete"
                 aria-label={DEV_MSG.COMM_DELETE}
                 disabled={busy}
-                onClick={() => void handleDelete()}
+                onClick={requestDelete}
                 style={{
                   padding: "8px 16px",
                   background: "#c53030",
@@ -776,6 +790,13 @@ export function CommunityDetailPanel({
           </section>
         </>
       ) : null}
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.COMM_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -731,6 +731,7 @@ export function ContentTypeDetailPanel({
   }
 
   async function handleDeleteLocalField(fieldName: string) {
+    setPendingDelete(null);
     if (!heldLockRef.current) {
       setError(DEV_MSG.CT_LOCK_REQUIRED);
       return;
@@ -739,7 +740,6 @@ export function ContentTypeDetailPanel({
     if (!name) {
       return;
     }
-    setPendingDelete(null);
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -947,11 +947,14 @@ export function ContentTypeDetailPanel({
   }
 
   async function handleDelete(): Promise<void> {
+    setPendingDelete(null);
     // Require a held lock in chrome; do not call DELETE (or lock) when unlocked.
     if (!heldLockRef.current || busy || detail == null) {
+      if (!heldLockRef.current) {
+        setError(DEV_MSG.CT_LOCK_REQUIRED);
+      }
       return;
     }
-    setPendingDelete(null);
     setBusy(true);
     setError(null);
     setNotice(null);

--- a/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ContentTypeDetailPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { resolveContentTypeObjectGuid } from "../api/displayFormatGuid";
 import {
   addLocalContentTypeField,
@@ -109,6 +110,7 @@ import {
   type ContentTypeFieldRulesHandle,
 } from "./ContentTypeFieldRulesSection";
 import { extractRestErrorMessage, isApiError } from "../api/client";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 import { catalogColors, tableHeaderRow, tableRow } from "./catalogStyles";
@@ -243,6 +245,9 @@ export function ContentTypeDetailPanel({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<
+    { kind: "type" } | { kind: "field"; name: string } | null
+  >(null);
   const [label, setLabel] = useState("");
   const [description, setDescription] = useState("");
   const [nameDraft, setNameDraft] = useState("");
@@ -709,6 +714,22 @@ export function ContentTypeDetailPanel({
     }
   }
 
+  function requestDeleteLocalField(
+    ev: React.MouseEvent<HTMLElement>,
+    fieldName: string,
+  ): void {
+    if (!heldLockRef.current) {
+      setError(DEV_MSG.CT_LOCK_REQUIRED);
+      return;
+    }
+    const name = fieldName.trim();
+    if (!name) {
+      return;
+    }
+    captureDialogOpener(ev.currentTarget);
+    setPendingDelete({ kind: "field", name });
+  }
+
   async function handleDeleteLocalField(fieldName: string) {
     if (!heldLockRef.current) {
       setError(DEV_MSG.CT_LOCK_REQUIRED);
@@ -718,9 +739,7 @@ export function ContentTypeDetailPanel({
     if (!name) {
       return;
     }
-    if (!window.confirm(DEV_MSG.CT_FIELD_DELETE_CONFIRM)) {
-      return;
-    }
+    setPendingDelete(null);
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -919,14 +938,20 @@ export function ContentTypeDetailPanel({
     }
   }
 
+  function requestDeleteType(ev: React.MouseEvent<HTMLElement>): void {
+    if (!heldLockRef.current || busy || detail == null) {
+      return;
+    }
+    captureDialogOpener(ev.currentTarget);
+    setPendingDelete({ kind: "type" });
+  }
+
   async function handleDelete(): Promise<void> {
     // Require a held lock in chrome; do not call DELETE (or lock) when unlocked.
     if (!heldLockRef.current || busy || detail == null) {
       return;
     }
-    if (!window.confirm(DEV_MSG.CT_DELETE_CONFIRM)) {
-      return;
-    }
+    setPendingDelete(null);
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -1422,7 +1447,7 @@ export function ContentTypeDetailPanel({
           data-testid="developer-ct-delete"
           aria-label={DEV_MSG.CT_DELETE}
           disabled={busy || !heldLock || detail == null}
-          onClick={() => void handleDelete()}
+          onClick={requestDeleteType}
           style={{
             padding: "8px 16px",
             background: heldLock && detail != null ? "#c53030" : catalogColors.disabled,
@@ -2422,7 +2447,7 @@ export function ContentTypeDetailPanel({
                               data-testid={`developer-ct-field-delete-${f.name}`}
                               aria-label={`${DEV_MSG.CT_FIELD_DELETE} ${f.name}`}
                               disabled={!canEdit}
-                              onClick={() => void handleDeleteLocalField(f.name || "")}
+                              onClick={(ev) => requestDeleteLocalField(ev, f.name || "")}
                               style={{
                                 ...smallBtnStyle,
                                 cursor: canEdit ? "pointer" : "not-allowed",
@@ -2474,6 +2499,23 @@ export function ContentTypeDetailPanel({
         objectGuid={objectGuid}
         objectKind="content-type"
         testIdPrefix="developer-ct-acl"
+      />
+      <CatalogConfirmDialog
+        open={pendingDelete != null}
+        busy={busy}
+        message={
+          pendingDelete?.kind === "field"
+            ? DEV_MSG.CT_FIELD_DELETE_CONFIRM
+            : DEV_MSG.CT_DELETE_CONFIRM
+        }
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={() => {
+          if (pendingDelete?.kind === "field") {
+            void handleDeleteLocalField(pendingDelete.name);
+          } else {
+            void handleDelete();
+          }
+        }}
       />
     </div>
   );

--- a/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/DisplayFormatDetailPanel.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import { listCommunities } from "../api/developer/assemblyApi";
 import {
@@ -62,6 +63,7 @@ import {
   toAllowedCommunitiesWriteBody,
   type AllowedCommunityMap,
 } from "./displayFormatCommunities";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 import { ObjectAclSection } from "./ObjectAclSection";
@@ -115,6 +117,7 @@ export function DisplayFormatDetailPanel({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [loading, setLoading] = useState(idOrName != null);
   const [draftColumns, setDraftColumns] = useState<DisplayFormatColumn[]>([]);
   const [addSource, setAddSource] = useState("");
@@ -292,9 +295,15 @@ export function DisplayFormatDetailPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (isNew || !writeKey || inflight.current) return;
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete(): Promise<void> {
     if (isNew || !writeKey || inflight.current) return;
-    if (!window.confirm(DEV_MSG.DF_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -575,7 +584,7 @@ export function DisplayFormatDetailPanel({
                 data-testid="developer-df-delete"
                 aria-label={DEV_MSG.DF_DELETE}
                 disabled={busy}
-                onClick={() => void handleDelete()}
+                onClick={requestDelete}
                 style={{
                   padding: "8px 16px",
                   background: "#c53030",
@@ -857,6 +866,13 @@ export function DisplayFormatDetailPanel({
           ) : null}
         </>
       ) : null}
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.DF_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/ItemFilterDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ItemFilterDetailPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import {
   createItemFilter,
@@ -36,6 +37,7 @@ import {
   tableHeaderRow,
   tableRow,
 } from "./catalogStyles";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
@@ -88,6 +90,7 @@ export function ItemFilterDetailPanel({
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(idOrName != null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const inflight = useRef(false);
 
   useEffect(() => {
@@ -193,9 +196,15 @@ export function ItemFilterDetailPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (isNew || !writeKey || inflight.current) return;
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete(): Promise<void> {
     if (isNew || !writeKey || inflight.current) return;
-    if (!window.confirm(DEV_MSG.IF_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -367,7 +376,7 @@ export function ItemFilterDetailPanel({
                 data-testid="developer-if-delete"
                 aria-label={DEV_MSG.IF_DELETE}
                 disabled={busy}
-                onClick={() => void handleDelete()}
+                onClick={requestDelete}
                 style={{
                   padding: "8px 16px",
                   background: "#c53030",
@@ -449,6 +458,13 @@ export function ItemFilterDetailPanel({
           ) : null}
         </>
       ) : null}
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.IF_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/KeywordEditorPanel.tsx
+++ b/WebUI/src/main/ts/developer/KeywordEditorPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import {
   createKeyword,
   deleteKeyword,
@@ -24,6 +25,7 @@ import {
 } from "../api/developer/keywordsApi";
 import type { KeywordChoiceSummary, KeywordSummary } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert } from "./catalogStyles";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
@@ -96,6 +98,7 @@ export function KeywordEditorPanel({
   );
   const [choicesText, setChoicesText] = useState(choicesToText(initial?.choices));
   const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -142,9 +145,15 @@ export function KeywordEditorPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (!id || isNew) return;
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete() {
     if (!id || isNew) return;
-    if (!window.confirm(DEV_MSG.KW_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     setBusy(true);
     setError(null);
     setNotice(null);
@@ -266,7 +275,7 @@ export function KeywordEditorPanel({
             data-testid="developer-kw-delete"
             aria-label="Delete keyword"
             disabled={busy}
-            onClick={() => void handleDelete()}
+            onClick={requestDelete}
             style={{
               padding: "8px 16px",
               background: "#c53030",
@@ -281,6 +290,13 @@ export function KeywordEditorPanel({
           </button>
         ) : null}
       </div>
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.KW_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/LocaleDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/LocaleDetailPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import {
   createLocale,
@@ -28,6 +29,7 @@ import {
 } from "../api/developer/localesApi";
 import type { LocaleDetail } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell } from "./catalogStyles";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
@@ -68,6 +70,7 @@ export function LocaleDetailPanel({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [loading, setLoading] = useState(idOrLang != null);
   const inflight = useRef(false);
 
@@ -157,9 +160,15 @@ export function LocaleDetailPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (isNew || !writeKey || inflight.current) return;
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete(): Promise<void> {
     if (isNew || !writeKey || inflight.current) return;
-    if (!window.confirm(DEV_MSG.LOC_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -333,7 +342,7 @@ export function LocaleDetailPanel({
                 data-testid="developer-loc-delete"
                 aria-label={DEV_MSG.LOC_DELETE}
                 disabled={busy}
-                onClick={() => void handleDelete()}
+                onClick={requestDelete}
                 style={{
                   padding: "8px 16px",
                   background: "#c53030",
@@ -427,6 +436,13 @@ export function LocaleDetailPanel({
           ) : null}
         </>
       ) : null}
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.LOC_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/SearchDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SearchDetailPanel.tsx
@@ -15,6 +15,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import {
   SEARCH_TYPE_STANDARD,
@@ -35,6 +36,7 @@ import {
   tableHeaderRow,
   tableRow,
 } from "./catalogStyles";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 import { ObjectAclSection } from "./ObjectAclSection";
@@ -122,6 +124,7 @@ export function SearchDetailPanel({
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(idOrName != null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const inflight = useRef(false);
 
   useEffect(() => {
@@ -283,9 +286,15 @@ export function SearchDetailPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (isNew || !writeKey || inflight.current) return;
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete(): Promise<void> {
     if (isNew || !writeKey || inflight.current) return;
-    if (!window.confirm(DEV_MSG.SR_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -478,7 +487,7 @@ export function SearchDetailPanel({
                 data-testid="developer-sr-delete"
                 aria-label={DEV_MSG.SR_DELETE}
                 disabled={busy}
-                onClick={() => void handleDelete()}
+                onClick={requestDelete}
                 style={{
                   padding: "8px 16px",
                   background: "#c53030",
@@ -754,6 +763,13 @@ export function SearchDetailPanel({
           ) : null}
         </>
       ) : null}
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.SR_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/SharedFieldGroupDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SharedFieldGroupDetailPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import {
   createSharedFieldGroup,
@@ -36,6 +37,7 @@ import {
   tableHeaderRow,
   tableRow,
 } from "./catalogStyles";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
@@ -73,6 +75,7 @@ export function SharedFieldGroupDetailPanel({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [loading, setLoading] = useState(name != null);
   const inflight = useRef(false);
 
@@ -158,9 +161,15 @@ export function SharedFieldGroupDetailPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (isNew || !writeKey || inflight.current) return;
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete(): Promise<void> {
     if (isNew || !writeKey || inflight.current) return;
-    if (!window.confirm(DEV_MSG.SF_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -290,7 +299,7 @@ export function SharedFieldGroupDetailPanel({
                 data-testid="developer-sf-delete"
                 aria-label={DEV_MSG.SF_DELETE}
                 disabled={busy}
-                onClick={() => void handleDelete()}
+                onClick={requestDelete}
                 style={{
                   padding: "8px 16px",
                   background: "#c53030",
@@ -395,6 +404,13 @@ export function SharedFieldGroupDetailPanel({
           ) : null}
         </>
       ) : null}
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.SF_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/SlotDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SlotDetailPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { extractRestErrorMessage, isApiError } from "../api/client";
 import {
   createSlot,
@@ -41,6 +42,7 @@ import {
 } from "../api/developer/designGaps";
 import type { SlotAssociationSummary, SlotDetail } from "../api/developer/types";
 import { catalogColors, backButton, errorAlert, metaGrid, monoCell, tableHeaderRow, tableRow } from "./catalogStyles";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
@@ -191,6 +193,7 @@ export function SlotDetailPanel({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [loading, setLoading] = useState(idOrName != null);
   const [name, setName] = useState("");
   const [label, setLabel] = useState("");
@@ -424,9 +427,15 @@ export function SlotDetailPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (isNew || !writeKey || inflight.current) return;
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete() {
     if (isNew || !writeKey || inflight.current) return;
-    if (!window.confirm(DEV_MSG.SLOT_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -960,7 +969,7 @@ export function SlotDetailPanel({
                 data-testid="developer-slot-delete"
                 aria-label={DEV_MSG.SLOT_DELETE}
                 disabled={busy}
-                onClick={() => void handleDelete()}
+                onClick={requestDelete}
                 style={{
                   padding: "8px 16px",
                   background: "#c53030",
@@ -990,6 +999,13 @@ export function SlotDetailPanel({
           ) : null}
         </>
       ) : null}
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.SLOT_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/SystemDefPanel.tsx
+++ b/WebUI/src/main/ts/developer/SystemDefPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import {
   addSystemDefField,
@@ -33,6 +34,7 @@ import {
   metaGrid,
   monoCell,
 } from "./catalogStyles";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 
@@ -111,6 +113,7 @@ export function SystemDefPanel(): React.ReactElement {
   const [writeError, setWriteError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [pendingDeleteName, setPendingDeleteName] = useState<string | null>(null);
   const [newName, setNewName] = useState("");
   const [newDataType, setNewDataType] = useState<string>("text");
   const [newSearchable, setNewSearchable] = useState(true);
@@ -206,9 +209,16 @@ export function SystemDefPanel(): React.ReactElement {
     }
   }
 
-  async function handleDelete(fieldName: string): Promise<void> {
+  function requestDelete(ev: React.MouseEvent<HTMLElement>, fieldName: string): void {
     if (!fieldName || inflight.current) return;
-    if (!window.confirm(DEV_MSG.SYS_DELETE_CONFIRM)) return;
+    captureDialogOpener(ev.currentTarget);
+    setPendingDeleteName(fieldName);
+  }
+
+  async function handleDelete(): Promise<void> {
+    const fieldName = pendingDeleteName;
+    if (!fieldName || inflight.current) return;
+    setPendingDeleteName(null);
     inflight.current = true;
     setBusy(true);
     setWriteError(null);
@@ -479,7 +489,7 @@ export function SystemDefPanel(): React.ReactElement {
                     data-testid="developer-sys-delete"
                     aria-label={`${DEV_MSG.SYS_DELETE} ${name}`}
                     disabled={busy || !name}
-                    onClick={() => void handleDelete(name)}
+                    onClick={(ev) => requestDelete(ev, name)}
                     style={{
                       padding: "4px 10px",
                       background: "#c53030",
@@ -508,6 +518,13 @@ export function SystemDefPanel(): React.ReactElement {
           </ul>
         </section>
       ) : null}
+      <CatalogConfirmDialog
+        open={pendingDeleteName != null}
+        busy={busy}
+        message={DEV_MSG.SYS_DELETE_CONFIRM}
+        onCancel={() => setPendingDeleteName(null)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import { resolveViewObjectGuid } from "../api/displayFormatGuid";
 import {
@@ -52,6 +53,7 @@ import {
   tableHeaderRow,
   tableRow,
 } from "./catalogStyles";
+import { CatalogConfirmDialog } from "./CatalogConfirmDialog";
 import { panelErrMsg } from "./errors";
 import { DEV_MSG } from "./messages";
 import { ObjectAclSection } from "./ObjectAclSection";
@@ -113,6 +115,7 @@ export function ViewDetailPanel({
   const [notice, setNotice] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(idOrName != null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [draftFields, setDraftFields] = useState<ViewFieldSummary[]>([]);
   const [addFieldName, setAddFieldName] = useState("");
   const [addOperator, setAddOperator] = useState("equal");
@@ -283,9 +286,15 @@ export function ViewDetailPanel({
     }
   }
 
+  function requestDelete(ev: React.MouseEvent<HTMLElement>): void {
+    if (isNew || !writeKey || inflight.current || protectedWrite) return;
+    captureDialogOpener(ev.currentTarget);
+    setConfirmOpen(true);
+  }
+
   async function handleDelete(): Promise<void> {
     if (isNew || !writeKey || inflight.current || protectedWrite) return;
-    if (!window.confirm(DEV_MSG.VW_DELETE_CONFIRM)) return;
+    setConfirmOpen(false);
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -499,7 +508,7 @@ export function ViewDetailPanel({
                 data-testid="developer-vw-delete"
                 aria-label={DEV_MSG.VW_DELETE}
                 disabled={busy}
-                onClick={() => void handleDelete()}
+                onClick={requestDelete}
                 style={{
                   padding: "8px 16px",
                   background: "#c53030",
@@ -794,6 +803,13 @@ export function ViewDetailPanel({
           ) : null}
         </>
       ) : null}
+      <CatalogConfirmDialog
+        open={confirmOpen}
+        busy={busy}
+        message={DEV_MSG.VW_DELETE_CONFIRM}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => void handleDelete()}
+      />
     </div>
   );
 }

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -32,6 +32,10 @@ export const DEV_MSG_KEYS = {
   SECTION_LOAD_FAILED:
     "perc.ui.developer@Unable to load {0}. Other Developer tabs remain available.",
   INTRO: "perc.ui.developer@Design-time tools for content types, assembly, and related CMS objects. Replaces the classic Workbench / Design surfaces.",
+  CATALOG_CONFIRM_TITLE: "perc.ui.developer@Confirm delete",
+  CATALOG_CONFIRM_HINT: "perc.ui.developer@This action cannot be undone.",
+  CATALOG_CONFIRM_SUBMIT: "perc.ui.developer@Delete",
+  CATALOG_CONFIRM_CANCEL: "perc.ui.developer@Cancel",
   SESSION_REDIRECT: "perc.ui.developer@Session expired - redirecting to login...",
   ACL_TITLE: "perc.ui.developer@Object ACL",
   ACL_HINT:

--- a/WebUI/src/test/ts/developer/ActionMenuDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ActionMenuDetailPanel.test.tsx
@@ -408,8 +408,6 @@ describe("ActionMenuDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getActionMenuDetailMock.mockResolvedValue(sampleDetail);
     deleteActionMenuMock.mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <ActionMenuDetailPanel
@@ -422,13 +420,11 @@ describe("ActionMenuDetailPanel", () => {
         expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-am-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
       expect(deleteActionMenuMock).toHaveBeenCalledWith("Edit");
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("surfaces 404 missing action menu on delete", async () => {
@@ -438,22 +434,18 @@ describe("ActionMenuDetailPanel", () => {
       statusText: "Not Found",
       body: { message: "Action menu not found" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       render(<ActionMenuDetailPanel idOrName="Edit" onBack={() => undefined} />);
       await waitFor(() => {
         expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-am-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
       });
       expect(screen.getByTestId("developer-am-detail-error").textContent).toContain(
         DEV_MSG.AM_NOT_FOUND,
       );
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("surfaces 409 and does not steal lock when deleting a system menu", async () => {
@@ -463,8 +455,6 @@ describe("ActionMenuDetailPanel", () => {
       statusText: "Conflict",
       body: { message: "System action menus cannot be updated or deleted via this API" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <ActionMenuDetailPanel
@@ -477,6 +467,7 @@ describe("ActionMenuDetailPanel", () => {
         expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-am-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
       });
@@ -484,9 +475,6 @@ describe("ActionMenuDetailPanel", () => {
         DEV_MSG.AM_SYSTEM,
       );
       expect(onDeleted).not.toHaveBeenCalled();
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("surfaces 400 body on edit instead of invalid-name chrome", async () => {

--- a/WebUI/src/test/ts/developer/ActionMenuDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ActionMenuDetailPanel.test.tsx
@@ -408,23 +408,23 @@ describe("ActionMenuDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getActionMenuDetailMock.mockResolvedValue(sampleDetail);
     deleteActionMenuMock.mockResolvedValue(undefined);
-      const onDeleted = vi.fn();
-      render(
-        <ActionMenuDetailPanel
-          idOrName="Edit"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-am-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(onDeleted).toHaveBeenCalled();
-      });
-      expect(deleteActionMenuMock).toHaveBeenCalledWith("Edit");
+    const onDeleted = vi.fn();
+    render(
+      <ActionMenuDetailPanel
+        idOrName="Edit"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-am-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteActionMenuMock).toHaveBeenCalledWith("Edit");
   });
 
   it("surfaces 404 missing action menu on delete", async () => {
@@ -434,18 +434,18 @@ describe("ActionMenuDetailPanel", () => {
       statusText: "Not Found",
       body: { message: "Action menu not found" },
     });
-      render(<ActionMenuDetailPanel idOrName="Edit" onBack={() => undefined} />);
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-am-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
-      });
-      expect(screen.getByTestId("developer-am-detail-error").textContent).toContain(
-        DEV_MSG.AM_NOT_FOUND,
-      );
+    render(<ActionMenuDetailPanel idOrName="Edit" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-am-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-detail-error").textContent).toContain(
+      DEV_MSG.AM_NOT_FOUND,
+    );
   });
 
   it("surfaces 409 and does not steal lock when deleting a system menu", async () => {
@@ -455,26 +455,24 @@ describe("ActionMenuDetailPanel", () => {
       statusText: "Conflict",
       body: { message: "System action menus cannot be updated or deleted via this API" },
     });
-      const onDeleted = vi.fn();
-      render(
-        <ActionMenuDetailPanel
-          idOrName="Edit"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-am-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
-      });
-      expect(screen.getByTestId("developer-am-detail-error").textContent).toContain(
-        DEV_MSG.AM_SYSTEM,
-      );
-      expect(onDeleted).not.toHaveBeenCalled();
+    const onDeleted = vi.fn();
+    render(
+      <ActionMenuDetailPanel
+        idOrName="Edit"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-am-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-detail-error").textContent).toContain(DEV_MSG.AM_SYSTEM);
+    expect(onDeleted).not.toHaveBeenCalled();
   });
 
   it("surfaces 400 body on edit instead of invalid-name chrome", async () => {

--- a/WebUI/src/test/ts/developer/ActionMenusPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ActionMenusPanel.test.tsx
@@ -157,8 +157,6 @@ describe("ActionMenusPanel", () => {
     listMock.mockResolvedValue([sampleMenu]);
     detailMock.mockResolvedValue(sampleDetail);
     deleteMock.mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       render(<ActionMenusPanel />);
       await waitFor(() => {
         expect(screen.getByTestId("developer-am-table")).toBeTruthy();
@@ -168,14 +166,12 @@ describe("ActionMenusPanel", () => {
         expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-am-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-am-list-notice")).toBeTruthy();
       });
       expect(screen.getByTestId("developer-am-list-notice").textContent).toBe(DEV_MSG.AM_DELETED);
       expect(screen.getByTestId("developer-am-panel")).toBeTruthy();
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("shows fallback when rejection has no message", async () => {

--- a/WebUI/src/test/ts/developer/ActionMenusPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ActionMenusPanel.test.tsx
@@ -157,21 +157,21 @@ describe("ActionMenusPanel", () => {
     listMock.mockResolvedValue([sampleMenu]);
     detailMock.mockResolvedValue(sampleDetail);
     deleteMock.mockResolvedValue(undefined);
-      render(<ActionMenusPanel />);
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-am-table")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-am-open"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-am-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-am-list-notice")).toBeTruthy();
-      });
-      expect(screen.getByTestId("developer-am-list-notice").textContent).toBe(DEV_MSG.AM_DELETED);
-      expect(screen.getByTestId("developer-am-panel")).toBeTruthy();
+    render(<ActionMenusPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-table")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-am-open"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-am-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-list-notice")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-list-notice").textContent).toBe(DEV_MSG.AM_DELETED);
+    expect(screen.getByTestId("developer-am-panel")).toBeTruthy();
   });
 
   it("shows fallback when rejection has no message", async () => {

--- a/WebUI/src/test/ts/developer/CatalogConfirmDialog.test.tsx
+++ b/WebUI/src/test/ts/developer/CatalogConfirmDialog.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { CatalogConfirmDialog } from "../../../main/ts/developer/CatalogConfirmDialog";
+import { DEV_MSG } from "../../../main/ts/developer/messages";
+
+describe("CatalogConfirmDialog (#4122)", () => {
+  it("renders an in-app modal with the catalog message", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <CatalogConfirmDialog
+        open
+        busy={false}
+        message={DEV_MSG.SR_DELETE_CONFIRM}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+    const dialog = screen.getByTestId("developer-catalog-confirm-dialog");
+    expect(dialog.getAttribute("role")).toBe("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(screen.getByTestId("developer-catalog-confirm-body").textContent).toBe(
+      DEV_MSG.SR_DELETE_CONFIRM,
+    );
+    expect(screen.getByTestId("developer-catalog-confirm-submit").textContent).toBe(
+      DEV_MSG.CATALOG_CONFIRM_SUBMIT,
+    );
+  });
+
+  it("does not render when closed", () => {
+    render(
+      <CatalogConfirmDialog
+        open={false}
+        busy={false}
+        message={DEV_MSG.SR_DELETE_CONFIRM}
+        onCancel={() => undefined}
+        onConfirm={() => undefined}
+      />,
+    );
+    expect(screen.queryByTestId("developer-catalog-confirm-dialog")).toBeNull();
+  });
+
+  it("cancel and confirm call the matching handlers", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <CatalogConfirmDialog
+        open
+        busy={false}
+        message={DEV_MSG.SR_DELETE_CONFIRM}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape cancels when not busy", () => {
+    const onCancel = vi.fn();
+    render(
+      <CatalogConfirmDialog
+        open
+        busy={false}
+        message={DEV_MSG.SR_DELETE_CONFIRM}
+        onCancel={onCancel}
+        onConfirm={() => undefined}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/WebUI/src/test/ts/developer/CommunityDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/CommunityDetailPanel.test.tsx
@@ -374,7 +374,6 @@ describe("CommunityDetailPanel", () => {
       statusText: "Conflict",
       body: { message: "Community has dependencies" },
     });
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
     const onDeleted = vi.fn();
     render(
       <CommunityDetailPanel
@@ -387,6 +386,7 @@ describe("CommunityDetailPanel", () => {
       expect(screen.getByTestId("developer-comm-delete")).toBeTruthy();
     });
     fireEvent.click(screen.getByTestId("developer-comm-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
     });
@@ -396,7 +396,6 @@ describe("CommunityDetailPanel", () => {
     );
     expect(onDeleted).not.toHaveBeenCalled();
     expect(screen.getByTestId("developer-comm-detail-title")).toBeTruthy();
-    confirm.mockRestore();
   });
 
   it("surfaces 403 non-Admin on delete", async () => {
@@ -406,25 +405,23 @@ describe("CommunityDetailPanel", () => {
       statusText: "Forbidden",
       body: { message: "Admin role required" },
     });
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
     render(<CommunityDetailPanel idOrName="Default" onBack={() => undefined} />);
     await waitFor(() => {
       expect(screen.getByTestId("developer-comm-delete")).toBeTruthy();
     });
     fireEvent.click(screen.getByTestId("developer-comm-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
     });
     expect(screen.getByTestId("developer-comm-detail-error").textContent).toContain(
       DEV_MSG.COMM_FORBIDDEN,
     );
-    confirm.mockRestore();
   });
 
   it("delete success returns to catalog via onDeleted", async () => {
     getCommunityDetail.mockResolvedValue(sampleDetail);
     deleteCommunity.mockResolvedValue(undefined);
-    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
     const onDeleted = vi.fn();
     render(
       <CommunityDetailPanel
@@ -437,10 +434,10 @@ describe("CommunityDetailPanel", () => {
       expect(screen.getByTestId("developer-comm-delete")).toBeTruthy();
     });
     fireEvent.click(screen.getByTestId("developer-comm-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
     await waitFor(() => {
       expect(onDeleted).toHaveBeenCalled();
     });
     expect(deleteCommunity).toHaveBeenCalledWith(sampleDetail.guid, false);
-    confirm.mockRestore();
   });
 });

--- a/WebUI/src/test/ts/developer/CommunityDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/CommunityDetailPanel.test.tsx
@@ -410,7 +410,7 @@ describe("CommunityDetailPanel", () => {
       expect(screen.getByTestId("developer-comm-delete")).toBeTruthy();
     });
     fireEvent.click(screen.getByTestId("developer-comm-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-comm-detail-error")).toBeTruthy();
     });

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -2031,8 +2031,6 @@ describe("ContentTypeDetailPanel", () => {
 
   it("deletes after lock and confirm", async () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <ContentTypeDetailPanel
@@ -2053,14 +2051,12 @@ describe("ContentTypeDetailPanel", () => {
         );
       });
       fireEvent.click(screen.getByTestId("developer-ct-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
       expect(deleteContentType).toHaveBeenCalledWith("percPage");
       expect(unlockContentType).not.toHaveBeenCalled();
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("unlocked DELETE 409 does not steal the lock", async () => {
@@ -2070,8 +2066,6 @@ describe("ContentTypeDetailPanel", () => {
       statusText: "Conflict",
       body: { message: "Design lock required" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <ContentTypeDetailPanel
@@ -2093,6 +2087,7 @@ describe("ContentTypeDetailPanel", () => {
       });
       lockContentType.mockClear();
       fireEvent.click(screen.getByTestId("developer-ct-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
       });
@@ -2102,9 +2097,6 @@ describe("ContentTypeDetailPanel", () => {
       expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
         DEV_MSG.CT_DELETE_LOCK_REQUIRED,
       );
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("surfaces 403 non-Admin on delete", async () => {
@@ -2114,8 +2106,6 @@ describe("ContentTypeDetailPanel", () => {
       statusText: "Forbidden",
       body: { message: "Admin role required" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
       await waitFor(() => {
         expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(
@@ -2129,15 +2119,13 @@ describe("ContentTypeDetailPanel", () => {
         );
       });
       fireEvent.click(screen.getByTestId("developer-ct-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
       });
       expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
         DEV_MSG.CT_FORBIDDEN,
       );
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("exports design XML without a lock (#4034)", async () => {
@@ -2386,6 +2374,7 @@ describe("ContentTypeDetailPanel", () => {
     expect((screen.getByTestId("developer-ct-field-add-name") as HTMLInputElement).value).toBe("");
     fireEvent.click(screen.getByTestId("developer-ct-field-add"));
     fireEvent.click(screen.getByTestId("developer-ct-field-delete-rx_note"));
+    expect(screen.queryByTestId("developer-catalog-confirm-dialog")).toBeNull();
     expect(addLocalContentTypeField).not.toHaveBeenCalled();
     expect(deleteLocalContentTypeField).not.toHaveBeenCalled();
   });
@@ -2501,7 +2490,6 @@ describe("ContentTypeDetailPanel", () => {
   });
 
   it("DELETEs a local field after lock and omits it from the catalog (#4045)", async () => {
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     getContentTypeDetail
       .mockResolvedValueOnce({
         ...sampleDetail,
@@ -2525,6 +2513,7 @@ describe("ContentTypeDetailPanel", () => {
       ).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-field-delete-rx_note"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
     await waitFor(() => {
       expect(deleteLocalContentTypeField).toHaveBeenCalledWith("percPage", "rx_note");
     });
@@ -2535,7 +2524,6 @@ describe("ContentTypeDetailPanel", () => {
       /Local field deleted/i,
     );
     expect(unlockContentType).not.toHaveBeenCalled();
-    confirmSpy.mockRestore();
   });
 
   it("keeps icon strategy disabled until lock (#4047)", async () => {

--- a/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ContentTypeDetailPanel.test.tsx
@@ -2031,32 +2031,62 @@ describe("ContentTypeDetailPanel", () => {
 
   it("deletes after lock and confirm", async () => {
     getContentTypeDetail.mockResolvedValue(sampleDetail);
-      const onDeleted = vi.fn();
-      render(
-        <ContentTypeDetailPanel
-          idOrName="percPage"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(
-          false,
-        );
-      });
-      fireEvent.click(screen.getByTestId("developer-ct-lock"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe(
-          "Locked by you",
-        );
-      });
-      fireEvent.click(screen.getByTestId("developer-ct-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(onDeleted).toHaveBeenCalled();
-      });
-      expect(deleteContentType).toHaveBeenCalledWith("percPage");
-      expect(unlockContentType).not.toHaveBeenCalled();
+    const onDeleted = vi.fn();
+    render(
+      <ContentTypeDetailPanel
+        idOrName="percPage"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteContentType).toHaveBeenCalledWith("percPage");
+    expect(unlockContentType).not.toHaveBeenCalled();
+  });
+
+  it("closes type-delete confirm if lock is released before submit", async () => {
+    getContentTypeDetail.mockResolvedValue(sampleDetail);
+    const onDeleted = vi.fn();
+    render(
+      <ContentTypeDetailPanel
+        idOrName="percPage"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Locked by you");
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-delete"));
+    expect(screen.getByTestId("developer-catalog-confirm-dialog")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("developer-ct-unlock"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    });
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("developer-catalog-confirm-dialog")).toBeNull();
+    });
+    expect(deleteContentType).not.toHaveBeenCalled();
+    expect(onDeleted).not.toHaveBeenCalled();
+    expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+      DEV_MSG.CT_LOCK_REQUIRED,
+    );
   });
 
   it("unlocked DELETE 409 does not steal the lock", async () => {
@@ -2066,37 +2096,33 @@ describe("ContentTypeDetailPanel", () => {
       statusText: "Conflict",
       body: { message: "Design lock required" },
     });
-      const onDeleted = vi.fn();
-      render(
-        <ContentTypeDetailPanel
-          idOrName="percPage"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(
-          false,
-        );
-      });
-      fireEvent.click(screen.getByTestId("developer-ct-lock"));
-      await waitFor(() => {
-        expect((screen.getByTestId("developer-ct-delete") as HTMLButtonElement).disabled).toBe(
-          false,
-        );
-      });
-      lockContentType.mockClear();
-      fireEvent.click(screen.getByTestId("developer-ct-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
-      });
-      expect(deleteContentType).toHaveBeenCalledTimes(1);
-      expect(lockContentType).not.toHaveBeenCalled();
-      expect(onDeleted).not.toHaveBeenCalled();
-      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
-        DEV_MSG.CT_DELETE_LOCK_REQUIRED,
-      );
+    const onDeleted = vi.fn();
+    render(
+      <ContentTypeDetailPanel
+        idOrName="percPage"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-delete") as HTMLButtonElement).disabled).toBe(false);
+    });
+    lockContentType.mockClear();
+    fireEvent.click(screen.getByTestId("developer-ct-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
+    });
+    expect(deleteContentType).toHaveBeenCalledTimes(1);
+    expect(lockContentType).not.toHaveBeenCalled();
+    expect(onDeleted).not.toHaveBeenCalled();
+    expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+      DEV_MSG.CT_DELETE_LOCK_REQUIRED,
+    );
   });
 
   it("surfaces 403 non-Admin on delete", async () => {
@@ -2106,26 +2132,22 @@ describe("ContentTypeDetailPanel", () => {
       statusText: "Forbidden",
       body: { message: "Admin role required" },
     });
-      render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
-      await waitFor(() => {
-        expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(
-          false,
-        );
-      });
-      fireEvent.click(screen.getByTestId("developer-ct-lock"));
-      await waitFor(() => {
-        expect((screen.getByTestId("developer-ct-delete") as HTMLButtonElement).disabled).toBe(
-          false,
-        );
-      });
-      fireEvent.click(screen.getByTestId("developer-ct-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
-      });
-      expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
-        DEV_MSG.CT_FORBIDDEN,
-      );
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-lock") as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect((screen.getByTestId("developer-ct-delete") as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+      DEV_MSG.CT_FORBIDDEN,
+    );
   });
 
   it("exports design XML without a lock (#4034)", async () => {
@@ -2513,7 +2535,7 @@ describe("ContentTypeDetailPanel", () => {
       ).toBe(false);
     });
     fireEvent.click(screen.getByTestId("developer-ct-field-delete-rx_note"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
     await waitFor(() => {
       expect(deleteLocalContentTypeField).toHaveBeenCalledWith("percPage", "rx_note");
     });
@@ -2524,6 +2546,37 @@ describe("ContentTypeDetailPanel", () => {
       /Local field deleted/i,
     );
     expect(unlockContentType).not.toHaveBeenCalled();
+  });
+
+  it("closes field-delete confirm if lock is released before submit", async () => {
+    getContentTypeDetail.mockResolvedValue({
+      ...sampleDetail,
+      fields: [{ name: "rx_note", label: "Note", fieldType: "local" }],
+    });
+    render(<ContentTypeDetailPanel idOrName="percPage" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-field-delete-rx_note")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-lock"));
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("developer-ct-field-delete-rx_note") as HTMLButtonElement).disabled,
+      ).toBe(false);
+    });
+    fireEvent.click(screen.getByTestId("developer-ct-field-delete-rx_note"));
+    expect(screen.getByTestId("developer-catalog-confirm-dialog")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("developer-ct-unlock"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-ct-lock-status").textContent).toBe("Not locked");
+    });
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("developer-catalog-confirm-dialog")).toBeNull();
+    });
+    expect(deleteLocalContentTypeField).not.toHaveBeenCalled();
+    expect(screen.getByTestId("developer-ct-detail-error").textContent).toContain(
+      DEV_MSG.CT_LOCK_REQUIRED,
+    );
   });
 
   it("keeps icon strategy disabled until lock (#4047)", async () => {

--- a/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
@@ -441,23 +441,23 @@ describe("DisplayFormatDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getDisplayFormatDetail.mockResolvedValue(sampleDetail);
     deleteDisplayFormat.mockResolvedValue(undefined);
-      const onDeleted = vi.fn();
-      render(
-        <DisplayFormatDetailPanel
-          idOrName="Default"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-df-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-df-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(onDeleted).toHaveBeenCalled();
-      });
-      expect(deleteDisplayFormat).toHaveBeenCalledWith("Default");
+    const onDeleted = vi.fn();
+    render(
+      <DisplayFormatDetailPanel
+        idOrName="Default"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-df-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteDisplayFormat).toHaveBeenCalledWith("Default");
   });
 
   it("surfaces 404 missing display format on delete", async () => {
@@ -467,18 +467,18 @@ describe("DisplayFormatDetailPanel", () => {
       statusText: "Not Found",
       body: { message: "Display format not found" },
     });
-      render(<DisplayFormatDetailPanel idOrName="Default" onBack={() => undefined} />);
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-df-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-df-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-df-detail-error")).toBeTruthy();
-      });
-      expect(screen.getByTestId("developer-df-detail-error").textContent).toContain(
-        DEV_MSG.DF_NOT_FOUND,
-      );
+    render(<DisplayFormatDetailPanel idOrName="Default" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-df-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-df-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-df-detail-error").textContent).toContain(
+      DEV_MSG.DF_NOT_FOUND,
+    );
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/DisplayFormatDetailPanel.test.tsx
@@ -441,8 +441,6 @@ describe("DisplayFormatDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getDisplayFormatDetail.mockResolvedValue(sampleDetail);
     deleteDisplayFormat.mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <DisplayFormatDetailPanel
@@ -455,13 +453,11 @@ describe("DisplayFormatDetailPanel", () => {
         expect(screen.getByTestId("developer-df-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-df-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
       expect(deleteDisplayFormat).toHaveBeenCalledWith("Default");
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("surfaces 404 missing display format on delete", async () => {
@@ -471,22 +467,18 @@ describe("DisplayFormatDetailPanel", () => {
       statusText: "Not Found",
       body: { message: "Display format not found" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       render(<DisplayFormatDetailPanel idOrName="Default" onBack={() => undefined} />);
       await waitFor(() => {
         expect(screen.getByTestId("developer-df-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-df-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-df-detail-error")).toBeTruthy();
       });
       expect(screen.getByTestId("developer-df-detail-error").textContent).toContain(
         DEV_MSG.DF_NOT_FOUND,
       );
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/ItemFilterDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ItemFilterDetailPanel.test.tsx
@@ -355,23 +355,23 @@ describe("ItemFilterDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getItemFilterDetail.mockResolvedValue(sampleDetail);
     deleteItemFilter.mockResolvedValue(undefined);
-      const onDeleted = vi.fn();
-      render(
-        <ItemFilterDetailPanel
-          idOrName="publicItems"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-if-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-if-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(onDeleted).toHaveBeenCalled();
-      });
-      expect(deleteItemFilter).toHaveBeenCalledWith("publicItems");
+    const onDeleted = vi.fn();
+    render(
+      <ItemFilterDetailPanel
+        idOrName="publicItems"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-if-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-if-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteItemFilter).toHaveBeenCalledWith("publicItems");
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/ItemFilterDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ItemFilterDetailPanel.test.tsx
@@ -355,8 +355,6 @@ describe("ItemFilterDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getItemFilterDetail.mockResolvedValue(sampleDetail);
     deleteItemFilter.mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <ItemFilterDetailPanel
@@ -369,13 +367,11 @@ describe("ItemFilterDetailPanel", () => {
         expect(screen.getByTestId("developer-if-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-if-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
       expect(deleteItemFilter).toHaveBeenCalledWith("publicItems");
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/LocaleDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/LocaleDetailPanel.test.tsx
@@ -322,8 +322,6 @@ describe("LocaleDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getLocaleDetail.mockResolvedValue(sampleDetail);
     deleteLocale.mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <LocaleDetailPanel idOrLang="en-us" onBack={() => undefined} onDeleted={onDeleted} />,
@@ -332,13 +330,11 @@ describe("LocaleDetailPanel", () => {
         expect(screen.getByTestId("developer-loc-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-loc-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
       expect(deleteLocale).toHaveBeenCalledWith("en-us");
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/LocaleDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/LocaleDetailPanel.test.tsx
@@ -322,19 +322,19 @@ describe("LocaleDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getLocaleDetail.mockResolvedValue(sampleDetail);
     deleteLocale.mockResolvedValue(undefined);
-      const onDeleted = vi.fn();
-      render(
-        <LocaleDetailPanel idOrLang="en-us" onBack={() => undefined} onDeleted={onDeleted} />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-loc-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-loc-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(onDeleted).toHaveBeenCalled();
-      });
-      expect(deleteLocale).toHaveBeenCalledWith("en-us");
+    const onDeleted = vi.fn();
+    render(
+      <LocaleDetailPanel idOrLang="en-us" onBack={() => undefined} onDeleted={onDeleted} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-loc-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-loc-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteLocale).toHaveBeenCalledWith("en-us");
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
@@ -359,8 +359,6 @@ describe("SearchDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getSearchDetail.mockResolvedValue(sampleDetail);
     deleteSearch.mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <SearchDetailPanel
@@ -373,13 +371,11 @@ describe("SearchDetailPanel", () => {
         expect(screen.getByTestId("developer-sr-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-sr-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
       expect(deleteSearch).toHaveBeenCalledWith("All Content");
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("surfaces 404 missing search on delete", async () => {
@@ -389,27 +385,46 @@ describe("SearchDetailPanel", () => {
       statusText: "Not Found",
       body: { message: "Search not found" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       render(<SearchDetailPanel idOrName="All Content" onBack={() => undefined} />);
       await waitFor(() => {
         expect(screen.getByTestId("developer-sr-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-sr-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-sr-detail-error")).toBeTruthy();
       });
       expect(screen.getByTestId("developer-sr-detail-error").textContent).toContain(
         DEV_MSG.SR_NOT_FOUND,
       );
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("does not show delete on create", () => {
     render(<SearchDetailPanel idOrName={null} onBack={() => undefined} />);
     expect(screen.queryByTestId("developer-sr-delete")).toBeNull();
+  });
+
+  it("cancel on in-app confirm does not delete", async () => {
+    getSearchDetail.mockResolvedValue(sampleDetail);
+    const onDeleted = vi.fn();
+    render(
+      <SearchDetailPanel
+        idOrName="All Content"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-delete"));
+    expect(screen.getByTestId("developer-catalog-confirm-dialog").getAttribute("role")).toBe(
+      "dialog",
+    );
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-cancel"));
+    expect(screen.queryByTestId("developer-catalog-confirm-dialog")).toBeNull();
+    expect(deleteSearch).not.toHaveBeenCalled();
+    expect(onDeleted).not.toHaveBeenCalled();
   });
 
   it("saves PUT body fields on a user search", async () => {

--- a/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
@@ -359,23 +359,23 @@ describe("SearchDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getSearchDetail.mockResolvedValue(sampleDetail);
     deleteSearch.mockResolvedValue(undefined);
-      const onDeleted = vi.fn();
-      render(
-        <SearchDetailPanel
-          idOrName="All Content"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-sr-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-sr-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(onDeleted).toHaveBeenCalled();
-      });
-      expect(deleteSearch).toHaveBeenCalledWith("All Content");
+    const onDeleted = vi.fn();
+    render(
+      <SearchDetailPanel
+        idOrName="All Content"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteSearch).toHaveBeenCalledWith("All Content");
   });
 
   it("surfaces 404 missing search on delete", async () => {
@@ -385,18 +385,18 @@ describe("SearchDetailPanel", () => {
       statusText: "Not Found",
       body: { message: "Search not found" },
     });
-      render(<SearchDetailPanel idOrName="All Content" onBack={() => undefined} />);
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-sr-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-sr-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-sr-detail-error")).toBeTruthy();
-      });
-      expect(screen.getByTestId("developer-sr-detail-error").textContent).toContain(
-        DEV_MSG.SR_NOT_FOUND,
-      );
+    render(<SearchDetailPanel idOrName="All Content" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-detail-error").textContent).toContain(
+      DEV_MSG.SR_NOT_FOUND,
+    );
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/SharedFieldGroupDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SharedFieldGroupDetailPanel.test.tsx
@@ -313,23 +313,23 @@ describe("SharedFieldGroupDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getSharedFieldGroupDetail.mockResolvedValue(sampleDetail);
     deleteSharedFieldGroup.mockResolvedValue(undefined);
-      const onDeleted = vi.fn();
-      render(
-        <SharedFieldGroupDetailPanel
-          name="shared"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-sf-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-sf-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(onDeleted).toHaveBeenCalled();
-      });
-      expect(deleteSharedFieldGroup).toHaveBeenCalledWith("shared");
+    const onDeleted = vi.fn();
+    render(
+      <SharedFieldGroupDetailPanel
+        name="shared"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sf-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-sf-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteSharedFieldGroup).toHaveBeenCalledWith("shared");
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/SharedFieldGroupDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SharedFieldGroupDetailPanel.test.tsx
@@ -313,8 +313,6 @@ describe("SharedFieldGroupDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getSharedFieldGroupDetail.mockResolvedValue(sampleDetail);
     deleteSharedFieldGroup.mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <SharedFieldGroupDetailPanel
@@ -327,13 +325,11 @@ describe("SharedFieldGroupDetailPanel", () => {
         expect(screen.getByTestId("developer-sf-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-sf-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
       expect(deleteSharedFieldGroup).toHaveBeenCalledWith("shared");
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/SlotDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SlotDetailPanel.test.tsx
@@ -450,23 +450,19 @@ describe("SlotDetailPanel", () => {
   it("deletes after confirm", async () => {
     getSlotDetail.mockResolvedValue(sampleDetail);
     deleteSlot.mockResolvedValue(undefined);
-      const onDeleted = vi.fn();
-      render(
-        <SlotDetailPanel
-          idOrName="rffList"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-slot-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(onDeleted).toHaveBeenCalled();
-      });
-      expect(deleteSlot).toHaveBeenCalledWith("rffList");
+    const onDeleted = vi.fn();
+    render(
+      <SlotDetailPanel idOrName="rffList" onBack={() => undefined} onDeleted={onDeleted} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-slot-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteSlot).toHaveBeenCalledWith("rffList");
   });
 
   it("surfaces 409 system-slot delete", async () => {
@@ -480,27 +476,27 @@ describe("SlotDetailPanel", () => {
       statusText: "Conflict",
       body: { message: "System slots cannot be deleted" },
     });
-      const onDeleted = vi.fn();
-      render(
-        <SlotDetailPanel
-          idOrName="sys_inline_link"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-slot-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
-      });
-      expect(deleteSlot).toHaveBeenCalledWith("sys_inline_link");
-      expect(screen.getByTestId("developer-slot-detail-error").textContent).toContain(
-        DEV_MSG.SLOT_DELETE_SYSTEM,
-      );
-      expect(onDeleted).not.toHaveBeenCalled();
+    const onDeleted = vi.fn();
+    render(
+      <SlotDetailPanel
+        idOrName="sys_inline_link"
+        onBack={() => undefined}
+        onDeleted={onDeleted}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-slot-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
+    });
+    expect(deleteSlot).toHaveBeenCalledWith("sys_inline_link");
+    expect(screen.getByTestId("developer-slot-detail-error").textContent).toContain(
+      DEV_MSG.SLOT_DELETE_SYSTEM,
+    );
+    expect(onDeleted).not.toHaveBeenCalled();
   });
 
   it("does not treat a generic 409 containing system as a system-slot delete", async () => {
@@ -510,29 +506,25 @@ describe("SlotDetailPanel", () => {
       statusText: "Conflict",
       body: { message: "ecosystem constraint" },
     });
-      const onDeleted = vi.fn();
-      render(
-        <SlotDetailPanel
-          idOrName="rffList"
-          onBack={() => undefined}
-          onDeleted={onDeleted}
-        />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-slot-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
-      });
-      expect(screen.getByTestId("developer-slot-detail-error").textContent).toContain(
-        DEV_MSG.SLOT_DELETE_ERROR,
-      );
-      expect(screen.getByTestId("developer-slot-detail-error").textContent).not.toContain(
-        DEV_MSG.SLOT_DELETE_SYSTEM,
-      );
-      expect(onDeleted).not.toHaveBeenCalled();
+    const onDeleted = vi.fn();
+    render(
+      <SlotDetailPanel idOrName="rffList" onBack={() => undefined} onDeleted={onDeleted} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-slot-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-detail-error").textContent).toContain(
+      DEV_MSG.SLOT_DELETE_ERROR,
+    );
+    expect(screen.getByTestId("developer-slot-detail-error").textContent).not.toContain(
+      DEV_MSG.SLOT_DELETE_SYSTEM,
+    );
+    expect(onDeleted).not.toHaveBeenCalled();
   });
 
   it("surfaces 403 non-Admin on delete", async () => {
@@ -542,18 +534,18 @@ describe("SlotDetailPanel", () => {
       statusText: "Forbidden",
       body: { message: "Admin role required" },
     });
-      render(<SlotDetailPanel idOrName="rffList" onBack={() => undefined} />);
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-slot-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
-      });
-      expect(screen.getByTestId("developer-slot-detail-error").textContent).toContain(
-        DEV_MSG.SLOT_FORBIDDEN,
-      );
+    render(<SlotDetailPanel idOrName="rffList" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-slot-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-slot-detail-error").textContent).toContain(
+      DEV_MSG.SLOT_FORBIDDEN,
+    );
   });
 
   async function renderLoadedSlot() {

--- a/WebUI/src/test/ts/developer/SlotDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SlotDetailPanel.test.tsx
@@ -450,8 +450,6 @@ describe("SlotDetailPanel", () => {
   it("deletes after confirm", async () => {
     getSlotDetail.mockResolvedValue(sampleDetail);
     deleteSlot.mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <SlotDetailPanel
@@ -464,13 +462,11 @@ describe("SlotDetailPanel", () => {
         expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-slot-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
       expect(deleteSlot).toHaveBeenCalledWith("rffList");
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("surfaces 409 system-slot delete", async () => {
@@ -484,8 +480,6 @@ describe("SlotDetailPanel", () => {
       statusText: "Conflict",
       body: { message: "System slots cannot be deleted" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <SlotDetailPanel
@@ -498,6 +492,7 @@ describe("SlotDetailPanel", () => {
         expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-slot-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
       });
@@ -506,9 +501,6 @@ describe("SlotDetailPanel", () => {
         DEV_MSG.SLOT_DELETE_SYSTEM,
       );
       expect(onDeleted).not.toHaveBeenCalled();
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("does not treat a generic 409 containing system as a system-slot delete", async () => {
@@ -518,8 +510,6 @@ describe("SlotDetailPanel", () => {
       statusText: "Conflict",
       body: { message: "ecosystem constraint" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <SlotDetailPanel
@@ -532,6 +522,7 @@ describe("SlotDetailPanel", () => {
         expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-slot-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
       });
@@ -542,9 +533,6 @@ describe("SlotDetailPanel", () => {
         DEV_MSG.SLOT_DELETE_SYSTEM,
       );
       expect(onDeleted).not.toHaveBeenCalled();
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("surfaces 403 non-Admin on delete", async () => {
@@ -554,22 +542,18 @@ describe("SlotDetailPanel", () => {
       statusText: "Forbidden",
       body: { message: "Admin role required" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       render(<SlotDetailPanel idOrName="rffList" onBack={() => undefined} />);
       await waitFor(() => {
         expect(screen.getByTestId("developer-slot-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-slot-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-slot-detail-error")).toBeTruthy();
       });
       expect(screen.getByTestId("developer-slot-detail-error").textContent).toContain(
         DEV_MSG.SLOT_FORBIDDEN,
       );
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   async function renderLoadedSlot() {

--- a/WebUI/src/test/ts/developer/SystemDefPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SystemDefPanel.test.tsx
@@ -331,7 +331,7 @@ describe("SystemDefPanel", () => {
       expect(screen.getByTestId("developer-sys-delete")).toBeTruthy();
     });
     fireEvent.click(screen.getByTestId("developer-sys-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-sys-empty")).toBeTruthy();
     });

--- a/WebUI/src/test/ts/developer/SystemDefPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SystemDefPanel.test.tsx
@@ -53,7 +53,6 @@ describe("SystemDefPanel", () => {
     updateMock.mockReset();
     addMock.mockReset();
     deleteMock.mockReset();
-    vi.spyOn(window, "confirm").mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -332,10 +331,10 @@ describe("SystemDefPanel", () => {
       expect(screen.getByTestId("developer-sys-delete")).toBeTruthy();
     });
     fireEvent.click(screen.getByTestId("developer-sys-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
     await waitFor(() => {
       expect(screen.getByTestId("developer-sys-empty")).toBeTruthy();
     });
     expect(deleteMock).toHaveBeenCalledWith("sys_title");
-    expect(window.confirm).toHaveBeenCalled();
   });
 });

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -403,19 +403,19 @@ describe("ViewDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getViewDetail.mockResolvedValue(sampleDetail);
     deleteView.mockResolvedValue(undefined);
-      const onDeleted = vi.fn();
-      render(
-        <ViewDetailPanel idOrName="My View" onBack={() => undefined} onDeleted={onDeleted} />,
-      );
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-vw-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-vw-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(onDeleted).toHaveBeenCalled();
-      });
-      expect(deleteView).toHaveBeenCalledWith("0-27-3");
+    const onDeleted = vi.fn();
+    render(
+      <ViewDetailPanel idOrName="My View" onBack={() => undefined} onDeleted={onDeleted} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+    expect(deleteView).toHaveBeenCalledWith("0-27-3");
   });
 
   it("surfaces 404 missing view on delete", async () => {
@@ -425,18 +425,18 @@ describe("ViewDetailPanel", () => {
       statusText: "Not Found",
       body: { message: "View not found" },
     });
-      render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-vw-delete")).toBeTruthy();
-      });
-      fireEvent.click(screen.getByTestId("developer-vw-delete"));
-      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
-      await waitFor(() => {
-        expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
-      });
-      expect(screen.getByTestId("developer-vw-detail-error").textContent).toContain(
-        DEV_MSG.VW_NOT_FOUND,
-      );
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-delete")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-delete"));
+    fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toContain(
+      DEV_MSG.VW_NOT_FOUND,
+    );
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -403,8 +403,6 @@ describe("ViewDetailPanel", () => {
   it("deletes after confirm and omits delete chrome in create mode", async () => {
     getViewDetail.mockResolvedValue(sampleDetail);
     deleteView.mockResolvedValue(undefined);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       const onDeleted = vi.fn();
       render(
         <ViewDetailPanel idOrName="My View" onBack={() => undefined} onDeleted={onDeleted} />,
@@ -413,13 +411,11 @@ describe("ViewDetailPanel", () => {
         expect(screen.getByTestId("developer-vw-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-vw-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(onDeleted).toHaveBeenCalled();
       });
       expect(deleteView).toHaveBeenCalledWith("0-27-3");
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("surfaces 404 missing view on delete", async () => {
@@ -429,22 +425,18 @@ describe("ViewDetailPanel", () => {
       statusText: "Not Found",
       body: { message: "View not found" },
     });
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-    try {
       render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
       await waitFor(() => {
         expect(screen.getByTestId("developer-vw-delete")).toBeTruthy();
       });
       fireEvent.click(screen.getByTestId("developer-vw-delete"));
+      fireEvent.click(screen.getByTestId("developer-catalog-confirm-submit"));
       await waitFor(() => {
         expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
       });
       expect(screen.getByTestId("developer-vw-detail-error").textContent).toContain(
         DEV_MSG.VW_NOT_FOUND,
       );
-    } finally {
-      confirmSpy.mockRestore();
-    }
   });
 
   it("does not show delete on create", () => {

--- a/WebUI/src/test/ts/developer/messages.i18n.test.ts
+++ b/WebUI/src/test/ts/developer/messages.i18n.test.ts
@@ -18,6 +18,8 @@ describe("Developer DEV_MSG i18n keys", () => {
 
   it("resolves English fallback without I18N global", () => {
     expect(DEV_MSG.TITLE).toBe("Developer");
+    expect(DEV_MSG.CATALOG_CONFIRM_TITLE).toBe("Confirm delete");
+    expect(DEV_MSG.CATALOG_CONFIRM_SUBMIT).toBe("Delete");
     expect(DEV_MSG.TAB_CONTENT_TYPES).toBe("Content Types");
     expect(DEV_MSG.ACL_SAVED).toBe("Object ACL saved.");
     expect(DEV_MSG.CT_LOCK).toBe("Lock");

--- a/modules/perc-qa-automation/frontend/tests/developer-action-menu-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-action-menu-editor.spec.js
@@ -35,6 +35,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 const {
   catalogOpenByExactName,
 } = require("./helpers/developer-catalog-selectors");
@@ -133,8 +134,6 @@ test.describe("Developer action menu editor (#4112 / UI-02)", () => {
   test("Admin create POST is saved in the editor (notice + name read-only)", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openActionMenusCatalog(page);
 
@@ -158,6 +157,7 @@ test.describe("Developer action menu editor (#4112 / UI-02)", () => {
     await expect(page.locator('[data-testid="developer-am-delete"]')).toBeVisible();
 
     await page.locator('[data-testid="developer-am-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-am-panel"]')).toBeVisible({
       timeout: 20_000,
     });
@@ -172,8 +172,6 @@ test.describe("Developer action menu editor (#4112 / UI-02)", () => {
   test("system menu Edit is not removed from the catalog after SPA delete", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openActionMenusCatalog(page);
     await expect(createdRow(page, "Edit")).toHaveCount(1, { timeout: 20_000 });
@@ -182,6 +180,7 @@ test.describe("Developer action menu editor (#4112 / UI-02)", () => {
     await expect(page.locator('[data-testid="developer-am-detail"]')).toBeVisible();
     await expect(page.locator('[data-testid="developer-am-delete"]')).toBeVisible();
     await page.locator('[data-testid="developer-am-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
 
     const err = page.locator('[data-testid="developer-am-detail-error"]');
     await expect(err).toBeVisible({ timeout: 20_000 });

--- a/modules/perc-qa-automation/frontend/tests/developer-catalog-delete-confirm.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-catalog-delete-confirm.spec.js
@@ -15,7 +15,10 @@
  */
 
 /**
- * Developer Locales create / save / delete chrome (#4005 CD-18 / parent #1690).
+ * Developer catalog in-app delete confirm (#4122 / parent #4112 / #1690).
+ *
+ * Uses Developer Locales create/delete as the live catalog family sample
+ * (same CatalogConfirmDialog as Searches, Views, Slots, …).
  *
  * Surface-filtered QA:
  * <pre>
@@ -23,7 +26,7 @@
  *   python docker/scripts/perc-devctl.py qa-health
  *   cd modules/perc-qa-automation/frontend
  *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=… \
- *     npm run test:surface -- --path tests/developer-locale-editor.spec.js
+ *     npm run test:surface -- --path tests/developer-catalog-delete-confirm.spec.js
  *   perc-devctl qa-down
  * </pre>
  */
@@ -41,12 +44,11 @@ function developerLocalesUrl() {
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
 }
 
-/** BCP-47-style unique language matching REST LANGUAGE_PATTERN. */
 function uniqueLang() {
   const a = Date.now().toString(36).replace(/[^a-z0-9]/g, "").slice(-4);
   const b = Math.random().toString(36).replace(/[^a-z0-9]/g, "").slice(2, 6);
   const suffix = `${a}${b}`.slice(0, 8);
-  return `xx-${suffix || "qa4005"}`;
+  return `xx-${suffix || "qa4122"}`;
 }
 
 async function openLocalesCatalog(page) {
@@ -93,74 +95,47 @@ function assertConsoleClean(pageErrors, consoleErrors) {
   ).toEqual([]);
 }
 
-test.describe("Developer locale editor (#4005 / CD-18)", () => {
-  test("Admin can create, save, and delete a locale", async ({ page }) => {
+test.describe("Developer catalog in-app delete confirm (#4122)", () => {
+  test("Locales delete uses in-app dialog, not window.confirm", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+    const nativeDialogs = [];
+    page.on("dialog", (dialog) => {
+      nativeDialogs.push(dialog.type());
+      void dialog.dismiss();
+    });
+
     await loginAsAdmin(page);
     await openLocalesCatalog(page);
 
     const lang = uniqueLang();
-    const label = `QA 4005 ${lang}`;
-    const savedLabel = `${label} saved`;
+    const label = `QA 4122 ${lang}`;
 
     await page.locator('[data-testid="developer-loc-new"]').click();
     await expect(page.locator('[data-testid="developer-loc-detail"]')).toBeVisible();
-    const saveBtn = page.locator('[data-testid="developer-loc-save"]');
-    await expect(saveBtn).toBeDisabled();
-
     await page.locator('[data-testid="developer-loc-language"]').fill(lang);
-    await expect(saveBtn).toBeDisabled();
     await page.locator('[data-testid="developer-loc-label"]').fill(label);
-    await expect(saveBtn).toBeEnabled();
-    await saveBtn.click();
-
+    await page.locator('[data-testid="developer-loc-save"]').click();
     const notice = page.locator('[data-testid="developer-loc-editor-notice"]');
     const saveError = page.locator('[data-testid="developer-loc-detail-error"]');
-    await expect(notice).toBeVisible({ timeout: 20_000 });
+    await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
     if (await saveError.isVisible()) {
       throw new Error(`Create failed: ${(await saveError.innerText()).trim()}`);
     }
 
-    await expect(page.locator('[data-testid="developer-loc-language"]')).toBeDisabled({
-      timeout: 20_000,
-    });
-    await expect(page.locator('[data-testid="developer-loc-language"]')).toHaveValue(lang);
-
-    await page.locator('[data-testid="developer-loc-label"]').fill(savedLabel);
-    await expect(saveBtn).toBeEnabled();
-    await saveBtn.click();
-    await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
-    if (await saveError.isVisible()) {
-      throw new Error(`Save failed: ${(await saveError.innerText()).trim()}`);
-    }
-
     await page.locator('[data-testid="developer-loc-delete"]').click();
+    const dialog = page.locator('[data-testid="developer-catalog-confirm-dialog"]');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute("role", "dialog");
+    await expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(nativeDialogs, "native window.confirm must not open").toEqual([]);
+
     await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-loc-panel"]')).toBeVisible({
       timeout: 20_000,
     });
     await expect(page.locator(`[data-loc-lang="${lang}"]`)).toHaveCount(0);
-
-    assertConsoleClean(pageErrors, consoleErrors);
-  });
-
-  test("duplicate language 409 is surfaced in the UI", async ({ page }) => {
-    test.setTimeout(120_000);
-    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-
-    await loginAsAdmin(page);
-    await openLocalesCatalog(page);
-
-    await page.locator('[data-testid="developer-loc-new"]').click();
-    await expect(page.locator('[data-testid="developer-loc-detail"]')).toBeVisible();
-    await page.locator('[data-testid="developer-loc-language"]').fill("en-us");
-    await page.locator('[data-testid="developer-loc-label"]').fill("Duplicate English");
-    await page.locator('[data-testid="developer-loc-save"]').click();
-
-    const err = page.locator('[data-testid="developer-loc-detail-error"]');
-    await expect(err).toBeVisible({ timeout: 20_000 });
-    await expect(err).toContainText(/already exists|409|duplicate/i);
+    expect(nativeDialogs).toEqual([]);
 
     assertConsoleClean(pageErrors, consoleErrors);
   });

--- a/modules/perc-qa-automation/frontend/tests/developer-community-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-community-editor.spec.js
@@ -30,6 +30,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 
 function developerCommunitiesUrl() {
   const q = new URLSearchParams({
@@ -96,8 +97,6 @@ test.describe("Developer community editor (#4077 / SE-01)", () => {
   test("Admin can create a uniquely named community and delete it", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openCommunitiesCatalog(page);
 
@@ -136,6 +135,7 @@ test.describe("Developer community editor (#4077 / SE-01)", () => {
     await expect(page.locator('[data-testid="developer-comm-detail"]')).toBeVisible();
     await expect(page.locator('[data-testid="developer-comm-roles-save"]')).toBeVisible();
     await page.locator('[data-testid="developer-comm-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-comm-panel"]')).toBeVisible({
       timeout: 20_000,
     });
@@ -147,8 +147,6 @@ test.describe("Developer community editor (#4077 / SE-01)", () => {
   test("duplicate name 409 is surfaced in the UI", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openCommunitiesCatalog(page);
 
@@ -180,6 +178,7 @@ test.describe("Developer community editor (#4077 / SE-01)", () => {
       await openCreated.click();
       await expect(page.locator('[data-testid="developer-comm-delete"]')).toBeVisible();
       await page.locator('[data-testid="developer-comm-delete"]').click();
+      await confirmDeveloperCatalogDelete(page);
     }
 
     assertConsoleClean(pageErrors, consoleErrors);

--- a/modules/perc-qa-automation/frontend/tests/developer-content-type-local-fields.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-content-type-local-fields.spec.js
@@ -31,6 +31,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 const {
   catalogRowSelector,
   catalogRowsSelector,
@@ -226,10 +227,6 @@ test.describe("Developer content type local field create/delete (CD-03 / #4045)"
     );
     const deleteBtn = page.locator(`[data-testid="developer-ct-field-delete-${fieldName}"]`);
 
-    page.on("dialog", (dialog) => {
-      void dialog.accept();
-    });
-
     let fieldPosts = 0;
     await page.route("**/services/contenttypes/**", async (route) => {
       const req = route.request();
@@ -306,6 +303,7 @@ test.describe("Developer content type local field create/delete (CD-03 / #4045)"
 
       await expect(deleteBtn).toBeEnabled();
       await deleteBtn.click();
+      await confirmDeveloperCatalogDelete(page);
       await expect(notice).toContainText(/Local field deleted/i, { timeout: 20_000 });
       await expect(fieldRow).toHaveCount(0);
     } finally {

--- a/modules/perc-qa-automation/frontend/tests/developer-display-format-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-display-format-editor.spec.js
@@ -151,8 +151,6 @@ test.describe("Developer display format editor (#4086 / UI-05)", () => {
   test("Admin can create a display format and see it in the catalog", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openDisplayFormatsCatalog(page);
 
@@ -201,8 +199,6 @@ test.describe("Developer display format editor (#4086 / UI-05)", () => {
   test("duplicate display format name 409 is surfaced in the UI", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openDisplayFormatsCatalog(page);
 

--- a/modules/perc-qa-automation/frontend/tests/developer-item-filter-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-item-filter-editor.spec.js
@@ -30,6 +30,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 
 function developerItemFiltersUrl() {
   const q = new URLSearchParams({
@@ -96,8 +97,6 @@ test.describe("Developer item filter editor (#4060 / AS-07)", () => {
   test("Admin can create, save, and delete an item filter", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openItemFiltersCatalog(page);
 
@@ -132,6 +131,7 @@ test.describe("Developer item filter editor (#4060 / AS-07)", () => {
     }
 
     await page.locator('[data-testid="developer-if-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-if-panel"]')).toBeVisible({
       timeout: 20_000,
     });

--- a/modules/perc-qa-automation/frontend/tests/developer-search-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-search-editor.spec.js
@@ -30,6 +30,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 
 function developerSearchesUrl() {
   const q = new URLSearchParams({
@@ -96,8 +97,6 @@ test.describe("Developer search editor (#4076 / UI-06)", () => {
   test("Admin can create and delete a standard search", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openSearchesCatalog(page);
 
@@ -136,6 +135,7 @@ test.describe("Developer search editor (#4076 / UI-06)", () => {
     await createdRow.click();
     await expect(page.locator('[data-testid="developer-sr-detail"]')).toBeVisible();
     await page.locator('[data-testid="developer-sr-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-sr-panel"]')).toBeVisible({
       timeout: 20_000,
     });
@@ -149,8 +149,6 @@ test.describe("Developer search editor (#4076 / UI-06)", () => {
   test("duplicate search name 409 is surfaced in the UI", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openSearchesCatalog(page);
 
@@ -185,6 +183,7 @@ test.describe("Developer search editor (#4076 / UI-06)", () => {
     await page.locator(`[data-sr-name="${searchName}"]`).click();
     await expect(page.locator('[data-testid="developer-sr-detail"]')).toBeVisible();
     await page.locator('[data-testid="developer-sr-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-sr-panel"]')).toBeVisible({
       timeout: 20_000,
     });

--- a/modules/perc-qa-automation/frontend/tests/developer-shared-fields-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-shared-fields-editor.spec.js
@@ -30,6 +30,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 
 function developerSharedFieldsUrl() {
   const q = new URLSearchParams({
@@ -96,8 +97,6 @@ test.describe("Developer shared field group editor (#4029 / CD-15)", () => {
   test("Admin can create, save, and delete a shared field group", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openSharedFieldsCatalog(page);
 
@@ -131,6 +130,7 @@ test.describe("Developer shared field group editor (#4029 / CD-15)", () => {
     }
 
     await page.locator('[data-testid="developer-sf-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-sf-panel"]')).toBeVisible({
       timeout: 20_000,
     });

--- a/modules/perc-qa-automation/frontend/tests/developer-slot-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-slot-editor.spec.js
@@ -30,6 +30,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 
 function developerSlotsUrl() {
   const q = new URLSearchParams({
@@ -96,8 +97,6 @@ test.describe("Developer slot editor (#4056 / AS-01)", () => {
   test("Admin can create a uniquely named slot and delete it", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openSlotsCatalog(page);
 
@@ -139,6 +138,7 @@ test.describe("Developer slot editor (#4056 / AS-01)", () => {
     await page.locator(`[data-slot-name="${name}"]`).click();
     await expect(page.locator('[data-testid="developer-slot-detail"]')).toBeVisible();
     await page.locator('[data-testid="developer-slot-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-slot-panel"]')).toBeVisible({
       timeout: 20_000,
     });
@@ -150,8 +150,6 @@ test.describe("Developer slot editor (#4056 / AS-01)", () => {
   test("duplicate name 409 is surfaced in the UI", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openSlotsCatalog(page);
 
@@ -182,6 +180,7 @@ test.describe("Developer slot editor (#4056 / AS-01)", () => {
       await openCreated.click();
       await expect(page.locator('[data-testid="developer-slot-delete"]')).toBeVisible();
       await page.locator('[data-testid="developer-slot-delete"]').click();
+      await confirmDeveloperCatalogDelete(page);
     }
 
     assertConsoleClean(pageErrors, consoleErrors);
@@ -190,8 +189,6 @@ test.describe("Developer slot editor (#4056 / AS-01)", () => {
   test("system slot delete is 409", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openSlotsCatalog(page);
 
@@ -209,6 +206,7 @@ test.describe("Developer slot editor (#4056 / AS-01)", () => {
     });
     await expect(page.locator('[data-testid="developer-slot-delete"]')).toBeVisible();
     await page.locator('[data-testid="developer-slot-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
 
     const err = page.locator('[data-testid="developer-slot-detail-error"]');
     await expect(err).toBeVisible({ timeout: 20_000 });

--- a/modules/perc-qa-automation/frontend/tests/developer-slot-finder-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-slot-finder-editor.spec.js
@@ -30,6 +30,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 
 const VALID_FINDER =
   "Java/global/percussion/slotcontentfinder/sys_RelationshipContentFinder";
@@ -122,6 +123,7 @@ async function deleteCurrentSlot(page, name) {
   const del = page.locator('[data-testid="developer-slot-delete"]');
   if (await del.isVisible()) {
     await del.click();
+    await confirmDeveloperCatalogDelete(page);
     const panel = page.locator('[data-testid="developer-slot-panel"]');
     const err = page.locator('[data-testid="developer-slot-detail-error"]');
     await expect(panel.or(err).first()).toBeVisible({ timeout: 20_000 });
@@ -130,6 +132,7 @@ async function deleteCurrentSlot(page, name) {
       if (await unlock.isEnabled()) {
         await unlock.click();
         await page.locator('[data-testid="developer-slot-delete"]').click();
+        await confirmDeveloperCatalogDelete(page);
         await expect(page.locator('[data-testid="developer-slot-panel"]')).toBeVisible({
           timeout: 20_000,
         });
@@ -145,8 +148,6 @@ test.describe("Developer slot finder editor (#4059 / AS-01)", () => {
   }) => {
     test.setTimeout(180_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openSlotsCatalog(page);
 

--- a/modules/perc-qa-automation/frontend/tests/developer-view-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-view-editor.spec.js
@@ -30,6 +30,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 
 function developerViewsUrl() {
   const q = new URLSearchParams({
@@ -96,8 +97,6 @@ test.describe("Developer view editor (#4085 / UI-07)", () => {
   test("Admin can create and delete a standard view", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openViewsCatalog(page);
 
@@ -136,6 +135,7 @@ test.describe("Developer view editor (#4085 / UI-07)", () => {
     await createdRow.click();
     await expect(page.locator('[data-testid="developer-vw-detail"]')).toBeVisible();
     await page.locator('[data-testid="developer-vw-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-vw-panel"]')).toBeVisible({
       timeout: 20_000,
     });
@@ -149,8 +149,6 @@ test.describe("Developer view editor (#4085 / UI-07)", () => {
   test("duplicate view name 409 is surfaced in the UI", async ({ page }) => {
     test.setTimeout(120_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openViewsCatalog(page);
 
@@ -185,6 +183,7 @@ test.describe("Developer view editor (#4085 / UI-07)", () => {
     await page.locator(`[data-vw-name="${viewName}"]`).click();
     await expect(page.locator('[data-testid="developer-vw-detail"]')).toBeVisible();
     await page.locator('[data-testid="developer-vw-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-vw-panel"]')).toBeVisible({
       timeout: 20_000,
     });

--- a/modules/perc-qa-automation/frontend/tests/developer-view-field-selection.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-view-field-selection.spec.js
@@ -33,6 +33,7 @@
 
 const { test, expect } = require("@playwright/test");
 const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
 
 function developerViewsUrl() {
   const q = new URLSearchParams({
@@ -169,8 +170,6 @@ test.describe("Developer view field-selection (#4111 / UI-08)", () => {
   }) => {
     test.setTimeout(180_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
-    page.on("dialog", (dialog) => dialog.accept());
-
     await loginAsAdmin(page);
     await openViewsCatalog(page);
 
@@ -261,6 +260,7 @@ test.describe("Developer view field-selection (#4111 / UI-08)", () => {
     }
 
     await page.locator('[data-testid="developer-vw-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-vw-panel"]')).toBeVisible({
       timeout: 20_000,
     });

--- a/modules/perc-qa-automation/frontend/tests/helpers/developer-catalog-confirm.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/developer-catalog-confirm.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * In-app Developer catalog delete confirm (#4122 / 508).
+ * Native window.confirm is not used on these surfaces.
+ */
+
+"use strict";
+
+const { expect } = require("@playwright/test");
+
+/**
+ * @param {import("@playwright/test").Page} page
+ */
+async function confirmDeveloperCatalogDelete(page) {
+  const dialog = page.locator('[data-testid="developer-catalog-confirm-dialog"]');
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  await expect(dialog).toHaveAttribute("role", "dialog");
+  await expect(dialog).toHaveAttribute("aria-modal", "true");
+  await page.locator('[data-testid="developer-catalog-confirm-submit"]').click();
+}
+
+/**
+ * @param {import("@playwright/test").Page} page
+ */
+async function cancelDeveloperCatalogDelete(page) {
+  const dialog = page.locator('[data-testid="developer-catalog-confirm-dialog"]');
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  await page.locator('[data-testid="developer-catalog-confirm-cancel"]').click();
+  await expect(dialog).toHaveCount(0);
+}
+
+module.exports = {
+  confirmDeveloperCatalogDelete,
+  cancelDeveloperCatalogDelete,
+};

--- a/product-docs/8.2/admin/developer-action-menus.md
+++ b/product-docs/8.2/admin/developer-action-menus.md
@@ -41,7 +41,8 @@ detail stay **read-only**.
    name); packaged menus such as **Copy** cannot be deleted (**409**).
 5. Optional: change label, description, menu type, or URL and **Save** again.
    Child entries, parameters, properties, and visibility are not written.
-6. Click **Delete** and confirm. The catalog returns with a green **Action
+6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
+   The catalog returns with a green **Action
    menu deleted** notice and no longer lists that user menu. Delete of a
    missing menu is **404**. Delete of a **system** menu is **409** and the row
    remains. A menu still used as a dependent, or locked by another user, is

--- a/product-docs/8.2/admin/developer-communities.md
+++ b/product-docs/8.2/admin/developer-communities.md
@@ -28,7 +28,8 @@ panels (for example content types).
    non-Admin session is **403**. After a successful create, the catalog
    includes the new row when you return to the list, and the detail panel
    still offers **role membership** save.
-5. Open an existing community and click **Delete community**, then confirm.
+5. Open an existing community and click **Delete community**, then confirm
+   in the in-app dialog (not a browser prompt).
    The catalog no longer lists that name. Delete of a missing community is
    **404**. A community that is still **in use** (dependencies) is **409**
    and remains — the SPA does **not** send `ignoredependencies` and does not

--- a/product-docs/8.2/admin/developer-content-types.md
+++ b/product-docs/8.2/admin/developer-content-types.md
@@ -253,7 +253,8 @@ After **Lock**:
    following `GET /services/contenttypes/{idOrName}` includes it.
 2. Duplicate names return **409**. The lock is still held. Fix the name and
    retry, or **Unlock**.
-3. Click **Delete** on a **local** field and confirm. The product DELETEs
+3. Click **Delete** on a **local** field and confirm in the in-app dialog
+   (not a browser prompt). The product DELETEs
    `DELETE /services/contenttypes/{idOrName}/fields/{fieldName}` (`204`). The
    catalog omits that field. System and shared fields have no Delete control
    (REST **400** if you try).
@@ -427,7 +428,8 @@ design-session lock. The catalog **Delete** control stays disabled until **Lock*
 succeeds. The product does **not** steal another user's lock.
 
 1. Open the type and click **Lock**. Status becomes **Locked by you**.
-2. Click **Delete content type** and confirm. The product calls
+2. Click **Delete content type** and confirm in the in-app dialog (not a
+   browser prompt). The product calls
    `DELETE /services/contenttypes/{idOrName}`. Success is **204**; the catalog
    omits the type and a following `GET /services/contenttypes/{idOrName}` is
    **404**.

--- a/product-docs/8.2/admin/developer-display-formats.md
+++ b/product-docs/8.2/admin/developer-display-formats.md
@@ -36,7 +36,8 @@ communities.
    returns that user format (not **404**, and not a packaged format such as
    **By_Author**).
 5. Optional: change label or description and **Save** again.
-6. Click **Delete** and confirm. The catalog no longer lists that format.
+6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
+   The catalog no longer lists that format.
    Delete of a missing format is **404**. A format still used as a dependent,
    or locked by another user, is **409**. Packaged system formats that REST
    rejects stay locked; the chrome surfaces that conflict and does not steal

--- a/product-docs/8.2/admin/developer-item-filters.md
+++ b/product-docs/8.2/admin/developer-item-filters.md
@@ -34,7 +34,8 @@ are not cleared. Nested rule create/edit remain REST-only.
 5. Change the description (or parent / authtype) and **Save** again. GET
    fields already on detail (`description`, `parentFilter`, `legacyAuthtype`,
    `rules`) round-trip on save.
-6. Click **Delete** and confirm. The catalog no longer lists that filter.
+6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
+   The catalog no longer lists that filter.
    Delete of a missing filter is **404**. A filter still associated with a
    content list is **409**.
 

--- a/product-docs/8.2/admin/developer-locales.md
+++ b/product-docs/8.2/admin/developer-locales.md
@@ -32,7 +32,8 @@ detail panel.
    that the locale already exists. After a successful create, the language
    field is read-only.
 5. Change the label (or description / status / base flag) and **Save** again.
-6. Click **Delete** and confirm. The catalog no longer lists that language.
+6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
+   The catalog no longer lists that language.
    Delete of a missing locale is **404**. A locale with remaining dependents
    is **409**.
 

--- a/product-docs/8.2/admin/developer-searches.md
+++ b/product-docs/8.2/admin/developer-searches.md
@@ -45,7 +45,8 @@ full Workbench FTS query designer.
    Click **Save field criteria**. An unknown field name is **400**. A
    packaged/system search does not show the editor (PUT of `fields` is **409**
    and does not steal another user's design lock).
-7. Click **Delete** and confirm. The catalog no longer lists that search.
+7. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
+   The catalog no longer lists that search.
    Delete of a missing search is **404**. A search still used as a dependent,
    or locked by another user, is **409**.
 

--- a/product-docs/8.2/admin/developer-shared-fields.md
+++ b/product-docs/8.2/admin/developer-shared-fields.md
@@ -33,7 +33,8 @@ control-property write remain REST-only.
 4. Click **Save**. A duplicate name is **409** and the editor shows that the
    group already exists. After a successful create, you can change the
    filename (or rename) and save again.
-5. Click **Delete** and confirm. The catalog no longer lists that group.
+5. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
+   The catalog no longer lists that group.
    Delete of a missing group is **404**.
 
 ## Limits

--- a/product-docs/8.2/admin/developer-slots.md
+++ b/product-docs/8.2/admin/developer-slots.md
@@ -32,7 +32,8 @@ fields. Unlock releases the design session without saving.
    the slot already exists. An invalid name or slot type is **400**. A
    non-Admin session is **403**. After a successful create, the name field is
    read-only and the catalog includes the new row when you return to the list.
-5. Open an existing non-system slot and click **Delete**, then confirm. The
+5. Open an existing non-system slot and click **Delete**, then confirm in
+   the in-app dialog (not a browser prompt). The
    catalog no longer lists that name. Delete of a **system slot** is **409**
    (system slots cannot be deleted). Locked-by-another-user is **409**.
    Non-Admin is **403**. Missing id/name is **404**.

--- a/product-docs/8.2/admin/developer-system-def.md
+++ b/product-docs/8.2/admin/developer-system-def.md
@@ -32,7 +32,8 @@ Those remain later slices.
 5. To **save** properties, change **Searchable** or **Occurrence** on a catalog
    row and click **Save fields**. The request lock is acquired and released on
    that save. Data type and read-only stay display-only.
-6. Click **Delete** on a row and confirm. The catalog no longer lists that
+6. Click **Delete** on a row and confirm in the in-app dialog (not a
+   browser prompt). The catalog no longer lists that
    field. System-mandatory and system-internal fields cannot be deleted
    (**400**).
 

--- a/product-docs/8.2/admin/developer-views.md
+++ b/product-docs/8.2/admin/developer-views.md
@@ -39,7 +39,8 @@ rest of the `sys_cxViews` family) stay protected.
    and returning to the list still shows the row).
 5. Optional: change label, description, type, or display format id and
    **Save** again.
-6. Click **Delete** and confirm. The catalog no longer lists that view.
+6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
+   The catalog no longer lists that view.
    Delete of a missing view is **404**. Inbox-family / custom URL views have
    no Delete control. A view still used as a dependent, or locked by another
    user, is **409**.

--- a/product-docs/8.2/developer/index.md
+++ b/product-docs/8.2/developer/index.md
@@ -42,6 +42,15 @@ Operators using **Developer → Display Formats** create/delete and column add/r
 
 Operators using **Developer → Action Menus** create/delete chrome: [Developer Action Menus](id:admin-developer-action-menus).
 
+## Accessibility — delete confirm
+
+Destructive **Delete** on Developer catalog editors (Searches, Views, Display
+Formats, Item Filters, Locales, Slots, Communities, Shared Fields, Keywords,
+System definition fields, Content Types, and Action Menus) uses an **in-app
+confirm dialog**, not the browser `window.confirm` prompt. The dialog is a
+modal with a title, message, **Cancel**, and **Delete**. Screen readers can
+announce it; Escape cancels when the delete is not in progress.
+
 ## Architecture snapshot
 
 ```text


### PR DESCRIPTION
## Summary

Developer catalog destructive deletes used `window.confirm`, which blocks the screen-reader announcement queue (508/WCAG). This PR adds a shared in-app `CatalogConfirmDialog` (peer Design `DeleteTemplateDialog` + `useDialogEscape`) and routes catalog family deletes through it.

Covered: Searches, Views, Display Formats, Item Filters, Locales, Slots, Communities, Shared Fields, Keywords, System Def fields, Content Types (type + local field), Action Menus.

Cluster #4151 is merged, so Action Menu confirm is included; create/persist chrome is unchanged.

Parent tracker: #4112 / #1690.

Fixes #4122

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Vitest 3757 passed.
2. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS; `npm run test:unit` 486 passed.
3. QA H2: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `qa-health` → `qa-deploy-webui` → in-cell StopJetty/StartJetty → `qa-health`.
4. Playwright: `npm run test:surface -- --path tests/developer-catalog-delete-confirm.spec.js` — 1 passed (Locales create → in-app dialog → delete). Console-clean yes. server.log-clean yes.
5. Manual: Developer catalog Delete opens a modal (`role=dialog`, `aria-modal=true`); Escape/Cancel does not delete; Delete submits.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/index.md` a11y note and admin Developer catalog delete steps
- [x] **Unit / module tests** — CatalogConfirmDialog + panel Vitest; cancel does not delete
- [x] **WebUI + Playwright** — `tests/developer-catalog-delete-confirm.spec.js` + existing catalog editor specs click the in-app confirm
- [x] **Build gates** — standalone clean install on `WebUI` and `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** `WebUI`, `modules/perc-qa-automation`
- **build_evidence:**
  - `cd WebUI && ../mvnw.cmd clean install` → **BUILD SUCCESS**; Vitest Test Files 416 passed, Tests 3757 passed
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (Maven: no Surefire tests)
  - `cd modules/perc-qa-automation/frontend && npm run test:unit` → 486 pass / 0 fail
- **downstream_checked:** none (no Java `final`/public API shape change)

### C5 UI proof

- `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` (`QA_CMS_HOST_PORT=9993`, container `perc-matrix-cms-h2`)
- `qa-health` RESULT:OK HTTP:200 HEALTH:healthy
- Deploy: `python docker/scripts/perc-devctl.py qa-deploy-webui` then in-cell `/opt/Percussion/jetty/StopJetty.sh` + `StartJetty.sh`; `qa-health` again RESULT:OK
- Playwright: `npm run test:surface -- --path tests/developer-catalog-delete-confirm.spec.js` → **1 passed**
- console-clean=yes; server.log-clean=yes

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
