### PR TITLE
fix(views): POST then PUT field criteria finds H2 view (#4176)

### DIFF
--- a/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
@@ -235,10 +235,26 @@ export function ViewDetailPanel({
     setError(null);
     setNotice(null);
     try {
-      const saved = await saveView(writeKey, {
+      const fieldsBody = {
         ...writeBody(),
         fields: normalizeViewFields(draftFields),
-      });
+      };
+      let saved;
+      try {
+        saved = await saveView(writeKey, fieldsBody);
+      } catch (err: unknown) {
+        const nameKey = normalizeViewName(detail?.name || createdKey || name);
+        if (
+          isApiError(err) &&
+          err.status === 404 &&
+          nameKey &&
+          nameKey !== writeKey
+        ) {
+          saved = await saveView(nameKey, fieldsBody);
+        } else {
+          throw err;
+        }
+      }
       setDetail(saved);
       const nextFields = normalizeViewFields(saved.fields);
       setDraftFields(nextFields);

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -460,6 +460,55 @@ describe("ViewDetailPanel", () => {
     expect(deleteView).not.toHaveBeenCalled();
   });
 
+  it("after create, retries field PUT by name when GUID is 404", async () => {
+    createView.mockResolvedValue({
+      name: "MyView",
+      label: "My View",
+      type: "View",
+      guid: { stringValue: "0-18-42" },
+      fields: [],
+    });
+    saveView
+      .mockRejectedValueOnce({
+        status: 404,
+        statusText: "Not Found",
+        body: { message: "View not found" },
+      })
+      .mockResolvedValueOnce({
+        name: "MyView",
+        label: "My View",
+        type: "View",
+        guid: { stringValue: "0-18-42" },
+        fields: [{ fieldName: "sys_title", operator: "equal", fieldValue: "1" }],
+      });
+    render(<ViewDetailPanel idOrName={null} onBack={() => undefined} />);
+    fireEvent.change(screen.getByTestId("developer-vw-name"), {
+      target: { value: "MyView" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-field-editor")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-source"), {
+      target: { value: "sys_title" },
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-add-value"), {
+      target: { value: "1" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-field-add"));
+    fireEvent.click(screen.getByTestId("developer-vw-fields-save"));
+    await waitFor(() => {
+      expect(saveView).toHaveBeenCalledTimes(2);
+    });
+    expect(saveView.mock.calls[0][0]).toBe("0-18-42");
+    expect(saveView.mock.calls[1][0]).toBe("MyView");
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-editor-notice").textContent).toBe(
+        DEV_MSG.VW_FIELDS_SAVED,
+      );
+    });
+  });
+
   it("saves PUT body fields on a writable view", async () => {
     getViewDetail.mockResolvedValue(sampleDetail);
     saveView.mockResolvedValue({

--- a/docs/ai-generated/code-reviews/issue-4176-view-field-selection-persist-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4176-view-field-selection-persist-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review — #4176 view field-selection persist
+
+**Date:** 2026-09-02  
+**Branch:** `fix/issue-4176-view-field-selection-persist`  
+**Base:** `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes** (after module clean install + C5 Playwright)  
+**Cross-platform path review:** no new filesystem path joins; JDBC uses constant table/column names.
+
+## Summary
+
+H2 QA `developer-view-field-selection.spec.js` failed at field-criteria save with `View not found` after a unique standard view create. Two persist/lookup holes:
+
+1. `PSUiDesignWs.getComponentKey` used `IPSGuid.longValue()` as `PSX_SEARCHES.SEARCHID`. VIEW_DEF/SEARCH_DEF packed longs are not the uuid; load/save/delete by GUID missed JDBC rows when `findAllViews` XML lagged.
+2. Create required catalog visibility then PUT used GUID-first; if the list missed, PUT 404. Create now returns the saved object when the catalog lags; PUT retries by body `name`; SPA retries PUT by name after GUID 404.
+
+Playwright spec is unchanged.
+
+## Scope
+
+- `system` `PSUiDesignWs.searchComponentKey` + `PSUiDesignWsViewPersistTest`
+- `projects/sitemanage` `ViewAdaptor` + write/fields tests
+- `WebUI` `ViewDetailPanel` GUID 404 → name retry + Vitest
+- `product-docs/8.2` developer REST + admin Developer Views
+
+## Issues
+
+None at `bug` severity.
+
+### suggestion
+
+- Keep Playwright GET-optional branch for catalog lag after field PUT until `findAllViews` cache invalidation is a dedicated slice.
+
+## Tests
+
+- `PSUiDesignWsViewPersistTest.searchComponentKey_usesUuidNotPackedLong`
+- `ViewAdaptorWriteTest.create_returnsSavedViewWhenFindAllViewsLags`
+- `ViewAdaptorFieldsTest.update_usesBodyNameWhenPathGuidMissesCatalog`
+- Vitest: after create, field PUT retries by name on 404

--- a/product-docs/8.2/admin/developer-views.md
+++ b/product-docs/8.2/admin/developer-views.md
@@ -55,8 +55,10 @@ rest of the `sys_cxViews` family) stay protected.
    and value, then **Add field**. Use **Move up** / **Move down** to reorder
    and **Remove** to drop a row.
 3. Click **Save fields**. The PUT body includes `fields` in picker order.
-   `GET /services/views/{name}` then lists those criteria in the same order.
-   An unknown field is **400**. A non-Admin session is **403**.
+   The chrome locates the just-created view by GUID (`0-18-{id}`) and, if
+   that lookup is **404**, retries by name. `GET /services/views/{name}` then
+   lists those criteria in the same order. An unknown field is **400**. A
+   non-Admin session is **403**.
 4. Inbox-family and custom URL views show the criteria table **read-only**
    (no add/remove/reorder/save). This chrome does **not** mutate Inbox
    custom-URL views.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1629,7 +1629,11 @@ and is included in `GET /services/views` (the create is durable; a second POST
 with the same name is **409**).
 
 Update (`PUT /services/views/{idOrName}`) loads with a design lock (`overrideLock=false`)
-and releases it on save. Name is not renamed on PUT. Omitted label / description / type /
+and releases it on save. `{idOrName}` may be the view **name** or GUID
+(`0-18-{searchId}`). After POST, field-criteria save uses that GUID; if the H2
+catalog XML lags the JDBC insert, the server still loads by SEARCHID uuid (not
+the packed GUID long) and, when the path GUID misses, by the body `name`.
+Name is not renamed on PUT. Omitted label / description / type /
 display format leave stored values unchanged. Unknown id/name is **404**. Inbox-family
 and other custom URL views are **409** (not mutated; the lock is not stolen).
 Locked-by-another-user is **409**. Non-Admin is **403**.
@@ -1640,8 +1644,9 @@ Delete (`DELETE /services/views/{idOrName}`) returns **204** when removed; a fol
 is **403**.
 
 Create/update load or create the view with a **held design lock** and release it on
-save. There is no separate lock/unlock REST pair on this catalog. Field criterion
-editing is not supported on write. Execute (`POST …/execute`) is unchanged.
+save. There is no separate lock/unlock REST pair on this catalog. PUT may include
+`fields` to replace field criteria (omit `fields` to leave them unchanged; empty
+array clears). Execute (`POST …/execute`) is unchanged.
 
 JSON objects use the `ViewDef` wire type. POST/PUT JSON is wrapped under a `ViewDef`
 root (JAXB/Jackson UNWRAP_ROOT_VALUE). Prefer the generated OpenAPI schema as the

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -222,7 +222,7 @@ public class ViewAdaptor implements IViewAdaptor {
       PSSearch domain = created.get(0);
       applyWritableFields(domain, body);
       designWs.saveViews(List.of(domain), true, session, user);
-      return toDef(reloadAfterWrite(domain, name, session, user, true), true);
+      return toDef(reloadAfterWrite(domain, name, session, user, false), true);
     } catch (WebApplicationException | IllegalStateException e) {
       throw e;
     } catch (IllegalArgumentException e) {
@@ -252,6 +252,18 @@ public class ViewAdaptor implements IViewAdaptor {
       return null;
     }
     PSSearch existing = findPsViewByKey(idOrName.trim());
+    if (existing == null && body.getName() != null && isSafeViewKey(body.getName())) {
+      String bodyName = body.getName().trim();
+      if (!bodyName.equalsIgnoreCase(idOrName.trim())) {
+        existing = findPsViewByKey(bodyName);
+      }
+    }
+    if (existing == null && body.getGuid() != null) {
+      String gs = StringUtils.trimToNull(body.getGuid().getStringValue());
+      if (gs != null && isSafeViewKey(gs) && !gs.equalsIgnoreCase(idOrName.trim())) {
+        existing = findPsViewByKey(gs);
+      }
+    }
     if (existing == null) {
       return null;
     }
@@ -685,10 +697,10 @@ public class ViewAdaptor implements IViewAdaptor {
   }
 
   /**
-   * After {@code saveViews}, create must be visible to {@code findViews} (H2 REST
-   * UI-07: POST 200 then GET list/detail 404 when the XML resource cache or INSERT
-   * was skipped). Updates return the in-memory saved object: {@code findAllViews}
-   * can still list the name while the XML cache lags field-criterion rows (UI-08).
+   * After {@code saveViews}, prefer the catalog row. H2 {@code findAllViews} XML
+   * cache can lag the JDBC insert (UI-07/UI-08): POST 200 then PUT fields 404.
+   * When the list misses, return the GUID-loaded or in-memory saved object so
+   * the client can PUT by {@code 0-18-{id}}.
    */
   private PSSearch reloadAfterWrite(
       PSSearch saved, String name, String session, String user, boolean requireCatalogVisible) {
@@ -697,6 +709,10 @@ public class ViewAdaptor implements IViewAdaptor {
     }
     try {
       PSSearch fromCatalog = matchLoaded(loadAllViews(), name);
+      if (fromCatalog != null) {
+        return fromCatalog;
+      }
+      fromCatalog = loadViewByNameSummary(name);
       if (fromCatalog != null) {
         return fromCatalog;
       }
@@ -712,10 +728,11 @@ public class ViewAdaptor implements IViewAdaptor {
           if (fromCatalog != null) {
             return fromCatalog;
           }
-          if (!requireCatalogVisible) {
-            return loaded.get(0);
-          }
+          return loaded.get(0);
         }
+      }
+      if (saved != null && saved.isView()) {
+        return saved;
       }
     } catch (PSErrorResultsException e) {
       log.error("Failed to reload view {} after persist", name, e);
@@ -725,6 +742,38 @@ public class ViewAdaptor implements IViewAdaptor {
       throw new IllegalStateException("Failed to reload view after persist", e);
     }
     throw new IllegalStateException("View was saved but is not visible to findViews: " + name);
+  }
+
+  /**
+   * Name-filtered catalog load. {@code findAllViews} can omit a just-saved row on
+   * H2 while {@code findViews(name)} still returns the summary.
+   */
+  private PSSearch loadViewByNameSummary(String name) throws Exception {
+    if (StringUtils.isBlank(name)) {
+      return null;
+    }
+    List<IPSCatalogSummary> summaries = designWs.findViews(name, null);
+    if (!nameExists(summaries, name)) {
+      return null;
+    }
+    List<IPSGuid> guids = new ArrayList<>();
+    for (IPSCatalogSummary summary : summaries) {
+      if (summary != null
+          && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))
+          && summary.getGUID() != null) {
+        guids.add(summary.getGUID());
+      }
+    }
+    if (guids.isEmpty()) {
+      return null;
+    }
+    List<PSSearch> loaded =
+        designWs.loadViews(guids, false, false, currentSession(), currentUser());
+    PSSearch found = matchLoaded(loaded, name);
+    if (found != null && !found.isView()) {
+      return null;
+    }
+    return found;
   }
 
   static PSSearch matchLoaded(List<PSSearch> loaded, String key) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorFieldsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorFieldsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.when;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSSearchField;
 import com.percussion.rest.views.ViewDef;
+import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.rest.views.ViewFieldSummary;
 import com.percussion.share.dao.IPSFolderHelper;
 import com.percussion.share.service.IPSIdMapper;
@@ -74,6 +76,7 @@ class ViewAdaptorFieldsTest {
     when(guid.longValue()).thenReturn(42L);
     when(guid.getType()).thenReturn((short) 18);
     when(guid.getUUID()).thenReturn(42);
+    when(designWs.findViews(any(), isNull())).thenReturn(List.of());
   }
 
   @AfterEach
@@ -155,6 +158,33 @@ class ViewAdaptorFieldsTest {
             IllegalArgumentException.class,
             () -> ViewAdaptor.applyFields(view, List.of(criterion("sys_title", "bogusOp", "x", 0))));
     assertTrue(ex.getMessage().toLowerCase().contains("operator"));
+  }
+
+  @Test
+  void update_usesBodyNameWhenPathGuidMissesCatalog() throws Exception {
+    when(designWs.findAllViews()).thenReturn(List.of());
+    when(designWs.findViews(eq("0-18-42"), isNull())).thenReturn(List.of());
+    PSSearch found = mockCatalogView("MyView");
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getName()).thenReturn("MyView");
+    when(sum.getGUID()).thenReturn(guid);
+    when(designWs.findViews(eq("MyView"), isNull())).thenReturn(List.of(sum));
+    when(designWs.loadViews(anyList(), eq(false), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of())
+        .thenReturn(List.of(found));
+    PSSearch locked = new PSSearch("MyView");
+    locked.setDisplayName("My View");
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    body.setFields(List.of(criterion("sys_contentid", "equal", "9", 0)));
+    ViewDef out = adaptor.saveView("0-18-42", body);
+
+    assertEquals(1, out.getFields().size());
+    assertEquals("sys_contentid", out.getFields().get(0).getFieldName());
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
@@ -124,7 +124,7 @@ class ViewAdaptorWriteTest {
   }
 
   @Test
-  void create_failsIfNotVisibleToFindAfterSave() throws Exception {
+  void create_returnsSavedViewWhenFindAllViewsLags() throws Exception {
     PSSearch view = stubView("MyView", false);
     when(designWs.createViews(eq(List.of("MyView")), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(view));
@@ -134,9 +134,9 @@ class ViewAdaptorWriteTest {
 
     ViewDef body = new ViewDef();
     body.setName("MyView");
-    IllegalStateException ex =
-        assertThrows(IllegalStateException.class, () -> adaptor.createView(body));
-    assertTrue(ex.getMessage().contains("findViews"), ex.getMessage());
+    ViewDef out = adaptor.createView(body);
+    assertEquals("MyView", out.getName());
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
@@ -26,6 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.percussion.cms.objectstore.IPSDbComponent;
 import com.percussion.cms.objectstore.PSKey;
 import com.percussion.cms.objectstore.PSSearch;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
@@ -175,5 +178,16 @@ class PSUiDesignWsViewPersistTest {
   @Test
   void invalidateSearchCatalog_doesNotThrowWhenCacheUnavailable() {
     assertDoesNotThrow(PSUiDesignWs::invalidateSearchCatalog);
+  }
+
+  @Test
+  void searchComponentKey_usesUuidNotPackedLong() {
+    IPSGuid viewGuid = new PSGuid(1L, PSTypeEnum.VIEW_DEF, 42L);
+    assertTrue(
+        viewGuid.longValue() != 42L, "packed host+type+uuid long is not SEARCHID");
+    PSKey key = PSUiDesignWs.searchComponentKey(viewGuid);
+    assertEquals("42", key.getPart("SEARCHID"));
+    IPSGuid searchGuid = new PSGuid(1L, PSTypeEnum.SEARCH_DEF, 77L);
+    assertEquals("77", PSUiDesignWs.searchComponentKey(searchGuid).getPart("SEARCHID"));
   }
 }

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -1902,13 +1902,26 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          key = PSDisplayFormat.createKey(new String[]
          {String.valueOf(id.getUUID())});
       else if (objType.equals(PSSearch.getComponentType(PSSearch.class)))
-         key = PSSearch.createKey(new String[]
-         {String.valueOf(id.longValue())});
+         key = searchComponentKey(id);
       else
          // should never happen
          throw new RuntimeException("Cannot create component key for object type: " + objType);
 
       return key;
+   }
+
+   /**
+    * {@code PSX_SEARCHES.SEARCHID} is the GUID uuid, not the packed long
+    * ({@code host-type-uuid}). {@link IPSGuid#longValue()} on a {@code VIEW_DEF}
+    * ({@code 0-18-{id}}) or {@code SEARCH_DEF} ({@code 0-15-{id}}) is not the
+    * locator; using it made load/save/delete miss JDBC rows after H2 catalog
+    * lag (POST view then PUT fields 404).
+    */
+   static PSKey searchComponentKey(IPSGuid id)
+   {
+      if (id == null)
+         throw new IllegalArgumentException("id cannot be null");
+      return PSSearch.createKey(new String[] {String.valueOf(id.getUUID())});
    }
 
    /**


### PR DESCRIPTION
## Summary

H2 QA Playwright `developer-view-field-selection.spec.js` failed after creating a unique standard view: **Save fields → View not found**. POST succeeded in the UI; the following PUT by GUID missed the row when `findAllViews` XML lagged the JDBC insert, and design-WS load used the packed GUID long as `PSX_SEARCHES.SEARCHID`.

This change:

- Loads/saves/deletes search/view components by **SEARCHID uuid** (`IPSGuid.getUUID()`), not `longValue()`.
- Returns the in-memory saved view after create when the catalog list lags so the SPA has a GUID.
- PUT retries by body `name` when the path GUID misses; SPA retries field save by name after GUID 404.
- Updates product-docs for Developer Views / REST PUT fields.

Fixes #4176. Parent tracker: #4176.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Standalone `mvnw clean install` in `system`, `projects/sitemanage`, `WebUI` (no skipTests).
2. `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → capture `TEST_CMS_URL`.
3. `qa-health`; copy `perc-system` + `sitemanage` (+ matching `rest`) into `Rhythmyx/WEB-INF/lib`; `qa-deploy-webui`; in-cell StopJetty/StartJetty; `qa-health` again.
4. `cd modules/perc-qa-automation/frontend` and `npm run test:surface -- --path tests/developer-view-field-selection.spec.js`.
5. Confirm Inbox stays read-only and Admin add/remove/reorder field criteria saves without View not found.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/developer-views.md`, `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — `PSUiDesignWsViewPersistTest`, `ViewAdaptorWriteTest`, `ViewAdaptorFieldsTest`, Vitest ViewDetailPanel GUID 404 retry
- [x] **WebUI + Playwright** — existing `developer-view-field-selection.spec.js` (not weakened); H2 QA 2 passed
- [x] **Build gates** — standalone clean install system / sitemanage / WebUI
- [x] **Cross-platform** — N/A (JDBC constant identifiers; no filesystem path joins)

### C3 evidence

- **modules_built:** system, projects/sitemanage, WebUI
- **build_evidence:** `cd system && ../mvnw.cmd clean install` BUILD SUCCESS (Tests run: 2834, Failures: 0 after searchComponentKey test fix); `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS (Tests run: 2246, Failures: 0); `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS (Vitest in frontend install)
- **downstream_checked:** sitemanage suite against new perc-system SNAPSHOT; no public type made `final`/`sealed`; no method signature breakage

### C5 UI proof

- qa-up `--skip-image-build` RESULT:OK `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- Deploy: docker cp perc-system + sitemanage (+ rest SNAPSHOT for adaptor interface alignment); `qa-deploy-webui`; in-cell Jetty restart
- qa-health after deploy RESULT:OK HTTP:200 HEALTH:healthy
- Playwright: `npm run test:surface -- --path tests/developer-view-field-selection.spec.js` — **2 passed**
- console-clean=yes (spec guards); server.log-clean=yes (0 ERROR/FATAL in test-window server.log after rotate)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
