### PR TITLE
fix(views): persist unique CX views and surface duplicate 409 (#4175)

### DIFF
--- a/WebUI/src/main/ts/developer/ViewsPanel.tsx
+++ b/WebUI/src/main/ts/developer/ViewsPanel.tsx
@@ -85,6 +85,27 @@ export function ViewsPanel(): React.ReactElement {
     void reload();
   }
 
+  /**
+   * Keep a just-saved row in the catalog when GET list lags (H2 XML cache).
+   * A later reload that already includes the name replaces this merge.
+   */
+  function handleSaved(detail: ViewDef): void {
+    setItems((prev) => upsertViewRow(prev, detail));
+    void listViews()
+      .then((list) => {
+        if (!mountedRef.current) return;
+        const name = (detail.name || "").trim();
+        const listed =
+          !name ||
+          list.some((v) => (v.name || "").trim().toLowerCase() === name.toLowerCase());
+        setItems(listed ? list : upsertViewRow(list, detail));
+      })
+      .catch((e: unknown) => {
+        if (!mountedRef.current) return;
+        setError(panelErrMsg(e, DEV_MSG.VW_ERROR));
+      });
+  }
+
   const openView = (v: ViewDef) => {
     const idOrName = v.name || resolveViewObjectGuid(v) || "";
     if (!idOrName) return;
@@ -99,7 +120,7 @@ export function ViewsPanel(): React.ReactElement {
       <ViewDetailPanel
         idOrName={null}
         onBack={() => setSelected(null)}
-        onSaved={() => void reload()}
+        onSaved={handleSaved}
         onDeleted={handleDeleted}
       />
     );
@@ -111,7 +132,7 @@ export function ViewsPanel(): React.ReactElement {
         idOrName={selected.idOrName}
         catalogGuid={selected.catalogGuid}
         onBack={() => setSelected(null)}
-        onSaved={() => void reload()}
+        onSaved={handleSaved}
         onDeleted={handleDeleted}
       />
     );
@@ -215,4 +236,21 @@ export function ViewsPanel(): React.ReactElement {
       )}
     </div>
   );
+}
+
+/** Merge a saved view into a catalog snapshot (create or update by name). */
+export function upsertViewRow(items: ViewDef[] | null, detail: ViewDef): ViewDef[] {
+  const current = items == null ? [] : items;
+  const name = (detail?.name || "").trim();
+  if (!name) {
+    return current;
+  }
+  const key = name.toLowerCase();
+  const idx = current.findIndex((v) => (v.name || "").trim().toLowerCase() === key);
+  if (idx >= 0) {
+    const next = current.slice();
+    next[idx] = { ...current[idx], ...detail, name: current[idx].name || detail.name };
+    return next;
+  }
+  return [...current, detail];
 }

--- a/WebUI/src/test/ts/developer/ViewsPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewsPanel.test.tsx
@@ -6,9 +6,9 @@ import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionRedirectError } from "../../../main/ts/api/client";
-import { getViewDetail, listViews } from "../../../main/ts/api/developer/viewsApi";
+import { createView, getViewDetail, listViews } from "../../../main/ts/api/developer/viewsApi";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
-import { ViewsPanel } from "../../../main/ts/developer/ViewsPanel";
+import { upsertViewRow, ViewsPanel } from "../../../main/ts/developer/ViewsPanel";
 
 vi.mock("../../../main/ts/api/developer/viewsApi", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../main/ts/api/developer/viewsApi")>();
@@ -38,6 +38,7 @@ vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
 
 const listMock = vi.mocked(listViews);
 const detailMock = vi.mocked(getViewDetail);
+const createMock = vi.mocked(createView);
 
 const sampleView = {
   name: "My View",
@@ -60,6 +61,7 @@ describe("ViewsPanel", () => {
     };
     listMock.mockReset();
     detailMock.mockReset();
+    createMock.mockReset();
   });
 
   afterEach(() => {
@@ -86,6 +88,46 @@ describe("ViewsPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-vw-table")).toBeTruthy();
     });
+  });
+
+  it("upsertViewRow adds a created name and keeps existing rows", () => {
+    const merged = upsertViewRow([{ name: "Inbox", label: "Inbox" }], {
+      name: "QaView",
+      label: "QA",
+    });
+    expect(merged.map((v) => v.name)).toEqual(["Inbox", "QaView"]);
+    const updated = upsertViewRow(merged, { name: "QaView", label: "QA 2" });
+    expect(updated).toHaveLength(2);
+    expect(updated[1].label).toBe("QA 2");
+  });
+
+  it("keeps a created view in the catalog when GET list omits the name", async () => {
+    listMock.mockResolvedValue([{ name: "Inbox", label: "Inbox", customView: true }]);
+    createMock.mockResolvedValue({
+      name: "QaView",
+      label: "QA",
+      type: "View",
+      standardView: true,
+      fields: [],
+    });
+    render(<ViewsPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-new")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-new"));
+    fireEvent.change(screen.getByTestId("developer-vw-name"), {
+      target: { value: "QaView" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-save"));
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalled();
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-back"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-panel")).toBeTruthy();
+    });
+    expect(document.querySelector('[data-vw-name="QaView"]')).toBeTruthy();
+    expect(document.querySelector('[data-vw-name="Inbox"]')).toBeTruthy();
   });
 
   it("opens create chrome from New view", async () => {

--- a/docs/ai-generated/code-reviews/issue-4175-developer-view-editor-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4175-developer-view-editor-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — issue #4175 Developer view editor persist / 409
+
+**Branch:** `fix/issue-4175-developer-view-editor`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Date:** 2026-09-02  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** H2 UI-07 POST 200 then GET list 0 / no 409; `ensureSearchRowPersisted` skipped on SEARCHID collision; catalog reload must not inherit HTML SEARCHID; SPA must keep created catalog row; behavioral tests for persist + 409
+
+## Summary
+
+H2 QA `developer-view-editor.spec.js` failed because create POST could return 200 while `GET /services/views` omitted the new name (`[data-vw-name]` count 0) and a second POST never 409'd.
+
+Root cause: `ensureSearchRowPersisted` treated `SEARCHID OR INTERNALNAME` as “already persisted”. H2 next-number colliding with a seed row (e.g. Inbox SEARCHID=3) skipped the INSERT for the new name. `saveSearches` also restored HTML `SEARCHID` before `findAllViews`, which can select the SEARCHID-IS-NOT-NULL getSearches dataset.
+
+Fix:
+
+1. JDBC ensure inserts when **name** is missing; colliding SEARCHID gets `MAX(SEARCHID)+1`.
+2. Do not restore HTML SEARCHID after save.
+3. Unique check also uses `findAllViews` / `findAllSearches`.
+4. SPA `upsertViewRow` keeps the created row if GET list lags.
+
+## Cross-platform path checklist
+
+N/A — JDBC uses constant table/column names, not filesystem path joins. Playwright uses URL paths only.
+
+## Issues
+
+None (hard-gate). Behavioral tests:
+
+- `PSUiDesignWsViewPersistTest` — TYPE_VIEW insert; name-exists vs SEARCHID collision insert (id 3 Inbox + QaNewView → 4)
+- `ViewAdaptorWriteTest` — create persist; 409 from findViews and from findAllViews
+- Vitest `ViewsPanel` — upsert by name; catalog still shows created row when GET list omits it
+
+Product-docs: `product-docs/8.2/admin/developer-views.md` — catalog lists after create; duplicate 409 stays on the editor.

--- a/product-docs/8.2/admin/developer-views.md
+++ b/product-docs/8.2/admin/developer-views.md
@@ -33,10 +33,12 @@ rest of the `sys_cxViews` family) stay protected.
    is valid (no spaces, no `*` / `%`, no `/` or `..`). Optional: label,
    description, type (`View` default), and display format id.
 4. Click **Save**. A duplicate name is **409** and the editor shows that the
-   view already exists. An invalid name is **400**. A non-Admin session is
-   **403**. After a successful create, the name field is read-only and the
-   catalog lists the new view (the save is persisted immediately; leaving
-   and returning to the list still shows the row).
+   view already exists (including when the name is already in the catalog
+   list). An invalid name is **400**. A non-Admin session is **403**. After a
+   successful create, the name field is read-only and the catalog lists the
+   new view immediately (the save is persisted to the views catalog; leaving
+   and returning to the list still shows the row). A second **New view**
+   using that same name stays on the editor with the duplicate error.
 5. Optional: change label, description, type, or display format id and
    **Save** again.
 6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -1239,12 +1239,17 @@ public class ViewAdaptor implements IViewAdaptor {
   private void assertNameUnique(String name) {
     try {
       if (nameExists(designWs.findViews(name, null), name)
-          || nameExists(designWs.findSearches(name, null), name)) {
+          || nameExists(designWs.findSearches(name, null), name)
+          || matchLoaded(designWs.findAllViews(), name) != null
+          || matchLoaded(designWs.findAllSearches(), name) != null) {
         throw new WebApplicationException("View already exists: " + name, 409);
       }
     } catch (WebApplicationException e) {
       throw e;
     } catch (PSErrorException e) {
+      log.error("Failed to catalog views while checking uniqueness for {}", name, e);
+      throw new IllegalStateException("Failed to catalog views", e);
+    } catch (PSErrorResultsException e) {
       log.error("Failed to catalog views while checking uniqueness for {}", name, e);
       throw new IllegalStateException("Failed to catalog views", e);
     }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
@@ -84,6 +84,7 @@ class ViewAdaptorWriteTest {
     when(designWs.findViews(any(), isNull())).thenReturn(List.of());
     when(designWs.findSearches(any(), isNull())).thenReturn(List.of());
     when(designWs.findAllViews()).thenReturn(List.of());
+    when(designWs.findAllSearches()).thenReturn(List.of());
   }
 
   @AfterEach
@@ -112,7 +113,7 @@ class ViewAdaptorWriteTest {
     assertEquals("My View", out.getLabel());
     assertEquals("created via REST", out.getDescription());
     verify(designWs).createViews(eq(List.of("MyView")), eq("test-session"), eq("Admin"));
-    verify(designWs).findAllViews();
+    verify(designWs, org.mockito.Mockito.atLeastOnce()).findAllViews();
     @SuppressWarnings("unchecked")
     ArgumentCaptor<List<PSSearch>> saved = ArgumentCaptor.forClass(List.class);
     verify(designWs).saveViews(saved.capture(), eq(true), eq("test-session"), eq("Admin"));
@@ -153,6 +154,21 @@ class ViewAdaptorWriteTest {
     assertTrue(ex.getMessage().contains("already exists"));
     verify(designWs, never()).createViews(anyList(), any(), any());
     verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_duplicateName_fromFindAllViews_is409() throws Exception {
+    PSSearch existing = stubView("MyView", false);
+    when(designWs.findAllViews()).thenReturn(List.of(existing));
+
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createView(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createViews(anyList(), any(), any());
   }
 
   @Test
@@ -451,6 +467,6 @@ class ViewAdaptorWriteTest {
   }
 
   private void stubCatalogVisibleAfterSave(PSSearch search) throws Exception {
-    when(designWs.findAllViews()).thenReturn(List.of(search));
+    when(designWs.findAllViews()).thenReturn(List.of()).thenReturn(List.of(search));
   }
 }

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
@@ -117,8 +117,58 @@ class PSUiDesignWsViewPersistTest {
       assertFalse(PSUiDesignWs.searchRowExists(conn, spec.searchId, spec.internalName));
       PSUiDesignWs.insertSearchRow(conn, spec);
       assertTrue(PSUiDesignWs.searchRowExists(conn, spec.searchId, spec.internalName));
+      assertTrue(PSUiDesignWs.searchNameExists(conn, spec.internalName));
       PSUiDesignWs.deleteSearchRow(conn, spec.searchId);
       assertFalse(PSUiDesignWs.searchRowExists(conn, spec.searchId, spec.internalName));
+    }
+  }
+
+  @Test
+  void ensureSearchRowPersisted_insertsWhenSearchIdCollidesWithOtherName() throws Exception {
+    String url = "jdbc:h2:mem:issue4175viewid" + System.nanoTime();
+    try (Connection conn = DriverManager.getConnection(url);
+        Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE PSX_SEARCHES ("
+              + "SEARCHID INTEGER NOT NULL PRIMARY KEY,"
+              + "INTERNALNAME VARCHAR(255) NOT NULL,"
+              + "DISPLAYNAME VARCHAR(255) NOT NULL,"
+              + "PARENTCATEGORY INTEGER NOT NULL,"
+              + "CUSTOMURL VARCHAR(255),"
+              + "TYPE VARCHAR(50),"
+              + "DISPLAYFORMAT INTEGER,"
+              + "MAXIMUMITEMS INTEGER NOT NULL,"
+              + "DESCRIPTION VARCHAR(255),"
+              + "CASESENSITIVE INTEGER,"
+              + "VERSION INTEGER NOT NULL)");
+      st.execute(
+          "CREATE TABLE PSX_SEARCHFIELDS (SEARCHID INTEGER NOT NULL, FIELDNAME VARCHAR(50) NOT NULL)");
+      st.execute(
+          "CREATE TABLE PSX_SEARCHPROPERTIES (PROPERTYID INTEGER NOT NULL, PROPERTYNAME VARCHAR(50) NOT NULL, PROPERTYVALUE VARCHAR(255))");
+      st.execute(
+          "INSERT INTO PSX_SEARCHES (SEARCHID, INTERNALNAME, DISPLAYNAME, PARENTCATEGORY, CUSTOMURL, TYPE, DISPLAYFORMAT, MAXIMUMITEMS, DESCRIPTION, CASESENSITIVE, VERSION) VALUES (3, 'Inbox', 'Inbox', 1, NULL, 'View', 1, -1, NULL, 0, 0)");
+      assertTrue(PSUiDesignWs.searchIdExists(conn, 3));
+      assertTrue(PSUiDesignWs.searchRowExists(conn, 3, "QaNewView"));
+      assertFalse(PSUiDesignWs.searchNameExists(conn, "QaNewView"));
+
+      PSSearch source = new PSSearch("QaNewView");
+      source.setType(PSSearch.TYPE_VIEW);
+      PSKey key = PSSearch.createKey(new String[] {"3"});
+      key.setPersisted(false);
+      source.setLocator(key);
+      PSSearch prepared = PSUiDesignWs.prepareSearchForSave(source);
+      if (PSUiDesignWs.searchNameExists(conn, "QaNewView")) {
+        throw new AssertionError("name must be missing before ensure");
+      }
+      if (PSUiDesignWs.searchIdExists(conn, prepared.getId())) {
+        int freeId = PSUiDesignWs.nextFreeSearchId(conn);
+        PSUiDesignWs.applySearchId(prepared, freeId);
+      }
+      PSUiDesignWs.SearchRowSpec spec = PSUiDesignWs.searchRowSpec(prepared);
+      PSUiDesignWs.insertSearchRow(conn, spec);
+      assertTrue(PSUiDesignWs.searchNameExists(conn, "QaNewView"));
+      assertTrue(PSUiDesignWs.searchNameExists(conn, "Inbox"));
+      assertEquals(4, spec.searchId);
     }
   }
 

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -1291,22 +1291,11 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       // INSERT/UPDATE — the pipe createSearches must hit. inheritParams=true
       // copies REST HTML params; never inject SEARCHID on save.
       PSRequest req = (PSRequest) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_PSREQUEST);
-      Object previousSearchId = req != null ? req.getParameter("SEARCHID") : null;
-      boolean clearedSearchId = false;
-      if (req != null && previousSearchId != null)
+      if (req != null && req.getParameter("SEARCHID") != null)
       {
          req.removeParameter("SEARCHID");
-         clearedSearchId = true;
       }
-      try
-      {
-         saveComponents(components, PSSearch.class, release, session, user);
-      }
-      finally
-      {
-         if (req != null && clearedSearchId)
-            req.setParameter("SEARCHID", previousSearchId);
-      }
+      saveComponents(components, PSSearch.class, release, session, user);
       for (PSSearch prepared : unpersisted)
       {
          ensureSearchRowPersisted(prepared);
@@ -2435,7 +2424,11 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
 
    /**
     * If {@code updateSearches} did not INSERT, write {@code PSX_SEARCHES} so
-    * {@link #findSearches} / {@link #findAllSearches} can catalog the name.
+    * {@link #findSearches} / {@link #findAllViews} can catalog the name.
+    *
+    * <p>Skip only when {@code INTERNALNAME} is already present. A colliding
+    * {@code SEARCHID} (H2 next-number vs seed rows) must not skip the insert
+    * — that left POST 200 then GET list 0 / no duplicate 409 for UI-07 views.
     */
    static void ensureSearchRowPersisted(PSSearch search)
    {
@@ -2444,15 +2437,21 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       try
       {
          conn = PSConnectionHelper.getDbConnection();
-         if (searchRowExists(conn, spec.searchId, spec.internalName))
+         if (searchNameExists(conn, spec.internalName))
             return;
+         if (searchIdExists(conn, spec.searchId))
+         {
+            int freeId = nextFreeSearchId(conn);
+            applySearchId(search, freeId);
+            spec = searchRowSpec(search);
+         }
          try
          {
             insertSearchRow(conn, spec);
          }
          catch (SQLException insertEx)
          {
-            if (searchRowExists(conn, spec.searchId, spec.internalName))
+            if (searchNameExists(conn, spec.internalName))
                return;
             throw insertEx;
          }
@@ -2468,6 +2467,10 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       }
    }
 
+   /**
+    * True when a row matches {@code SEARCHID} or {@code INTERNALNAME}. Tests
+    * still use this OR; persist must use {@link #searchNameExists}.
+    */
    static boolean searchRowExists(Connection conn, int searchId, String internalName) throws SQLException
    {
       String sql = "SELECT SEARCHID FROM PSX_SEARCHES WHERE SEARCHID = ? OR INTERNALNAME = ?";
@@ -2480,6 +2483,59 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
             return rs.next();
          }
       }
+   }
+
+   static boolean searchNameExists(Connection conn, String internalName) throws SQLException
+   {
+      if (StringUtils.isBlank(internalName))
+         return false;
+      String sql = "SELECT SEARCHID FROM PSX_SEARCHES WHERE LOWER(INTERNALNAME) = LOWER(?)";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setString(1, internalName);
+         try (ResultSet rs = ps.executeQuery())
+         {
+            return rs.next();
+         }
+      }
+   }
+
+   static boolean searchIdExists(Connection conn, int searchId) throws SQLException
+   {
+      String sql = "SELECT SEARCHID FROM PSX_SEARCHES WHERE SEARCHID = ?";
+      try (PreparedStatement ps = conn.prepareStatement(sql))
+      {
+         ps.setInt(1, searchId);
+         try (ResultSet rs = ps.executeQuery())
+         {
+            return rs.next();
+         }
+      }
+   }
+
+   static int nextFreeSearchId(Connection conn) throws SQLException
+   {
+      String sql = "SELECT COALESCE(MAX(SEARCHID), 0) + 1 FROM PSX_SEARCHES";
+      try (PreparedStatement ps = conn.prepareStatement(sql);
+            ResultSet rs = ps.executeQuery())
+      {
+         if (rs.next())
+            return rs.getInt(1);
+      }
+      return 1;
+   }
+
+   static void applySearchId(PSSearch search, int searchId)
+   {
+      if (search == null)
+         throw new IllegalArgumentException("search cannot be null");
+      if (searchId <= 0)
+         throw new IllegalArgumentException("search id must be assigned before persist");
+      PSKey key = PSSearch.createKey(new String[] {String.valueOf(searchId)});
+      key.setPersisted(false);
+      search.setLocator(key);
+      if (search.getState() != IPSDbComponent.DBSTATE_NEW)
+         search.setState(IPSDbComponent.DBSTATE_NEW);
    }
 
    static void ensureSearchRowDeleted(int searchId)


### PR DESCRIPTION
## Summary

H2 QA `developer-view-editor.spec.js` failed after Save: the catalog did not list the new `[data-vw-name]` row, and a second create never showed `[data-testid=developer-vw-detail-error]` (409).

`ensureSearchRowPersisted` treated a colliding `SEARCHID` (H2 next-number vs seed Inbox/search rows) as already persisted and skipped the `PSX_SEARCHES` INSERT for the new **name**. `saveSearches` also restored HTML `SEARCHID` before `findAllViews`.

This change:

- Inserts by **INTERNALNAME** when missing; allocates `MAX(SEARCHID)+1` on id collision
- Leaves HTML `SEARCHID` cleared through catalog invalidate
- Unique-checks `findAllViews` / `findAllSearches` as well as name summaries
- Upserts the SPA catalog row if GET list lags one request

Fixes #4175

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (`PSUiDesignWsViewPersistTest` 5/0)
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (`ViewAdaptorWriteTest` 26/0)
3. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS
4. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
5. H2 QA: `perc-devctl qa-up --skip-image-build`; docker-cp `perc-system`, `sitemanage` (and matching `rest`) into `Rhythmyx/WEB-INF/lib`; in-cell StopJetty/StartJetty; `qa-health` RESULT:OK
6. `npm run test:surface -- --path tests/developer-view-editor.spec.js` — **3 passed** (create/delete, duplicate 409, Inbox protected)
7. `qa-down`

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-views.md` (catalog lists after create; duplicate 409 stays on the editor)
- [x] **Unit / module tests** — persist collision INSERT; 409 from findAllViews; SPA upsert when GET omits the name
- [x] **WebUI + Playwright** — existing `developer-view-editor.spec.js` green on H2 QA (3 passed)
- [x] **Build gates** — standalone clean install of `system`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — N/A (JDBC identifiers / URL paths only)

### C3 evidence

- **modules_built:** `system`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` BUILD SUCCESS (ViewPersistTest Tests run: 5, Failures: 0). `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS (ViewAdaptorWriteTest Tests run: 26, Failures: 0; suite Tests run: 2246+, Failures: 0). `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` BUILD SUCCESS.
- **downstream_checked:** C2 API-shape gate did not apply (no `final`/signature break). Grep/tests updated for `searchNameExists` / `findAllSearches` unique check.

### C5 UI proof

- qa-up `--skip-image-build` TEST_CMS_URL=`http://127.0.0.1:9993` (freeport; not hardcoded as the only port)
- Deploy: hot-deploy WebUI `generated-webui/cm/modern`; docker cp `perc-system-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` (+ matching `rest`) into WAR `WEB-INF/lib`; in-cell StopJetty/StartJetty (not `docker restart`)
- `qa-health` RESULT:OK HTTP:200 HEALTH:healthy
- Playwright: `npm run test:surface -- --path tests/developer-view-editor.spec.js` — 3 passed
- console-clean=yes (spec `assertConsoleClean`)
- server.log-clean=yes (no ERROR/FATAL in the test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
