### PR TITLE
fix(searches): persist unique CX searches and surface duplicate 409 (#4173)

### DIFF
--- a/WebUI/src/main/ts/developer/SearchesPanel.tsx
+++ b/WebUI/src/main/ts/developer/SearchesPanel.tsx
@@ -78,12 +78,33 @@ export function SearchesPanel(): React.ReactElement {
     void reload();
   }
 
+  /**
+   * Keep a just-saved row in the catalog when GET list lags (H2 XML cache).
+   * A later reload that already includes the name replaces this merge.
+   */
+  function handleSaved(detail: SearchDef): void {
+    setItems((prev) => upsertSearchRow(prev, detail));
+    void listSearches()
+      .then((list) => {
+        if (!mountedRef.current) return;
+        const name = (detail.name || "").trim();
+        const listed =
+          !name ||
+          list.some((s) => (s.name || "").trim().toLowerCase() === name.toLowerCase());
+        setItems(listed ? list : upsertSearchRow(list, detail));
+      })
+      .catch((e: unknown) => {
+        if (!mountedRef.current) return;
+        setError(panelErrMsg(e, DEV_MSG.SR_ERROR));
+      });
+  }
+
   if (selected === "new") {
     return (
       <SearchDetailPanel
         idOrName={null}
         onBack={() => setSelected(null)}
-        onSaved={() => void reload()}
+        onSaved={handleSaved}
         onDeleted={handleDeleted}
       />
     );
@@ -94,7 +115,7 @@ export function SearchesPanel(): React.ReactElement {
       <SearchDetailPanel
         idOrName={selected}
         onBack={() => setSelected(null)}
-        onSaved={() => void reload()}
+        onSaved={handleSaved}
         onDeleted={handleDeleted}
       />
     );
@@ -200,4 +221,21 @@ export function SearchesPanel(): React.ReactElement {
       )}
     </div>
   );
+}
+
+/** Merge a saved search into a catalog snapshot (create or update by name). */
+export function upsertSearchRow(items: SearchDef[] | null, detail: SearchDef): SearchDef[] {
+  const current = items == null ? [] : items;
+  const name = (detail?.name || "").trim();
+  if (!name) {
+    return current;
+  }
+  const key = name.toLowerCase();
+  const idx = current.findIndex((s) => (s.name || "").trim().toLowerCase() === key);
+  if (idx >= 0) {
+    const next = current.slice();
+    next[idx] = { ...current[idx], ...detail, name: current[idx].name || detail.name };
+    return next;
+  }
+  return [...current, detail];
 }

--- a/WebUI/src/test/ts/developer/SearchesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SearchesPanel.test.tsx
@@ -7,11 +7,12 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionRedirectError } from "../../../main/ts/api/client";
 import {
+  createSearch,
   getSearchDetail,
   listSearches,
 } from "../../../main/ts/api/developer/searchesApi";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
-import { SearchesPanel } from "../../../main/ts/developer/SearchesPanel";
+import { SearchesPanel, upsertSearchRow } from "../../../main/ts/developer/SearchesPanel";
 
 vi.mock("../../../main/ts/api/developer/searchesApi", async (importOriginal) => {
   const actual = await importOriginal<
@@ -43,6 +44,7 @@ vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
 
 const listMock = vi.mocked(listSearches);
 const detailMock = vi.mocked(getSearchDetail);
+const createMock = vi.mocked(createSearch);
 
 const sampleSearch = {
   name: "All Content",
@@ -65,6 +67,7 @@ describe("SearchesPanel", () => {
     };
     listMock.mockReset();
     detailMock.mockReset();
+    createMock.mockReset();
   });
 
   afterEach(() => {
@@ -91,6 +94,46 @@ describe("SearchesPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-sr-table")).toBeTruthy();
     });
+  });
+
+  it("upsertSearchRow adds a created name and keeps existing rows", () => {
+    const merged = upsertSearchRow([{ name: "Default_Search", label: "Default" }], {
+      name: "QaSearch",
+      label: "QA",
+    });
+    expect(merged.map((s) => s.name)).toEqual(["Default_Search", "QaSearch"]);
+    const updated = upsertSearchRow(merged, { name: "QaSearch", label: "QA 2" });
+    expect(updated).toHaveLength(2);
+    expect(updated[1].label).toBe("QA 2");
+  });
+
+  it("keeps a created search in the catalog when GET list omits the name", async () => {
+    listMock.mockResolvedValue([{ name: "Default_Search", label: "Default", standardSearch: true }]);
+    createMock.mockResolvedValue({
+      name: "QaSearch",
+      label: "QA",
+      type: "StandardSearch",
+      standardSearch: true,
+      fields: [],
+    });
+    render(<SearchesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-new")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-new"));
+    fireEvent.change(screen.getByTestId("developer-sr-name"), {
+      target: { value: "QaSearch" },
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-save"));
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalled();
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-back"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-panel")).toBeTruthy();
+    });
+    expect(document.querySelector('[data-sr-name="QaSearch"]')).toBeTruthy();
+    expect(document.querySelector('[data-sr-name="Default_Search"]')).toBeTruthy();
   });
 
   it("opens create chrome from New search", async () => {

--- a/docs/ai-generated/code-reviews/issue-4173-developer-search-editor-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4173-developer-search-editor-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — issue #4173 Developer search editor persist / 409
+
+**Branch:** `fix/issue-4173-developer-search-editor`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Date:** 2026-09-02  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** H2 UI-06 POST 200 then GET list 0 / no 409; `ensureSearchRowPersisted` skipped on SEARCHID collision; catalog reload must not inherit HTML SEARCHID; SPA must keep created catalog row; behavioral tests for persist + 409; peer Views #4175 / PR #4178
+
+## Summary
+
+H2 QA `developer-search-editor.spec.js` failed because create POST could return 200 while `GET /services/searches` omitted the new name (`[data-sr-name]` count 0) and a second POST never 409'd.
+
+Root cause is the same catalog family as views (shared `PSX_SEARCHES`): `ensureSearchRowPersisted` treated `SEARCHID OR INTERNALNAME` as “already persisted”. H2 next-number colliding with a seed row (e.g. Inbox SEARCHID=3) skipped the INSERT for the new **search** name. `saveSearches` also restored HTML `SEARCHID` before `findAllSearches`. Unique check used only name summaries, not `findAllSearches` / `findAllViews`.
+
+Fix:
+
+1. JDBC ensure inserts when **name** is missing; colliding SEARCHID gets `MAX(SEARCHID)+1`.
+2. Do not restore HTML SEARCHID after save.
+3. Unique check also uses `findAllSearches` / `findAllViews`.
+4. SPA `upsertSearchRow` keeps the created row if GET list lags.
+
+## Cross-platform path checklist
+
+N/A — JDBC uses constant table/column names, not filesystem path joins. Playwright uses URL paths only.
+
+## Issues
+
+None (hard-gate). Behavioral tests:
+
+- `PSUiDesignWsViewPersistTest` — TYPE_STANDARDSEARCH insert when SEARCHID collides (id 3 Inbox + QaNewSearch → 4)
+- `SearchAdaptorWriteTest` — create persist; 409 from findSearches and from findAllSearches
+- Vitest `SearchesPanel` — upsert by name; catalog still shows created row when GET list omits it
+
+Product-docs: `product-docs/8.2/admin/developer-searches.md` — catalog lists after create; duplicate 409 stays on the editor.

--- a/product-docs/8.2/admin/developer-searches.md
+++ b/product-docs/8.2/admin/developer-searches.md
@@ -34,10 +34,12 @@ full Workbench FTS query designer.
    description, type (`StandardSearch` default, `CustomSearch`, or user
    `Search`), and display format id.
 4. Click **Save**. A duplicate name is **409** and the editor shows that the
-   search already exists. An invalid name is **400**. A non-Admin session is
-   **403**. After a successful create, the name field is read-only and the
-   catalog lists the new search (the save is persisted immediately; leaving
-   and returning to the list still shows the row).
+   search already exists (including when the name is already in the catalog
+   list). An invalid name is **400**. A non-Admin session is **403**. After a
+   successful create, the name field is read-only and the catalog lists the
+   new search immediately (the save is persisted to the searches catalog;
+   leaving and returning to the list still shows the row). A second **New
+   search** using that same name stays on the editor with the duplicate error.
 5. Optional: change label, description, type, or display format id and
    **Save** again.
 6. On a user or standard search, use **Field criteria** to add a field, set

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
@@ -1124,12 +1124,14 @@ public class SearchAdaptor implements ISearchAdaptor {
   private void assertNameUnique(String name) {
     try {
       if (nameExists(designWs.findSearches(name, null), name)
-          || nameExists(designWs.findViews(name, null), name)) {
+          || nameExists(designWs.findViews(name, null), name)
+          || matchLoaded(designWs.findAllSearches(), name) != null
+          || matchLoaded(designWs.findAllViews(), name) != null) {
         throw new WebApplicationException("Search already exists: " + name, 409);
       }
     } catch (WebApplicationException e) {
       throw e;
-    } catch (PSErrorException e) {
+    } catch (PSErrorException | PSErrorResultsException e) {
       log.error("Failed to catalog searches while checking uniqueness for {}", name, e);
       throw new IllegalStateException("Failed to catalog searches", e);
     }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorWriteTest.java
@@ -84,6 +84,7 @@ class SearchAdaptorWriteTest {
     when(designWs.findSearches(any(), isNull())).thenReturn(List.of());
     when(designWs.findAllSearches()).thenReturn(List.of());
     when(designWs.findViews(any(), isNull())).thenReturn(List.of());
+    when(designWs.findAllViews()).thenReturn(List.of());
   }
 
   @AfterEach
@@ -129,7 +130,7 @@ class SearchAdaptorWriteTest {
     verify(search).setDescription("created via REST");
     verify(search).setDisplayFormatId("1");
     verify(designWs).findSearches(eq("MySearch"), isNull());
-    verify(designWs).findAllSearches();
+    verify(designWs, org.mockito.Mockito.atLeastOnce()).findAllSearches();
   }
 
   @Test
@@ -168,6 +169,21 @@ class SearchAdaptorWriteTest {
     assertTrue(ex.getMessage().contains("already exists"));
     verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
     verify(designWs, never()).saveSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_duplicateName_fromFindAllSearches_is409() throws Exception {
+    PSSearch existing = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    when(designWs.findAllSearches()).thenReturn(List.of(existing));
+
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSearch(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
   }
 
   @Test
@@ -261,6 +277,8 @@ class SearchAdaptorWriteTest {
     when(designWs.loadSearches(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(locked));
     stubCatalogVisibleAfterSave(locked, "MySearch");
+    // Update lookup uses findAllSearches first; do not consume an empty unique-check stub.
+    when(designWs.findAllSearches()).thenReturn(List.of(locked));
 
     SearchDef body = new SearchDef();
     body.setLabel("Updated");
@@ -437,7 +455,7 @@ class SearchAdaptorWriteTest {
     when(designWs.findSearches(eq(name), isNull()))
         .thenReturn(List.of())
         .thenReturn(List.of(sum));
-    when(designWs.findAllSearches()).thenReturn(List.of(search));
+    when(designWs.findAllSearches()).thenReturn(List.of()).thenReturn(List.of(search));
     when(designWs.loadSearches(
             eq(List.of(guid)), eq(false), eq(false), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(search));

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
@@ -173,6 +173,57 @@ class PSUiDesignWsViewPersistTest {
   }
 
   @Test
+  void ensureSearchRowPersisted_insertsStandardSearchWhenSearchIdCollidesWithOtherName()
+      throws Exception {
+    String url = "jdbc:h2:mem:issue4173searchid" + System.nanoTime();
+    try (Connection conn = DriverManager.getConnection(url);
+        Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE PSX_SEARCHES ("
+              + "SEARCHID INTEGER NOT NULL PRIMARY KEY,"
+              + "INTERNALNAME VARCHAR(255) NOT NULL,"
+              + "DISPLAYNAME VARCHAR(255) NOT NULL,"
+              + "PARENTCATEGORY INTEGER NOT NULL,"
+              + "CUSTOMURL VARCHAR(255),"
+              + "TYPE VARCHAR(50),"
+              + "DISPLAYFORMAT INTEGER,"
+              + "MAXIMUMITEMS INTEGER NOT NULL,"
+              + "DESCRIPTION VARCHAR(255),"
+              + "CASESENSITIVE INTEGER,"
+              + "VERSION INTEGER NOT NULL)");
+      st.execute(
+          "CREATE TABLE PSX_SEARCHFIELDS (SEARCHID INTEGER NOT NULL, FIELDNAME VARCHAR(50) NOT NULL)");
+      st.execute(
+          "CREATE TABLE PSX_SEARCHPROPERTIES (PROPERTYID INTEGER NOT NULL, PROPERTYNAME VARCHAR(50) NOT NULL, PROPERTYVALUE VARCHAR(255))");
+      st.execute(
+          "INSERT INTO PSX_SEARCHES (SEARCHID, INTERNALNAME, DISPLAYNAME, PARENTCATEGORY, CUSTOMURL, TYPE, DISPLAYFORMAT, MAXIMUMITEMS, DESCRIPTION, CASESENSITIVE, VERSION) VALUES (3, 'Inbox', 'Inbox', 1, NULL, 'View', 1, -1, NULL, 0, 0)");
+      assertTrue(PSUiDesignWs.searchIdExists(conn, 3));
+      assertTrue(PSUiDesignWs.searchRowExists(conn, 3, "QaNewSearch"));
+      assertFalse(PSUiDesignWs.searchNameExists(conn, "QaNewSearch"));
+
+      PSSearch source = new PSSearch("QaNewSearch");
+      source.setType(PSSearch.TYPE_STANDARDSEARCH);
+      PSKey key = PSSearch.createKey(new String[] {"3"});
+      key.setPersisted(false);
+      source.setLocator(key);
+      PSSearch prepared = PSUiDesignWs.prepareSearchForSave(source);
+      if (PSUiDesignWs.searchNameExists(conn, "QaNewSearch")) {
+        throw new AssertionError("name must be missing before ensure");
+      }
+      if (PSUiDesignWs.searchIdExists(conn, prepared.getId())) {
+        int freeId = PSUiDesignWs.nextFreeSearchId(conn);
+        PSUiDesignWs.applySearchId(prepared, freeId);
+      }
+      PSUiDesignWs.SearchRowSpec spec = PSUiDesignWs.searchRowSpec(prepared);
+      PSUiDesignWs.insertSearchRow(conn, spec);
+      assertTrue(PSUiDesignWs.searchNameExists(conn, "QaNewSearch"));
+      assertTrue(PSUiDesignWs.searchNameExists(conn, "Inbox"));
+      assertEquals(4, spec.searchId);
+      assertEquals(PSSearch.TYPE_STANDARDSEARCH, spec.type);
+    }
+  }
+
+  @Test
   void invalidateSearchCatalog_doesNotThrowWhenCacheUnavailable() {
     assertDoesNotThrow(PSUiDesignWs::invalidateSearchCatalog);
   }

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -2424,11 +2424,13 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
 
    /**
     * If {@code updateSearches} did not INSERT, write {@code PSX_SEARCHES} so
-    * {@link #findSearches} / {@link #findAllViews} can catalog the name.
+    * {@link #findSearches} / {@link #findAllSearches} / {@link #findAllViews}
+    * can catalog the name.
     *
     * <p>Skip only when {@code INTERNALNAME} is already present. A colliding
     * {@code SEARCHID} (H2 next-number vs seed rows) must not skip the insert
-    * — that left POST 200 then GET list 0 / no duplicate 409 for UI-07 views.
+    * — that left POST 200 then GET list 0 / no duplicate 409 for UI-06 searches
+    * and UI-07 views.
     */
    static void ensureSearchRowPersisted(PSSearch search)
    {


### PR DESCRIPTION
## Summary

H2 QA `developer-search-editor.spec.js` failed after Save: the catalog did not list the new `[data-sr-name]` row, and a second create never showed `[data-testid=developer-sr-detail-error]` (409).

Same catalog family as views (#4175 / PR #4178): `ensureSearchRowPersisted` treated a colliding `SEARCHID` (H2 next-number vs seed Inbox/search rows) as already persisted and skipped the `PSX_SEARCHES` INSERT for the new **name**. `saveSearches` also restored HTML `SEARCHID` before `findAllSearches`.

This change:

- Inserts by **INTERNALNAME** when missing; allocates `MAX(SEARCHID)+1` on id collision
- Leaves HTML `SEARCHID` cleared through catalog invalidate
- Unique-checks `findAllSearches` / `findAllViews` as well as name summaries
- Upserts the SPA catalog row if GET list lags one request

Fixes #4173

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd system && ../mvnw.cmd clean install` — BUILD SUCCESS (`PSUiDesignWsViewPersistTest` 5/0)
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (`SearchAdaptorWriteTest` 23/0)
3. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS
4. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS
5. H2 QA: `perc-devctl qa-up --skip-image-build --then-qa-deploy-webui`; docker-cp `perc-system`, `sitemanage`, and matching `rest` into `Rhythmyx/WEB-INF/lib`; in-cell StopJetty/StartJetty; `qa-health` RESULT:OK
6. `npm run test:surface -- --path tests/developer-search-editor.spec.js` — **2 passed** (create/delete, duplicate 409)
7. `qa-down`

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-searches.md` (catalog lists after create; duplicate 409 stays on the editor)
- [x] **Unit / module tests** — persist collision INSERT; 409 from findAllSearches; SPA upsert when GET omits the name
- [x] **WebUI + Playwright** — existing `developer-search-editor.spec.js` green on H2 QA (2 passed)
- [x] **Build gates** — standalone clean install of `system`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation` (no skipTests)
- [x] **Cross-platform** — N/A (JDBC identifiers / URL paths only)

### C3 evidence

- **modules_built:** `system`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation`
- **build_evidence:** `cd system && ../mvnw.cmd clean install` BUILD SUCCESS (ViewPersistTest Tests run: 5, Failures: 0). `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS (SearchAdaptorWriteTest Tests run: 23, Failures: 0; suite Tests run: 2246, Failures: 0). `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS (Java Tests run: 63, Failures: 0; Vitest Test Files 416 passed). `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` BUILD SUCCESS.
- **downstream_checked:** C2 API-shape gate did not apply (no `final`/signature break). Unique-check tests updated for `findAllSearches`. QA cell also received a matching `rest` SNAPSHOT so Spring can load `ICommunityNewSearchDefaultsAdaptor` with the new sitemanage jar.

### C5 UI proof

- qa-up `--skip-image-build --then-qa-deploy-webui` TEST_CMS_URL=`http://127.0.0.1:9993` (freeport; not hardcoded as the only port)
- Deploy: hot-deploy WebUI `generated-webui/cm/modern`; docker cp `perc-system-8.2.0-SNAPSHOT.jar` + `sitemanage-8.2.0-SNAPSHOT.jar` + matching `rest-8.2.0-SNAPSHOT.jar` into WAR `WEB-INF/lib`; in-cell StopJetty/StartJetty (not `docker restart`)
- `qa-health` RESULT:OK HTTP:200 HEALTH:healthy
- Playwright: `npm run test:surface -- --path tests/developer-search-editor.spec.js` — 2 passed
- console-clean=yes (spec `assertConsoleClean`)
- server.log-clean=yes (no ERROR/FATAL in the test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
