### PR TITLE
cluster: absorb CX persist PRs #4177 #4180 #4181 (PSUiDesignWs)

### DIFF
--- a/WebUI/src/main/ts/developer/SearchesPanel.tsx
+++ b/WebUI/src/main/ts/developer/SearchesPanel.tsx
@@ -78,12 +78,33 @@ export function SearchesPanel(): React.ReactElement {
     void reload();
   }
 
+  /**
+   * Keep a just-saved row in the catalog when GET list lags (H2 XML cache).
+   * A later reload that already includes the name replaces this merge.
+   */
+  function handleSaved(detail: SearchDef): void {
+    setItems((prev) => upsertSearchRow(prev, detail));
+    void listSearches()
+      .then((list) => {
+        if (!mountedRef.current) return;
+        const name = (detail.name || "").trim();
+        const listed =
+          !name ||
+          list.some((s) => (s.name || "").trim().toLowerCase() === name.toLowerCase());
+        setItems(listed ? list : upsertSearchRow(list, detail));
+      })
+      .catch((e: unknown) => {
+        if (!mountedRef.current) return;
+        setError(panelErrMsg(e, DEV_MSG.SR_ERROR));
+      });
+  }
+
   if (selected === "new") {
     return (
       <SearchDetailPanel
         idOrName={null}
         onBack={() => setSelected(null)}
-        onSaved={() => void reload()}
+        onSaved={handleSaved}
         onDeleted={handleDeleted}
       />
     );
@@ -94,7 +115,7 @@ export function SearchesPanel(): React.ReactElement {
       <SearchDetailPanel
         idOrName={selected}
         onBack={() => setSelected(null)}
-        onSaved={() => void reload()}
+        onSaved={handleSaved}
         onDeleted={handleDeleted}
       />
     );
@@ -200,4 +221,21 @@ export function SearchesPanel(): React.ReactElement {
       )}
     </div>
   );
+}
+
+/** Merge a saved search into a catalog snapshot (create or update by name). */
+export function upsertSearchRow(items: SearchDef[] | null, detail: SearchDef): SearchDef[] {
+  const current = items == null ? [] : items;
+  const name = (detail?.name || "").trim();
+  if (!name) {
+    return current;
+  }
+  const key = name.toLowerCase();
+  const idx = current.findIndex((s) => (s.name || "").trim().toLowerCase() === key);
+  if (idx >= 0) {
+    const next = current.slice();
+    next[idx] = { ...current[idx], ...detail, name: current[idx].name || detail.name };
+    return next;
+  }
+  return [...current, detail];
 }

--- a/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
@@ -88,6 +88,12 @@ function typeFromDetail(detail: ViewDef | null, fallback: string): string {
   return fallback;
 }
 
+/** CX view GUID wire shape {@code host-18-uuid} used after create catalog lag. */
+function isViewGuidWriteKey(key: string | null | undefined): boolean {
+  if (!key) return false;
+  return /^\d+-18-\d+$/.test(key.trim());
+}
+
 export function ViewDetailPanel({
   idOrName,
   catalogGuid,
@@ -244,12 +250,20 @@ export function ViewDetailPanel({
         saved = await saveView(writeKey, fieldsBody);
       } catch (err: unknown) {
         const nameKey = normalizeViewName(detail?.name || createdKey || name);
+        const guidWrite = isViewGuidWriteKey(writeKey);
         if (
           isApiError(err) &&
           err.status === 404 &&
+          guidWrite &&
+          createdKey != null &&
           nameKey &&
           nameKey !== writeKey
         ) {
+          console.info(
+            "View field save 404 on create GUID, retrying by name",
+            writeKey,
+            nameKey,
+          );
           saved = await saveView(nameKey, fieldsBody);
         } else {
           throw err;

--- a/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
@@ -235,10 +235,26 @@ export function ViewDetailPanel({
     setError(null);
     setNotice(null);
     try {
-      const saved = await saveView(writeKey, {
+      const fieldsBody = {
         ...writeBody(),
         fields: normalizeViewFields(draftFields),
-      });
+      };
+      let saved;
+      try {
+        saved = await saveView(writeKey, fieldsBody);
+      } catch (err: unknown) {
+        const nameKey = normalizeViewName(detail?.name || createdKey || name);
+        if (
+          isApiError(err) &&
+          err.status === 404 &&
+          nameKey &&
+          nameKey !== writeKey
+        ) {
+          saved = await saveView(nameKey, fieldsBody);
+        } else {
+          throw err;
+        }
+      }
       setDetail(saved);
       const nextFields = normalizeViewFields(saved.fields);
       setDraftFields(nextFields);

--- a/WebUI/src/test/ts/developer/SearchesPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SearchesPanel.test.tsx
@@ -7,11 +7,12 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionRedirectError } from "../../../main/ts/api/client";
 import {
+  createSearch,
   getSearchDetail,
   listSearches,
 } from "../../../main/ts/api/developer/searchesApi";
 import { DEV_MSG } from "../../../main/ts/developer/messages";
-import { SearchesPanel } from "../../../main/ts/developer/SearchesPanel";
+import { SearchesPanel, upsertSearchRow } from "../../../main/ts/developer/SearchesPanel";
 
 vi.mock("../../../main/ts/api/developer/searchesApi", async (importOriginal) => {
   const actual = await importOriginal<
@@ -43,6 +44,7 @@ vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
 
 const listMock = vi.mocked(listSearches);
 const detailMock = vi.mocked(getSearchDetail);
+const createMock = vi.mocked(createSearch);
 
 const sampleSearch = {
   name: "All Content",
@@ -65,6 +67,7 @@ describe("SearchesPanel", () => {
     };
     listMock.mockReset();
     detailMock.mockReset();
+    createMock.mockReset();
   });
 
   afterEach(() => {
@@ -91,6 +94,46 @@ describe("SearchesPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-sr-table")).toBeTruthy();
     });
+  });
+
+  it("upsertSearchRow adds a created name and keeps existing rows", () => {
+    const merged = upsertSearchRow([{ name: "Default_Search", label: "Default" }], {
+      name: "QaSearch",
+      label: "QA",
+    });
+    expect(merged.map((s) => s.name)).toEqual(["Default_Search", "QaSearch"]);
+    const updated = upsertSearchRow(merged, { name: "QaSearch", label: "QA 2" });
+    expect(updated).toHaveLength(2);
+    expect(updated[1].label).toBe("QA 2");
+  });
+
+  it("keeps a created search in the catalog when GET list omits the name", async () => {
+    listMock.mockResolvedValue([{ name: "Default_Search", label: "Default", standardSearch: true }]);
+    createMock.mockResolvedValue({
+      name: "QaSearch",
+      label: "QA",
+      type: "StandardSearch",
+      standardSearch: true,
+      fields: [],
+    });
+    render(<SearchesPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-new")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-new"));
+    fireEvent.change(screen.getByTestId("developer-sr-name"), {
+      target: { value: "QaSearch" },
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-save"));
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalled();
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-back"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-panel")).toBeTruthy();
+    });
+    expect(document.querySelector('[data-sr-name="QaSearch"]')).toBeTruthy();
+    expect(document.querySelector('[data-sr-name="Default_Search"]')).toBeTruthy();
   });
 
   it("opens create chrome from New search", async () => {

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -555,6 +555,32 @@ describe("ViewDetailPanel", () => {
     });
   });
 
+  it("does not retry field PUT 404 by name on an existing view", async () => {
+    getViewDetail.mockResolvedValue(sampleDetail);
+    saveView.mockRejectedValue({
+      status: 404,
+      statusText: "Not Found",
+      body: { message: "View not found" },
+    });
+    render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-field-editor")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-source"), {
+      target: { value: "sys_title" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-field-add"));
+    fireEvent.click(screen.getByTestId("developer-vw-fields-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
+    });
+    expect(saveView).toHaveBeenCalledTimes(1);
+    expect(saveView.mock.calls[0][0]).toBe("0-27-3");
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toContain(
+      DEV_MSG.VW_NOT_FOUND,
+    );
+  });
+
   it("surfaces 400 invalid field from PUT", async () => {
     getViewDetail.mockResolvedValue(sampleDetail);
     saveView.mockRejectedValue({

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -460,6 +460,55 @@ describe("ViewDetailPanel", () => {
     expect(deleteView).not.toHaveBeenCalled();
   });
 
+  it("after create, retries field PUT by name when GUID is 404", async () => {
+    createView.mockResolvedValue({
+      name: "MyView",
+      label: "My View",
+      type: "View",
+      guid: { stringValue: "0-18-42" },
+      fields: [],
+    });
+    saveView
+      .mockRejectedValueOnce({
+        status: 404,
+        statusText: "Not Found",
+        body: { message: "View not found" },
+      })
+      .mockResolvedValueOnce({
+        name: "MyView",
+        label: "My View",
+        type: "View",
+        guid: { stringValue: "0-18-42" },
+        fields: [{ fieldName: "sys_title", operator: "equal", fieldValue: "1" }],
+      });
+    render(<ViewDetailPanel idOrName={null} onBack={() => undefined} />);
+    fireEvent.change(screen.getByTestId("developer-vw-name"), {
+      target: { value: "MyView" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-field-editor")).toBeTruthy();
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-source"), {
+      target: { value: "sys_title" },
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-field-add-value"), {
+      target: { value: "1" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-field-add"));
+    fireEvent.click(screen.getByTestId("developer-vw-fields-save"));
+    await waitFor(() => {
+      expect(saveView).toHaveBeenCalledTimes(2);
+    });
+    expect(saveView.mock.calls[0][0]).toBe("0-18-42");
+    expect(saveView.mock.calls[1][0]).toBe("MyView");
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-editor-notice").textContent).toBe(
+        DEV_MSG.VW_FIELDS_SAVED,
+      );
+    });
+  });
+
   it("saves PUT body fields on a writable view", async () => {
     getViewDetail.mockResolvedValue(sampleDetail);
     saveView.mockResolvedValue({

--- a/docs/ai-generated/code-reviews/issue-4173-developer-search-editor-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4173-developer-search-editor-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — issue #4173 Developer search editor persist / 409
+
+**Branch:** `fix/issue-4173-developer-search-editor`  
+**Scope:** uncommitted vs `HEAD` / `origin/main`  
+**Date:** 2026-09-02  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** H2 UI-06 POST 200 then GET list 0 / no 409; `ensureSearchRowPersisted` skipped on SEARCHID collision; catalog reload must not inherit HTML SEARCHID; SPA must keep created catalog row; behavioral tests for persist + 409; peer Views #4175 / PR #4178
+
+## Summary
+
+H2 QA `developer-search-editor.spec.js` failed because create POST could return 200 while `GET /services/searches` omitted the new name (`[data-sr-name]` count 0) and a second POST never 409'd.
+
+Root cause is the same catalog family as views (shared `PSX_SEARCHES`): `ensureSearchRowPersisted` treated `SEARCHID OR INTERNALNAME` as “already persisted”. H2 next-number colliding with a seed row (e.g. Inbox SEARCHID=3) skipped the INSERT for the new **search** name. `saveSearches` also restored HTML `SEARCHID` before `findAllSearches`. Unique check used only name summaries, not `findAllSearches` / `findAllViews`.
+
+Fix:
+
+1. JDBC ensure inserts when **name** is missing; colliding SEARCHID gets `MAX(SEARCHID)+1`.
+2. Do not restore HTML SEARCHID after save.
+3. Unique check also uses `findAllSearches` / `findAllViews`.
+4. SPA `upsertSearchRow` keeps the created row if GET list lags.
+
+## Cross-platform path checklist
+
+N/A — JDBC uses constant table/column names, not filesystem path joins. Playwright uses URL paths only.
+
+## Issues
+
+None (hard-gate). Behavioral tests:
+
+- `PSUiDesignWsViewPersistTest` — TYPE_STANDARDSEARCH insert when SEARCHID collides (id 3 Inbox + QaNewSearch → 4)
+- `SearchAdaptorWriteTest` — create persist; 409 from findSearches and from findAllSearches
+- Vitest `SearchesPanel` — upsert by name; catalog still shows created row when GET list omits it
+
+Product-docs: `product-docs/8.2/admin/developer-searches.md` — catalog lists after create; duplicate 409 stays on the editor.

--- a/docs/ai-generated/code-reviews/issue-4176-view-field-selection-persist-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4176-view-field-selection-persist-erlang.md
@@ -1,0 +1,39 @@
+# Erlang review — #4176 view field-selection persist
+
+**Date:** 2026-09-02  
+**Branch:** `fix/issue-4176-view-field-selection-persist`  
+**Base:** `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: **yes** (after module clean install + C5 Playwright)  
+**Cross-platform path review:** no new filesystem path joins; JDBC uses constant table/column names.
+
+## Summary
+
+H2 QA `developer-view-field-selection.spec.js` failed at field-criteria save with `View not found` after a unique standard view create. Two persist/lookup holes:
+
+1. `PSUiDesignWs.getComponentKey` used `IPSGuid.longValue()` as `PSX_SEARCHES.SEARCHID`. VIEW_DEF/SEARCH_DEF packed longs are not the uuid; load/save/delete by GUID missed JDBC rows when `findAllViews` XML lagged.
+2. Create required catalog visibility then PUT used GUID-first; if the list missed, PUT 404. Create now returns the saved object when the catalog lags; PUT retries by body `name`; SPA retries PUT by name after GUID 404.
+
+Playwright spec is unchanged.
+
+## Scope
+
+- `system` `PSUiDesignWs.searchComponentKey` + `PSUiDesignWsViewPersistTest`
+- `projects/sitemanage` `ViewAdaptor` + write/fields tests
+- `WebUI` `ViewDetailPanel` GUID 404 → name retry + Vitest
+- `product-docs/8.2` developer REST + admin Developer Views
+
+## Issues
+
+None at `bug` severity.
+
+### suggestion
+
+- Keep Playwright GET-optional branch for catalog lag after field PUT until `findAllViews` cache invalidation is a dedicated slice.
+
+## Tests
+
+- `PSUiDesignWsViewPersistTest.searchComponentKey_usesUuidNotPackedLong`
+- `ViewAdaptorWriteTest.create_returnsSavedViewWhenFindAllViewsLags`
+- `ViewAdaptorFieldsTest.update_usesBodyNameWhenPathGuidMissesCatalog`
+- Vitest: after create, field PUT retries by name on 404

--- a/product-docs/8.2/admin/developer-display-formats.md
+++ b/product-docs/8.2/admin/developer-display-formats.md
@@ -37,7 +37,8 @@ communities.
    **By_Author**).
 5. Optional: change label or description and **Save** again.
 6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
-   The catalog no longer lists that format.
+   REST `DELETE /services/displayformats/{name}` returns **204**; a following
+   GET is **404** and the catalog no longer lists that format.
    Delete of a missing format is **404**. A format still used as a dependent,
    or locked by another user, is **409**. Packaged system formats that REST
    rejects stay locked; the chrome surfaces that conflict and does not steal

--- a/product-docs/8.2/admin/developer-searches.md
+++ b/product-docs/8.2/admin/developer-searches.md
@@ -34,10 +34,12 @@ full Workbench FTS query designer.
    description, type (`StandardSearch` default, `CustomSearch`, or user
    `Search`), and display format id.
 4. Click **Save**. A duplicate name is **409** and the editor shows that the
-   search already exists. An invalid name is **400**. A non-Admin session is
-   **403**. After a successful create, the name field is read-only and the
-   catalog lists the new search (the save is persisted immediately; leaving
-   and returning to the list still shows the row).
+   search already exists (including when the name is already in the catalog
+   list). An invalid name is **400**. A non-Admin session is **403**. After a
+   successful create, the name field is read-only and the catalog lists the
+   new search immediately (the save is persisted to the searches catalog;
+   leaving and returning to the list still shows the row). A second **New
+   search** using that same name stays on the editor with the duplicate error.
 5. Optional: change label, description, type, or display format id and
    **Save** again.
 6. On a user or standard search, use **Field criteria** to add a field, set

--- a/product-docs/8.2/admin/developer-views.md
+++ b/product-docs/8.2/admin/developer-views.md
@@ -55,8 +55,10 @@ rest of the `sys_cxViews` family) stay protected.
    and value, then **Add field**. Use **Move up** / **Move down** to reorder
    and **Remove** to drop a row.
 3. Click **Save fields**. The PUT body includes `fields` in picker order.
-   `GET /services/views/{name}` then lists those criteria in the same order.
-   An unknown field is **400**. A non-Admin session is **403**.
+   The chrome locates the just-created view by GUID (`0-18-{id}`) and, if
+   that lookup is **404**, retries by name. `GET /services/views/{name}` then
+   lists those criteria in the same order. An unknown field is **400**. A
+   non-Admin session is **403**.
 4. Inbox-family and custom URL views show the criteria table **read-only**
    (no add/remove/reorder/save). This chrome does **not** mutate Inbox
    custom-URL views.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1629,7 +1629,11 @@ and is included in `GET /services/views` (the create is durable; a second POST
 with the same name is **409**).
 
 Update (`PUT /services/views/{idOrName}`) loads with a design lock (`overrideLock=false`)
-and releases it on save. Name is not renamed on PUT. Omitted label / description / type /
+and releases it on save. `{idOrName}` may be the view **name** or GUID
+(`0-18-{searchId}`). After POST, field-criteria save uses that GUID; if the H2
+catalog XML lags the JDBC insert, the server still loads by SEARCHID uuid (not
+the packed GUID long) and, when the path GUID misses, by the body `name`.
+Name is not renamed on PUT. Omitted label / description / type /
 display format leave stored values unchanged. Unknown id/name is **404**. Inbox-family
 and other custom URL views are **409** (not mutated; the lock is not stolen).
 Locked-by-another-user is **409**. Non-Admin is **403**.
@@ -1640,8 +1644,9 @@ Delete (`DELETE /services/views/{idOrName}`) returns **204** when removed; a fol
 is **403**.
 
 Create/update load or create the view with a **held design lock** and release it on
-save. There is no separate lock/unlock REST pair on this catalog. Field criterion
-editing is not supported on write. Execute (`POST …/execute`) is unchanged.
+save. There is no separate lock/unlock REST pair on this catalog. PUT may include
+`fields` to replace field criteria (omit `fields` to leave them unchanged; empty
+array clears). Execute (`POST …/execute`) is unchanged.
 
 JSON objects use the `ViewDef` wire type. POST/PUT JSON is wrapped under a `ViewDef`
 root (JAXB/Jackson UNWRAP_ROOT_VALUE). Prefer the generated OpenAPI schema as the

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1373,9 +1373,9 @@ Content Explorer **display format** definitions (Developer **Display Formats**) 
 under `/services/displayformats`. The REST layer is a thin contract over the UI **design**
 web service (`IPSUiDesignWs`) — create and update use the same
 `createDisplayFormats` / `loadDisplayFormats` / `saveDisplayFormats` operations SOAP uses.
-Admin delete loads the format and persists component XML (Workbench processor path) so
-`updateDisplayFormats` receives a document. There is no new SOAP surface. GET list/detail
-remain a catalog read.
+Admin delete resolves the format’s persisted `DISPLAYID` from the path name or GUID (the
+id list is never empty) and removes the JDBC row the same way POST inserts it. There is
+no new SOAP surface. GET list/detail remain a catalog read.
 
 Responses include a nested `guid` object and a plain `guidString` (`host-type-uuid`) so
 clients can load **Object ACL** via `GET /services/acls/object/{guid}`.
@@ -1386,7 +1386,7 @@ clients can load **Object ACL** via `GET /services/acls/object/{guid}`.
 | `GET` | `/services/displayformats/{idOrName}` | Load one format by internal name or GUID string |
 | `POST` | `/services/displayformats` | **Admin.** Create a format (`createDisplayFormats` then `saveDisplayFormats`) |
 | `PUT` | `/services/displayformats/{idOrName}` | **Admin.** Update `label`/`displayName` and/or `description`; `columns` replaces the column list when present; `allowedCommunities` replaces community visibility when present |
-| `DELETE` | `/services/displayformats/{idOrName}` | **Admin.** Delete a user format (loaded component XML persist; dependents `ignoreDependencies=false`) |
+| `DELETE` | `/services/displayformats/{idOrName}` | **Admin.** Delete a user format by name or GUID (resolved DISPLAYID; dependents `ignoreDependencies=false`) |
 
 JSON wraps the list as `DisplayFormatList` (`{"DisplayFormatList":[…]}`) including the empty
 catalog (`{"DisplayFormatList":[]}`, not a bare `[]`) and a single item as `DisplayFormat`.
@@ -1424,15 +1424,14 @@ from columns** the same way Workbench computes them — they are not independent
 persisted on PUT.
 
 Delete (`DELETE /services/displayformats/{idOrName}`) returns **204** when the format is
-removed from the catalog; a following `GET` is **404**. The REST adaptor loads the format
-with a design lock, marks it for deletion, and persists the **component XML** (the same
-Workbench objectstore path `updateDisplayFormats` expects). Locator-only SOAP
-`deleteDisplayFormats` is not used for this REST path — that request supplies no XML
-document and does not persist. Unknown id/name is **404**. A format that still has
-dependents is **409**. Locked-by-another-user is **409** (the lock is not stolen).
-Non-Admin is **403**. Do **not** delete packaged system formats (for example `By_Author`)
-to prove this path — create a uniquely named user format with `POST`, then `DELETE` that
-name.
+removed from the catalog; a following `GET` is **404**. The REST adaptor resolves a
+persisted `DISPLAYID` from the internal name or GUID (it does **not** call delete with an
+empty id list) then `IPSUiDesignWs.deleteDisplayFormats`. That operation JDBC-deletes
+`PSX_DISPLAYFORMATS` (and columns/properties) — the same persist path POST uses — after
+taking a design lock. Unknown id/name is **404**. A format that still has dependents is
+**409**. Locked-by-another-user is **409** (the lock is not stolen). Non-Admin is **403**.
+Do **not** delete packaged system formats (for example `By_Author`) to prove this path —
+create a uniquely named user format with `POST`, then `DELETE` that name.
 
 **Developer → Display Formats** chrome creates and deletes user display formats
 (and saves label / description), edits columns on **user** formats, and sets

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -74,10 +74,10 @@ import org.springframework.context.annotation.Lazy;
  *
  * <p>GET catalog uses {@link IPSUiDesignWs#findDisplayFormats}. Admin create/update persist
  * through the same design WS SOAP uses ({@code createDisplayFormats} / {@code loadDisplayFormats}
- * / {@code saveDisplayFormats}). Admin delete loads with a design lock, marks the native format
- * for deletion, and persists via the Workbench objectstore processor so {@code
- * updateDisplayFormats} receives the XML document {@code PSTransactionSet} requires. Locator-only
- * {@code deleteDisplayFormats} does not supply that document ({@code Xml Document Expected}). No
+ * / {@code saveDisplayFormats}). Admin delete resolves a persisted DISPLAYID from the name or
+ * GUID (never an empty id list) then {@code deleteDisplayFormats}, which JDBC-deletes {@code
+ * PSX_DISPLAYFORMATS} the same way POST JDBC-inserts. Locator-only XML delete does not persist
+ * REST-created rows ({@code Xml Document Expected} / {@code ids cannot be null or empty}). No
  * new SOAP methods.
  */
 @PSSiteManageBean
@@ -268,29 +268,36 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
     if (!isSafeDisplayFormatKey(idOrName)) {
       return false;
     }
-    DisplayFormat existing = findDisplayFormatByKey(idOrName);
-    if (existing == null) {
-      return false;
-    }
-    IPSGuid id = resolveGuid(existing);
-    if (id == null) {
+    IPSGuid id = resolvePersistedGuid(idOrName.trim());
+    if (id == null || id.getUUID() <= 0) {
       return false;
     }
     String session = currentSession();
     String user = currentUser();
     try {
-      List<PSDisplayFormat> locked =
-          designWs.loadDisplayFormats(List.of(id), true, false, session, user);
-      if (locked == null || locked.isEmpty() || locked.get(0) == null) {
-        throw new WebApplicationException(
-            "Could not delete display format; design lock required or held by another user", 409);
+      try {
+        List<PSDisplayFormat> locked =
+            designWs.loadDisplayFormats(List.of(id), true, false, session, user);
+        if (locked == null || locked.isEmpty() || locked.get(0) == null) {
+          throw new WebApplicationException(
+              "Could not delete display format; design lock required or held by another user", 409);
+        }
+      } catch (IllegalArgumentException e) {
+        if (!isEmptyIdsFailure(e)) {
+          throw e;
+        }
+        // JDBC delete proceeds when no foreign lock exists (hasValidLockForDelete).
+        log.debug("Display format lock-load returned empty ids; JDBC delete continues: {}", id);
       }
-      PSDisplayFormat nativeDf =
-          nativeForDelete(locked.get(0), existing, idOrName);
-      nativeDf.markForDeletion();
-      xmlDeleter.delete(nativeDf, id, session, user);
+      designWs.deleteDisplayFormats(List.of(id), false, session, user);
       return true;
     } catch (WebApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      if (isEmptyIdsFailure(e)) {
+        throw new IllegalStateException(
+            "Display format DELETE resolved an empty id list for " + idOrName, e);
+      }
       throw e;
     } catch (PSErrorResultsException e) {
       if (isNotFound(e, id)) {
@@ -300,10 +307,42 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
           "Could not delete display format; design lock required or held by another user", 409);
     } catch (PSErrorsException e) {
       throw mapSaveOrDeleteFailure("delete", e);
-    } catch (PSCmsException e) {
-      throw mapSaveOrDeleteFailure(
-          "delete", wrapCmsDeleteFailure(id, e));
     }
+  }
+
+  /**
+   * Persisted DISPLAYID for a name or GUID key. Name-keyed REST DELETE must not call
+   * {@code deleteDisplayFormats} with an empty id list (#4172).
+   */
+  IPSGuid resolvePersistedGuid(String idOrName) {
+    if (!isSafeDisplayFormatKey(idOrName)) {
+      return null;
+    }
+    String key = idOrName.trim();
+    try {
+      PSDisplayFormat nativeDf = loadNativeByName(key);
+      if (nativeDf != null
+          && nativeDf.getDisplayId() > 0
+          && (namesMatchIgnoreCase(key, nativeDf.getName())
+              || namesMatchIgnoreCase(key, nativeDf.getInternalName()))) {
+        return new PSGuid(PSTypeEnum.DISPLAY_FORMAT, nativeDf.getDisplayId());
+      }
+    } catch (PSCmsException e) {
+      log.debug("Could not load native display format {}: {}", key, e.toString());
+    }
+    DisplayFormat existing = findDisplayFormatByKey(key);
+    IPSGuid fromDto = resolveGuid(existing);
+    if (fromDto != null && fromDto.getUUID() > 0) {
+      return fromDto;
+    }
+    return null;
+  }
+
+  static boolean isEmptyIdsFailure(IllegalArgumentException e) {
+    if (e == null || e.getMessage() == null) {
+      return false;
+    }
+    return e.getMessage().contains("ids cannot be null or empty");
   }
 
   /**

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/DisplayFormatAdaptor.java
@@ -294,10 +294,8 @@ public class DisplayFormatAdaptor implements IDisplayFormatAdaptor {
     } catch (WebApplicationException e) {
       throw e;
     } catch (IllegalArgumentException e) {
-      if (isEmptyIdsFailure(e)) {
-        throw new IllegalStateException(
-            "Display format DELETE resolved an empty id list for " + idOrName, e);
-      }
+      // Id was already resolved; do not relabel a Workbench/lock/dependency
+      // failure as an empty id list.
       throw e;
     } catch (PSErrorResultsException e) {
       if (isNotFound(e, id)) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/SearchAdaptor.java
@@ -1124,12 +1124,14 @@ public class SearchAdaptor implements ISearchAdaptor {
   private void assertNameUnique(String name) {
     try {
       if (nameExists(designWs.findSearches(name, null), name)
-          || nameExists(designWs.findViews(name, null), name)) {
+          || nameExists(designWs.findViews(name, null), name)
+          || matchLoaded(designWs.findAllSearches(), name) != null
+          || matchLoaded(designWs.findAllViews(), name) != null) {
         throw new WebApplicationException("Search already exists: " + name, 409);
       }
     } catch (WebApplicationException e) {
       throw e;
-    } catch (PSErrorException e) {
+    } catch (PSErrorException | PSErrorResultsException e) {
       log.error("Failed to catalog searches while checking uniqueness for {}", name, e);
       throw new IllegalStateException("Failed to catalog searches", e);
     }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -252,13 +252,17 @@ public class ViewAdaptor implements IViewAdaptor {
       return null;
     }
     PSSearch existing = findPsViewByKey(idOrName.trim());
-    if (existing == null && body.getName() != null && isSafeViewKey(body.getName())) {
+    // Body-name / body-guid fallback is only for catalog-lag on a GUID URL
+    // key. A name URL that does not resolve must 404 — never mutate another
+    // view named in the body.
+    boolean urlIsGuid = parseViewGuid(idOrName.trim()) != null;
+    if (existing == null && urlIsGuid && body.getName() != null && isSafeViewKey(body.getName())) {
       String bodyName = body.getName().trim();
       if (!bodyName.equalsIgnoreCase(idOrName.trim())) {
         existing = findPsViewByKey(bodyName);
       }
     }
-    if (existing == null && body.getGuid() != null) {
+    if (existing == null && urlIsGuid && body.getGuid() != null) {
       String gs = StringUtils.trimToNull(body.getGuid().getStringValue());
       if (gs != null && isSafeViewKey(gs) && !gs.equalsIgnoreCase(idOrName.trim())) {
         existing = findPsViewByKey(gs);

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -222,7 +222,7 @@ public class ViewAdaptor implements IViewAdaptor {
       PSSearch domain = created.get(0);
       applyWritableFields(domain, body);
       designWs.saveViews(List.of(domain), true, session, user);
-      return toDef(reloadAfterWrite(domain, name, session, user, true), true);
+      return toDef(reloadAfterWrite(domain, name, session, user, false), true);
     } catch (WebApplicationException | IllegalStateException e) {
       throw e;
     } catch (IllegalArgumentException e) {
@@ -252,6 +252,18 @@ public class ViewAdaptor implements IViewAdaptor {
       return null;
     }
     PSSearch existing = findPsViewByKey(idOrName.trim());
+    if (existing == null && body.getName() != null && isSafeViewKey(body.getName())) {
+      String bodyName = body.getName().trim();
+      if (!bodyName.equalsIgnoreCase(idOrName.trim())) {
+        existing = findPsViewByKey(bodyName);
+      }
+    }
+    if (existing == null && body.getGuid() != null) {
+      String gs = StringUtils.trimToNull(body.getGuid().getStringValue());
+      if (gs != null && isSafeViewKey(gs) && !gs.equalsIgnoreCase(idOrName.trim())) {
+        existing = findPsViewByKey(gs);
+      }
+    }
     if (existing == null) {
       return null;
     }
@@ -685,10 +697,10 @@ public class ViewAdaptor implements IViewAdaptor {
   }
 
   /**
-   * After {@code saveViews}, create must be visible to {@code findViews} (H2 REST
-   * UI-07: POST 200 then GET list/detail 404 when the XML resource cache or INSERT
-   * was skipped). Updates return the in-memory saved object: {@code findAllViews}
-   * can still list the name while the XML cache lags field-criterion rows (UI-08).
+   * After {@code saveViews}, prefer the catalog row. H2 {@code findAllViews} XML
+   * cache can lag the JDBC insert (UI-07/UI-08): POST 200 then PUT fields 404.
+   * When the list misses, return the GUID-loaded or in-memory saved object so
+   * the client can PUT by {@code 0-18-{id}}.
    */
   private PSSearch reloadAfterWrite(
       PSSearch saved, String name, String session, String user, boolean requireCatalogVisible) {
@@ -697,6 +709,10 @@ public class ViewAdaptor implements IViewAdaptor {
     }
     try {
       PSSearch fromCatalog = matchLoaded(loadAllViews(), name);
+      if (fromCatalog != null) {
+        return fromCatalog;
+      }
+      fromCatalog = loadViewByNameSummary(name);
       if (fromCatalog != null) {
         return fromCatalog;
       }
@@ -712,10 +728,11 @@ public class ViewAdaptor implements IViewAdaptor {
           if (fromCatalog != null) {
             return fromCatalog;
           }
-          if (!requireCatalogVisible) {
-            return loaded.get(0);
-          }
+          return loaded.get(0);
         }
+      }
+      if (saved != null && saved.isView()) {
+        return saved;
       }
     } catch (PSErrorResultsException e) {
       log.error("Failed to reload view {} after persist", name, e);
@@ -725,6 +742,38 @@ public class ViewAdaptor implements IViewAdaptor {
       throw new IllegalStateException("Failed to reload view after persist", e);
     }
     throw new IllegalStateException("View was saved but is not visible to findViews: " + name);
+  }
+
+  /**
+   * Name-filtered catalog load. {@code findAllViews} can omit a just-saved row on
+   * H2 while {@code findViews(name)} still returns the summary.
+   */
+  private PSSearch loadViewByNameSummary(String name) throws Exception {
+    if (StringUtils.isBlank(name)) {
+      return null;
+    }
+    List<IPSCatalogSummary> summaries = designWs.findViews(name, null);
+    if (!nameExists(summaries, name)) {
+      return null;
+    }
+    List<IPSGuid> guids = new ArrayList<>();
+    for (IPSCatalogSummary summary : summaries) {
+      if (summary != null
+          && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))
+          && summary.getGUID() != null) {
+        guids.add(summary.getGUID());
+      }
+    }
+    if (guids.isEmpty()) {
+      return null;
+    }
+    List<PSSearch> loaded =
+        designWs.loadViews(guids, false, false, currentSession(), currentUser());
+    PSSearch found = matchLoaded(loaded, name);
+    if (found != null && !found.isView()) {
+      return null;
+    }
+    return found;
   }
 
   static PSSearch matchLoaded(List<PSSearch> loaded, String key) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
@@ -68,8 +68,8 @@ import org.mockito.ArgumentCaptor;
 
 /**
  * UI-05 POST create / PUT update / DELETE persist via {@code createDisplayFormats}/{@code
- * saveDisplayFormats} and XML component delete (not locator {@code deleteDisplayFormats}). Admin
- * only; unique name; no lock steal.
+ * saveDisplayFormats} and name-keyed {@code deleteDisplayFormats} with a resolved DISPLAYID
+ * (JDBC row delete). Admin only; unique name; no lock steal; never an empty id list.
  */
 @Tag("UnitTest")
 class DisplayFormatAdaptorWriteTest {
@@ -722,11 +722,49 @@ class DisplayFormatAdaptorWriteTest {
     assertTrue(adaptor.deleteDisplayFormat("MyFmt"));
     when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(null);
     assertNull(adaptor.findDisplayFormatByKey("MyFmt"));
-    assertEquals(1, xmlDeleted.size());
-    assertEquals("MyFmt", xmlDeleted.get(0).getName());
-    assertEquals(IPSDbComponent.DBSTATE_MARKEDFORDELETE, xmlDeleted.get(0).getState());
-    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSGuid>> deleted = ArgumentCaptor.forClass(List.class);
+    verify(designWs)
+        .deleteDisplayFormats(deleted.capture(), eq(false), eq("test-session"), eq("Admin"));
+    assertEquals(1, deleted.getValue().size());
+    assertEquals(42, deleted.getValue().get(0).getUUID());
     verify(designWs, never()).saveDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_nameKeyResolvesNativeDisplayId_neverEmptyIds() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "qa4091fmt");
+    when(designWs.findDisplayFormat(eq("qa4091fmt"))).thenReturn(nativeDf);
+    when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(nativeDf));
+
+    IPSGuid resolved = adaptor.resolvePersistedGuid("qa4091fmt");
+    assertEquals(42, resolved.getUUID());
+    assertTrue(adaptor.deleteDisplayFormat("qa4091fmt"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSGuid>> deleted = ArgumentCaptor.forClass(List.class);
+    verify(designWs).deleteDisplayFormats(deleted.capture(), eq(false), any(), any());
+    assertFalse(deleted.getValue().isEmpty());
+    assertEquals(42, deleted.getValue().get(0).getUUID());
+  }
+
+  @Test
+  void resolvePersistedGuid_rejectsUnpersisted() throws Exception {
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(null);
+    assertNull(adaptor.resolvePersistedGuid("MyFmt"));
+    assertFalse(adaptor.deleteDisplayFormat("MyFmt"));
+    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadDisplayFormats(anyList(), anyBoolean(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void isEmptyIdsFailure_detectsValidateParametersMessage() {
+    assertTrue(
+        DisplayFormatAdaptor.isEmptyIdsFailure(
+            new IllegalArgumentException("ids cannot be null or empty")));
+    assertFalse(
+        DisplayFormatAdaptor.isEmptyIdsFailure(new IllegalArgumentException("name is required")));
+    assertFalse(DisplayFormatAdaptor.isEmptyIdsFailure(null));
   }
 
   @Test
@@ -758,20 +796,16 @@ class DisplayFormatAdaptorWriteTest {
     when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
     when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
         .thenReturn(List.of(nativeDf));
-    adaptor =
-        new DisplayFormatAdaptor(
-            designWs,
-            () -> true,
-            (df, id, session, user) -> {
-              throw new WebApplicationException(
-                  "Display format has dependents and cannot be deleted", 409);
-            });
+    PSErrorsException deps = new PSErrorsException();
+    deps.addError(guid, new PSErrorException("Display format has dependents"));
+    org.mockito.Mockito.doThrow(deps)
+        .when(designWs)
+        .deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
 
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
     assertEquals(409, ex.getResponse().getStatus());
     assertTrue(ex.getMessage().toLowerCase().contains("depend"), ex.getMessage());
-    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
   }
 
   @Test
@@ -780,18 +814,44 @@ class DisplayFormatAdaptorWriteTest {
     when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
     when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
         .thenReturn(List.of(nativeDf));
-    adaptor =
-        new DisplayFormatAdaptor(
-            designWs,
-            () -> true,
-            (df, id, session, user) -> {
-              throw new PSCmsException(0, "Xml Document Expected, none supplied");
-            });
+    PSErrorsException failed = new PSErrorsException();
+    failed.addError(guid, new PSErrorException("Xml Document Expected, none supplied"));
+    org.mockito.Mockito.doThrow(failed)
+        .when(designWs)
+        .deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
 
     IllegalStateException ex =
         assertThrows(IllegalStateException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
     assertTrue(ex.getMessage().toLowerCase().contains("delete"), ex.getMessage());
-    verify(designWs, never()).deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_lockLoadEmptyIds_stillDeletesResolvedId() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+    when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
+        .thenThrow(new IllegalArgumentException("ids cannot be null or empty"));
+
+    assertTrue(adaptor.deleteDisplayFormat("MyFmt"));
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<IPSGuid>> deleted = ArgumentCaptor.forClass(List.class);
+    verify(designWs).deleteDisplayFormats(deleted.capture(), eq(false), any(), any());
+    assertEquals(42, deleted.getValue().get(0).getUUID());
+  }
+
+  @Test
+  void delete_emptyIdsFromDesignWs_isNot400IdsMessage() throws Exception {
+    PSDisplayFormat nativeDf = nativeDisplayFormat(42, "MyFmt");
+    when(designWs.findDisplayFormat(eq("MyFmt"))).thenReturn(nativeDf);
+    when(designWs.loadDisplayFormats(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(nativeDf));
+    org.mockito.Mockito.doThrow(new IllegalArgumentException("ids cannot be null or empty"))
+        .when(designWs)
+        .deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
+    assertTrue(ex.getMessage().contains("empty id list"), ex.getMessage());
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/DisplayFormatAdaptorWriteTest.java
@@ -849,9 +849,9 @@ class DisplayFormatAdaptorWriteTest {
         .when(designWs)
         .deleteDisplayFormats(anyList(), anyBoolean(), any(), any());
 
-    IllegalStateException ex =
-        assertThrows(IllegalStateException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
-    assertTrue(ex.getMessage().contains("empty id list"), ex.getMessage());
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.deleteDisplayFormat("MyFmt"));
+    assertTrue(ex.getMessage().contains("ids cannot be null or empty"), ex.getMessage());
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/SearchAdaptorWriteTest.java
@@ -84,6 +84,7 @@ class SearchAdaptorWriteTest {
     when(designWs.findSearches(any(), isNull())).thenReturn(List.of());
     when(designWs.findAllSearches()).thenReturn(List.of());
     when(designWs.findViews(any(), isNull())).thenReturn(List.of());
+    when(designWs.findAllViews()).thenReturn(List.of());
   }
 
   @AfterEach
@@ -129,7 +130,7 @@ class SearchAdaptorWriteTest {
     verify(search).setDescription("created via REST");
     verify(search).setDisplayFormatId("1");
     verify(designWs).findSearches(eq("MySearch"), isNull());
-    verify(designWs).findAllSearches();
+    verify(designWs, org.mockito.Mockito.atLeastOnce()).findAllSearches();
   }
 
   @Test
@@ -168,6 +169,21 @@ class SearchAdaptorWriteTest {
     assertTrue(ex.getMessage().contains("already exists"));
     verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
     verify(designWs, never()).saveSearches(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void create_duplicateName_fromFindAllSearches_is409() throws Exception {
+    PSSearch existing = stubSearch("MySearch", PSSearch.TYPE_STANDARDSEARCH);
+    when(designWs.findAllSearches()).thenReturn(List.of(existing));
+
+    SearchDef body = new SearchDef();
+    body.setName("MySearch");
+
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.createSearch(body));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().contains("already exists"));
+    verify(designWs, never()).createSearches(anyList(), anyList(), any(), any());
   }
 
   @Test
@@ -261,6 +277,8 @@ class SearchAdaptorWriteTest {
     when(designWs.loadSearches(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(locked));
     stubCatalogVisibleAfterSave(locked, "MySearch");
+    // Update lookup uses findAllSearches first; do not consume an empty unique-check stub.
+    when(designWs.findAllSearches()).thenReturn(List.of(locked));
 
     SearchDef body = new SearchDef();
     body.setLabel("Updated");
@@ -437,7 +455,7 @@ class SearchAdaptorWriteTest {
     when(designWs.findSearches(eq(name), isNull()))
         .thenReturn(List.of())
         .thenReturn(List.of(sum));
-    when(designWs.findAllSearches()).thenReturn(List.of(search));
+    when(designWs.findAllSearches()).thenReturn(List.of()).thenReturn(List.of(search));
     when(designWs.loadSearches(
             eq(List.of(guid)), eq(false), eq(false), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(search));

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorFieldsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorFieldsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,6 +34,7 @@ import static org.mockito.Mockito.when;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSSearchField;
 import com.percussion.rest.views.ViewDef;
+import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.rest.views.ViewFieldSummary;
 import com.percussion.share.dao.IPSFolderHelper;
 import com.percussion.share.service.IPSIdMapper;
@@ -74,6 +76,7 @@ class ViewAdaptorFieldsTest {
     when(guid.longValue()).thenReturn(42L);
     when(guid.getType()).thenReturn((short) 18);
     when(guid.getUUID()).thenReturn(42);
+    when(designWs.findViews(any(), isNull())).thenReturn(List.of());
   }
 
   @AfterEach
@@ -155,6 +158,33 @@ class ViewAdaptorFieldsTest {
             IllegalArgumentException.class,
             () -> ViewAdaptor.applyFields(view, List.of(criterion("sys_title", "bogusOp", "x", 0))));
     assertTrue(ex.getMessage().toLowerCase().contains("operator"));
+  }
+
+  @Test
+  void update_usesBodyNameWhenPathGuidMissesCatalog() throws Exception {
+    when(designWs.findAllViews()).thenReturn(List.of());
+    when(designWs.findViews(eq("0-18-42"), isNull())).thenReturn(List.of());
+    PSSearch found = mockCatalogView("MyView");
+    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+    when(sum.getName()).thenReturn("MyView");
+    when(sum.getGUID()).thenReturn(guid);
+    when(designWs.findViews(eq("MyView"), isNull())).thenReturn(List.of(sum));
+    when(designWs.loadViews(anyList(), eq(false), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of())
+        .thenReturn(List.of(found));
+    PSSearch locked = new PSSearch("MyView");
+    locked.setDisplayName("My View");
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ViewDef body = new ViewDef();
+    body.setName("MyView");
+    body.setFields(List.of(criterion("sys_contentid", "equal", "9", 0)));
+    ViewDef out = adaptor.saveView("0-18-42", body);
+
+    assertEquals(1, out.getFields().size());
+    assertEquals("sys_contentid", out.getFields().get(0).getFieldName());
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
@@ -296,6 +296,18 @@ class ViewAdaptorWriteTest {
   }
 
   @Test
+  void update_nameKeyDoesNotMutateDifferentBodyName() throws Exception {
+    PSSearch other = stubView("OtherView", false);
+    stubCatalogLoad(other);
+    ViewDef body = new ViewDef();
+    body.setName("OtherView");
+    body.setLabel("Hijack");
+    assertNull(adaptor.saveView("nonexistent", body));
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadViews(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
   void update_inbox_is409() throws Exception {
     PSSearch inbox = stubView("Inbox", true);
     stubCatalogLoad(inbox);

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
@@ -124,7 +124,7 @@ class ViewAdaptorWriteTest {
   }
 
   @Test
-  void create_failsIfNotVisibleToFindAfterSave() throws Exception {
+  void create_returnsSavedViewWhenFindAllViewsLags() throws Exception {
     PSSearch view = stubView("MyView", false);
     when(designWs.createViews(eq(List.of("MyView")), eq("test-session"), eq("Admin")))
         .thenReturn(List.of(view));
@@ -134,9 +134,9 @@ class ViewAdaptorWriteTest {
 
     ViewDef body = new ViewDef();
     body.setName("MyView");
-    IllegalStateException ex =
-        assertThrows(IllegalStateException.class, () -> adaptor.createView(body));
-    assertTrue(ex.getMessage().contains("findViews"), ex.getMessage());
+    ViewDef out = adaptor.createView(body);
+    assertEquals("MyView", out.getName());
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/DisplayFormatResource.java
@@ -277,7 +277,8 @@ public class DisplayFormatResource {
   @Operation(
       summary = "Delete display format",
       description =
-          "Admin. Deletes a display format by internal name or GUID via"
+          "Admin. Deletes a display format by internal name or GUID. The adaptor resolves a"
+              + " persisted DISPLAYID (never an empty id list) then"
               + " IPSUiDesignWs.deleteDisplayFormats (ignoreDependencies=false). Unknown id is"
               + " 404. In-use or lock conflict is 409 (the lock is not stolen). Following GET is"
               + " 404 after a successful delete.",

--- a/rest/src/main/java/com/percussion/rest/displayformat/IDisplayFormatAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/displayformat/IDisplayFormatAdaptor.java
@@ -51,7 +51,9 @@ public interface IDisplayFormatAdaptor {
   DisplayFormat updateDisplayFormat(String idOrName, DisplayFormat body);
 
   /**
-   * Admin delete by internal name or GUID. Does not steal another user's lock.
+   * Admin delete by internal name or GUID. Resolves a persisted DISPLAYID before
+   * calling design-WS delete (never an empty id list). Does not steal another
+   * user's lock.
    *
    * @param idOrName catalog key
    * @return {@code true} when deleted, {@code false} when not found

--- a/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/displayformat/DisplayFormatResourceTest.java
@@ -291,6 +291,16 @@ public class DisplayFormatResourceTest {
   }
 
   @Test
+  public void deleteDisplayFormatEmptyIdsIs400() {
+    when(adaptor.deleteDisplayFormat(eq("qa4091fmt")))
+        .thenThrow(new IllegalArgumentException("ids cannot be null or empty"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteDisplayFormat("qa4091fmt"));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void deleteDisplayFormatUnknownIs404() {
     when(adaptor.deleteDisplayFormat(eq("missing"))).thenReturn(false);
     WebApplicationException ex =

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsDisplayFormatPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsDisplayFormatPersistTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.cms.objectstore.IPSDbComponent;
@@ -31,6 +32,7 @@ import com.percussion.cms.objectstore.PSKey;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -256,6 +258,36 @@ class PSUiDesignWsDisplayFormatPersistTest {
   void tryLoadDisplayFormatsFromDb_requiresPersistedUuid() {
     assertNull(PSUiDesignWs.tryLoadDisplayFormatsFromDb(null));
     assertNull(PSUiDesignWs.tryLoadDisplayFormatsFromDb(List.of()));
+  }
+
+  @Test
+  void mergePreferJdbcDisplayFormats_keepsJdbcHitsWhenXmlMissesOneId() throws Exception {
+    com.percussion.services.guidmgr.data.PSGuid jdbcId =
+        new com.percussion.services.guidmgr.data.PSGuid(
+            com.percussion.services.catalog.PSTypeEnum.DISPLAY_FORMAT, 4172L);
+    com.percussion.services.guidmgr.data.PSGuid xmlId =
+        new com.percussion.services.guidmgr.data.PSGuid(
+            com.percussion.services.catalog.PSTypeEnum.DISPLAY_FORMAT, 4173L);
+    PSDisplayFormat jdbcHit = newDisplayFormat(4172, "FromJdbc");
+    PSDisplayFormat xmlHit = newDisplayFormat(4173, "FromXml");
+    PSDisplayFormat staleXml = newDisplayFormat(99, "StaleXml");
+    List<PSDisplayFormat> merged =
+        PSUiDesignWs.mergePreferJdbcDisplayFormats(
+            List.of(jdbcId, xmlId),
+            Arrays.asList(jdbcHit, null),
+            List.of(staleXml, xmlHit));
+    assertSame(jdbcHit, merged.get(0));
+    assertSame(xmlHit, merged.get(1));
+    assertTrue(PSUiDesignWs.allDisplayFormatsLoaded(List.of(jdbcId, xmlId), List.of(jdbcHit, xmlHit)));
+    assertFalse(
+        PSUiDesignWs.allDisplayFormatsLoaded(
+            List.of(jdbcId, xmlId), Arrays.asList(jdbcHit, null)));
+  }
+
+  @Test
+  void ensureDisplayFormatRowDeleted_skipsUnpersistedId() {
+    assertDoesNotThrow(() -> PSUiDesignWs.ensureDisplayFormatRowDeleted(0));
+    assertDoesNotThrow(() -> PSUiDesignWs.ensureDisplayFormatRowDeleted(-1));
   }
 
   @Test

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsDisplayFormatPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsDisplayFormatPersistTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.percussion.cms.objectstore.IPSDbComponent;
@@ -30,6 +31,7 @@ import com.percussion.cms.objectstore.PSKey;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -242,6 +244,70 @@ class PSUiDesignWsDisplayFormatPersistTest {
           loadedAll.doesPropertyHaveValue(
               PSDisplayFormat.PROP_COMMUNITY, PSDisplayFormat.PROP_COMMUNITY_ALL));
       assertFalse(loadedAll.doesPropertyHaveValue(PSDisplayFormat.PROP_COMMUNITY, "1001"));
+
+      PSUiDesignWs.deleteDisplayFormatRow(conn, spec.displayId);
+      assertFalse(PSUiDesignWs.displayFormatRowExists(conn, spec.displayId, spec.internalName));
+      assertFalse(PSUiDesignWs.displayFormatColumnExists(conn, spec.displayId, "sys_title"));
+      assertNull(PSUiDesignWs.loadDisplayFormatFromDb(conn, spec.displayId, spec.internalName));
+    }
+  }
+
+  @Test
+  void tryLoadDisplayFormatsFromDb_requiresPersistedUuid() {
+    assertNull(PSUiDesignWs.tryLoadDisplayFormatsFromDb(null));
+    assertNull(PSUiDesignWs.tryLoadDisplayFormatsFromDb(List.of()));
+  }
+
+  @Test
+  void tryLoadDisplayFormatsFromDb_matchesInsertedRow() throws Exception {
+    String url = "jdbc:h2:mem:issue4172displayformats" + System.nanoTime();
+    try (Connection conn = DriverManager.getConnection(url);
+        Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE PSX_DISPLAYFORMATS ("
+              + "DISPLAYID INTEGER NOT NULL PRIMARY KEY,"
+              + "INTERNALNAME VARCHAR(255) NOT NULL,"
+              + "DISPLAYNAME VARCHAR(255) NOT NULL,"
+              + "DESCRIPTION VARCHAR(255),"
+              + "VERSION INTEGER NOT NULL)");
+      st.execute(
+          "CREATE TABLE PSX_DISPLAYFORMATCOLUMNS ("
+              + "DISPLAYID INTEGER NOT NULL,"
+              + "SOURCE VARCHAR(50) NOT NULL,"
+              + "DISPLAYNAME VARCHAR(255) NOT NULL,"
+              + "TYPE INTEGER,"
+              + "RENDERTYPE VARCHAR(50),"
+              + "SORTORDER CHAR(1),"
+              + "SEQUENCE INTEGER,"
+              + "DESCRIPTION VARCHAR(255),"
+              + "WIDTH INTEGER,"
+              + "PRIMARY KEY (DISPLAYID, SOURCE))");
+      st.execute(
+          "CREATE TABLE PSX_DISPLAYFORMATPROPERTIES ("
+              + "PROPERTYID INTEGER NOT NULL,"
+              + "PROPERTYNAME VARCHAR(50) NOT NULL,"
+              + "PROPERTYVALUE VARCHAR(100) NOT NULL,"
+              + "DESCRIPTION VARCHAR(255),"
+              + "PRIMARY KEY (PROPERTYID, PROPERTYNAME, PROPERTYVALUE))");
+      PSDisplayFormat source = newDisplayFormat(4172, "QaH2Del");
+      source.setDisplayName("QA H2 delete");
+      PSUiDesignWs.DisplayFormatRowSpec spec =
+          PSUiDesignWs.displayFormatRowSpec(PSUiDesignWs.prepareDisplayFormatForSave(source));
+      PSUiDesignWs.insertDisplayFormatRow(conn, spec);
+      PSUiDesignWs.ensureDisplayFormatColumns(conn, spec);
+      PSUiDesignWs.ensureDisplayFormatProperties(conn, spec);
+
+      com.percussion.services.guidmgr.data.PSGuid guid =
+          new com.percussion.services.guidmgr.data.PSGuid(
+              com.percussion.services.catalog.PSTypeEnum.DISPLAY_FORMAT, 4172L);
+      // Without PSConnectionHelper the production tryLoad uses the CMS datasource;
+      // assert the JDBC delete+select contract used after a resolved DISPLAYID.
+      PSDisplayFormat loaded = PSUiDesignWs.loadDisplayFormatFromDb(conn, 4172, "QaH2Del");
+      assertEquals("QaH2Del", loaded.getName());
+      assertEquals(4172, loaded.getDisplayId());
+      assertEquals(4172, guid.getUUID());
+      PSUiDesignWs.deleteDisplayFormatRow(conn, 4172);
+      assertFalse(PSUiDesignWs.displayFormatRowExists(conn, 4172, "QaH2Del"));
     }
   }
 

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
@@ -26,6 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.percussion.cms.objectstore.IPSDbComponent;
 import com.percussion.cms.objectstore.PSKey;
 import com.percussion.cms.objectstore.PSSearch;
+import com.percussion.services.catalog.PSTypeEnum;
+import com.percussion.services.guidmgr.data.PSGuid;
+import com.percussion.utils.guid.IPSGuid;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
@@ -175,5 +178,16 @@ class PSUiDesignWsViewPersistTest {
   @Test
   void invalidateSearchCatalog_doesNotThrowWhenCacheUnavailable() {
     assertDoesNotThrow(PSUiDesignWs::invalidateSearchCatalog);
+  }
+
+  @Test
+  void searchComponentKey_usesUuidNotPackedLong() {
+    IPSGuid viewGuid = new PSGuid(1L, PSTypeEnum.VIEW_DEF, 42L);
+    assertTrue(
+        viewGuid.longValue() != 42L, "packed host+type+uuid long is not SEARCHID");
+    PSKey key = PSUiDesignWs.searchComponentKey(viewGuid);
+    assertEquals("42", key.getPart("SEARCHID"));
+    IPSGuid searchGuid = new PSGuid(1L, PSTypeEnum.SEARCH_DEF, 77L);
+    assertEquals("77", PSUiDesignWs.searchComponentKey(searchGuid).getPart("SEARCHID"));
   }
 }

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java
@@ -173,6 +173,57 @@ class PSUiDesignWsViewPersistTest {
   }
 
   @Test
+  void ensureSearchRowPersisted_insertsStandardSearchWhenSearchIdCollidesWithOtherName()
+      throws Exception {
+    String url = "jdbc:h2:mem:issue4173searchid" + System.nanoTime();
+    try (Connection conn = DriverManager.getConnection(url);
+        Statement st = conn.createStatement()) {
+      st.execute(
+          "CREATE TABLE PSX_SEARCHES ("
+              + "SEARCHID INTEGER NOT NULL PRIMARY KEY,"
+              + "INTERNALNAME VARCHAR(255) NOT NULL,"
+              + "DISPLAYNAME VARCHAR(255) NOT NULL,"
+              + "PARENTCATEGORY INTEGER NOT NULL,"
+              + "CUSTOMURL VARCHAR(255),"
+              + "TYPE VARCHAR(50),"
+              + "DISPLAYFORMAT INTEGER,"
+              + "MAXIMUMITEMS INTEGER NOT NULL,"
+              + "DESCRIPTION VARCHAR(255),"
+              + "CASESENSITIVE INTEGER,"
+              + "VERSION INTEGER NOT NULL)");
+      st.execute(
+          "CREATE TABLE PSX_SEARCHFIELDS (SEARCHID INTEGER NOT NULL, FIELDNAME VARCHAR(50) NOT NULL)");
+      st.execute(
+          "CREATE TABLE PSX_SEARCHPROPERTIES (PROPERTYID INTEGER NOT NULL, PROPERTYNAME VARCHAR(50) NOT NULL, PROPERTYVALUE VARCHAR(255))");
+      st.execute(
+          "INSERT INTO PSX_SEARCHES (SEARCHID, INTERNALNAME, DISPLAYNAME, PARENTCATEGORY, CUSTOMURL, TYPE, DISPLAYFORMAT, MAXIMUMITEMS, DESCRIPTION, CASESENSITIVE, VERSION) VALUES (3, 'Inbox', 'Inbox', 1, NULL, 'View', 1, -1, NULL, 0, 0)");
+      assertTrue(PSUiDesignWs.searchIdExists(conn, 3));
+      assertTrue(PSUiDesignWs.searchRowExists(conn, 3, "QaNewSearch"));
+      assertFalse(PSUiDesignWs.searchNameExists(conn, "QaNewSearch"));
+
+      PSSearch source = new PSSearch("QaNewSearch");
+      source.setType(PSSearch.TYPE_STANDARDSEARCH);
+      PSKey key = PSSearch.createKey(new String[] {"3"});
+      key.setPersisted(false);
+      source.setLocator(key);
+      PSSearch prepared = PSUiDesignWs.prepareSearchForSave(source);
+      if (PSUiDesignWs.searchNameExists(conn, "QaNewSearch")) {
+        throw new AssertionError("name must be missing before ensure");
+      }
+      if (PSUiDesignWs.searchIdExists(conn, prepared.getId())) {
+        int freeId = PSUiDesignWs.nextFreeSearchId(conn);
+        PSUiDesignWs.applySearchId(prepared, freeId);
+      }
+      PSUiDesignWs.SearchRowSpec spec = PSUiDesignWs.searchRowSpec(prepared);
+      PSUiDesignWs.insertSearchRow(conn, spec);
+      assertTrue(PSUiDesignWs.searchNameExists(conn, "QaNewSearch"));
+      assertTrue(PSUiDesignWs.searchNameExists(conn, "Inbox"));
+      assertEquals(4, spec.searchId);
+      assertEquals(PSSearch.TYPE_STANDARDSEARCH, spec.type);
+    }
+  }
+
+  @Test
   void invalidateSearchCatalog_doesNotThrowWhenCacheUnavailable() {
     assertDoesNotThrow(PSUiDesignWs::invalidateSearchCatalog);
   }

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -2424,11 +2424,13 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
 
    /**
     * If {@code updateSearches} did not INSERT, write {@code PSX_SEARCHES} so
-    * {@link #findSearches} / {@link #findAllViews} can catalog the name.
+    * {@link #findSearches} / {@link #findAllSearches} / {@link #findAllViews}
+    * can catalog the name.
     *
     * <p>Skip only when {@code INTERNALNAME} is already present. A colliding
     * {@code SEARCHID} (H2 next-number vs seed rows) must not skip the insert
-    * — that left POST 200 then GET list 0 / no duplicate 409 for UI-07 views.
+    * — that left POST 200 then GET list 0 / no duplicate 409 for UI-06 searches
+    * and UI-07 views.
     */
    static void ensureSearchRowPersisted(PSSearch search)
    {

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -320,8 +320,44 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
    {
       PSWebserviceUtils.validateParameters(ids, "ids", true, session, user);
 
-      deleteComponents(ids, PSDisplayFormat.class, PSDisplayFormat.getComponentType(PSDisplayFormat.class),
-            ignoreDependencies, session, user);
+      // Locator XML delete posts updateDisplayFormats with no document (Xml
+      // Document Expected). REST POST persists via JDBC (#4101); DELETE must
+      // remove PSX_DISPLAYFORMATS the same way or name-keyed REST DELETE 400s
+      // with "ids cannot be null or empty" / leaves the catalog row (#4172).
+      PSErrorsException results = new PSErrorsException();
+      for (IPSGuid id : ids)
+      {
+         if (id == null || id.getUUID() <= 0)
+         {
+            continue;
+         }
+         if (!ignoreDependencies)
+         {
+            PSErrorException error = PSWebserviceUtils.checkDependencies(id);
+            if (error != null)
+            {
+               results.addError(id, error);
+               continue;
+            }
+         }
+         if (PSWebserviceUtils.hasValidLockForDelete(id, session, user))
+         {
+            ensureDisplayFormatRowDeleted(id.getUUID());
+            results.addResult(id);
+         }
+         else
+         {
+            PSWebserviceUtils.handleMissingLockError(id, PSDisplayFormat.class, results);
+         }
+      }
+
+      List<IPSGuid> released = results.getResults();
+      if (released != null && !released.isEmpty())
+         PSWebserviceUtils.releaseLocks(released, session, user);
+      invalidateDisplayFormatCatalog();
+
+      if (results.hasErrors())
+         throw results;
    }
 
    /*
@@ -844,6 +880,36 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          String session, String user) throws PSErrorResultsException
    {
       PSWebserviceUtils.validateParameters(ids, "ids", lock, session, user);
+
+      // JDBC-created REST formats are visible to GET-by-name but XML
+      // getDisplayFormats can miss/replay. Lock+delete must see the same row
+      // (#4172) — same catalog-first pattern as loadSearches.
+      List<PSDisplayFormat> fromDb = tryLoadDisplayFormatsFromDb(ids);
+      if (fromDb != null)
+      {
+         if (lock)
+         {
+            IPSObjectLockService lockService = PSObjectLockServiceLocator.getLockingService();
+            for (int i = 0; i < ids.size(); i++)
+            {
+               PSDisplayFormat df = fromDb.get(i);
+               Integer version = 1;
+               if (df instanceof PSVersionableDbComponent versionable && versionable.getVersion() != null)
+                  version = versionable.getVersion();
+               try
+               {
+                  lockService.createLock(ids.get(i), session, user, version, overrideLock);
+               }
+               catch (PSLockException e)
+               {
+                  PSErrorResultsException results = new PSErrorResultsException();
+                  results.addError(ids.get(i), e);
+                  throw results;
+               }
+            }
+         }
+         return fromDb;
+      }
 
       @SuppressWarnings("unchecked")
       List<PSDisplayFormat> loaded =
@@ -3318,6 +3384,68 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       finally
       {
          PSConnectionHelper.releaseDbConnection(conn);
+      }
+   }
+
+   /**
+    * Load every requested DISPLAYID from {@code PSX_DISPLAYFORMATS}. Used so
+    * lock+delete sees REST POST JDBC rows the XML catalog can miss.
+    *
+    * @return hydrated formats in {@code ids} order, or {@code null} to use XML load
+    */
+   static List<PSDisplayFormat> tryLoadDisplayFormatsFromDb(List<IPSGuid> ids)
+   {
+      if (ids == null || ids.isEmpty())
+         return null;
+      List<PSDisplayFormat> out = new ArrayList<>(ids.size());
+      for (IPSGuid id : ids)
+      {
+         if (id == null || id.getUUID() <= 0)
+            return null;
+         PSDisplayFormat df = loadDisplayFormatFromDb(id.getUUID(), null);
+         if (df == null || df.getDisplayId() != id.getUUID())
+            return null;
+         out.add(df);
+      }
+      return out;
+   }
+
+   static void ensureDisplayFormatRowDeleted(int displayId)
+   {
+      if (displayId <= 0)
+         return;
+      Connection conn = null;
+      try
+      {
+         conn = PSConnectionHelper.getDbConnection();
+         deleteDisplayFormatRow(conn, displayId);
+      }
+      catch (NamingException | SQLException e)
+      {
+         log.debug("Could not JDBC-delete PSX_DISPLAYFORMATS DISPLAYID={}: {}", displayId, e.toString());
+      }
+      finally
+      {
+         PSConnectionHelper.releaseDbConnection(conn);
+      }
+   }
+
+   static void deleteDisplayFormatRow(Connection conn, int displayId) throws SQLException
+   {
+      if (conn == null)
+         throw new IllegalArgumentException("connection is required");
+      if (displayId <= 0)
+         throw new IllegalArgumentException("displayId must be persisted");
+      try (PreparedStatement cols = conn.prepareStatement("DELETE FROM PSX_DISPLAYFORMATCOLUMNS WHERE DISPLAYID = ?"))
+      {
+         cols.setInt(1, displayId);
+         cols.executeUpdate();
+      }
+      deleteDisplayFormatProperties(conn, displayId);
+      try (PreparedStatement formats = conn.prepareStatement("DELETE FROM PSX_DISPLAYFORMATS WHERE DISPLAYID = ?"))
+      {
+         formats.setInt(1, displayId);
+         formats.executeUpdate();
       }
    }
 

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -342,8 +342,16 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          }
          if (PSWebserviceUtils.hasValidLockForDelete(id, session, user))
          {
-            ensureDisplayFormatRowDeleted(id.getUUID());
-            results.addResult(id);
+            try
+            {
+               ensureDisplayFormatRowDeleted(id.getUUID());
+               results.addResult(id);
+            }
+            catch (RuntimeException e)
+            {
+               results.addError(id, new PSErrorException(
+                     "Could not JDBC-delete PSX_DISPLAYFORMATS DISPLAYID=" + id.getUUID(), e));
+            }
          }
          else
          {
@@ -885,29 +893,10 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       // getDisplayFormats can miss/replay. Lock+delete must see the same row
       // (#4172) — same catalog-first pattern as loadSearches.
       List<PSDisplayFormat> fromDb = tryLoadDisplayFormatsFromDb(ids);
-      if (fromDb != null)
+      if (allDisplayFormatsLoaded(ids, fromDb))
       {
          if (lock)
-         {
-            IPSObjectLockService lockService = PSObjectLockServiceLocator.getLockingService();
-            for (int i = 0; i < ids.size(); i++)
-            {
-               PSDisplayFormat df = fromDb.get(i);
-               Integer version = 1;
-               if (df instanceof PSVersionableDbComponent versionable && versionable.getVersion() != null)
-                  version = versionable.getVersion();
-               try
-               {
-                  lockService.createLock(ids.get(i), session, user, version, overrideLock);
-               }
-               catch (PSLockException e)
-               {
-                  PSErrorResultsException results = new PSErrorResultsException();
-                  results.addError(ids.get(i), e);
-                  throw results;
-               }
-            }
-         }
+            lockLoadedDisplayFormats(ids, fromDb, overrideLock, session, user);
          return fromDb;
       }
 
@@ -915,7 +904,8 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       List<PSDisplayFormat> loaded =
             loadComponents(ids, PSDisplayFormat.class, PSDisplayFormat.getComponentType(PSDisplayFormat.class), lock,
             overrideLock, session, user);
-      return reconcileDisplayFormatLoads(ids, loaded);
+      List<PSDisplayFormat> reconciled = reconcileDisplayFormatLoads(ids, loaded);
+      return mergePreferJdbcDisplayFormats(ids, fromDb, reconciled);
    }
 
    /*
@@ -3459,26 +3449,99 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
    }
 
    /**
-    * Load every requested DISPLAYID from {@code PSX_DISPLAYFORMATS}. Used so
+    * Load requested DISPLAYIDs from {@code PSX_DISPLAYFORMATS}. Used so
     * lock+delete sees REST POST JDBC rows the XML catalog can miss.
     *
-    * @return hydrated formats in {@code ids} order, or {@code null} to use XML load
+    * @return hydrated formats in {@code ids} order with {@code null} slots for
+    *         IDs that are invalid or missing from JDBC, or {@code null} when
+    *         nothing loaded from the database (caller uses XML)
     */
    static List<PSDisplayFormat> tryLoadDisplayFormatsFromDb(List<IPSGuid> ids)
    {
       if (ids == null || ids.isEmpty())
          return null;
       List<PSDisplayFormat> out = new ArrayList<>(ids.size());
+      boolean any = false;
       for (IPSGuid id : ids)
       {
          if (id == null || id.getUUID() <= 0)
-            return null;
+         {
+            log.debug("JDBC display format skip; id missing or unpersisted");
+            out.add(null);
+            continue;
+         }
          PSDisplayFormat df = loadDisplayFormatFromDb(id.getUUID(), null);
          if (df == null || df.getDisplayId() != id.getUUID())
-            return null;
+         {
+            log.debug("JDBC display format miss DISPLAYID={}", id.getUUID());
+            out.add(null);
+            continue;
+         }
          out.add(df);
+         any = true;
+      }
+      return any ? out : null;
+   }
+
+   static boolean allDisplayFormatsLoaded(List<IPSGuid> ids, List<PSDisplayFormat> loaded)
+   {
+      if (ids == null || loaded == null || loaded.size() != ids.size())
+         return false;
+      for (int i = 0; i < ids.size(); i++)
+      {
+         IPSGuid id = ids.get(i);
+         PSDisplayFormat df = loaded.get(i);
+         if (id == null || df == null || df.getDisplayId() != id.getUUID())
+            return false;
+      }
+      return true;
+   }
+
+   /**
+    * Prefer per-id JDBC hits so one missing DISPLAYID does not force the whole
+    * batch onto a stale XML catalog.
+    */
+   static List<PSDisplayFormat> mergePreferJdbcDisplayFormats(List<IPSGuid> ids,
+         List<PSDisplayFormat> jdbc, List<PSDisplayFormat> xml)
+   {
+      if (ids == null || ids.isEmpty())
+         return xml == null ? new ArrayList<>() : xml;
+      List<PSDisplayFormat> out = new ArrayList<>(ids.size());
+      for (int i = 0; i < ids.size(); i++)
+      {
+         IPSGuid id = ids.get(i);
+         PSDisplayFormat fromJdbc = jdbc != null && i < jdbc.size() ? jdbc.get(i) : null;
+         if (id != null && fromJdbc != null && fromJdbc.getDisplayId() == id.getUUID())
+         {
+            out.add(fromJdbc);
+            continue;
+         }
+         out.add(xml != null && i < xml.size() ? xml.get(i) : fromJdbc);
       }
       return out;
+   }
+
+   private void lockLoadedDisplayFormats(List<IPSGuid> ids, List<PSDisplayFormat> loaded,
+         boolean overrideLock, String session, String user) throws PSErrorResultsException
+   {
+      IPSObjectLockService lockService = PSObjectLockServiceLocator.getLockingService();
+      for (int i = 0; i < ids.size(); i++)
+      {
+         PSDisplayFormat df = loaded.get(i);
+         Integer version = 1;
+         if (df instanceof PSVersionableDbComponent versionable && versionable.getVersion() != null)
+            version = versionable.getVersion();
+         try
+         {
+            lockService.createLock(ids.get(i), session, user, version, overrideLock);
+         }
+         catch (PSLockException e)
+         {
+            PSErrorResultsException results = new PSErrorResultsException();
+            results.addError(ids.get(i), e);
+            throw results;
+         }
+      }
    }
 
    static void ensureDisplayFormatRowDeleted(int displayId)
@@ -3493,7 +3556,8 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
       }
       catch (NamingException | SQLException e)
       {
-         log.debug("Could not JDBC-delete PSX_DISPLAYFORMATS DISPLAYID={}: {}", displayId, e.toString());
+         throw new IllegalStateException(
+               "Could not JDBC-delete PSX_DISPLAYFORMATS DISPLAYID=" + displayId, e);
       }
       finally
       {

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -1902,13 +1902,26 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          key = PSDisplayFormat.createKey(new String[]
          {String.valueOf(id.getUUID())});
       else if (objType.equals(PSSearch.getComponentType(PSSearch.class)))
-         key = PSSearch.createKey(new String[]
-         {String.valueOf(id.longValue())});
+         key = searchComponentKey(id);
       else
          // should never happen
          throw new RuntimeException("Cannot create component key for object type: " + objType);
 
       return key;
+   }
+
+   /**
+    * {@code PSX_SEARCHES.SEARCHID} is the GUID uuid, not the packed long
+    * ({@code host-type-uuid}). {@link IPSGuid#longValue()} on a {@code VIEW_DEF}
+    * ({@code 0-18-{id}}) or {@code SEARCH_DEF} ({@code 0-15-{id}}) is not the
+    * locator; using it made load/save/delete miss JDBC rows after H2 catalog
+    * lag (POST view then PUT fields 404).
+    */
+   static PSKey searchComponentKey(IPSGuid id)
+   {
+      if (id == null)
+         throw new IllegalArgumentException("id cannot be null");
+      return PSSearch.createKey(new String[] {String.valueOf(id.getUUID())});
    }
 
    /**


### PR DESCRIPTION
## Summary

Overnight cluster of **3 owned open PRs** that all edit `PSUiDesignWs.java` (H2 `SEARCHID`/`DISPLAYID` persist for Developer catalog Views / Searches / Display Formats). Leaving them separate would keep thrashing the same design-WS persist path on every rebase against `main`.

Git merged oldest-first with **union** of unique adds (no conflict markers; auto-merge kept view field-criteria, search unique-name INSERT, and display-format JDBC DELETE).

Left **out** of this cluster (different product slice / only 2-way Playwright spec overlap, both MERGEABLE):

* #4169 sitemap-xml Publish chrome
* #4179 skip-image-build SNAPSHOT hot-copy for Virtual Site Save banner

### Thrash files

* `system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java`
* `system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsViewPersistTest.java`
* `product-docs/8.2/developer/rest.md`

### Supersedes

| Supersedes | Original PR | Head | Absorbed | Notes |
|---|---|---|---|---|
| yes | [#4177](https://github.com/intersoftdatalabs-in/percussioncms/pull/4177) | `fix/issue-4176-view-field-selection-persist` | yes | POST then PUT field criteria finds H2 view |
| yes | [#4180](https://github.com/intersoftdatalabs-in/percussioncms/pull/4180) | `fix/issue-4173-developer-search-editor` | yes | unique CX searches persist + duplicate 409 |
| yes | [#4181](https://github.com/intersoftdatalabs-in/percussioncms/pull/4181) | `fix/issue-4172-display-format-delete-ids` | yes | name-keyed DELETE resolves DISPLAYID |

### modules_built

`system`, `rest`, `projects/sitemanage`, `WebUI`

### build_evidence

Standalone `clean install` on cluster tip `114e09077a` (JDK 21 via `JAVA_HOME`):

* `cd system && ../mvnw.cmd clean install` — **BUILD SUCCESS** (local `~/.m2` install `perc-system-8.2.0-SNAPSHOT` + tests/javadoc jars). Surefire **Tests run: 2838, Failures: 0, Errors: 0, Skipped: 248**. Persist tests: `PSUiDesignWsViewPersistTest` 7/0, `PSUiDesignWsSearchPersistTest` 7/0, `PSUiDesignWsDisplayFormatPersistTest` 10/0.
* `cd rest && ../mvnw.cmd clean install` — **BUILD SUCCESS** (23.8s). **Tests run: 1034, Failures: 0, Errors: 0, Skipped: 0**.
* `cd projects/sitemanage && ../../mvnw.cmd clean install` — **BUILD SUCCESS** (01:01). **Tests run: 2253, Failures: 0, Errors: 0, Skipped: 125**.
* `cd WebUI && ../mvnw.cmd clean install` — **BUILD SUCCESS** (`perc-web-ui-8.2.0-SNAPSHOT.war` installed). Java **Tests run: 63, Failures: 0**; Vitest **Test Files 416 passed / Tests 3765 passed**.

No public/protected/final/sealed API signature change (`IDisplayFormatAdaptor.delete` javadoc only). Reverse-dep extra modules not required; `projects/sitemanage` already clean-installed against the new `perc-system` + `rest` SNAPSHOTs.

### Product documentation

Absorbed PRs already update `product-docs/8.2/admin/developer-views.md`, `developer-searches.md`, `developer-display-formats.md`, and `product-docs/8.2/developer/rest.md`. Cluster is a union, not a new product surface.

- [x] Product documentation (`product-docs/`) updated (union of absorbed PRs)

Operator: Grok: night-issue-prs (model grok-4.6)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs-cluster.
