### PR TITLE
fix(rest): bind Admin ActionMenu POST, skip Jettison JAXB (#4171)

### DIFF
--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1506,7 +1506,8 @@ PUT round-trips GET detail fields already exposed (`label`, `description`,
 | `DELETE` | `/services/actions/{idOrName}` | **Admin.** Delete a user action menu (`deleteActions`, `ignoreDependencies=false`) |
 
 JSON may wrap a single item as `ActionMenu`. **Create** `POST /services/actions`
-sends that envelope (or a flat object with `name`). Do not post
+sends that envelope (or a flat object with `name`). The collection POST is bound
+as `ActionMenu` (not JAXB `allowedWorkflowTransitionsRequest`). Do not post
 `allowedWorkflowTransitionsRequest` on the collection path — that finder lives at
 `POST /services/actions/find/transitions`. Integrators should unwrap the
 `ActionMenu` envelope and read `guid.stringValue` (never assume the GUID is

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -160,6 +160,12 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="jacksonContextResolver" />
             <ref bean="authorizationFilter" />
         </jaxrs:providers>
+        <!-- #4171: do not auto-register Jettison JSONProvider. It JAXB-binds
+             POST /actions as allowedWorkflowTransitionsRequest (finder is
+             /find/transitions). Jackson + ActionMenuJsonReader own JSON. -->
+        <jaxrs:properties>
+            <entry key="skip.default.json.provider.registration" value="true"/>
+        </jaxrs:properties>
         <jaxrs:features>
             <!-- CXF 3.1+/4.x: use LoggingFeature bean (requires cxf-rt-features-logging).
                  Legacy <cxf:logging/> under core NS has no BeanDefinitionParser without that module. -->

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -226,6 +226,10 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(
         displayFormatReader < jackson,
         DISPLAY_FORMAT_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        restBlock.contains("skip.default.json.provider.registration"),
+        "rest-jax-rs must skip Jettison JSONProvider (POST /actions JAXB "
+            + "allowedWorkflowTransitionsRequest)");
   }
 
   private static Path resolveRepoRoot() {

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
@@ -46,6 +46,8 @@ import tools.jackson.databind.json.JsonMapper;
  * This reader binds wrap and flat shapes before {@code jacksonProvider}.
  *
  * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code jacksonProvider}.
+ * rest-jax-rs also sets {@code skip.default.json.provider.registration} so Jettison JAXB cannot
+ * bind this body as {@code allowedWorkflowTransitionsRequest} (#4171).
  */
 @Provider
 @Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.actions;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
 
@@ -27,8 +28,12 @@ import java.util.Arrays;
  * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
  * {@code contentIds} and {@code assignmentTypeIds} as JSON arrays, not Optional beans (issue #3388
  * slice 10 / #3432).
+ *
+ * <p>Root name is explicit so JAXB/Jettison cannot treat an {@code ActionMenu} envelope as this
+ * type on {@code POST /actions} (#4171). Finder POST is {@code /actions/find/transitions}.
  */
-@XmlRootElement
+@XmlRootElement(name = "allowedWorkflowTransitionsRequest")
+@JsonRootName("allowedWorkflowTransitionsRequest")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AllowedWorkflowTransitionsRequest {
 

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.provider.JAXBElementProvider;
 import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.jupiter.api.AfterEach;
@@ -79,7 +80,9 @@ public class ActionMenuCreateCxfUnmarshallTest {
     jackson.setMapper(
         (tools.jackson.databind.json.JsonMapper)
             new JacksonContextResolver().getContext(ActionMenu.class));
-    factory.setUserProviders(Arrays.asList(custom, jackson, new JacksonContextResolver()));
+    factory.setUserProviders(
+        Arrays.asList(
+            custom, jackson, new JacksonContextResolver(), new JAXBElementProvider<>()));
 
     MessageImpl message = new MessageImpl();
     MessageBodyReader<ActionMenu> selected =
@@ -117,6 +120,20 @@ public class ActionMenuCreateCxfUnmarshallTest {
   @Test
   public void cxfPostFlatActionMenuInvokesCreate() throws Exception {
     assertCreatePost(FLAT, "cxfFlat", "local://issue-4123-actions-flat");
+  }
+
+  @Test
+  public void cxfPostWrappedActionMenuWithJaxbProviderStillInvokesCreate() throws Exception {
+    assertCreatePost(WRAPPED, "cxfN1", "local://issue-4171-actions-jaxb");
+  }
+
+  @Test
+  public void jacksonBarrierBindsWrappedActionMenuWithoutCustomReader() {
+    ActionMenu menu =
+        new JacksonContextResolver()
+            .getContext(ActionMenu.class)
+            .readValue(WRAPPED, ActionMenu.class);
+    assertEquals("cxfN1", menu.getName());
   }
 
   private void assertCreatePost(String json, String expectedName, String address) throws Exception {
@@ -169,6 +186,7 @@ public class ActionMenuCreateCxfUnmarshallTest {
             new AllowedContentTypeMenusRequestJsonReader(),
             jackson,
             new JacksonContextResolver(),
+            new JAXBElementProvider<>(),
             new WebApplicationExceptionMapper()));
     Server created = sf.create();
     assertNotNull(created, "CXF local server must start");


### PR DESCRIPTION
## Summary

Cycle Verify residual for Developer Action Menus create (`tests/developer-action-menu-editor.spec.js`). Live Admin `POST /services/actions` failed with JAXB `unexpected element ActionMenu; expected allowedWorkflowTransitionsRequest` when CXF’s default Jettison JSON provider bound the collection POST as the workflow-transitions finder DTO.

This PR:

- Sets `skip.default.json.provider.registration` on `rest-jax-rs` so Jackson + `ActionMenuJsonReader` own JSON (finder stays at `POST /actions/find/transitions`).
- Pins `@XmlRootElement` / `@JsonRootName` on `AllowedWorkflowTransitionsRequest` to `allowedWorkflowTransitionsRequest`.
- CXF tests include `JAXBElementProvider` and lock wrapped/flat create POST to `createActionMenu`.
- Integrator note in `product-docs/8.2/developer/rest.md`.

H2 QA must dual-ship **rest + sitemanage + perc-system** (and WebUI `cm/modern`) into the WAR — `--then-qa-deploy-webui` alone is not enough.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4171
Partial #4112
Parent #1690

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 1035, Failures: 0).
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2174, Failures: 0, Errors: 0, Skipped: 125).
3. H2 QA: `perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` → `qa-health` RESULT:OK HTTP:200 HEALTH:healthy.
4. Hot-copy `rest-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar`, exploded `sitemanage-beans.xml`, `perc-system-8.2.0-SNAPSHOT.jar` into `Rhythmyx/WEB-INF/lib`; `qa-deploy-webui`; in-cell StopJetty/StartJetty; `qa-health` again.
5. `npm run test:surface -- --path tests/developer-action-menu-editor.spec.js` — **3 passed**. console-clean=yes (spec guards). server.log-clean=yes (no ActionMenu ERROR/FATAL).
6. `perc-devctl.py qa-down`

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (Action menus create POST is `ActionMenu`, not `allowedWorkflowTransitionsRequest`)
- [x] **Unit / module tests** — CXF unmarshall + CatalogRestJaxrsRegistrationTest; rest and sitemanage standalone `clean install`
- [x] **WebUI + Playwright** — existing spec not weakened; H2 surface path **3 passed**
- [x] **Build gates** — rest + sitemanage standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:** `cd rest && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 1035 Failures: 0; `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS Tests run: 2174 Failures: 0 Errors: 0 Skipped: 125
- **downstream_checked:** sitemanage (depends on rest) standalone clean install; no `extends ActionMenu` subclasses

### C5 UI proof

- qa-up `--skip-image-build`; TEST_CMS_URL=`http://127.0.0.1:9993`
- Dual-ship rest + sitemanage + perc-system WAR jars + exploded beans.xml + `qa-deploy-webui`
- Playwright: `npm run test:surface -- --path tests/developer-action-menu-editor.spec.js` — 3 passed
- console-clean=yes; server.log-clean=yes

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
