### PR TITLE
feat(rest): PUT usage/command round-trip for user action menus (#4183)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-4183-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4183-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — issue 4183
+
+**Branch:** `fix/issue-4183-action-menu-usage-command-put`  
+**Scope:** uncommitted vs HEAD + not in origin/main  
+**Date:** 2026-09-02  
+**Memory patterns hit:** change-class closure (rest resource + adaptor + tests + Spring stub already present + product-docs); behavioral tests for new persist logic; no new path I/O.
+
+## Summary
+
+Admin `PUT /services/actions/{idOrName}` now persists Workbench Usage/Command fields (`handler`, URL, URL parameters, command/usage properties) on user menus and returns them on the PUT DTO (GET-round-trip). System menus remain 409; non-Admin 403; missing 404. Visibility contexts are ignored (slice #4184). SPA tabs not touched (#4185).
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None (bugs).
+
+### Notes (non-blocking)
+
+- Parameter replace uses `removeParameter` so persisted rows are marked for delete rather than `clear()`.
+- `sys_restUserMenu` is not overwritten from the PUT body.
+- Cross-platform path checklist: N/A (no filesystem path logic in this diff).
+- C5 Playwright: N/A (REST/Java only; no WebUI screen).
+
+## Tests
+
+- `rest`: `ActionMenuResourceTest` usage/command delegate; existing 403/404/409.
+- `sitemanage`: `ActionMenuAdaptorWriteTest` persist + DTO round-trip, invalid handler, omit-null parameters, empty-array clear.
+- Spring `ActionsTestAdaptor` already implements `saveActionMenu` (no new interface).

--- a/product-docs/8.2/admin/developer-action-menus.md
+++ b/product-docs/8.2/admin/developer-action-menus.md
@@ -21,8 +21,9 @@ be updated or deleted from this catalog. A mutate or delete attempt is **409**;
 the product does not steal the design lock (`overrideLock=false`).
 
 This is **not** the Workbench cascading-children composer (UI-04) or the
-usage / command / visibility tabs (UI-03). Parameters and properties on
-detail stay **read-only**.
+SPA usage / command / visibility tabs. Integrators can persist usage and
+command fields on **PUT** (handler, URL, URL parameters, command properties);
+those tabs in this chrome remain later. Visibility contexts are not written.
 
 ## Product path — create, delete
 
@@ -40,7 +41,8 @@ detail stay **read-only**.
    lists the new name immediately (`GET /services/actions/catalog` and GET by
    name); packaged menus such as **Copy** cannot be deleted (**409**).
 5. Optional: change label, description, menu type, or URL and **Save** again.
-   Child entries, parameters, properties, and visibility are not written.
+   Child entries and visibility are not written from this chrome. REST
+   **PUT** can persist handler, URL parameters, and command properties.
 6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
    The catalog returns with a green **Action
    menu deleted** notice and no longer lists that user menu. Delete of a
@@ -53,7 +55,8 @@ detail stay **read-only**.
 
 - Name is immutable after create.
 - Cascading child menu composition is not in this chrome (UI-04).
-- Usage / command / visibility tab editing is not in this chrome (UI-03).
+- Usage / command / visibility tab editing is not in this chrome; REST PUT
+  honors usage/command fields (see [REST API — Action menus](id:developer-rest)).
 - System menus cannot be updated or deleted here.
 
 ## REST
@@ -65,7 +68,7 @@ The chrome calls:
 | List | `GET /services/actions/catalog` |
 | Load | `GET /services/actions/catalog/{idOrName}` |
 | Create | `POST /services/actions` (`name` required; unique, no spaces) |
-| Save | `PUT /services/actions/{idOrName}` (label, description, menuType, url) |
+| Save | `PUT /services/actions/{idOrName}` (label, description, menuType, url, handler, parameters, command properties) |
 | Delete | `DELETE /services/actions/{idOrName}` (`204` on success) |
 
 Writes lock the menu for the request (`overrideLock=false`) and release it on

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1480,9 +1480,11 @@ rows are written to `RXMENUACTION` so Hibernate `findActionMenusTree` (GET
 `/services/actions/catalog` and GET by name) includes a user menu immediately
 after POST, and omits it after DELETE. There is no new SOAP surface.
 **Developer → Action Menus** chrome creates and deletes user menus (and saves
-label / description / menuType / url); cascading children composition (UI-04)
-and usage/command/visibility tab completeness (UI-03) are later slices — see
-[Developer Action Menus](id:admin-developer-action-menus). Finder helpers
+label / description / menuType / url). Admin **PUT** also round-trips Workbench
+**Usage** and **Command** fields on user menus (`handler`, `url`, `parameters`,
+and command/usage `properties`). Cascading children composition (UI-04) and
+visibility contexts / SPA usage-command-visibility tabs remain later slices —
+see [Developer Action Menus](id:admin-developer-action-menus). Finder helpers
 (`GET /services/actions/find`, content-type and template finders) are unchanged.
 After POST the editor notice confirms the save. Packaged menus (for example
 **Copy**) are **409** on PUT/DELETE, not **404**.
@@ -1495,14 +1497,23 @@ updated or deleted — **409**; the design lock is not stolen (`overrideLock=fal
 If Workbench path resolution fails, PUT/DELETE also return **409** (fail closed)
 so a lookup error cannot bypass that protection.
 PUT round-trips GET detail fields already exposed (`label`, `description`,
-`menuType`, `url`). Name is the catalog key and is not renamed on PUT.
+`menuType`, `url`) plus usage/command fields: `handler` (`CLIENT` or `SERVER`),
+`url`, `parameters` (name/value/description URL parameters; a present array
+replaces the collection, including empty), and `properties` used as Workbench
+Usage/Command (for example `AcceleratorKey`, `MnemonicKey`, `ShortDescription`,
+`SmallIcon`, `launchesWindow`, `SupportsMultiSelect`, `refreshHint`, `target`,
+`targetStyle`). Omitted `handler` / `parameters` / `properties` leave the
+stored values. The REST user-menu marker property is not overwritten. Name is
+the catalog key and is not renamed on PUT. Invalid `handler` or `menuType` is
+**400**. Visibility contexts (`visibilityContexts`, `uiContexts`) are ignored
+on PUT.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/actions/catalog` | List action menus (tree roots with children) |
 | `GET` | `/services/actions/catalog/{idOrName}` | Load one menu by name, numeric id, or GUID string |
 | `POST` | `/services/actions` | **Admin.** Create a user action menu (`createActions` then `saveActions`) |
-| `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, and/or url |
+| `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, url, handler, parameters, and command/usage properties |
 | `DELETE` | `/services/actions/{idOrName}` | **Admin.** Delete a user action menu (`deleteActions`, `ignoreDependencies=false`) |
 
 JSON may wrap a single item as `ActionMenu`. **Create** `POST /services/actions`

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -59,6 +59,8 @@ import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
@@ -733,6 +735,133 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       domain.setURL(body.getUrl());
     }
     applyMenuType(domain, body.getMenuType());
+    applyHandler(domain, body.getHandler());
+    applyParameters(domain, body.getParameters());
+    applyCommandProperties(domain, body.getProperties());
+  }
+
+  /**
+   * Workbench Usage handler: {@code CLIENT} or {@code SERVER}. Blank leaves the existing
+   * handler. Visibility contexts are not applied here (UI-03 slice 2).
+   */
+  static void applyHandler(PSAction domain, String raw) {
+    if (domain == null || StringUtils.isBlank(raw)) {
+      return;
+    }
+    String handler = raw.trim();
+    if (PSAction.HANDLER_CLIENT.equalsIgnoreCase(handler)) {
+      domain.setClientAction(true);
+      return;
+    }
+    if (PSAction.HANDLER_SERVER.equalsIgnoreCase(handler)) {
+      domain.setClientAction(false);
+      return;
+    }
+    throw new IllegalArgumentException("Invalid handler: " + raw);
+  }
+
+  /**
+   * Replaces URL parameters when the PUT body includes {@code parameters} (empty array
+   * clears). {@code null} leaves the existing collection. Names must be non-blank.
+   */
+  static void applyParameters(PSAction domain, ActionMenuParameter[] parameters) {
+    if (domain == null || parameters == null) {
+      return;
+    }
+    PSActionParameters dest = domain.getParameters();
+    Map<String, ActionMenuParameter> incoming = new LinkedHashMap<>();
+    for (ActionMenuParameter param : parameters) {
+      if (param == null || StringUtils.isBlank(param.getName())) {
+        continue;
+      }
+      incoming.put(param.getName().trim(), param);
+    }
+    List<String> toRemove = new ArrayList<>();
+    Iterator<?> it = dest.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (next instanceof PSActionParameter existing) {
+        if (!containsIgnoreCase(incoming.keySet(), existing.getName())) {
+          toRemove.add(existing.getName());
+        }
+      }
+    }
+    for (String name : toRemove) {
+      dest.removeParameter(name);
+    }
+    for (ActionMenuParameter param : incoming.values()) {
+      String name = param.getName().trim();
+      dest.setParameter(name, param.getValue() == null ? "" : param.getValue());
+      PSActionParameter stored = findParameter(dest, name);
+      if (stored != null && param.getDescription() != null) {
+        stored.setDescription(param.getDescription());
+      }
+    }
+  }
+
+  /**
+   * Merges Workbench Usage/Command properties by name. {@code null} leaves existing
+   * properties. Never overwrites {@link #REST_USER_MENU_PROP}. Visibility is not applied.
+   */
+  static void applyCommandProperties(PSAction domain, ActionMenuProperty[] properties) {
+    if (domain == null || properties == null) {
+      return;
+    }
+    PSActionProperties dest = domain.getProperties();
+    for (ActionMenuProperty prop : properties) {
+      if (prop == null || StringUtils.isBlank(prop.getName())) {
+        continue;
+      }
+      String name = prop.getName().trim();
+      if (REST_USER_MENU_PROP.equalsIgnoreCase(name)) {
+        continue;
+      }
+      dest.setProperty(name, prop.getValue() == null ? "" : prop.getValue());
+      PSActionProperty stored = findProperty(dest, name);
+      if (stored != null && prop.getDescription() != null) {
+        stored.setDescription(prop.getDescription());
+      }
+    }
+  }
+
+  static boolean containsIgnoreCase(Iterable<String> names, String needle) {
+    if (names == null || StringUtils.isBlank(needle)) {
+      return false;
+    }
+    for (String name : names) {
+      if (needle.equalsIgnoreCase(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static PSActionParameter findParameter(PSActionParameters params, String name) {
+    if (params == null || StringUtils.isBlank(name)) {
+      return null;
+    }
+    Iterator<?> it = params.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (next instanceof PSActionParameter param && name.equalsIgnoreCase(param.getName())) {
+        return param;
+      }
+    }
+    return null;
+  }
+
+  static PSActionProperty findProperty(PSActionProperties props, String name) {
+    if (props == null || StringUtils.isBlank(name)) {
+      return null;
+    }
+    Iterator<?> it = props.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (next instanceof PSActionProperty prop && name.equalsIgnoreCase(prop.getName())) {
+        return prop;
+      }
+    }
+    return null;
   }
 
   static ActionType resolveCreateType(ActionMenu body) {
@@ -817,7 +946,49 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     if (guid != null) {
       menu.setGuid(copyGuid(guid));
     }
+    menu.setParameters(toDtoParameters(action.getParameters()));
+    menu.setProperties(toDtoProperties(action.getProperties()));
     return menu;
+  }
+
+  static ActionMenuParameter[] toDtoParameters(PSActionParameters params) {
+    if (params == null || params.size() == 0) {
+      return new ActionMenuParameter[0];
+    }
+    List<ActionMenuParameter> out = new ArrayList<>();
+    Iterator<?> it = params.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (!(next instanceof PSActionParameter param) || StringUtils.isBlank(param.getName())) {
+        continue;
+      }
+      ActionMenuParameter dto = new ActionMenuParameter();
+      dto.setName(param.getName());
+      dto.setValue(param.getValue());
+      dto.setDescription(param.getDescription());
+      out.add(dto);
+    }
+    return out.toArray(ActionMenuParameter[]::new);
+  }
+
+  static ActionMenuProperty[] toDtoProperties(PSActionProperties props) {
+    if (props == null || props.size() == 0) {
+      return new ActionMenuProperty[0];
+    }
+    List<ActionMenuProperty> out = new ArrayList<>();
+    Iterator<?> it = props.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (!(next instanceof PSActionProperty prop) || StringUtils.isBlank(prop.getName())) {
+        continue;
+      }
+      ActionMenuProperty dto = new ActionMenuProperty();
+      dto.setName(prop.getName());
+      dto.setValue(prop.getValue());
+      dto.setDescription(prop.getDescription());
+      out.add(dto);
+    }
+    return out.toArray(ActionMenuProperty[]::new);
   }
 
   static String restMenuType(PSAction action) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -35,8 +35,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.cms.objectstore.PSAction;
+import com.percussion.cms.objectstore.PSActionParameter;
 import com.percussion.rest.actions.ActionMenu;
 import com.percussion.rest.actions.ActionMenuList;
+import com.percussion.rest.actions.ActionMenuParameter;
+import com.percussion.rest.actions.ActionMenuProperty;
+import com.percussion.rest.actions.ActionMenuVisibilityContext;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -255,6 +259,116 @@ class ActionMenuAdaptorWriteTest {
     verify(designWs).saveActions(anyList(), eq(true), eq("test-session"), eq("Admin"));
     verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
     verify(designWs).loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_usageAndCommand_roundTripsOnPutAndDto() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    existing.getProperties().setProperty(ActionMenuAdaptor.REST_USER_MENU_PROP, PSAction.YES);
+    existing.getParameters().setParameter("oldParam", "old");
+    stubCatalogLoad(existing);
+    PSAction locked = stubAction("MyMenu", 42);
+    locked.getProperties().setProperty(ActionMenuAdaptor.REST_USER_MENU_PROP, PSAction.YES);
+    locked.getParameters().setParameter("oldParam", "old");
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ActionMenu body = new ActionMenu();
+    body.setHandler(PSAction.HANDLER_CLIENT);
+    body.setUrl("/sys_cxSupport/foo.xml");
+    ActionMenuParameter param = new ActionMenuParameter();
+    param.setName("sys_contentid");
+    param.setValue("PSX_CONTENTID");
+    param.setDescription("content id");
+    body.setParameters(new ActionMenuParameter[] {param});
+    ActionMenuProperty accel = new ActionMenuProperty();
+    accel.setName(PSAction.PROP_ACCEL_KEY);
+    accel.setValue("ctrl S");
+    ActionMenuProperty mnem = new ActionMenuProperty();
+    mnem.setName(PSAction.PROP_MNEM_KEY);
+    mnem.setValue("S");
+    ActionMenuProperty launch = new ActionMenuProperty();
+    launch.setName(PSAction.PROP_LAUNCH_NEW_WND);
+    launch.setValue(PSAction.YES);
+    ActionMenuProperty marker = new ActionMenuProperty();
+    marker.setName(ActionMenuAdaptor.REST_USER_MENU_PROP);
+    marker.setValue(PSAction.NO);
+    body.setProperties(new ActionMenuProperty[] {accel, mnem, launch, marker});
+    ActionMenuVisibilityContext vis = new ActionMenuVisibilityContext();
+    vis.setValue("should-not-persist");
+    body.setVisibilityContexts(new ActionMenuVisibilityContext[] {vis});
+
+    ActionMenu out = adaptor.saveActionMenu("MyMenu", body);
+
+    assertEquals(PSAction.HANDLER_CLIENT, out.getHandler());
+    assertEquals("/sys_cxSupport/foo.xml", out.getUrl());
+    assertEquals(1, out.getParameters().length);
+    assertEquals("sys_contentid", out.getParameters()[0].getName());
+    assertEquals("PSX_CONTENTID", out.getParameters()[0].getValue());
+    assertEquals("content id", out.getParameters()[0].getDescription());
+    assertEquals("ctrl S", propertyValue(out, PSAction.PROP_ACCEL_KEY));
+    assertEquals("S", propertyValue(out, PSAction.PROP_MNEM_KEY));
+    assertEquals(PSAction.YES, propertyValue(out, PSAction.PROP_LAUNCH_NEW_WND));
+    assertEquals(PSAction.YES, propertyValue(out, ActionMenuAdaptor.REST_USER_MENU_PROP));
+    assertNull(out.getVisibilityContexts());
+    assertTrue(locked.isClientAction());
+    assertEquals("/sys_cxSupport/foo.xml", locked.getURL());
+    assertEquals("PSX_CONTENTID", locked.getParameters().getParameter("sys_contentid"));
+    assertNull(locked.getParameters().getParameter("oldParam"));
+    assertEquals("ctrl S", locked.getProperty(PSAction.PROP_ACCEL_KEY));
+    assertEquals(PSAction.YES, locked.getProperty(ActionMenuAdaptor.REST_USER_MENU_PROP));
+    verify(designWs).saveActions(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_invalidHandler_is400BeforeSave() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    PSAction locked = stubAction("MyMenu", 42);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+    ActionMenu body = new ActionMenu();
+    body.setHandler("neither");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.saveActionMenu("MyMenu", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("handler"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void applyWritableFields_nullParametersLeavesExisting() {
+    PSAction domain = stubAction("MyMenu", 42);
+    domain.getParameters().setParameter("keep", "1");
+    ActionMenu body = new ActionMenu();
+    body.setLabel("Updated");
+    ActionMenuAdaptor.applyWritableFields(domain, body);
+    assertEquals("1", domain.getParameters().getParameter("keep"));
+    assertEquals("Updated", domain.getLabel());
+  }
+
+  @Test
+  void applyParameters_emptyArrayClears() {
+    PSAction domain = stubAction("MyMenu", 42);
+    domain.getParameters().setParameter("gone", "x");
+    ActionMenuAdaptor.applyParameters(domain, new ActionMenuParameter[0]);
+    assertEquals(0, domain.getParameters().size());
+  }
+
+  @Test
+  void toDto_mapsHandlerParametersAndProperties() {
+    PSAction action = stubAction("MyMenu", 42);
+    action.setClientAction(false);
+    action.setURL("/cmd");
+    action.getParameters().add(new PSActionParameter("p1", "v1", "d1"));
+    action.getProperties().setProperty(PSAction.PROP_SHORT_DESC, "tip");
+    ActionMenu dto = ActionMenuAdaptor.toDto(action);
+    assertEquals(PSAction.HANDLER_SERVER, dto.getHandler());
+    assertEquals("/cmd", dto.getUrl());
+    assertEquals(1, dto.getParameters().length);
+    assertEquals("p1", dto.getParameters()[0].getName());
+    assertEquals("v1", dto.getParameters()[0].getValue());
+    assertEquals("d1", dto.getParameters()[0].getDescription());
+    assertEquals("tip", propertyValue(dto, PSAction.PROP_SHORT_DESC));
   }
 
   @Test
@@ -611,6 +725,18 @@ class ActionMenuAdaptorWriteTest {
     PSAction action = new PSAction(name, name);
     action.setGUID(new PSGuid(PSTypeEnum.ACTION, id));
     return action;
+  }
+
+  private static String propertyValue(ActionMenu menu, String name) {
+    if (menu.getProperties() == null) {
+      return null;
+    }
+    for (ActionMenuProperty prop : menu.getProperties()) {
+      if (prop != null && name.equalsIgnoreCase(prop.getName())) {
+        return prop.getValue();
+      }
+    }
+    return null;
   }
 
   private void stubCatalogLoad(PSAction action) throws Exception {

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -71,8 +71,9 @@ public class ActionMenuResource {
       summary = "List action menus (catalog)",
       description =
           "Lists CX action menus for the Developer module. Admin create/save/delete user menus"
-              + " via POST/PUT/DELETE on this resource. Cascading children composition and"
-              + " usage/command/visibility tabs remain later slices.",
+              + " via POST/PUT/DELETE on this resource. PUT round-trips usage/command fields"
+              + " (handler, url, parameters, command properties). Visibility contexts and"
+              + " cascading children composition remain later slices.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -254,11 +255,12 @@ public class ActionMenuResource {
   @Operation(
       summary = "Update action menu",
       description =
-          "Admin. Updates label, description, menuType, and/or url by name, numeric id, or GUID."
-              + " Name is the catalog key and is not renamed on PUT. Loads with a design lock"
-              + " (overrideLock=false) and releases on save. Unknown id is 404. Lock/dependency"
-              + " conflict is 409. System menus are 409 (not mutated; the lock is not stolen)."
-              + " Cascading children composition is a later slice.",
+          "Admin. Updates label, description, menuType, url, handler, URL parameters, and"
+              + " command/usage properties by name, numeric id, or GUID. Name is the catalog"
+              + " key and is not renamed on PUT. Loads with a design lock (overrideLock=false)"
+              + " and releases on save. Unknown id is 404. Lock/dependency conflict is 409."
+              + " System menus are 409 (not mutated; the lock is not stolen). Visibility"
+              + " contexts and cascading children composition are later slices.",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
@@ -53,7 +53,9 @@ public interface IActionMenuAdaptor {
    * saveActions} release). Does not steal another user's lock. System menus are not mutated.
    *
    * @param idOrName catalog key (same rules as {@link #findMenuByKey})
-   * @param body required writable fields (label, description, menuType, url as exposed on GET)
+   * @param body required writable fields (label, description, menuType, url, handler,
+   *     parameters, and command/usage properties as exposed on GET). Visibility is not
+   *     mutated.
    * @return the persisted menu, or {@code null} when missing/unsafe
    */
   ActionMenu saveActionMenu(String idOrName, ActionMenu body);

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -261,6 +261,36 @@ public class ActionMenuResourceTest {
   }
 
   @Test
+  public void updateActionMenuUsageCommandDelegates() {
+    ActionMenu body = new ActionMenu();
+    body.setHandler("CLIENT");
+    body.setUrl("/sys_cxSupport/foo.xml");
+    ActionMenuParameter param = new ActionMenuParameter();
+    param.setName("sys_contentid");
+    param.setValue("PSX_CONTENTID");
+    body.setParameters(new ActionMenuParameter[] {param});
+    ActionMenuProperty accel = new ActionMenuProperty();
+    accel.setName("AcceleratorKey");
+    accel.setValue("ctrl S");
+    body.setProperties(new ActionMenuProperty[] {accel});
+    ActionMenu updated = new ActionMenu();
+    updated.setName("MyMenu");
+    updated.setHandler("CLIENT");
+    updated.setUrl("/sys_cxSupport/foo.xml");
+    updated.setParameters(body.getParameters());
+    updated.setProperties(body.getProperties());
+    when(adaptor.saveActionMenu(eq("MyMenu"), eq(body))).thenReturn(updated);
+
+    ActionMenu out = resource.updateActionMenu("MyMenu", body);
+
+    assertEquals("CLIENT", out.getHandler());
+    assertEquals("/sys_cxSupport/foo.xml", out.getUrl());
+    assertEquals("sys_contentid", out.getParameters()[0].getName());
+    assertEquals("ctrl S", out.getProperties()[0].getValue());
+    verify(adaptor).saveActionMenu("MyMenu", body);
+  }
+
+  @Test
   public void updateActionMenuUnknownIs404() {
     when(adaptor.saveActionMenu(eq("missing"), any())).thenReturn(null);
     WebApplicationException ex =


### PR DESCRIPTION
## Summary

Admin `PUT /services/actions/{idOrName}` now persists Workbench **Usage** and **Command** fields on **user** action menus and returns them on the PUT response (GET-round-trip): `handler` (CLIENT/SERVER), `url`, URL `parameters`, and command/usage `properties` (AcceleratorKey, MnemonicKey, ShortDescription, SmallIcon, launchesWindow, SupportsMultiSelect, refreshHint, target, targetStyle, plus other named properties).

Name remains the catalog key (not renamed). System menus stay **409**. Non-Admin **403**. Missing **404**. Invalid handler/menuType **400**. Visibility contexts are ignored (slice #4184). SPA usage/command tabs are not implemented (slice #4185). JAXB POST create is unchanged (#4171).

Fixes #4183
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Unit: `ActionMenuResourceTest.updateActionMenuUsageCommandDelegates` plus existing 403/404/409 resource tests.
2. Adaptor: `ActionMenuAdaptorWriteTest.update_usageAndCommand_roundTripsOnPutAndDto` (handler, url, parameters replace, command properties, REST user-menu marker preserved, visibility ignored); invalid handler before save; omitted parameters leave existing; empty array clears parameters.
3. Standalone module `clean install` (this PR).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` Action menus; `product-docs/8.2/admin/developer-action-menus.md` REST table
- [x] **Unit / module tests** — behavioral tests; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; SPA tabs are #4185)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:**
  - `cd rest; ..\mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 1034, Failures: 0). `ActionMenuResourceTest` Tests run: 30, Failures: 0.
  - `cd projects/sitemanage; ..\..\mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 2179, Failures: 0). `ActionMenuAdaptorWriteTest` Tests run: 45, Failures: 0.
- **downstream_checked:** C2 API-shape gate did not apply (no `final`/signature break). Grep of `saveActionMenu(`: rest resource + existing `ActionsTestAdaptor` Spring stub + sitemanage adaptor (built). WebUI client already sent ActionMenu JSON and is unchanged.

### C5 UI proof

N/A — REST/Java only; no WebUI SPA/chrome change.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
