### PR TITLE
feat(rest): PUT visibilityContexts + uiContexts round-trip for user action menus (#4184)

### DIFF
--- a/docs/ai-generated/code-reviews/issue-4183-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4183-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — issue 4183
+
+**Branch:** `fix/issue-4183-action-menu-usage-command-put`  
+**Scope:** uncommitted vs HEAD + not in origin/main  
+**Date:** 2026-09-02  
+**Memory patterns hit:** change-class closure (rest resource + adaptor + tests + Spring stub already present + product-docs); behavioral tests for new persist logic; no new path I/O.
+
+## Summary
+
+Admin `PUT /services/actions/{idOrName}` now persists Workbench Usage/Command fields (`handler`, URL, URL parameters, command/usage properties) on user menus and returns them on the PUT DTO (GET-round-trip). System menus remain 409; non-Admin 403; missing 404. Visibility contexts are ignored (slice #4184). SPA tabs not touched (#4185).
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None (bugs).
+
+### Notes (non-blocking)
+
+- Parameter replace uses `removeParameter` so persisted rows are marked for delete rather than `clear()`.
+- `sys_restUserMenu` is not overwritten from the PUT body.
+- Cross-platform path checklist: N/A (no filesystem path logic in this diff).
+- C5 Playwright: N/A (REST/Java only; no WebUI screen).
+
+## Tests
+
+- `rest`: `ActionMenuResourceTest` usage/command delegate; existing 403/404/409.
+- `sitemanage`: `ActionMenuAdaptorWriteTest` persist + DTO round-trip, invalid handler, omit-null parameters, empty-array clear.
+- Spring `ActionsTestAdaptor` already implements `saveActionMenu` (no new interface).

--- a/docs/ai-generated/code-reviews/issue-4184-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4184-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review — issue 4184
+
+**Branch:** `fix/issue-4184-action-menu-visibility-put`  
+**Scope:** stacked on #4183 / PR #4190; visibility/uiContexts persist + GET overlay  
+**Date:** 2026-09-02  
+**Memory patterns hit:** change-class closure (rest resource + adaptor + tests + Spring stub already present + product-docs); behavioral tests for new persist logic; no new path I/O.
+
+## Summary
+
+Admin `PUT /services/actions/{idOrName}` persists Workbench Visibility (`visibilityContexts`) and mode-uicontexts (`uiContexts`) on user menus and returns them on the PUT DTO. GET catalog detail overlays an unlocked design load so the same fields round-trip. Invalid names/ids are 400. System menus remain 409; non-Admin 403. SPA tabs not touched (#4185). Does not re-implement usage/command (#4183).
+
+## Recommendation
+
+approve
+
+## Gate
+
+May commit/push: yes
+
+## Issues
+
+None (bugs).
+
+### Notes (non-blocking)
+
+- Visibility replace uses `removeContext` so persisted rows are marked for delete rather than `clear()`.
+- `null` arrays leave existing collections; empty arrays clear (same as URL parameters).
+- GET overlay failures are debug-logged and do not 409 catalog detail.
+- Cross-platform path checklist: N/A (no filesystem path logic in this diff).
+- C5 Playwright: N/A (REST/Java only; no WebUI screen).
+
+## Tests
+
+- `rest`: `ActionMenuResourceTest` visibility delegate, invalid 400, non-Admin 403; existing 409/404.
+- `sitemanage`: `ActionMenuAdaptorWriteTest` persist + DTO round-trip, invalid visibility/uiContext, omit-null, empty-array clear, GET overlay.

--- a/product-docs/8.2/admin/developer-action-menus.md
+++ b/product-docs/8.2/admin/developer-action-menus.md
@@ -41,8 +41,9 @@ those tabs in this chrome remain later. Visibility contexts are not written.
    lists the new name immediately (`GET /services/actions/catalog` and GET by
    name); packaged menus such as **Copy** cannot be deleted (**409**).
 5. Optional: change label, description, menu type, or URL and **Save** again.
-   Child entries and visibility are not written from this chrome. REST
-   **PUT** can persist handler, URL parameters, and command properties.
+   Child entries are not written from this chrome. REST **PUT** can persist
+   handler, URL parameters, command properties, visibility contexts, and
+   mode-uicontexts.
 6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
    The catalog returns with a green **Action
    menu deleted** notice and no longer lists that user menu. Delete of a
@@ -56,7 +57,8 @@ those tabs in this chrome remain later. Visibility contexts are not written.
 - Name is immutable after create.
 - Cascading child menu composition is not in this chrome (UI-04).
 - Usage / command / visibility tab editing is not in this chrome; REST PUT
-  honors usage/command fields (see [REST API — Action menus](id:developer-rest)).
+  honors usage, command, and visibility fields (see
+  [REST API — Action menus](id:developer-rest)).
 - System menus cannot be updated or deleted here.
 
 ## REST
@@ -68,7 +70,7 @@ The chrome calls:
 | List | `GET /services/actions/catalog` |
 | Load | `GET /services/actions/catalog/{idOrName}` |
 | Create | `POST /services/actions` (`name` required; unique, no spaces) |
-| Save | `PUT /services/actions/{idOrName}` (label, description, menuType, url, handler, parameters, command properties) |
+| Save | `PUT /services/actions/{idOrName}` (label, description, menuType, url, handler, parameters, command properties, visibilityContexts, uiContexts) |
 | Delete | `DELETE /services/actions/{idOrName}` (`204` on success) |
 
 Writes lock the menu for the request (`overrideLock=false`) and release it on

--- a/product-docs/8.2/admin/developer-action-menus.md
+++ b/product-docs/8.2/admin/developer-action-menus.md
@@ -21,8 +21,9 @@ be updated or deleted from this catalog. A mutate or delete attempt is **409**;
 the product does not steal the design lock (`overrideLock=false`).
 
 This is **not** the Workbench cascading-children composer (UI-04) or the
-usage / command / visibility tabs (UI-03). Parameters and properties on
-detail stay **read-only**.
+SPA usage / command / visibility tabs. Integrators can persist usage and
+command fields on **PUT** (handler, URL, URL parameters, command properties);
+those tabs in this chrome remain later. Visibility contexts are not written.
 
 ## Product path — create, delete
 
@@ -40,7 +41,8 @@ detail stay **read-only**.
    lists the new name immediately (`GET /services/actions/catalog` and GET by
    name); packaged menus such as **Copy** cannot be deleted (**409**).
 5. Optional: change label, description, menu type, or URL and **Save** again.
-   Child entries, parameters, properties, and visibility are not written.
+   Child entries and visibility are not written from this chrome. REST
+   **PUT** can persist handler, URL parameters, and command properties.
 6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
    The catalog returns with a green **Action
    menu deleted** notice and no longer lists that user menu. Delete of a
@@ -53,7 +55,8 @@ detail stay **read-only**.
 
 - Name is immutable after create.
 - Cascading child menu composition is not in this chrome (UI-04).
-- Usage / command / visibility tab editing is not in this chrome (UI-03).
+- Usage / command / visibility tab editing is not in this chrome; REST PUT
+  honors usage/command fields (see [REST API — Action menus](id:developer-rest)).
 - System menus cannot be updated or deleted here.
 
 ## REST
@@ -65,7 +68,7 @@ The chrome calls:
 | List | `GET /services/actions/catalog` |
 | Load | `GET /services/actions/catalog/{idOrName}` |
 | Create | `POST /services/actions` (`name` required; unique, no spaces) |
-| Save | `PUT /services/actions/{idOrName}` (label, description, menuType, url) |
+| Save | `PUT /services/actions/{idOrName}` (label, description, menuType, url, handler, parameters, command properties) |
 | Delete | `DELETE /services/actions/{idOrName}` (`204` on success) |
 
 Writes lock the menu for the request (`overrideLock=false`) and release it on

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1481,9 +1481,10 @@ rows are written to `RXMENUACTION` so Hibernate `findActionMenusTree` (GET
 after POST, and omits it after DELETE. There is no new SOAP surface.
 **Developer → Action Menus** chrome creates and deletes user menus (and saves
 label / description / menuType / url). Admin **PUT** also round-trips Workbench
-**Usage** and **Command** fields on user menus (`handler`, `url`, `parameters`,
-and command/usage `properties`). Cascading children composition (UI-04) and
-visibility contexts / SPA usage-command-visibility tabs remain later slices —
+**Usage**, **Command**, and **Visibility** fields on user menus (`handler`,
+`url`, `parameters`, command/usage `properties`, `visibilityContexts`, and
+`uiContexts`). Cascading children composition (UI-04) and SPA
+usage-command-visibility tabs remain later slices —
 see [Developer Action Menus](id:admin-developer-action-menus). Finder helpers
 (`GET /services/actions/find`, content-type and template finders) are unchanged.
 After POST the editor notice confirms the save. Packaged menus (for example
@@ -1497,23 +1498,31 @@ updated or deleted — **409**; the design lock is not stolen (`overrideLock=fal
 If Workbench path resolution fails, PUT/DELETE also return **409** (fail closed)
 so a lookup error cannot bypass that protection.
 PUT round-trips GET detail fields already exposed (`label`, `description`,
-`menuType`, `url`) plus usage/command fields: `handler` (`CLIENT` or `SERVER`),
-`url`, `parameters` (name/value/description URL parameters; a present array
-replaces the collection, including empty), and `properties` used as Workbench
-Usage/Command (for example `AcceleratorKey`, `MnemonicKey`, `ShortDescription`,
-`SmallIcon`, `launchesWindow`, `SupportsMultiSelect`, `refreshHint`, `target`,
-`targetStyle`). Omitted `handler` / `parameters` / `properties` leave the
-stored values. The REST user-menu marker property is not overwritten. Name is
-the catalog key and is not renamed on PUT. Invalid `handler` or `menuType` is
-**400**. Visibility contexts (`visibilityContexts`, `uiContexts`) are ignored
-on PUT.
+`menuType`, `url`) plus usage/command/visibility fields: `handler` (`CLIENT` or
+`SERVER`), `url`, `parameters` (name/value/description URL parameters; a
+present array replaces the collection, including empty), `properties` used as
+Workbench Usage/Command (for example `AcceleratorKey`, `MnemonicKey`,
+`ShortDescription`, `SmallIcon`, `launchesWindow`, `SupportsMultiSelect`,
+`refreshHint`, `target`, `targetStyle`), `visibilityContexts` (Workbench
+Visibility; each element is a context `name` plus one `value` — repeat the
+name for multiple values), and `uiContexts` (mode-uicontext mappings with
+numeric `modeId` and `contextId`). Omitted `handler` / `parameters` /
+`properties` / `visibilityContexts` / `uiContexts` leave the stored values.
+An empty `visibilityContexts` or `uiContexts` array clears that collection.
+The REST user-menu marker property is not overwritten. Name is the catalog key
+and is not renamed on PUT. Invalid `handler`, `menuType`, visibility context
+name, or uiContext id is **400**. Visibility context `name` is `1`–`11`
+(Workbench `VIS_CONTEXT_*`) or an alias such as `community`, `contentType`,
+`roles`, `workflows`, `checkoutStatus`, `folderSecurity`. GET
+`/services/actions/catalog/{idOrName}` returns the same visibility and
+uiContexts after a successful PUT.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/actions/catalog` | List action menus (tree roots with children) |
 | `GET` | `/services/actions/catalog/{idOrName}` | Load one menu by name, numeric id, or GUID string |
 | `POST` | `/services/actions` | **Admin.** Create a user action menu (`createActions` then `saveActions`) |
-| `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, url, handler, parameters, and command/usage properties |
+| `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, url, handler, parameters, command/usage properties, visibilityContexts, and uiContexts |
 | `DELETE` | `/services/actions/{idOrName}` | **Admin.** Delete a user action menu (`deleteActions`, `ignoreDependencies=false`) |
 
 JSON may wrap a single item as `ActionMenu`. **Create** `POST /services/actions`

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1480,9 +1480,11 @@ rows are written to `RXMENUACTION` so Hibernate `findActionMenusTree` (GET
 `/services/actions/catalog` and GET by name) includes a user menu immediately
 after POST, and omits it after DELETE. There is no new SOAP surface.
 **Developer → Action Menus** chrome creates and deletes user menus (and saves
-label / description / menuType / url); cascading children composition (UI-04)
-and usage/command/visibility tab completeness (UI-03) are later slices — see
-[Developer Action Menus](id:admin-developer-action-menus). Finder helpers
+label / description / menuType / url). Admin **PUT** also round-trips Workbench
+**Usage** and **Command** fields on user menus (`handler`, `url`, `parameters`,
+and command/usage `properties`). Cascading children composition (UI-04) and
+visibility contexts / SPA usage-command-visibility tabs remain later slices —
+see [Developer Action Menus](id:admin-developer-action-menus). Finder helpers
 (`GET /services/actions/find`, content-type and template finders) are unchanged.
 After POST the editor notice confirms the save. Packaged menus (for example
 **Copy**) are **409** on PUT/DELETE, not **404**.
@@ -1495,14 +1497,23 @@ updated or deleted — **409**; the design lock is not stolen (`overrideLock=fal
 If Workbench path resolution fails, PUT/DELETE also return **409** (fail closed)
 so a lookup error cannot bypass that protection.
 PUT round-trips GET detail fields already exposed (`label`, `description`,
-`menuType`, `url`). Name is the catalog key and is not renamed on PUT.
+`menuType`, `url`) plus usage/command fields: `handler` (`CLIENT` or `SERVER`),
+`url`, `parameters` (name/value/description URL parameters; a present array
+replaces the collection, including empty), and `properties` used as Workbench
+Usage/Command (for example `AcceleratorKey`, `MnemonicKey`, `ShortDescription`,
+`SmallIcon`, `launchesWindow`, `SupportsMultiSelect`, `refreshHint`, `target`,
+`targetStyle`). Omitted `handler` / `parameters` / `properties` leave the
+stored values. The REST user-menu marker property is not overwritten. Name is
+the catalog key and is not renamed on PUT. Invalid `handler` or `menuType` is
+**400**. Visibility contexts (`visibilityContexts`, `uiContexts`) are ignored
+on PUT.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/actions/catalog` | List action menus (tree roots with children) |
 | `GET` | `/services/actions/catalog/{idOrName}` | Load one menu by name, numeric id, or GUID string |
 | `POST` | `/services/actions` | **Admin.** Create a user action menu (`createActions` then `saveActions`) |
-| `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, and/or url |
+| `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, url, handler, parameters, and command/usage properties |
 | `DELETE` | `/services/actions/{idOrName}` | **Admin.** Delete a user action menu (`deleteActions`, `ignoreDependencies=false`) |
 
 JSON may wrap a single item as `ActionMenu`. **Create** `POST /services/actions`

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -59,6 +59,8 @@ import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
@@ -733,6 +735,133 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       domain.setURL(body.getUrl());
     }
     applyMenuType(domain, body.getMenuType());
+    applyHandler(domain, body.getHandler());
+    applyParameters(domain, body.getParameters());
+    applyCommandProperties(domain, body.getProperties());
+  }
+
+  /**
+   * Workbench Usage handler: {@code CLIENT} or {@code SERVER}. Blank leaves the existing
+   * handler. Visibility contexts are not applied here (UI-03 slice 2).
+   */
+  static void applyHandler(PSAction domain, String raw) {
+    if (domain == null || StringUtils.isBlank(raw)) {
+      return;
+    }
+    String handler = raw.trim();
+    if (PSAction.HANDLER_CLIENT.equalsIgnoreCase(handler)) {
+      domain.setClientAction(true);
+      return;
+    }
+    if (PSAction.HANDLER_SERVER.equalsIgnoreCase(handler)) {
+      domain.setClientAction(false);
+      return;
+    }
+    throw new IllegalArgumentException("Invalid handler: " + raw);
+  }
+
+  /**
+   * Replaces URL parameters when the PUT body includes {@code parameters} (empty array
+   * clears). {@code null} leaves the existing collection. Names must be non-blank.
+   */
+  static void applyParameters(PSAction domain, ActionMenuParameter[] parameters) {
+    if (domain == null || parameters == null) {
+      return;
+    }
+    PSActionParameters dest = domain.getParameters();
+    Map<String, ActionMenuParameter> incoming = new LinkedHashMap<>();
+    for (ActionMenuParameter param : parameters) {
+      if (param == null || StringUtils.isBlank(param.getName())) {
+        continue;
+      }
+      incoming.put(param.getName().trim(), param);
+    }
+    List<String> toRemove = new ArrayList<>();
+    Iterator<?> it = dest.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (next instanceof PSActionParameter existing) {
+        if (!containsIgnoreCase(incoming.keySet(), existing.getName())) {
+          toRemove.add(existing.getName());
+        }
+      }
+    }
+    for (String name : toRemove) {
+      dest.removeParameter(name);
+    }
+    for (ActionMenuParameter param : incoming.values()) {
+      String name = param.getName().trim();
+      dest.setParameter(name, param.getValue() == null ? "" : param.getValue());
+      PSActionParameter stored = findParameter(dest, name);
+      if (stored != null && param.getDescription() != null) {
+        stored.setDescription(param.getDescription());
+      }
+    }
+  }
+
+  /**
+   * Merges Workbench Usage/Command properties by name. {@code null} leaves existing
+   * properties. Never overwrites {@link #REST_USER_MENU_PROP}. Visibility is not applied.
+   */
+  static void applyCommandProperties(PSAction domain, ActionMenuProperty[] properties) {
+    if (domain == null || properties == null) {
+      return;
+    }
+    PSActionProperties dest = domain.getProperties();
+    for (ActionMenuProperty prop : properties) {
+      if (prop == null || StringUtils.isBlank(prop.getName())) {
+        continue;
+      }
+      String name = prop.getName().trim();
+      if (REST_USER_MENU_PROP.equalsIgnoreCase(name)) {
+        continue;
+      }
+      dest.setProperty(name, prop.getValue() == null ? "" : prop.getValue());
+      PSActionProperty stored = findProperty(dest, name);
+      if (stored != null && prop.getDescription() != null) {
+        stored.setDescription(prop.getDescription());
+      }
+    }
+  }
+
+  static boolean containsIgnoreCase(Iterable<String> names, String needle) {
+    if (names == null || StringUtils.isBlank(needle)) {
+      return false;
+    }
+    for (String name : names) {
+      if (needle.equalsIgnoreCase(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static PSActionParameter findParameter(PSActionParameters params, String name) {
+    if (params == null || StringUtils.isBlank(name)) {
+      return null;
+    }
+    Iterator<?> it = params.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (next instanceof PSActionParameter param && name.equalsIgnoreCase(param.getName())) {
+        return param;
+      }
+    }
+    return null;
+  }
+
+  static PSActionProperty findProperty(PSActionProperties props, String name) {
+    if (props == null || StringUtils.isBlank(name)) {
+      return null;
+    }
+    Iterator<?> it = props.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (next instanceof PSActionProperty prop && name.equalsIgnoreCase(prop.getName())) {
+        return prop;
+      }
+    }
+    return null;
   }
 
   static ActionType resolveCreateType(ActionMenu body) {
@@ -817,7 +946,49 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     if (guid != null) {
       menu.setGuid(copyGuid(guid));
     }
+    menu.setParameters(toDtoParameters(action.getParameters()));
+    menu.setProperties(toDtoProperties(action.getProperties()));
     return menu;
+  }
+
+  static ActionMenuParameter[] toDtoParameters(PSActionParameters params) {
+    if (params == null || params.size() == 0) {
+      return new ActionMenuParameter[0];
+    }
+    List<ActionMenuParameter> out = new ArrayList<>();
+    Iterator<?> it = params.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (!(next instanceof PSActionParameter param) || StringUtils.isBlank(param.getName())) {
+        continue;
+      }
+      ActionMenuParameter dto = new ActionMenuParameter();
+      dto.setName(param.getName());
+      dto.setValue(param.getValue());
+      dto.setDescription(param.getDescription());
+      out.add(dto);
+    }
+    return out.toArray(ActionMenuParameter[]::new);
+  }
+
+  static ActionMenuProperty[] toDtoProperties(PSActionProperties props) {
+    if (props == null || props.size() == 0) {
+      return new ActionMenuProperty[0];
+    }
+    List<ActionMenuProperty> out = new ArrayList<>();
+    Iterator<?> it = props.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (!(next instanceof PSActionProperty prop) || StringUtils.isBlank(prop.getName())) {
+        continue;
+      }
+      ActionMenuProperty dto = new ActionMenuProperty();
+      dto.setName(prop.getName());
+      dto.setValue(prop.getValue());
+      dto.setDescription(prop.getDescription());
+      out.add(dto);
+    }
+    return out.toArray(ActionMenuProperty[]::new);
   }
 
   static String restMenuType(PSAction action) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -86,6 +86,29 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   /** JDBC persist marker on REST-created user menus ({@code RXMENUACTIONPROPERTIES}). */
   static final String REST_USER_MENU_PROP = RxmActionMenuConstants.REST_USER_MENU_PROP;
 
+  /**
+   * Workbench visibility context names are {@code 1}–{@code 11} ({@link
+   * PSActionVisibilityContext} {@code VIS_CONTEXT_*}). Aliases are case-insensitive and
+   * ignore spaces, hyphens, and underscores.
+   */
+  static final Map<String, String> VISIBILITY_CONTEXT_ALIASES =
+      Map.ofEntries(
+          Map.entry("assignmenttype", PSActionVisibilityContext.VIS_CONTEXT_ASSIGNMENT_TYPE),
+          Map.entry("community", PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY),
+          Map.entry("contenttype", PSActionVisibilityContext.VIS_CONTEXT_CONTENT_TYPE),
+          Map.entry("objecttype", PSActionVisibilityContext.VIS_CONTEXT_OBJECT_TYPE),
+          Map.entry("clientcontext", PSActionVisibilityContext.VIS_CONTEXT_CLIENT_CONTEXT),
+          Map.entry("checkoutstatus", PSActionVisibilityContext.VIS_CONTEXT_CHECKOUT_STATUS),
+          Map.entry("roles", PSActionVisibilityContext.VIS_CONTEXT_ROLES_TYPE),
+          Map.entry("role", PSActionVisibilityContext.VIS_CONTEXT_ROLES_TYPE),
+          Map.entry("locales", PSActionVisibilityContext.VIS_CONTEXT_LOCALES_TYPE),
+          Map.entry("locale", PSActionVisibilityContext.VIS_CONTEXT_LOCALES_TYPE),
+          Map.entry("workflows", PSActionVisibilityContext.VIS_CONTEXT_WORKFLOWS_TYPE),
+          Map.entry("workflow", PSActionVisibilityContext.VIS_CONTEXT_WORKFLOWS_TYPE),
+          Map.entry("publishable", PSActionVisibilityContext.VIS_CONTEXT_PUBLISHABLE_TYPE),
+          Map.entry("publishabletype", PSActionVisibilityContext.VIS_CONTEXT_PUBLISHABLE_TYPE),
+          Map.entry("foldersecurity", PSActionVisibilityContext.VIS_CONTEXT_FOLDER_SECURITY));
+
   private final IPSUiDesignWs service;
   private final BooleanSupplier adminChecker;
   private final Supplier<List<PSActionMenu>> hibernateMenus;
@@ -266,13 +289,54 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       String key = idOrName.trim();
       try {
         List<ActionMenu> all = findMenus(null, null, null, null, null);
-        return matchMenuInTree(all, key);
+        ActionMenu catalog = matchMenuInTree(all, key);
+        overlayDesignVisibility(catalog);
+        return catalog;
       } catch (PSErrorResultsException e) {
         log.debug("Action menu lookup failed for {}: {}", key, e.toString());
         return null;
       }
     } finally {
       clearRequestHibernateIndex();
+    }
+  }
+
+  /**
+   * GET catalog detail is Hibernate-backed; overlay visibility/uiContexts from an unlocked
+   * design load so PUT then GET round-trips Workbench Visibility. Failures leave the catalog
+   * DTO unchanged (no 409 on GET).
+   */
+  void overlayDesignVisibility(ActionMenu catalog) {
+    if (catalog == null) {
+      return;
+    }
+    IPSGuid id = null;
+    if (catalog.getGuid() != null && StringUtils.isNotBlank(catalog.getGuid().getStringValue())) {
+      id = parseActionGuid(catalog.getGuid().getStringValue());
+    }
+    if (id == null && catalog.getId() > 0) {
+      try {
+        id = PSAction.getGuidFromId(catalog.getId());
+      } catch (RuntimeException e) {
+        return;
+      }
+    }
+    if (id == null) {
+      return;
+    }
+    try {
+      List<PSAction> loaded =
+          service.loadActions(
+              List.of(id), false, false, currentSession(), currentUser());
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        return;
+      }
+      PSAction domain = loaded.get(0);
+      catalog.setVisibilityContexts(toDtoVisibilityContexts(domain.getVisibilityContexts()));
+      catalog.setUiContexts(toDtoUiContexts(domain.getModeUIContexts()));
+    } catch (RuntimeException | PSErrorResultsException e) {
+      log.debug(
+          "Action menu design overlay skipped for {}: {}", catalog.getName(), e.toString());
     }
   }
 
@@ -738,11 +802,13 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     applyHandler(domain, body.getHandler());
     applyParameters(domain, body.getParameters());
     applyCommandProperties(domain, body.getProperties());
+    applyVisibilityContexts(domain, body.getVisibilityContexts());
+    applyUiContexts(domain, body.getUiContexts());
   }
 
   /**
    * Workbench Usage handler: {@code CLIENT} or {@code SERVER}. Blank leaves the existing
-   * handler. Visibility contexts are not applied here (UI-03 slice 2).
+   * handler.
    */
   static void applyHandler(PSAction domain, String raw) {
     if (domain == null || StringUtils.isBlank(raw)) {
@@ -801,7 +867,7 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
 
   /**
    * Merges Workbench Usage/Command properties by name. {@code null} leaves existing
-   * properties. Never overwrites {@link #REST_USER_MENU_PROP}. Visibility is not applied.
+   * properties. Never overwrites {@link #REST_USER_MENU_PROP}.
    */
   static void applyCommandProperties(PSAction domain, ActionMenuProperty[] properties) {
     if (domain == null || properties == null) {
@@ -848,6 +914,136 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       }
     }
     return null;
+  }
+
+  /**
+   * Replaces Workbench Visibility contexts when the PUT body includes {@code
+   * visibilityContexts} (empty array clears). {@code null} leaves the existing collection.
+   * Each element is one named context plus one value (repeat the name for multiple values).
+   * Unknown names are {@link IllegalArgumentException} (HTTP 400).
+   */
+  static void applyVisibilityContexts(
+      PSAction domain, ActionMenuVisibilityContext[] visibilityContexts) {
+    if (domain == null || visibilityContexts == null) {
+      return;
+    }
+    LinkedHashMap<String, List<String>> grouped = new LinkedHashMap<>();
+    Map<String, String> descriptions = new LinkedHashMap<>();
+    for (ActionMenuVisibilityContext dto : visibilityContexts) {
+      if (dto == null) {
+        continue;
+      }
+      String name = resolveVisibilityContextName(dto.getName());
+      String value = dto.getValue() == null ? "" : dto.getValue();
+      grouped.computeIfAbsent(name, key -> new ArrayList<>()).add(value);
+      if (dto.getDescription() != null) {
+        descriptions.put(name, dto.getDescription());
+      }
+    }
+    PSActionVisibilityContexts dest = domain.getVisibilityContexts();
+    List<String> existing = new ArrayList<>();
+    Iterator<?> it = dest.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (next instanceof PSActionVisibilityContext ctx && StringUtils.isNotBlank(ctx.getName())) {
+        existing.add(ctx.getName());
+      }
+    }
+    for (String name : existing) {
+      dest.removeContext(name);
+    }
+    for (Map.Entry<String, List<String>> entry : grouped.entrySet()) {
+      String name = entry.getKey();
+      String[] values = entry.getValue().toArray(String[]::new);
+      dest.add(new PSActionVisibilityContext(name, values, descriptions.get(name)));
+    }
+  }
+
+  /**
+   * Replaces mode-uicontext mappings when the PUT body includes {@code uiContexts} (empty
+   * array clears). {@code null} leaves the existing collection. {@code modeId} and {@code
+   * contextId} must be numeric. Duplicate mode/context pairs are {@link
+   * IllegalArgumentException} (HTTP 400).
+   */
+  static void applyUiContexts(PSAction domain, ActionMenuModeUIContext[] uiContexts) {
+    if (domain == null || uiContexts == null) {
+      return;
+    }
+    LinkedHashMap<String, ActionMenuModeUIContext> unique = new LinkedHashMap<>();
+    for (ActionMenuModeUIContext dto : uiContexts) {
+      if (dto == null) {
+        continue;
+      }
+      String modeId = requireNumericId(dto.getModeId(), "modeId");
+      String contextId = requireNumericId(dto.getContextId(), "contextId");
+      String key = modeId + ":" + contextId;
+      if (unique.containsKey(key)) {
+        throw new IllegalArgumentException("Duplicate uiContext mode/context: " + key);
+      }
+      unique.put(key, dto);
+    }
+    PSDbComponentCollection dest = domain.getModeUIContexts();
+    List<PSMenuModeContextMapping> existing = new ArrayList<>();
+    Iterator<?> it = dest.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (next instanceof PSMenuModeContextMapping mapping) {
+        existing.add(mapping);
+      }
+    }
+    for (PSMenuModeContextMapping mapping : existing) {
+      dest.remove(mapping);
+    }
+    String actionId = String.valueOf(Math.max(domain.getId(), 0));
+    for (ActionMenuModeUIContext dto : unique.values()) {
+      PSMenuModeContextMapping mapping =
+          new PSMenuModeContextMapping(
+              dto.getModeId().trim(), dto.getContextId().trim(), actionId);
+      mapping.setModeName(dto.getModeName());
+      mapping.setContextName(dto.getContextName());
+      dest.add(mapping);
+    }
+  }
+
+  /**
+   * Maps a REST visibility context name to a Workbench {@code VIS_CONTEXT_*} id ({@code
+   * 1}–{@code 11}). Package-visible for tests.
+   */
+  static String resolveVisibilityContextName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("visibility context name is required");
+    }
+    String trimmed = raw.trim();
+    if (trimmed.chars().allMatch(Character::isDigit)) {
+      int n;
+      try {
+        n = Integer.parseInt(trimmed);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Invalid visibility context: " + raw);
+      }
+      if (n >= 1 && n <= 11) {
+        return Integer.toString(n);
+      }
+      throw new IllegalArgumentException("Invalid visibility context: " + raw);
+    }
+    String aliasKey =
+        trimmed.toLowerCase().replace("_", "").replace("-", "").replace(" ", "");
+    String mapped = VISIBILITY_CONTEXT_ALIASES.get(aliasKey);
+    if (mapped != null) {
+      return mapped;
+    }
+    throw new IllegalArgumentException("Invalid visibility context: " + raw);
+  }
+
+  static String requireNumericId(String raw, String field) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException(field + " is required");
+    }
+    String trimmed = raw.trim();
+    if (!trimmed.chars().allMatch(Character::isDigit)) {
+      throw new IllegalArgumentException("Invalid " + field + ": " + raw);
+    }
+    return trimmed;
   }
 
   static PSActionProperty findProperty(PSActionProperties props, String name) {
@@ -948,6 +1144,8 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     }
     menu.setParameters(toDtoParameters(action.getParameters()));
     menu.setProperties(toDtoProperties(action.getProperties()));
+    menu.setVisibilityContexts(toDtoVisibilityContexts(action.getVisibilityContexts()));
+    menu.setUiContexts(toDtoUiContexts(action.getModeUIContexts()));
     return menu;
   }
 
@@ -989,6 +1187,62 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
       out.add(dto);
     }
     return out.toArray(ActionMenuProperty[]::new);
+  }
+
+  static ActionMenuVisibilityContext[] toDtoVisibilityContexts(
+      PSActionVisibilityContexts visibilityContexts) {
+    if (visibilityContexts == null || visibilityContexts.size() == 0) {
+      return new ActionMenuVisibilityContext[0];
+    }
+    List<ActionMenuVisibilityContext> out = new ArrayList<>();
+    Iterator<?> it = visibilityContexts.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (!(next instanceof PSActionVisibilityContext ctx)
+          || StringUtils.isBlank(ctx.getName())) {
+        continue;
+      }
+      boolean any = false;
+      Iterator<?> values = ctx.iterator();
+      while (values.hasNext()) {
+        any = true;
+        ActionMenuVisibilityContext dto = new ActionMenuVisibilityContext();
+        dto.setName(ctx.getName());
+        dto.setDescription(ctx.getDescription());
+        Object value = values.next();
+        dto.setValue(value == null ? "" : String.valueOf(value));
+        out.add(dto);
+      }
+      if (!any) {
+        ActionMenuVisibilityContext dto = new ActionMenuVisibilityContext();
+        dto.setName(ctx.getName());
+        dto.setDescription(ctx.getDescription());
+        out.add(dto);
+      }
+    }
+    return out.toArray(ActionMenuVisibilityContext[]::new);
+  }
+
+  static ActionMenuModeUIContext[] toDtoUiContexts(PSDbComponentCollection modeUiContexts) {
+    if (modeUiContexts == null || modeUiContexts.size() == 0) {
+      return new ActionMenuModeUIContext[0];
+    }
+    List<ActionMenuModeUIContext> out = new ArrayList<>();
+    Iterator<?> it = modeUiContexts.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (!(next instanceof PSMenuModeContextMapping mapping)) {
+        continue;
+      }
+      ActionMenuModeUIContext dto = new ActionMenuModeUIContext();
+      dto.setModeId(mapping.getModeId());
+      dto.setModeName(mapping.getModeName());
+      dto.setContextId(mapping.getContextId());
+      dto.setContextName(mapping.getContextName());
+      dto.setDescription(mapping.getDescription());
+      out.add(dto);
+    }
+    return out.toArray(ActionMenuModeUIContext[]::new);
   }
 
   static String restMenuType(PSAction action) {
@@ -1324,42 +1578,6 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     }
     log.error("Failed to {} action menu via UI design WS", verb, e);
     return new IllegalStateException("Failed to " + verb + " action menu", e);
-  }
-
-  private ActionMenuVisibilityContext[] copyVisibilityContexts(
-      PSActionVisibilityContexts visibilityContexts) {
-    var ctxs = new ArrayList<ActionMenuVisibilityContext>();
-    var it = visibilityContexts.iterator();
-    while (it.hasNext()) {
-      var v = (PSActionVisibilityContext) it.next();
-      var amc = new ActionMenuVisibilityContext();
-      var values = new ArrayList<>();
-      var vit = v.iterator();
-      while (vit.hasNext()) {
-        values.add(vit.next());
-      }
-      amc.setDescription(v.getDescription());
-      amc.setName(v.getName());
-      // TODO: Set values if needed
-      ctxs.add(amc);
-    }
-    return ctxs.toArray(new ActionMenuVisibilityContext[0]);
-  }
-
-  private ActionMenuModeUIContext[] copyUIContexts(PSDbComponentCollection modeUIContexts) {
-    var uictx = new ArrayList<ActionMenuModeUIContext>();
-    var it = modeUIContexts.iterator();
-    while (it.hasNext()) {
-      var mode = (PSMenuModeContextMapping) it.next();
-      var restMode = new ActionMenuModeUIContext();
-      restMode.setContextId(mode.getContextId());
-      restMode.setContextName(mode.getContextName());
-      restMode.setModeId(mode.getModeId());
-      restMode.setModeName(mode.getModeName());
-      restMode.setDescription(mode.getDescription());
-      uictx.add(restMode);
-    }
-    return uictx.toArray(new ActionMenuModeUIContext[0]);
   }
 
   private ActionMenuParameter[] copyParameters(PSActionParameters parameters) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ApiUtils.java
@@ -897,9 +897,12 @@ public class ApiUtils {
         }
         ActionMenuVisibilityContext vc = new ActionMenuVisibilityContext();
 
+        vc.setName(String.valueOf(v.getPrimaryKey().getContextid()));
         vc.setDescription(v.getPrimaryKey().getDescription());
         vc.setValue(v.getPrimaryKey().getValue());
-        vc.setUiContext(copyUIContext(v.getContext()));
+        if (v.getContext() != null) {
+          vc.setUiContext(copyUIContext(v.getContext()));
+        }
         vis.add(vc);
       }
     }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -35,8 +35,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.percussion.cms.objectstore.PSAction;
+import com.percussion.cms.objectstore.PSActionParameter;
 import com.percussion.rest.actions.ActionMenu;
 import com.percussion.rest.actions.ActionMenuList;
+import com.percussion.rest.actions.ActionMenuParameter;
+import com.percussion.rest.actions.ActionMenuProperty;
+import com.percussion.rest.actions.ActionMenuVisibilityContext;
 import com.percussion.services.catalog.IPSCatalogSummary;
 import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
@@ -255,6 +259,116 @@ class ActionMenuAdaptorWriteTest {
     verify(designWs).saveActions(anyList(), eq(true), eq("test-session"), eq("Admin"));
     verify(designWs, never()).createActions(anyList(), anyList(), any(), any());
     verify(designWs).loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_usageAndCommand_roundTripsOnPutAndDto() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    existing.getProperties().setProperty(ActionMenuAdaptor.REST_USER_MENU_PROP, PSAction.YES);
+    existing.getParameters().setParameter("oldParam", "old");
+    stubCatalogLoad(existing);
+    PSAction locked = stubAction("MyMenu", 42);
+    locked.getProperties().setProperty(ActionMenuAdaptor.REST_USER_MENU_PROP, PSAction.YES);
+    locked.getParameters().setParameter("oldParam", "old");
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ActionMenu body = new ActionMenu();
+    body.setHandler(PSAction.HANDLER_CLIENT);
+    body.setUrl("/sys_cxSupport/foo.xml");
+    ActionMenuParameter param = new ActionMenuParameter();
+    param.setName("sys_contentid");
+    param.setValue("PSX_CONTENTID");
+    param.setDescription("content id");
+    body.setParameters(new ActionMenuParameter[] {param});
+    ActionMenuProperty accel = new ActionMenuProperty();
+    accel.setName(PSAction.PROP_ACCEL_KEY);
+    accel.setValue("ctrl S");
+    ActionMenuProperty mnem = new ActionMenuProperty();
+    mnem.setName(PSAction.PROP_MNEM_KEY);
+    mnem.setValue("S");
+    ActionMenuProperty launch = new ActionMenuProperty();
+    launch.setName(PSAction.PROP_LAUNCH_NEW_WND);
+    launch.setValue(PSAction.YES);
+    ActionMenuProperty marker = new ActionMenuProperty();
+    marker.setName(ActionMenuAdaptor.REST_USER_MENU_PROP);
+    marker.setValue(PSAction.NO);
+    body.setProperties(new ActionMenuProperty[] {accel, mnem, launch, marker});
+    ActionMenuVisibilityContext vis = new ActionMenuVisibilityContext();
+    vis.setValue("should-not-persist");
+    body.setVisibilityContexts(new ActionMenuVisibilityContext[] {vis});
+
+    ActionMenu out = adaptor.saveActionMenu("MyMenu", body);
+
+    assertEquals(PSAction.HANDLER_CLIENT, out.getHandler());
+    assertEquals("/sys_cxSupport/foo.xml", out.getUrl());
+    assertEquals(1, out.getParameters().length);
+    assertEquals("sys_contentid", out.getParameters()[0].getName());
+    assertEquals("PSX_CONTENTID", out.getParameters()[0].getValue());
+    assertEquals("content id", out.getParameters()[0].getDescription());
+    assertEquals("ctrl S", propertyValue(out, PSAction.PROP_ACCEL_KEY));
+    assertEquals("S", propertyValue(out, PSAction.PROP_MNEM_KEY));
+    assertEquals(PSAction.YES, propertyValue(out, PSAction.PROP_LAUNCH_NEW_WND));
+    assertEquals(PSAction.YES, propertyValue(out, ActionMenuAdaptor.REST_USER_MENU_PROP));
+    assertNull(out.getVisibilityContexts());
+    assertTrue(locked.isClientAction());
+    assertEquals("/sys_cxSupport/foo.xml", locked.getURL());
+    assertEquals("PSX_CONTENTID", locked.getParameters().getParameter("sys_contentid"));
+    assertNull(locked.getParameters().getParameter("oldParam"));
+    assertEquals("ctrl S", locked.getProperty(PSAction.PROP_ACCEL_KEY));
+    assertEquals(PSAction.YES, locked.getProperty(ActionMenuAdaptor.REST_USER_MENU_PROP));
+    verify(designWs).saveActions(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_invalidHandler_is400BeforeSave() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    PSAction locked = stubAction("MyMenu", 42);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+    ActionMenu body = new ActionMenu();
+    body.setHandler("neither");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.saveActionMenu("MyMenu", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("handler"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void applyWritableFields_nullParametersLeavesExisting() {
+    PSAction domain = stubAction("MyMenu", 42);
+    domain.getParameters().setParameter("keep", "1");
+    ActionMenu body = new ActionMenu();
+    body.setLabel("Updated");
+    ActionMenuAdaptor.applyWritableFields(domain, body);
+    assertEquals("1", domain.getParameters().getParameter("keep"));
+    assertEquals("Updated", domain.getLabel());
+  }
+
+  @Test
+  void applyParameters_emptyArrayClears() {
+    PSAction domain = stubAction("MyMenu", 42);
+    domain.getParameters().setParameter("gone", "x");
+    ActionMenuAdaptor.applyParameters(domain, new ActionMenuParameter[0]);
+    assertEquals(0, domain.getParameters().size());
+  }
+
+  @Test
+  void toDto_mapsHandlerParametersAndProperties() {
+    PSAction action = stubAction("MyMenu", 42);
+    action.setClientAction(false);
+    action.setURL("/cmd");
+    action.getParameters().add(new PSActionParameter("p1", "v1", "d1"));
+    action.getProperties().setProperty(PSAction.PROP_SHORT_DESC, "tip");
+    ActionMenu dto = ActionMenuAdaptor.toDto(action);
+    assertEquals(PSAction.HANDLER_SERVER, dto.getHandler());
+    assertEquals("/cmd", dto.getUrl());
+    assertEquals(1, dto.getParameters().length);
+    assertEquals("p1", dto.getParameters()[0].getName());
+    assertEquals("v1", dto.getParameters()[0].getValue());
+    assertEquals("d1", dto.getParameters()[0].getDescription());
+    assertEquals("tip", propertyValue(dto, PSAction.PROP_SHORT_DESC));
   }
 
   @Test
@@ -611,6 +725,18 @@ class ActionMenuAdaptorWriteTest {
     PSAction action = new PSAction(name, name);
     action.setGUID(new PSGuid(PSTypeEnum.ACTION, id));
     return action;
+  }
+
+  private static String propertyValue(ActionMenu menu, String name) {
+    if (menu.getProperties() == null) {
+      return null;
+    }
+    for (ActionMenuProperty prop : menu.getProperties()) {
+      if (prop != null && name.equalsIgnoreCase(prop.getName())) {
+        return prop.getValue();
+      }
+    }
+    return null;
   }
 
   private void stubCatalogLoad(PSAction action) throws Exception {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -36,8 +36,11 @@ import static org.mockito.Mockito.when;
 
 import com.percussion.cms.objectstore.PSAction;
 import com.percussion.cms.objectstore.PSActionParameter;
+import com.percussion.cms.objectstore.PSActionVisibilityContext;
+import com.percussion.cms.objectstore.PSMenuModeContextMapping;
 import com.percussion.rest.actions.ActionMenu;
 import com.percussion.rest.actions.ActionMenuList;
+import com.percussion.rest.actions.ActionMenuModeUIContext;
 import com.percussion.rest.actions.ActionMenuParameter;
 import com.percussion.rest.actions.ActionMenuProperty;
 import com.percussion.rest.actions.ActionMenuVisibilityContext;
@@ -294,9 +297,6 @@ class ActionMenuAdaptorWriteTest {
     marker.setName(ActionMenuAdaptor.REST_USER_MENU_PROP);
     marker.setValue(PSAction.NO);
     body.setProperties(new ActionMenuProperty[] {accel, mnem, launch, marker});
-    ActionMenuVisibilityContext vis = new ActionMenuVisibilityContext();
-    vis.setValue("should-not-persist");
-    body.setVisibilityContexts(new ActionMenuVisibilityContext[] {vis});
 
     ActionMenu out = adaptor.saveActionMenu("MyMenu", body);
 
@@ -310,7 +310,6 @@ class ActionMenuAdaptorWriteTest {
     assertEquals("S", propertyValue(out, PSAction.PROP_MNEM_KEY));
     assertEquals(PSAction.YES, propertyValue(out, PSAction.PROP_LAUNCH_NEW_WND));
     assertEquals(PSAction.YES, propertyValue(out, ActionMenuAdaptor.REST_USER_MENU_PROP));
-    assertNull(out.getVisibilityContexts());
     assertTrue(locked.isClientAction());
     assertEquals("/sys_cxSupport/foo.xml", locked.getURL());
     assertEquals("PSX_CONTENTID", locked.getParameters().getParameter("sys_contentid"));
@@ -318,6 +317,139 @@ class ActionMenuAdaptorWriteTest {
     assertEquals("ctrl S", locked.getProperty(PSAction.PROP_ACCEL_KEY));
     assertEquals(PSAction.YES, locked.getProperty(ActionMenuAdaptor.REST_USER_MENU_PROP));
     verify(designWs).saveActions(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_visibilityAndUiContexts_roundTripsOnPutAndDto() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    existing.getVisibilityContexts().addContext(PSActionVisibilityContext.VIS_CONTEXT_ROLES_TYPE, "old");
+    stubCatalogLoad(existing);
+    PSAction locked = stubAction("MyMenu", 42);
+    locked.getVisibilityContexts().addContext(PSActionVisibilityContext.VIS_CONTEXT_ROLES_TYPE, "old");
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ActionMenu body = new ActionMenu();
+    ActionMenuVisibilityContext community = new ActionMenuVisibilityContext();
+    community.setName("community");
+    community.setValue("100");
+    community.setDescription("community id");
+    ActionMenuVisibilityContext community2 = new ActionMenuVisibilityContext();
+    community2.setName(PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY);
+    community2.setValue("200");
+    ActionMenuVisibilityContext contentType = new ActionMenuVisibilityContext();
+    contentType.setName("contentType");
+    contentType.setValue("5");
+    body.setVisibilityContexts(
+        new ActionMenuVisibilityContext[] {community, community2, contentType});
+    ActionMenuModeUIContext ui = new ActionMenuModeUIContext();
+    ui.setModeId("1");
+    ui.setModeName("CX");
+    ui.setContextId("2");
+    ui.setContextName("Folder");
+    body.setUiContexts(new ActionMenuModeUIContext[] {ui});
+
+    ActionMenu out = adaptor.saveActionMenu("MyMenu", body);
+
+    assertEquals(3, out.getVisibilityContexts().length);
+    assertEquals(PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY, out.getVisibilityContexts()[0].getName());
+    assertEquals("100", out.getVisibilityContexts()[0].getValue());
+    assertEquals("community id", out.getVisibilityContexts()[0].getDescription());
+    assertEquals("200", out.getVisibilityContexts()[1].getValue());
+    assertEquals(PSActionVisibilityContext.VIS_CONTEXT_CONTENT_TYPE, out.getVisibilityContexts()[2].getName());
+    assertEquals("5", out.getVisibilityContexts()[2].getValue());
+    assertEquals(1, out.getUiContexts().length);
+    assertEquals("1", out.getUiContexts()[0].getModeId());
+    assertEquals("CX", out.getUiContexts()[0].getModeName());
+    assertEquals("2", out.getUiContexts()[0].getContextId());
+    assertEquals("Folder", out.getUiContexts()[0].getContextName());
+    assertNull(locked.getVisibilityContexts().getContext(PSActionVisibilityContext.VIS_CONTEXT_ROLES_TYPE));
+    assertEquals(
+        "100",
+        firstVisibilityValue(locked, PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY));
+    assertEquals(1, locked.getModeUIContexts().size());
+    verify(designWs).saveActions(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_invalidVisibility_is400BeforeSave() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    PSAction locked = stubAction("MyMenu", 42);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+    ActionMenu body = new ActionMenu();
+    ActionMenuVisibilityContext vis = new ActionMenuVisibilityContext();
+    vis.setName("not-a-context");
+    vis.setValue("x");
+    body.setVisibilityContexts(new ActionMenuVisibilityContext[] {vis});
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.saveActionMenu("MyMenu", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("visibility"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_invalidUiContext_is400BeforeSave() throws Exception {
+    PSAction existing = stubAction("MyMenu", 42);
+    stubCatalogLoad(existing);
+    PSAction locked = stubAction("MyMenu", 42);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+    ActionMenu body = new ActionMenu();
+    ActionMenuModeUIContext ui = new ActionMenuModeUIContext();
+    ui.setModeId("cx");
+    ui.setContextId("2");
+    body.setUiContexts(new ActionMenuModeUIContext[] {ui});
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.saveActionMenu("MyMenu", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("modeid"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void applyVisibilityContexts_emptyArrayClears() {
+    PSAction domain = stubAction("MyMenu", 42);
+    domain.getVisibilityContexts().addContext(PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY, "1");
+    ActionMenuAdaptor.applyVisibilityContexts(domain, new ActionMenuVisibilityContext[0]);
+    assertEquals(0, domain.getVisibilityContexts().size());
+  }
+
+  @Test
+  void applyWritableFields_nullVisibilityLeavesExisting() {
+    PSAction domain = stubAction("MyMenu", 42);
+    domain.getVisibilityContexts().addContext(PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY, "keep");
+    ActionMenu body = new ActionMenu();
+    body.setLabel("Updated");
+    ActionMenuAdaptor.applyWritableFields(domain, body);
+    assertEquals("Updated", domain.getLabel());
+    assertEquals(
+        "keep",
+        firstVisibilityValue(domain, PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY));
+  }
+
+  @Test
+  void overlayDesignVisibility_copiesFromUnlockedLoad() throws Exception {
+    ActionMenu catalog = new ActionMenu();
+    catalog.setName("MyMenu");
+    catalog.setId(42);
+    PSAction loaded = stubAction("MyMenu", 42);
+    loaded.getVisibilityContexts().addContext(PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY, "100");
+    PSMenuModeContextMapping mapping = new PSMenuModeContextMapping("1", "2", "42");
+    mapping.setModeName("CX");
+    mapping.setContextName("Folder");
+    loaded.getModeUIContexts().add(mapping);
+    when(designWs.loadActions(anyList(), eq(false), eq(false), any(), any()))
+        .thenReturn(List.of(loaded));
+
+    adaptor.overlayDesignVisibility(catalog);
+
+    assertEquals(1, catalog.getVisibilityContexts().length);
+    assertEquals(PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY, catalog.getVisibilityContexts()[0].getName());
+    assertEquals("100", catalog.getVisibilityContexts()[0].getValue());
+    assertEquals(1, catalog.getUiContexts().length);
+    assertEquals("1", catalog.getUiContexts()[0].getModeId());
+    assertEquals("Folder", catalog.getUiContexts()[0].getContextName());
   }
 
   @Test
@@ -361,6 +493,10 @@ class ActionMenuAdaptorWriteTest {
     action.setURL("/cmd");
     action.getParameters().add(new PSActionParameter("p1", "v1", "d1"));
     action.getProperties().setProperty(PSAction.PROP_SHORT_DESC, "tip");
+    action.getVisibilityContexts().addContext(PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY, "9");
+    PSMenuModeContextMapping mapping = new PSMenuModeContextMapping("3", "4", "42");
+    mapping.setModeName("Mode");
+    action.getModeUIContexts().add(mapping);
     ActionMenu dto = ActionMenuAdaptor.toDto(action);
     assertEquals(PSAction.HANDLER_SERVER, dto.getHandler());
     assertEquals("/cmd", dto.getUrl());
@@ -369,6 +505,11 @@ class ActionMenuAdaptorWriteTest {
     assertEquals("v1", dto.getParameters()[0].getValue());
     assertEquals("d1", dto.getParameters()[0].getDescription());
     assertEquals("tip", propertyValue(dto, PSAction.PROP_SHORT_DESC));
+    assertEquals(1, dto.getVisibilityContexts().length);
+    assertEquals(PSActionVisibilityContext.VIS_CONTEXT_COMMUNITY, dto.getVisibilityContexts()[0].getName());
+    assertEquals("9", dto.getVisibilityContexts()[0].getValue());
+    assertEquals("3", dto.getUiContexts()[0].getModeId());
+    assertEquals("Mode", dto.getUiContexts()[0].getModeName());
   }
 
   @Test
@@ -725,6 +866,15 @@ class ActionMenuAdaptorWriteTest {
     PSAction action = new PSAction(name, name);
     action.setGUID(new PSGuid(PSTypeEnum.ACTION, id));
     return action;
+  }
+
+  private static String firstVisibilityValue(PSAction action, String name) {
+    PSActionVisibilityContext ctx = action.getVisibilityContexts().getContext(name);
+    if (ctx == null) {
+      return null;
+    }
+    var it = ctx.iterator();
+    return it.hasNext() ? it.next() : null;
   }
 
   private static String propertyValue(ActionMenu menu, String name) {

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -101,9 +101,9 @@ public class ActionMenuResource {
   @Operation(
       summary = "Get action menu detail",
       description =
-          "Loads one action menu by name or numeric id. Admin PUT/DELETE use"
-              + " /services/actions/{idOrName}. Cascading entry composition remains a later"
-              + " slice.",
+          "Loads one action menu by name or numeric id, including visibilityContexts and"
+              + " uiContexts when present. Admin PUT/DELETE use /services/actions/{idOrName}."
+              + " Cascading entry composition remains a later slice.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -255,12 +255,13 @@ public class ActionMenuResource {
   @Operation(
       summary = "Update action menu",
       description =
-          "Admin. Updates label, description, menuType, url, handler, URL parameters, and"
-              + " command/usage properties by name, numeric id, or GUID. Name is the catalog"
-              + " key and is not renamed on PUT. Loads with a design lock (overrideLock=false)"
-              + " and releases on save. Unknown id is 404. Lock/dependency conflict is 409."
-              + " System menus are 409 (not mutated; the lock is not stolen). Visibility"
-              + " contexts and cascading children composition are later slices.",
+          "Admin. Updates label, description, menuType, url, handler, URL parameters,"
+              + " command/usage properties, visibilityContexts, and uiContexts by name, numeric"
+              + " id, or GUID. Name is the catalog key and is not renamed on PUT. Loads with a"
+              + " design lock (overrideLock=false) and releases on save. Unknown id is 404."
+              + " Lock/dependency conflict is 409. System menus are 409 (not mutated; the lock"
+              + " is not stolen). Invalid visibility or uiContext payload is 400. Cascading"
+              + " children composition is a later slice.",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -71,8 +71,9 @@ public class ActionMenuResource {
       summary = "List action menus (catalog)",
       description =
           "Lists CX action menus for the Developer module. Admin create/save/delete user menus"
-              + " via POST/PUT/DELETE on this resource. Cascading children composition and"
-              + " usage/command/visibility tabs remain later slices.",
+              + " via POST/PUT/DELETE on this resource. PUT round-trips usage/command fields"
+              + " (handler, url, parameters, command properties). Visibility contexts and"
+              + " cascading children composition remain later slices.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -254,11 +255,12 @@ public class ActionMenuResource {
   @Operation(
       summary = "Update action menu",
       description =
-          "Admin. Updates label, description, menuType, and/or url by name, numeric id, or GUID."
-              + " Name is the catalog key and is not renamed on PUT. Loads with a design lock"
-              + " (overrideLock=false) and releases on save. Unknown id is 404. Lock/dependency"
-              + " conflict is 409. System menus are 409 (not mutated; the lock is not stolen)."
-              + " Cascading children composition is a later slice.",
+          "Admin. Updates label, description, menuType, url, handler, URL parameters, and"
+              + " command/usage properties by name, numeric id, or GUID. Name is the catalog"
+              + " key and is not renamed on PUT. Loads with a design lock (overrideLock=false)"
+              + " and releases on save. Unknown id is 404. Lock/dependency conflict is 409."
+              + " System menus are 409 (not mutated; the lock is not stolen). Visibility"
+              + " contexts and cascading children composition are later slices.",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
@@ -53,7 +53,9 @@ public interface IActionMenuAdaptor {
    * saveActions} release). Does not steal another user's lock. System menus are not mutated.
    *
    * @param idOrName catalog key (same rules as {@link #findMenuByKey})
-   * @param body required writable fields (label, description, menuType, url as exposed on GET)
+   * @param body required writable fields (label, description, menuType, url, handler,
+   *     parameters, and command/usage properties as exposed on GET). Visibility is not
+   *     mutated.
    * @return the persisted menu, or {@code null} when missing/unsafe
    */
   ActionMenu saveActionMenu(String idOrName, ActionMenu body);

--- a/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
@@ -54,8 +54,8 @@ public interface IActionMenuAdaptor {
    *
    * @param idOrName catalog key (same rules as {@link #findMenuByKey})
    * @param body required writable fields (label, description, menuType, url, handler,
-   *     parameters, and command/usage properties as exposed on GET). Visibility is not
-   *     mutated.
+   *     parameters, command/usage properties, visibilityContexts, and uiContexts as exposed
+   *     on GET).
    * @return the persisted menu, or {@code null} when missing/unsafe
    */
   ActionMenu saveActionMenu(String idOrName, ActionMenu body);

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -291,6 +291,54 @@ public class ActionMenuResourceTest {
   }
 
   @Test
+  public void updateActionMenuVisibilityDelegates() {
+    ActionMenu body = new ActionMenu();
+    ActionMenuVisibilityContext vis = new ActionMenuVisibilityContext();
+    vis.setName("community");
+    vis.setValue("100");
+    body.setVisibilityContexts(new ActionMenuVisibilityContext[] {vis});
+    ActionMenuModeUIContext ui = new ActionMenuModeUIContext();
+    ui.setModeId("1");
+    ui.setContextId("2");
+    body.setUiContexts(new ActionMenuModeUIContext[] {ui});
+    ActionMenu updated = new ActionMenu();
+    updated.setName("MyMenu");
+    updated.setVisibilityContexts(body.getVisibilityContexts());
+    updated.setUiContexts(body.getUiContexts());
+    when(adaptor.saveActionMenu(eq("MyMenu"), eq(body))).thenReturn(updated);
+
+    ActionMenu out = resource.updateActionMenu("MyMenu", body);
+
+    assertEquals("community", out.getVisibilityContexts()[0].getName());
+    assertEquals("100", out.getVisibilityContexts()[0].getValue());
+    assertEquals("1", out.getUiContexts()[0].getModeId());
+    verify(adaptor).saveActionMenu("MyMenu", body);
+  }
+
+  @Test
+  public void updateActionMenuInvalidVisibilityIs400() {
+    when(adaptor.saveActionMenu(eq("MyMenu"), any()))
+        .thenThrow(new IllegalArgumentException("Invalid visibility context: nope"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateActionMenu("MyMenu", new ActionMenu()));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("visibility"));
+  }
+
+  @Test
+  public void updateActionMenuNonAdminIs403() {
+    when(adaptor.saveActionMenu(eq("MyMenu"), any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateActionMenu("MyMenu", new ActionMenu()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void updateActionMenuUnknownIs404() {
     when(adaptor.saveActionMenu(eq("missing"), any())).thenReturn(null);
     WebApplicationException ex =

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -261,6 +261,36 @@ public class ActionMenuResourceTest {
   }
 
   @Test
+  public void updateActionMenuUsageCommandDelegates() {
+    ActionMenu body = new ActionMenu();
+    body.setHandler("CLIENT");
+    body.setUrl("/sys_cxSupport/foo.xml");
+    ActionMenuParameter param = new ActionMenuParameter();
+    param.setName("sys_contentid");
+    param.setValue("PSX_CONTENTID");
+    body.setParameters(new ActionMenuParameter[] {param});
+    ActionMenuProperty accel = new ActionMenuProperty();
+    accel.setName("AcceleratorKey");
+    accel.setValue("ctrl S");
+    body.setProperties(new ActionMenuProperty[] {accel});
+    ActionMenu updated = new ActionMenu();
+    updated.setName("MyMenu");
+    updated.setHandler("CLIENT");
+    updated.setUrl("/sys_cxSupport/foo.xml");
+    updated.setParameters(body.getParameters());
+    updated.setProperties(body.getProperties());
+    when(adaptor.saveActionMenu(eq("MyMenu"), eq(body))).thenReturn(updated);
+
+    ActionMenu out = resource.updateActionMenu("MyMenu", body);
+
+    assertEquals("CLIENT", out.getHandler());
+    assertEquals("/sys_cxSupport/foo.xml", out.getUrl());
+    assertEquals("sys_contentid", out.getParameters()[0].getName());
+    assertEquals("ctrl S", out.getProperties()[0].getValue());
+    verify(adaptor).saveActionMenu("MyMenu", body);
+  }
+
+  @Test
   public void updateActionMenuUnknownIs404() {
     when(adaptor.saveActionMenu(eq("missing"), any())).thenReturn(null);
     WebApplicationException ex =


### PR DESCRIPTION
## Summary

Admin `PUT /services/actions/{idOrName}` now persists Workbench **Visibility** (`visibilityContexts`) and **mode-uicontexts** (`uiContexts`) on **user** action menus and returns them on the PUT response. GET `/services/actions/catalog/{idOrName}` overlays an unlocked design load so those fields round-trip after save.

Each `visibilityContexts` element is one context `name` plus one `value` (repeat the name for multiple values). Names are Workbench `1`–`11` (`VIS_CONTEXT_*`) or aliases such as `community`, `contentType`, `roles`. `uiContexts` require numeric `modeId` and `contextId`. Omitted arrays leave stored values; empty arrays clear. Invalid payload is **400**. System menus stay **409**. Non-Admin **403**.

Stacks on usage/command PUT (#4183 / PR #4190); does not duplicate handler/url work. SPA usage/command/visibility tabs are not implemented (slice #4185). JAXB POST create is unchanged (#4171).

Fixes #4184
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Unit: `ActionMenuResourceTest.updateActionMenuVisibilityDelegates`, invalid visibility **400**, non-Admin **403**, plus existing 404/409 resource tests.
2. Adaptor: `ActionMenuAdaptorWriteTest.update_visibilityAndUiContexts_roundTripsOnPutAndDto`; invalid visibility/uiContext before save; omitted arrays leave existing; empty array clears; GET overlay copies unlocked design load; usage/command still round-trips.
3. Standalone module `clean install` (this PR).

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` Action menus; `product-docs/8.2/admin/developer-action-menus.md` REST table
- [x] **Unit / module tests** — behavioral tests; changed modules green under standalone `mvnw clean install`
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; SPA tabs are #4185)
- [x] **Build gates** — each changed Maven module: standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no path/file I/O)

### C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:**
  - `cd rest; ..\mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 1037, Failures: 0). `ActionMenuResourceTest` Tests run: 33, Failures: 0.
  - `cd projects/sitemanage; ..\..\mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 2257, Failures: 0, Skipped: 125). `ActionMenuAdaptorWriteTest` Tests run: 51, Failures: 0.
- **downstream_checked:** C2 API-shape gate did not apply (no `final`/signature break). `saveActionMenu(` unchanged. Grep/build of rest resource + existing `ActionsTestAdaptor` Spring stub + sitemanage adaptor (built).

### C5 UI proof

N/A — REST/Java only; no WebUI SPA/chrome change.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
