### PR TITLE
test(qa): sitemap-xml rebuild without Jetty restart (#4188)

### DIFF
--- a/docs/ai-generated/code-reviews/4188-sitemap-xml-rebuild-playwright-erlang.md
+++ b/docs/ai-generated/code-reviews/4188-sitemap-xml-rebuild-playwright-erlang.md
@@ -1,0 +1,27 @@
+# Erlang review — #4188 sitemap-xml H2 Playwright rebuild
+
+Date: 2026-09-02
+Scope: `modules/perc-qa-automation` Playwright helper/spec + `product-docs/8.2` operator notes.
+
+## Verdict
+
+Pass for this slice. No production Java/WebUI chrome change. Live save/Build/Preview tests for sitemap-xml are unchanged.
+
+## Bugs
+
+None found.
+
+## Tests
+
+- Unit: rebuild fixture files exist, distinct body token, no live crawl URLs.
+- Live: first Build + docker cp of current sitemap.xml/pages + second Build without Jetty restart; pagesWritten increases; preview HTML lastmod/body change.
+
+## Cross-platform
+
+- Host paths use `path.join`.
+- In-container dest is POSIX `/opt/Percussion/tmp/...` with `/` (Linux QA cell / ZIP-style dest).
+- No `os.tmpdir` / `%TEMP%`.
+
+## Product docs
+
+Admin Sites: rebuild after sitemap loc/lastmod/page edit; no CMS/Jetty restart.

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -6167,6 +6167,8 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
       timeout: 15_000,
     });
+    await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
     expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-site-virtual-source.spec.js
@@ -50,6 +50,8 @@
  * sitemap-xml live Preview deploys a local sitemap.xml fixture, Builds, then streams last-build
  * home HTML (no live crawl). sitemap-xml live Publish deploys a local sitemap.xml fixture then
  * POST /virtual/publish copies assembled HTML; leftover remoteUrl/credentials stay 400 (no live crawl).
+ * sitemap-xml live rebuild copies an edited sitemap.xml into the cell (docker cp), runs a
+ * second Build without restarting Jetty, and asserts assembled HTML / pagesWritten change.
  *
  * Surface-filtered QA mode:
  * <pre>
@@ -90,6 +92,10 @@ const {
 const {
   deploySitemapXmlVirtualFixtureToQaCell,
   assertPublishedSitemapXmlFilesOnQaCell,
+  copySitemapXmlRebuildIntoQaCell,
+  SITEMAP_XML_VIRTUAL_BUILD_MARKER,
+  SITEMAP_XML_VIRTUAL_REBUILD_MARKER,
+  SITEMAP_XML_VIRTUAL_REBUILD_LASTMOD,
 } = require("./helpers/sitemap-xml-virtual-qa-fixture");
 const { saveVirtualSiteAndExpectSaved } = require("./helpers/virtual-site-save");
 const {
@@ -104,6 +110,50 @@ function developerSectionUrl(section) {
     _: String(Date.now()),
   });
   return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+/**
+ * Last-build home HTML via Admin preview REST (same-origin cookies).
+ * Path segments are encoded; remaining {@code ..} is rejected.
+ */
+async function readVirtualPreviewHomeHtml(page, siteName) {
+  const statusUrl = `${BASE_URL}/Rhythmyx/services/sites/${encodeURIComponent(siteName)}/virtual/preview`;
+  const statusResp = await page.request.get(statusUrl);
+  const statusBody = await statusResp.text();
+  expect(
+    statusResp.ok(),
+    `GET /virtual/preview HTTP ${statusResp.status()}: ${statusBody}`,
+  ).toBeTruthy();
+  let statusJson = {};
+  try {
+    statusJson = JSON.parse(statusBody);
+  } catch {
+    throw new Error(`Preview status was not JSON: ${statusBody}`);
+  }
+  const statusRoot =
+    statusJson.VirtualSitePreviewStatus ||
+    statusJson.virtualSitePreviewStatus ||
+    statusJson;
+  expect(
+    statusRoot.available === true || statusRoot.available === "true",
+    `preview available: ${statusBody}`,
+  ).toBeTruthy();
+  const homePath = String(statusRoot.homePath || "")
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "");
+  expect(homePath, `homePath in ${statusBody}`).toMatch(/index\.html$/);
+  const fileUrl = `${BASE_URL}/Rhythmyx/services/sites/${encodeURIComponent(siteName)}/virtual/preview/${homePath
+    .split("/")
+    .filter((seg) => seg.length > 0 && seg !== "." && seg !== "..")
+    .map((seg) => encodeURIComponent(seg))
+    .join("/")}`;
+  const fileResp = await page.request.get(fileUrl);
+  const html = await fileResp.text();
+  expect(
+    fileResp.ok(),
+    `GET preview home HTTP ${fileResp.status()} ${fileUrl}: ${html.slice(0, 400)}`,
+  ).toBeTruthy();
+  return html;
 }
 
 test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => {
@@ -5987,6 +6037,136 @@ test.describe("Developer Site Virtual Site source panel (#2956 / #3020)", () => 
     });
     await expect(page.locator('[data-testid="developer-site-virtual-preview"]')).toHaveCount(0);
     await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+    expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
+  });
+
+  test("sitemap-xml live rebuild after in-cell sitemap.xml edit without Jetty restart (#4188)", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(String(err)));
+    page.on("console", (msg) => {
+      if (msg.type() !== "error") {
+        return;
+      }
+      const text = msg.text();
+      if (/Failed to load resource:.*404/.test(text)) {
+        return;
+      }
+      pageErrors.push(text);
+    });
+
+    const sitemapRoot = deploySitemapXmlVirtualFixtureToQaCell();
+
+    await page.goto(developerSectionUrl("sites"), {
+      waitUntil: "networkidle",
+    });
+    await expect(page.locator('[data-testid="tab-developer-sites"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const settled = page.locator(
+      [
+        '[data-testid="developer-site-panel"]',
+        '[data-testid="developer-site-empty"]',
+        '[data-testid="developer-site-error"]',
+      ].join(", "),
+    );
+    await expect(settled.first()).toBeVisible({ timeout: 30_000 });
+    if (await page.locator('[data-testid="developer-site-empty"]').isVisible().catch(() => false)) {
+      throw new Error("No sites in catalog — live sitemap-xml rebuild requires a site row");
+    }
+    if (await page.locator('[data-testid="developer-site-error"]').isVisible().catch(() => false)) {
+      throw new Error(
+        `Sites catalog error: ${await page.locator('[data-testid="developer-site-error"]').textContent()}`,
+      );
+    }
+
+    const rows = page.locator(catalogRowsSelector("developer-site-row"));
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+    await rows.first().locator('[data-testid="developer-site-open"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-form"]')).toBeVisible({
+      timeout: 20_000,
+    });
+
+    const siteName = (
+      await page.locator('[data-testid="developer-site-detail-title"]').textContent()
+    ).trim();
+    expect(siteName, "Site detail title required for preview URL").toBeTruthy();
+
+    const kind = page.locator('[data-testid="developer-site-virtual-source-kind"]');
+    await kind.selectOption("sitemap-xml");
+    await expect(page.locator('[data-testid="developer-site-virtual-root-path"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-sitemap-xml-hint"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+    await page.locator('[data-testid="developer-site-virtual-root-path"]').fill(sitemapRoot);
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator('[data-testid="developer-site-virtual-build"]')).toBeVisible();
+
+    const firstBuildPromise = page.waitForResponse(
+      (resp) =>
+        resp.request().method() === "POST" && /\/virtual\/build(\?|$)/.test(resp.url()),
+    );
+    await page.locator('[data-testid="developer-site-virtual-build"]').click();
+    const firstBuildResp = await firstBuildPromise;
+    const firstBuildBody = await firstBuildResp.text();
+    expect(
+      firstBuildResp.ok(),
+      `first POST /virtual/build HTTP ${firstBuildResp.status()}: ${firstBuildBody}`,
+    ).toBeTruthy();
+    await expect(page.locator('[data-testid="developer-site-virtual-build-success"]')).toBeVisible({
+      timeout: 60_000,
+    });
+    const firstPagesText = (
+      await page.locator('[data-testid="developer-site-virtual-build-pages"]').textContent()
+    ).trim();
+    const firstPages = Number.parseInt(firstPagesText, 10);
+    expect(firstPages, `first pages written: ${firstPagesText}`).toBeGreaterThan(0);
+    const firstHtml = await readVirtualPreviewHomeHtml(page, siteName);
+    expect(firstHtml, "first assemble should include the original fixture body").toContain(
+      SITEMAP_XML_VIRTUAL_BUILD_MARKER,
+    );
+    expect(firstHtml).not.toContain(SITEMAP_XML_VIRTUAL_REBUILD_MARKER);
+
+    copySitemapXmlRebuildIntoQaCell();
+
+    const secondBuildPromise = page.waitForResponse(
+      (resp) =>
+        resp.request().method() === "POST" && /\/virtual\/build(\?|$)/.test(resp.url()),
+    );
+    await page.locator('[data-testid="developer-site-virtual-build"]').click();
+    const secondBuildResp = await secondBuildPromise;
+    const secondBuildBody = await secondBuildResp.text();
+    expect(
+      secondBuildResp.ok(),
+      `second POST /virtual/build HTTP ${secondBuildResp.status()}: ${secondBuildBody}`,
+    ).toBeTruthy();
+    await expect(page.locator('[data-testid="developer-site-virtual-build-success"]')).toBeVisible({
+      timeout: 60_000,
+    });
+    const secondPagesText = (
+      await page.locator('[data-testid="developer-site-virtual-build-pages"]').textContent()
+    ).trim();
+    const secondPages = Number.parseInt(secondPagesText, 10);
+    expect(secondPages, `second pages written: ${secondPagesText}`).toBeGreaterThan(firstPages);
+    const secondHtml = await readVirtualPreviewHomeHtml(page, siteName);
+    expect(secondHtml, "second assemble should include the edited sitemap page body").toContain(
+      SITEMAP_XML_VIRTUAL_REBUILD_MARKER,
+    );
+    expect(secondHtml).toContain(`Last modified: ${SITEMAP_XML_VIRTUAL_REBUILD_LASTMOD}`);
+    expect(secondHtml).not.toContain(SITEMAP_XML_VIRTUAL_BUILD_MARKER);
+    expect(secondHtml).not.toBe(firstHtml);
+    await expect(page.locator('[data-testid="developer-site-virtual-publish"]')).toHaveCount(0);
+
+    await kind.selectOption("repository");
+    await page.locator('[data-testid="developer-site-virtual-save"]').click();
+    await expect(page.locator('[data-testid="developer-site-virtual-saved"]')).toBeVisible({
+      timeout: 15_000,
+    });
     expect(pageErrors, `uncaught page errors: ${pageErrors.join(" | ")}`).toEqual([]);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/fixtures/sitemap-xml-virtual-site/pages/about.md
+++ b/modules/perc-qa-automation/frontend/tests/fixtures/sitemap-xml-virtual-site/pages/about.md
@@ -1,0 +1,4 @@
+---
+title: Sitemap About
+---
+Hello from sitemap about.

--- a/modules/perc-qa-automation/frontend/tests/fixtures/sitemap-xml-virtual-site/pages/index-rebuild.md
+++ b/modules/perc-qa-automation/frontend/tests/fixtures/sitemap-xml-virtual-site/pages/index-rebuild.md
@@ -1,0 +1,4 @@
+---
+title: Sitemap Home Rebuild
+---
+Sitemap rebuild token BBB.

--- a/modules/perc-qa-automation/frontend/tests/fixtures/sitemap-xml-virtual-site/sitemap-rebuild.xml
+++ b/modules/perc-qa-automation/frontend/tests/fixtures/sitemap-xml-virtual-site/sitemap-rebuild.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>pages/index.md</loc>
+    <lastmod>2026-12-31</lastmod>
+  </url>
+  <url>
+    <loc>pages/about.md</loc>
+    <lastmod>2026-12-31</lastmod>
+  </url>
+</urlset>

--- a/modules/perc-qa-automation/frontend/tests/helpers/sitemap-xml-virtual-qa-fixture.js
+++ b/modules/perc-qa-automation/frontend/tests/helpers/sitemap-xml-virtual-qa-fixture.js
@@ -21,6 +21,9 @@
  * and POST /virtual/publish against a local sitemap.xml (no live crawl URLs or
  * credentials). Loc {@code pages/index.md} slugs to {@code index} and assembles
  * {@code 8.2/index.html}.
+ *
+ * Rebuild coverage copies an edited sitemap.xml (and page bodies) over the
+ * in-cell tree with {@code docker cp} — no Jetty restart.
  */
 
 const { execFileSync } = require("node:child_process");
@@ -38,6 +41,15 @@ const SITEMAP_XML_VIRTUAL_PUBLISHED_HTML = "8.2/index.html";
 
 /** Marker expected in published HTML (same as the page body). */
 const SITEMAP_XML_VIRTUAL_PUBLISH_MARKER = SITEMAP_XML_VIRTUAL_BUILD_MARKER;
+
+/** Marker copied over {@code pages/index.md} for a second Build (#4188). */
+const SITEMAP_XML_VIRTUAL_REBUILD_MARKER = "Sitemap rebuild token BBB.";
+
+/** lastmod written into the in-cell sitemap.xml for a second Build (#4188). */
+const SITEMAP_XML_VIRTUAL_REBUILD_LASTMOD = "2026-12-31";
+
+/** Extra loc body copied for a second Build ({@code pages/about.md}). */
+const SITEMAP_XML_VIRTUAL_REBUILD_ABOUT_MARKER = "Hello from sitemap about.";
 
 function qaCmsContainer() {
   const fromEnv = (
@@ -177,15 +189,43 @@ function assertPublishedSitemapXmlFilesOnQaCell(publishPath) {
   return html;
 }
 
+/**
+ * Overwrite in-cell {@code sitemap.xml} plus page bodies after the first Build.
+ * Uses {@code docker cp} into the existing Linux tree — does not restart Jetty.
+ *
+ * @returns {string} in-container root path (same as {@link deploySitemapXmlVirtualFixtureToQaCell})
+ */
+function copySitemapXmlRebuildIntoQaCell() {
+  const hostDir = sitemapXmlVirtualFixtureHostDir();
+  const sitemap = path.join(hostDir, "sitemap-rebuild.xml");
+  const indexPage = path.join(hostDir, "pages", "index-rebuild.md");
+  const aboutPage = path.join(hostDir, "pages", "about.md");
+  for (const file of [sitemap, indexPage, aboutPage]) {
+    if (!fs.existsSync(file)) {
+      throw new Error(`sitemap-xml Virtual Site rebuild fixture missing: ${file}`);
+    }
+  }
+  const container = qaCmsContainer();
+  dockerExec(container, ["mkdir", "-p", `${SITEMAP_XML_VIRTUAL_QA_ROOT}/pages`]);
+  dockerCp(sitemap, `${container}:${SITEMAP_XML_VIRTUAL_QA_ROOT}/sitemap.xml`);
+  dockerCp(indexPage, `${container}:${SITEMAP_XML_VIRTUAL_QA_ROOT}/pages/index.md`);
+  dockerCp(aboutPage, `${container}:${SITEMAP_XML_VIRTUAL_QA_ROOT}/pages/about.md`);
+  return SITEMAP_XML_VIRTUAL_QA_ROOT;
+}
+
 module.exports = {
   SITEMAP_XML_VIRTUAL_QA_ROOT,
   SITEMAP_XML_VIRTUAL_BUILD_MARKER,
   SITEMAP_XML_VIRTUAL_PUBLISHED_HTML,
   SITEMAP_XML_VIRTUAL_PUBLISH_MARKER,
+  SITEMAP_XML_VIRTUAL_REBUILD_MARKER,
+  SITEMAP_XML_VIRTUAL_REBUILD_LASTMOD,
+  SITEMAP_XML_VIRTUAL_REBUILD_ABOUT_MARKER,
   sitemapXmlVirtualFixtureHostDir,
   deploySitemapXmlVirtualFixtureToQaCell,
   normalizeQaPublishDestPath,
   posixJoin,
   assertPublishedSitemapXmlFilesOnQaCell,
+  copySitemapXmlRebuildIntoQaCell,
   qaCmsContainer,
 };

--- a/modules/perc-qa-automation/frontend/tests/unit/sitemap-xml-virtual-qa-fixture.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/sitemap-xml-virtual-qa-fixture.test.js
@@ -32,6 +32,9 @@ const {
   SITEMAP_XML_VIRTUAL_BUILD_MARKER,
   SITEMAP_XML_VIRTUAL_PUBLISHED_HTML,
   SITEMAP_XML_VIRTUAL_PUBLISH_MARKER,
+  SITEMAP_XML_VIRTUAL_REBUILD_MARKER,
+  SITEMAP_XML_VIRTUAL_REBUILD_LASTMOD,
+  SITEMAP_XML_VIRTUAL_REBUILD_ABOUT_MARKER,
   sitemapXmlVirtualFixtureHostDir,
   normalizeQaPublishDestPath,
   posixJoin,
@@ -109,5 +112,21 @@ describe("sitemap-xml-virtual-qa-fixture", () => {
       "/opt/Percussion/pub/8.2/index.html",
     );
     assert.throws(() => posixJoin("/opt/Percussion/pub", "../etc/passwd"), /unsafe/);
+  });
+
+  it("rebuild fixtures overwrite loc/lastmod/pages without live crawl URLs (#4188)", () => {
+    const dir = sitemapXmlVirtualFixtureHostDir();
+    const sitemap = fs.readFileSync(path.join(dir, "sitemap-rebuild.xml"), "utf8");
+    assert.match(sitemap, /urlset/);
+    assert.match(sitemap, /pages\/index\.md/);
+    assert.match(sitemap, /pages\/about\.md/);
+    assert.match(sitemap, new RegExp(SITEMAP_XML_VIRTUAL_REBUILD_LASTMOD));
+    assert.doesNotMatch(sitemap, /<loc>\s*https?:\/\//i);
+    const indexRebuild = fs.readFileSync(path.join(dir, "pages", "index-rebuild.md"), "utf8");
+    assert.match(indexRebuild, new RegExp(SITEMAP_XML_VIRTUAL_REBUILD_MARKER.replace(/\./g, "\\.")));
+    assert.doesNotMatch(indexRebuild, new RegExp(SITEMAP_XML_VIRTUAL_BUILD_MARKER.replace(/\./g, "\\.")));
+    const about = fs.readFileSync(path.join(dir, "pages", "about.md"), "utf8");
+    assert.match(about, new RegExp(SITEMAP_XML_VIRTUAL_REBUILD_ABOUT_MARKER));
+    assert.notEqual(SITEMAP_XML_VIRTUAL_BUILD_MARKER, SITEMAP_XML_VIRTUAL_REBUILD_MARKER);
   });
 });

--- a/modules/perc-qa-automation/frontend/tests/unit/sitemap-xml-virtual-qa-fixture.test.js
+++ b/modules/perc-qa-automation/frontend/tests/unit/sitemap-xml-virtual-qa-fixture.test.js
@@ -123,10 +123,11 @@ describe("sitemap-xml-virtual-qa-fixture", () => {
     assert.match(sitemap, new RegExp(SITEMAP_XML_VIRTUAL_REBUILD_LASTMOD));
     assert.doesNotMatch(sitemap, /<loc>\s*https?:\/\//i);
     const indexRebuild = fs.readFileSync(path.join(dir, "pages", "index-rebuild.md"), "utf8");
-    assert.match(indexRebuild, new RegExp(SITEMAP_XML_VIRTUAL_REBUILD_MARKER.replace(/\./g, "\\.")));
-    assert.doesNotMatch(indexRebuild, new RegExp(SITEMAP_XML_VIRTUAL_BUILD_MARKER.replace(/\./g, "\\.")));
+    // Exact substring checks — avoid RegExp(marker) (`.` is a metacharacter; CodeQL js/incomplete-sanitization).
+    assert.ok(indexRebuild.includes(SITEMAP_XML_VIRTUAL_REBUILD_MARKER));
+    assert.ok(!indexRebuild.includes(SITEMAP_XML_VIRTUAL_BUILD_MARKER));
     const about = fs.readFileSync(path.join(dir, "pages", "about.md"), "utf8");
-    assert.match(about, new RegExp(SITEMAP_XML_VIRTUAL_REBUILD_ABOUT_MARKER));
+    assert.ok(about.includes(SITEMAP_XML_VIRTUAL_REBUILD_ABOUT_MARKER));
     assert.notEqual(SITEMAP_XML_VIRTUAL_BUILD_MARKER, SITEMAP_XML_VIRTUAL_REBUILD_MARKER);
   });
 });

--- a/product-docs/8.2/admin/sites.md
+++ b/product-docs/8.2/admin/sites.md
@@ -290,7 +290,9 @@ a local RSS 2.0 or Atom XML fixture (`feed.xml` / `atom.xml` or `_config.yaml` `
 loopback `rss.url` only — no live feed credentials). After you save **iCalendar**, Build
 runs against a local RFC 5545 fixture (`calendar.ics` or `_config.yaml` `icalendar.file`;
 no CalDAV). After you save **Sitemap XML**, Build runs against a local `sitemap.xml` fixture
-(`sitemap.xml` or `_config.yaml` `sitemap.file`; no live crawl). After that Git/CSV/SQL/HTTP JSON/object-storage/rss-atom/icalendar/sitemap-xml Build succeeds,
+(`sitemap.xml` or `_config.yaml` `sitemap.file`; no live crawl). Edit loc, lastmod, or
+the referenced page files on the CMS host and choose **Build Virtual Site** again — assembled
+output updates without a Jetty restart. After that Git/CSV/SQL/HTTP JSON/object-storage/rss-atom/icalendar/sitemap-xml Build succeeds,
 **Preview assembled site** streams last-build home HTML. **Publish Virtual Site** copies
 that HTML to the Site filesystem root for Git/CSV/SQL/HTTP JSON/object-storage/rss-atom/icalendar/sitemap-xml.
 
@@ -336,10 +338,11 @@ that HTML to the Site filesystem root for Git/CSV/SQL/HTTP JSON/object-storage/r
    (`feed.xml` / `atom.xml` / `rss.file` / loopback `rss.url`) or `_config.yaml`
    change — or after an iCalendar fixture (`calendar.ics` / `icalendar.file`) or
    `_config.yaml` change — or after a sitemap.xml `<loc>` / `<lastmod>` / path edit
-   or a `_config.yaml` `sitemap.file` change — choose **Build Virtual Site** again. The build re-reads the current tree
-   (and re-fetches when a Git remote is configured) — **do not restart the CMS** just
-   to pick up those edits. There is no file watcher; the next explicit build is the
-   refresh.
+   or a `_config.yaml` `sitemap.file` change (or referenced local page files) — choose
+   **Build Virtual Site** again. The build re-reads the current tree
+   (and re-fetches when a Git remote is configured) — **do not restart the CMS** (and do
+   **not** restart Jetty) just to pick up those edits. There is no file watcher; the next
+   explicit build is the refresh.
 6. Wait for the busy indicator, then review:
    - **Success** — pages written, absolute output path (default under
      `{install}/tmp/virtual-sites/{siteKey}` when no custom output is set).

--- a/product-docs/8.2/developer/virtual-sites.md
+++ b/product-docs/8.2/developer/virtual-sites.md
@@ -869,7 +869,7 @@ sitemap.xml fixture** under `virtual.rootPath` (`sitemap.xml` or `_config.yaml`
 `virtual.remoteUrl`, credential properties, and cloud `rootPath` URLs are **400**. No live
 crawl, no robots.txt fetch, and no secrets on the REST envelope. Each Build re-reads the
 current `sitemap.xml` loc/lastmod/path and `_config.yaml` `sitemap.file` (no parsed-page
-cache; no JVM restart; no file watchers). A second Admin `POST /sites/{nameOrId}/virtual/build`
+cache; no JVM restart; no Jetty restart; no file watchers). A second Admin `POST /sites/{nameOrId}/virtual/build`
 after a Path/Files edit of `sitemap.xml` loc/lastmod, `sitemap.file`, or referenced page
 Markdown returns `pagesWritten > 0` HTML that matches the **current** files — no Jetty
 restart. Git, CSV, SQL, HTTP JSON, object-storage, rss-atom, and icalendar Build paths


### PR DESCRIPTION
## Summary

Parent: #2678. Slice: H2 Playwright for Developer Sites **Build Virtual Site** on a saved `sitemap-xml` source after an in-cell `sitemap.xml` edit.

Adds a live rebuild case that `docker cp`s an updated sitemap + page bodies into the QA cell, runs a **second Build without restarting Jetty**, and asserts `pagesWritten` increases and last-build Preview HTML reflects the new loc/lastmod/body. Existing live save/Build/Preview assertions (#4174 / PR #4179, #4164, #4165) are unchanged.

Product-docs 8.2 admin Sites (and developer Virtual Sites REST Build) document rebuild after sitemap loc/lastmod/page edit with **no CMS/Jetty restart**.

Fixes #4188

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install`
2. `cd modules/perc-qa-automation/frontend && npm run test:unit` (sitemap rebuild fixture unit tests)
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up` then `qa-health` (use printed `TEST_CMS_URL`; skip-image-build cells also need current SPA + `perc-system`/`rest`/`sitemanage` in `WEB-INF/lib` so sitemap-xml save is allowed)
4. `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js --grep sitemap-xml`
5. Confirm live save/Build/Preview still pass and the new rebuild test asserts HTML/pagesWritten change without Jetty restart
6. `python docker/scripts/perc-devctl.py qa-down`

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/sites.md` and `product-docs/8.2/developer/virtual-sites.md` (rebuild after sitemap.xml loc/lastmod/page edit; no Jetty restart)
- [x] **Unit / module tests** — sitemap-xml fixture rebuild unit tests; perc-qa-automation standalone clean install green
- [x] **WebUI + Playwright** — extended `developer-site-virtual-source.spec.js`; C5 surface grep sitemap-xml **5 passed** including rebuild (#4188)
- [x] **Build gates** — standalone `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` (no skipTests); C2 N/A
- [x] **Cross-platform** — host paths via `path.join`; in-container dest POSIX `/opt/Percussion/tmp/...`

### C3 evidence

- **modules_built:** `modules/perc-qa-automation`
- **build_evidence:** `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → **BUILD SUCCESS** (Total time 2.933 s). Java Tests run: 0 (module has no Java tests). `npm run test:unit` → tests 487, pass 487, fail 0. `scripts\ci-smoke-product-docs.bat` → OK (`tmp/product-docs-site/8.2/index.html`).
- **downstream_checked:** none (C2 did not apply — Playwright/docs only; no public Java API / `final` / `sealed` change)

### C5 UI proof

- **qa-up:** H2 cell `perc-matrix-cms-h2`; `TEST_CMS_URL=http://127.0.0.1:9993`
- **health:** `qa-health` RESULT:OK HTTP:200 HEALTH:healthy (after SPA copy, after perc-system/rest/sitemanage docker cp + in-cell StopJetty/StartJetty)
- **Playwright:** `npm run test:surface -- --path tests/developer-site-virtual-source.spec.js --grep sitemap-xml` → **5 passed (12.6s)** including live save+reload, live Build, live Preview, and rebuild without Jetty restart
- **console-clean:** yes (pageerror/console error lists empty in specs)
- **server.log-clean:** yes (test window AUTH-1001 login success only; no feature ERROR/FATAL)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
