### PR TITLE
feat(webui): SPA UI-02 action menu create/delete (#4112)

### DIFF
--- a/WebUI/src/test/ts/developer/ActionMenusPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ActionMenusPanel.test.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionRedirectError } from "../../../main/ts/api/client";
 import {
+  createActionMenu,
   deleteActionMenu,
   getActionMenuDetail,
   listActionMenus,
@@ -44,6 +45,7 @@ vi.mock("../../../main/ts/developer/ObjectAclSection", () => ({
 
 const listMock = vi.mocked(listActionMenus);
 const detailMock = vi.mocked(getActionMenuDetail);
+const createMock = vi.mocked(createActionMenu);
 const deleteMock = vi.mocked(deleteActionMenu);
 
 const sampleMenu = {
@@ -72,6 +74,7 @@ describe("ActionMenusPanel", () => {
     };
     listMock.mockReset();
     detailMock.mockReset();
+    createMock.mockReset();
     deleteMock.mockReset();
   });
 
@@ -107,6 +110,43 @@ describe("ActionMenusPanel", () => {
     expect(screen.getByTestId("developer-am-detail")).toBeTruthy();
     expect(screen.getByTestId("developer-am-save")).toBeDisabled();
     expect(detailMock).not.toHaveBeenCalled();
+  });
+
+  it("lists the created user menu after save and back", async () => {
+    const created = {
+      name: "MyMenu",
+      label: "My Menu",
+      menuType: "MENUITEM",
+    };
+    listMock.mockResolvedValueOnce([]).mockResolvedValue([created]);
+    createMock.mockResolvedValue(created);
+    render(<ActionMenusPanel />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-empty")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("developer-am-new"));
+    fireEvent.change(screen.getByTestId("developer-am-name"), {
+      target: { value: "MyMenu" },
+    });
+    fireEvent.change(screen.getByTestId("developer-am-label"), {
+      target: { value: "My Menu" },
+    });
+    fireEvent.click(screen.getByTestId("developer-am-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-editor-notice")).toBeTruthy();
+    });
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "MyMenu", label: "My Menu" }),
+    );
+    await waitFor(() => {
+      expect(listMock).toHaveBeenCalledTimes(2);
+    });
+    fireEvent.click(screen.getByTestId("developer-am-back"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-am-table")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-am-table").textContent).toContain("MyMenu");
+    expect(screen.getByTestId("developer-am-open").getAttribute("data-am-name")).toBe("MyMenu");
   });
 
   it("shows empty state when API returns no action menus", async () => {

--- a/docs/ai-generated/code-reviews/issue-4112-erlang.md
+++ b/docs/ai-generated/code-reviews/issue-4112-erlang.md
@@ -1,0 +1,23 @@
+# Erlang review — issue #4112 SPA UI-02 action menu create/delete
+
+**Branch:** `feat/issue-4112-spa-ui02-create-delete`  
+**Base:** `origin/main`  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Cross-platform path checklist:** N/A (no new filesystem path I/O; REST/URL paths use `/`)
+
+## Summary
+
+Finish Developer Action Menus SPA create (POST) and delete (DELETE) on the existing REST surface. Stacks open #4189 / #4171 JAXB bind (`skip.default.json.provider.registration` on `rest-jax-rs`, explicit finder DTO root name). Does not re-implement REST write or steal UI-03 PUT/tabs (cluster #4194). Playwright now asserts catalog GET lists the created name and GET after DELETE is 404. Vitest covers invalid 400, duplicate 409, missing 404, non-Admin 403, system 409, and catalog list after create+back.
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable I/O).
+
+## Notes
+
+- SPA chrome already existed on `main` (cluster #4151); remaining acceptance was live POST bind + catalog include/omit.
+- UI-03 usage/command/visibility and UI-04 children are not claimed.
+- Memory patterns hit: dual-ship rest+sitemanage+perc-system into H2 QA WAR; do not docker-restart the cell.
+
+> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.

--- a/modules/perc-qa-automation/frontend/tests/developer-action-menu-editor.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-action-menu-editor.spec.js
@@ -17,10 +17,10 @@
 /**
  * Developer Action Menus create / delete chrome (#4112 UI-02 / parent #1690).
  *
- * SPA catalog exposes New + detail save/delete. Live POST create is asserted
- * by the editor notice. Catalog GET after POST may still miss the row when
- * design-WS saveActions does not flush Hibernate RXMENUACTION (same class as
- * display-format #4101) — that persist gap is a REST residual, not SPA chrome.
+ * SPA catalog New POSTs a user menu; GET catalog lists it; detail DELETE
+ * omits it (following GET is 404). System menus stay in the catalog (409).
+ * Stacks REST JAXB bind (#4189 / #4171) so POST is ActionMenu, not the
+ * workflow-transitions finder DTO. Does not claim UI-03/UI-04.
  *
  * Surface-filtered QA:
  * <pre>
@@ -107,6 +107,44 @@ function createdRow(page, menuName) {
   );
 }
 
+/**
+ * Same-origin fetch so OWASP CSRF + session cookies apply.
+ *
+ * @param {import("@playwright/test").Page} page
+ * @param {string} path
+ * @param {string} method
+ * @returns {Promise<{status: number, text: string}>}
+ */
+async function inPageJson(page, path, method) {
+  return page.evaluate(
+    async ({ path: url, method: httpMethod }) => {
+      const tokenObj = window.OWASP_CSRFTOKEN;
+      const metaToken = document.querySelector('meta[name="_csrf"]');
+      const metaHeader = document.querySelector('meta[name="_csrf_header"]');
+      const token =
+        (tokenObj && tokenObj.token) || (metaToken && metaToken.content) || "";
+      const headerName =
+        (metaHeader && metaHeader.content) || "OWASP-CSRFTOKEN";
+      const headers = { Accept: "application/json" };
+      if (token) {
+        headers[headerName] = token;
+      }
+      const res = await fetch(url, {
+        method: httpMethod,
+        credentials: "same-origin",
+        headers,
+      });
+      const text = await res.text();
+      return { status: res.status, text };
+    },
+    { path, method },
+  );
+}
+
+function nameInJson(text, name) {
+  return new RegExp(`"name"\\s*:\\s*"${name}"`).test(text);
+}
+
 test.describe("Developer action menu editor (#4112 / UI-02)", () => {
   test("catalog lists system Edit and opens create chrome", async ({ page }) => {
     test.setTimeout(120_000);
@@ -131,8 +169,8 @@ test.describe("Developer action menu editor (#4112 / UI-02)", () => {
     assertConsoleClean(pageErrors, consoleErrors);
   });
 
-  test("Admin create POST is saved in the editor (notice + name read-only)", async ({ page }) => {
-    test.setTimeout(120_000);
+  test("Admin create POST is listed then DELETE omits it (GET 404)", async ({ page }) => {
+    test.setTimeout(180_000);
     const { pageErrors, consoleErrors } = attachConsoleGuards(page);
     await loginAsAdmin(page);
     await openActionMenusCatalog(page);
@@ -156,6 +194,21 @@ test.describe("Developer action menu editor (#4112 / UI-02)", () => {
     await expect(page.locator('[data-testid="developer-am-name"]')).toBeDisabled();
     await expect(page.locator('[data-testid="developer-am-delete"]')).toBeVisible();
 
+    const catalog = await inPageJson(page, "/Rhythmyx/services/actions/catalog", "GET");
+    expect(catalog.status, `GET catalog (got ${catalog.status}): ${catalog.text}`).toBe(200);
+    expect(
+      nameInJson(catalog.text, menuName),
+      `GET catalog must list ${menuName}: ${catalog.text}`,
+    ).toBeTruthy();
+
+    await page.locator('[data-testid="developer-am-back"]').click();
+    await expect(page.locator('[data-testid="developer-am-panel"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(createdRow(page, menuName)).toHaveCount(1, { timeout: 20_000 });
+
+    await createdRow(page, menuName).click();
+    await expect(page.locator('[data-testid="developer-am-detail"]')).toBeVisible();
     await page.locator('[data-testid="developer-am-delete"]').click();
     await confirmDeveloperCatalogDelete(page);
     await expect(page.locator('[data-testid="developer-am-panel"]')).toBeVisible({
@@ -164,7 +217,17 @@ test.describe("Developer action menu editor (#4112 / UI-02)", () => {
     const listNotice = page.locator('[data-testid="developer-am-list-notice"]');
     await expect(listNotice).toBeVisible({ timeout: 20_000 });
     await expect(listNotice).toContainText(/deleted/i);
+    await expect(createdRow(page, menuName)).toHaveCount(0);
 
+    const afterDelete = await inPageJson(
+      page,
+      `/Rhythmyx/services/actions/catalog/${encodeURIComponent(menuName)}`,
+      "GET",
+    );
+    expect(
+      afterDelete.status,
+      `GET after DELETE must be 404 (got ${afterDelete.status}): ${afterDelete.text}`,
+    ).toBe(404);
 
     assertConsoleClean(pageErrors, consoleErrors);
   });

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1506,7 +1506,8 @@ PUT round-trips GET detail fields already exposed (`label`, `description`,
 | `DELETE` | `/services/actions/{idOrName}` | **Admin.** Delete a user action menu (`deleteActions`, `ignoreDependencies=false`) |
 
 JSON may wrap a single item as `ActionMenu`. **Create** `POST /services/actions`
-sends that envelope (or a flat object with `name`). Do not post
+sends that envelope (or a flat object with `name`). The collection POST is bound
+as `ActionMenu` (not JAXB `allowedWorkflowTransitionsRequest`). Do not post
 `allowedWorkflowTransitionsRequest` on the collection path — that finder lives at
 `POST /services/actions/find/transitions`. Integrators should unwrap the
 `ActionMenu` envelope and read `guid.stringValue` (never assume the GUID is

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -160,6 +160,12 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="jacksonContextResolver" />
             <ref bean="authorizationFilter" />
         </jaxrs:providers>
+        <!-- #4171: do not auto-register Jettison JSONProvider. It JAXB-binds
+             POST /actions as allowedWorkflowTransitionsRequest (finder is
+             /find/transitions). Jackson + ActionMenuJsonReader own JSON. -->
+        <jaxrs:properties>
+            <entry key="skip.default.json.provider.registration" value="true"/>
+        </jaxrs:properties>
         <jaxrs:features>
             <!-- CXF 3.1+/4.x: use LoggingFeature bean (requires cxf-rt-features-logging).
                  Legacy <cxf:logging/> under core NS has no BeanDefinitionParser without that module. -->

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -226,6 +226,10 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(
         displayFormatReader < jackson,
         DISPLAY_FORMAT_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        restBlock.contains("skip.default.json.provider.registration"),
+        "rest-jax-rs must skip Jettison JSONProvider (POST /actions JAXB "
+            + "allowedWorkflowTransitionsRequest)");
   }
 
   private static Path resolveRepoRoot() {

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
@@ -46,6 +46,8 @@ import tools.jackson.databind.json.JsonMapper;
  * This reader binds wrap and flat shapes before {@code jacksonProvider}.
  *
  * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code jacksonProvider}.
+ * rest-jax-rs also sets {@code skip.default.json.provider.registration} so Jettison JAXB cannot
+ * bind this body as {@code allowedWorkflowTransitionsRequest} (#4171).
  */
 @Provider
 @Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.actions;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
 
@@ -27,8 +28,12 @@ import java.util.Arrays;
  * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
  * {@code contentIds} and {@code assignmentTypeIds} as JSON arrays, not Optional beans (issue #3388
  * slice 10 / #3432).
+ *
+ * <p>Root name is explicit so JAXB/Jettison cannot treat an {@code ActionMenu} envelope as this
+ * type on {@code POST /actions} (#4171). Finder POST is {@code /actions/find/transitions}.
  */
-@XmlRootElement
+@XmlRootElement(name = "allowedWorkflowTransitionsRequest")
+@JsonRootName("allowedWorkflowTransitionsRequest")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AllowedWorkflowTransitionsRequest {
 

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.provider.JAXBElementProvider;
 import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.jupiter.api.AfterEach;
@@ -79,7 +80,9 @@ public class ActionMenuCreateCxfUnmarshallTest {
     jackson.setMapper(
         (tools.jackson.databind.json.JsonMapper)
             new JacksonContextResolver().getContext(ActionMenu.class));
-    factory.setUserProviders(Arrays.asList(custom, jackson, new JacksonContextResolver()));
+    factory.setUserProviders(
+        Arrays.asList(
+            custom, jackson, new JacksonContextResolver(), new JAXBElementProvider<>()));
 
     MessageImpl message = new MessageImpl();
     MessageBodyReader<ActionMenu> selected =
@@ -117,6 +120,20 @@ public class ActionMenuCreateCxfUnmarshallTest {
   @Test
   public void cxfPostFlatActionMenuInvokesCreate() throws Exception {
     assertCreatePost(FLAT, "cxfFlat", "local://issue-4123-actions-flat");
+  }
+
+  @Test
+  public void cxfPostWrappedActionMenuWithJaxbProviderStillInvokesCreate() throws Exception {
+    assertCreatePost(WRAPPED, "cxfN1", "local://issue-4171-actions-jaxb");
+  }
+
+  @Test
+  public void jacksonBarrierBindsWrappedActionMenuWithoutCustomReader() {
+    ActionMenu menu =
+        new JacksonContextResolver()
+            .getContext(ActionMenu.class)
+            .readValue(WRAPPED, ActionMenu.class);
+    assertEquals("cxfN1", menu.getName());
   }
 
   private void assertCreatePost(String json, String expectedName, String address) throws Exception {
@@ -169,6 +186,7 @@ public class ActionMenuCreateCxfUnmarshallTest {
             new AllowedContentTypeMenusRequestJsonReader(),
             jackson,
             new JacksonContextResolver(),
+            new JAXBElementProvider<>(),
             new WebApplicationExceptionMapper()));
     Server created = sf.create();
     assertNotNull(created, "CXF local server must start");


### PR DESCRIPTION
## Summary

Developer **Action Menus** catalog can **create** a user menu (`POST /services/actions`) and **delete** a selected user menu (`DELETE /services/actions/{idOrName}`). After create, **GET catalog lists the new name**; after delete, following GET is **404**. System menus (e.g. **Edit**) are **409** and remain in the catalog.

SPA chrome was already on `main` (cluster #4151). This slice finishes UI-02 acceptance:

- Stacks open **#4189 / #4171** JAXB bind (`skip.default.json.provider.registration` on `rest-jax-rs`) so collection POST is `ActionMenu`, not `allowedWorkflowTransitionsRequest`. Does **not** re-implement REST write.
- Playwright: catalog New, GET catalog includes the created name, DELETE omits it (GET 404), system Edit not removed.
- Vitest: invalid name 400, duplicate 409, missing 404, non-Admin 403, system 409, catalog lists created row after save+back.

Does **not** steal UI-03 usage/command/visibility (cluster **#4194** / #4183/#4184/#4185) or UI-04 children.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4112  
Parent #1690  
Stacked #4189 / Partial #4171

## Test plan

1. Vitest: `ActionMenusPanel` create+back lists the row; `ActionMenuDetailPanel` / `actionMenusApi` 400/409/404/403/system.
2. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 1035, Failures: 0).
3. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2246, Failures: 0, Errors: 0, Skipped: 125).
4. `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS (Vitest Tests 3765 passed).
5. `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` — BUILD SUCCESS.
6. H2 QA: `perc-devctl.py qa-up --skip-image-build --then-qa-deploy-webui` → `TEST_CMS_URL=http://127.0.0.1:9993` → docker cp rest + sitemanage + perc-system + `sitemanage-beans.xml` into `Rhythmyx/WEB-INF` → in-cell StopJetty/StartJetty → `npm run test:surface -- --path tests/developer-action-menu-editor.spec.js` — **3 passed**.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/admin/developer-action-menus.md` (existing on main) + `developer/rest.md` JAXB bind note from stacked #4189
- [x] **Unit / module tests** — Vitest create/delete status mapping + catalog list after create; rest/sitemanage/WebUI/perc-qa-automation standalone `clean install`
- [x] **WebUI + Playwright** — `tests/developer-action-menu-editor.spec.js` (3 passed)
- [x] **Build gates** — rest, projects/sitemanage, WebUI, modules/perc-qa-automation standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`, `WebUI`, `modules/perc-qa-automation`
- **build_evidence:** `cd rest && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 1035 Failures: 0; `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS Tests run: 2246 Failures: 0 Errors: 0 Skipped: 125; `cd WebUI && ../mvnw.cmd clean install` BUILD SUCCESS Vitest Tests 3765 passed; `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` BUILD SUCCESS
- **downstream_checked:** sitemanage standalone clean install (depends on rest); grepped `extends AllowedWorkflowTransitionsRequest` (none); no Java type sealed/final

### C5 UI proof

- `perc-devctl.py qa-up --skip-image-build --then-qa-deploy-webui` `TEST_CMS_URL=http://127.0.0.1:9993` container `perc-matrix-cms-h2`
- Docker `Health.Status=healthy` after in-cell StopJetty/StartJetty (no `Failed startup of context` / `NoClassDefFoundError`)
- Dual-ship rest + sitemanage + perc-system WAR jars + exploded `sitemanage-beans.xml` + `qa-deploy-webui`
- Playwright: `npm run test:surface -- --path tests/developer-action-menu-editor.spec.js` — **3 passed** (7.0s)
- console-clean=yes (spec pageerror/console guards)
- server.log-clean=yes (no ActionMenu ERROR/FATAL in the test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
