### PR TITLE
feat(rest): UI-04 cascading children validation (#4205)

### DIFF
--- a/product-docs/8.2/admin/developer-action-menus.md
+++ b/product-docs/8.2/admin/developer-action-menus.md
@@ -40,7 +40,8 @@ detail stay **read-only**.
    lists the new name immediately (`GET /services/actions/catalog` and GET by
    name); packaged menus such as **Copy** cannot be deleted (**409**).
 5. Optional: change label, description, menu type, or URL and **Save** again.
-   Child entries, parameters, properties, and visibility are not written.
+   Child entries are not written from this Save (use REST children PUT).
+   Parameters, properties, and visibility are not written.
 6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
    The catalog returns with a green **Action
    menu deleted** notice and no longer lists that user menu. Delete of a
@@ -52,7 +53,8 @@ detail stay **read-only**.
 ## Limits
 
 - Name is immutable after create.
-- Cascading child menu composition is not in this chrome (UI-04).
+- Cascading child menu composition is not in this chrome (UI-04 SPA). Admins
+  can persist ordered children with REST `PUT /services/actions/{idOrName}/children`.
 - Usage / command / visibility tab editing is not in this chrome (UI-03).
 - System menus cannot be updated or deleted here.
 
@@ -66,6 +68,7 @@ The chrome calls:
 | Load | `GET /services/actions/catalog/{idOrName}` |
 | Create | `POST /services/actions` (`name` required; unique, no spaces) |
 | Save | `PUT /services/actions/{idOrName}` (label, description, menuType, url) |
+| Children | `PUT /services/actions/{idOrName}/children` (ordered name/id list; not called by this chrome yet) |
 | Delete | `DELETE /services/actions/{idOrName}` (`204` on success) |
 
 Writes lock the menu for the request (`overrideLock=false`) and release it on

--- a/product-docs/8.2/admin/developer-action-menus.md
+++ b/product-docs/8.2/admin/developer-action-menus.md
@@ -68,7 +68,7 @@ The chrome calls:
 | Load | `GET /services/actions/catalog/{idOrName}` |
 | Create | `POST /services/actions` (`name` required; unique, no spaces) |
 | Save | `PUT /services/actions/{idOrName}` (label, description, menuType, url) |
-| Children | `PUT /services/actions/{idOrName}/children` (ordered name/id list; not called by this chrome yet) |
+| Children | `PUT /services/actions/{idOrName}/children` (ordered name/id list; cycle/unknown/duplicate child is 400; not called by this chrome yet) |
 | Delete | `DELETE /services/actions/{idOrName}` (`204` on success) |
 
 Writes lock the menu for the request (`overrideLock=false`) and release it on

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1500,10 +1500,12 @@ PUT round-trips GET detail fields already exposed (`label`, `description`,
 **Children PUT** (`PUT /services/actions/{idOrName}/children`) replaces
 `RXMENUACTIONRELATION` for a user cascading `MENU` (type `MENU` with a blank
 URL). The body is an `ActionMenuList`: a JSON array, `{"ActionMenuList":[…]}`,
-or `{"children":[…]}`. Each element is identified by **`name`**, numeric
+`{"children":[…]}`, or `{"ActionMenu":{"children":[…]}}`. Each element is identified by **`name`**, numeric
 **`id`**, or **`guid.stringValue`** (the same catalog keys as GET). Array
 **order** is persisted (child `SORTORDER` plus relation rows). Other fields on
-those child objects are ignored. An empty array clears children. Parent
+those child objects are ignored. An empty array (or an `ActionMenu` envelope with
+no `children`) clears children. An unrecognized JSON object (for example
+`{"foo":"bar"}`) is **400** — it is not treated as an empty list. Parent
 `PUT /services/actions/{idOrName}` does **not** honor nested `children`
 (label/type/url only). Illegal graphs fail closed — the server does **not**
 persist a partial association list. A **cycle** (parent listed as its own

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1480,8 +1480,9 @@ rows are written to `RXMENUACTION` so Hibernate `findActionMenusTree` (GET
 `/services/actions/catalog` and GET by name) includes a user menu immediately
 after POST, and omits it after DELETE. There is no new SOAP surface.
 **Developer → Action Menus** chrome creates and deletes user menus (and saves
-label / description / menuType / url); cascading children composition (UI-04)
-and usage/command/visibility tab completeness (UI-03) are later slices — see
+label / description / menuType / url). Ordered **child associations** on a user
+cascading `MENU` use `PUT /services/actions/{idOrName}/children` (UI-04).
+Usage/command/visibility tab completeness (UI-03) remains a later slice — see
 [Developer Action Menus](id:admin-developer-action-menus). Finder helpers
 (`GET /services/actions/find`, content-type and template finders) are unchanged.
 After POST the editor notice confirms the save. Packaged menus (for example
@@ -1496,13 +1497,25 @@ If Workbench path resolution fails, PUT/DELETE also return **409** (fail closed)
 so a lookup error cannot bypass that protection.
 PUT round-trips GET detail fields already exposed (`label`, `description`,
 `menuType`, `url`). Name is the catalog key and is not renamed on PUT.
+**Children PUT** (`PUT /services/actions/{idOrName}/children`) replaces
+`RXMENUACTIONRELATION` for a user cascading `MENU` (type `MENU` with a blank
+URL). The body is an `ActionMenuList`: a JSON array, `{"ActionMenuList":[…]}`,
+or `{"children":[…]}`. Each element is identified by **`name`**, numeric
+**`id`**, or **`guid.stringValue`** (the same catalog keys as GET). Array
+**order** is persisted (child `SORTORDER` plus relation rows). Other fields on
+those child objects are ignored. An empty array clears children. Parent
+`PUT /services/actions/{idOrName}` does **not** honor nested `children`
+(label/type/url only). A non-cascading parent is **400**. Unknown parent or
+child is **404**. System parent is **409**. Following GET
+`/services/actions/catalog/{idOrName}` returns those children in order.
 
 | Method | Path | Purpose |
 |--------|------|---------|
 | `GET` | `/services/actions/catalog` | List action menus (tree roots with children) |
 | `GET` | `/services/actions/catalog/{idOrName}` | Load one menu by name, numeric id, or GUID string |
 | `POST` | `/services/actions` | **Admin.** Create a user action menu (`createActions` then `saveActions`) |
-| `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, and/or url |
+| `PUT` | `/services/actions/{idOrName}` | **Admin.** Update label, description, menuType, and/or url (not children) |
+| `PUT` | `/services/actions/{idOrName}/children` | **Admin.** Replace ordered child associations on a user cascading MENU |
 | `DELETE` | `/services/actions/{idOrName}` | **Admin.** Delete a user action menu (`deleteActions`, `ignoreDependencies=false`) |
 
 JSON may wrap a single item as `ActionMenu`. **Create** `POST /services/actions`

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1505,9 +1505,15 @@ or `{"children":[…]}`. Each element is identified by **`name`**, numeric
 **order** is persisted (child `SORTORDER` plus relation rows). Other fields on
 those child objects are ignored. An empty array clears children. Parent
 `PUT /services/actions/{idOrName}` does **not** honor nested `children`
-(label/type/url only). A non-cascading parent is **400**. Unknown parent or
-child is **404**. System parent is **409**. Following GET
-`/services/actions/catalog/{idOrName}` returns those children in order.
+(label/type/url only). Illegal graphs fail closed — the server does **not**
+persist a partial association list. A **cycle** (parent listed as its own
+child, or A→B→A through existing descendants) is **400**. An **unknown
+child** id/name is **400**. A **duplicate child** in one payload (same name
+or same resolved id twice) is **400**. A non-cascading parent is **400**.
+Missing **parent** is **404**. Non-Admin (or missing request session/user) is
+**403**. System parent is **409**. Following GET
+`/services/actions/catalog/{idOrName}` returns those children in order (or the
+previous children when the write was rejected).
 
 | Method | Path | Purpose |
 |--------|------|---------|

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -62,9 +62,11 @@ import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
@@ -783,8 +785,8 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   }
 
   /**
-   * Resolve child catalog keys to assigned {@link PSAction}s. Unknown child is HTTP 404. Missing
-   * identity on a child row is 400.
+   * Resolve child catalog keys to assigned {@link PSAction}s. Unknown, duplicate, or cyclic children
+   * are HTTP 400 and the caller must not persist a partial graph.
    */
   List<PSAction> resolveChildActions(PSAction parent, ActionMenuList children) {
     if (children == null || children.isEmpty()) {
@@ -792,24 +794,122 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     }
     int parentId = parent != null ? parent.getId() : -1;
     List<PSAction> resolved = new ArrayList<>(children.size());
+    Set<String> seenKeys = new HashSet<>();
+    Set<Integer> seenIds = new HashSet<>();
     for (ActionMenu child : children) {
       String key = childCatalogKey(child);
       if (!isSafeMenuKey(key)) {
         throw new IllegalArgumentException("child name or id is required");
+      }
+      String keyNorm = key.trim().toLowerCase();
+      if (!seenKeys.add(keyNorm)) {
+        throw new IllegalArgumentException("duplicate child in payload");
       }
       PSAction found = findPsActionByKey(key.trim());
       if (found == null) {
         found = findHibernateActionByKey(key.trim());
       }
       if (found == null || found.getId() <= 0) {
-        throw new WebApplicationException("Action menu not found", 404);
+        throw new IllegalArgumentException("unknown child action menu");
+      }
+      if (!seenIds.add(found.getId())) {
+        throw new IllegalArgumentException("duplicate child in payload");
       }
       if (parentId > 0 && found.getId() == parentId) {
-        throw new IllegalArgumentException("a menu cannot be a child of itself");
+        throw new IllegalArgumentException("cascading menu cycle");
       }
       resolved.add(found);
     }
+    rejectChildCycles(parent, resolved);
     return resolved;
+  }
+
+  /**
+   * Fail closed if attaching {@code children} would create a parent-in-descendants cycle (A→B→A
+   * or parent listed as its own child). Does not mutate the graph.
+   */
+  void rejectChildCycles(PSAction parent, List<PSAction> children) {
+    int parentId = parent != null ? parent.getId() : -1;
+    if (parentId <= 0 || children == null || children.isEmpty()) {
+      return;
+    }
+    for (PSAction child : children) {
+      if (child == null) {
+        continue;
+      }
+      if (child.getId() == parentId
+          || descendantContainsParent(child, parentId, new HashSet<>())) {
+        throw new IllegalArgumentException("cascading menu cycle");
+      }
+    }
+  }
+
+  /**
+   * True when {@code parentId} is already in {@code node}'s existing descendant graph (design-WS
+   * children and/or Hibernate nested tree).
+   */
+  boolean descendantContainsParent(PSAction node, int parentId, Set<Integer> seen) {
+    if (node == null || node.getId() <= 0 || parentId <= 0 || seen == null) {
+      return false;
+    }
+    if (!seen.add(node.getId())) {
+      return false;
+    }
+    PSChildActions kids = node.getChildren();
+    if (kids != null) {
+      Iterator<?> it = kids.iterator();
+      while (it.hasNext()) {
+        int childId = childActionId(it.next());
+        if (childId == parentId) {
+          return true;
+        }
+        if (childId > 0) {
+          PSAction child = findPsActionByKey(Integer.toString(childId));
+          if (child == null) {
+            child = findHibernateActionByKey(Integer.toString(childId));
+          }
+          if (descendantContainsParent(child, parentId, seen)) {
+            return true;
+          }
+        }
+      }
+    }
+    PSActionMenu hibernate = requestHibernateIndex().get(Integer.toString(node.getId()));
+    if (hibernate != null && hibernate.getChildren() != null) {
+      for (PSActionMenu child : hibernate.getChildren()) {
+        if (child == null) {
+          continue;
+        }
+        int childId = child.getActionId();
+        if (childId == parentId) {
+          return true;
+        }
+        if (childId > 0) {
+          PSAction loaded = findPsActionByKey(Integer.toString(childId));
+          if (loaded == null) {
+            loaded = psActionFromHibernate(child);
+          }
+          if (descendantContainsParent(loaded, parentId, seen)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  static int childActionId(Object child) {
+    if (child instanceof PSMenuChild menuChild) {
+      try {
+        return Integer.parseInt(menuChild.getChildActionId());
+      } catch (NumberFormatException e) {
+        return -1;
+      }
+    }
+    if (child instanceof PSAction action) {
+      return action.getId();
+    }
+    return -1;
   }
 
   static String childCatalogKey(ActionMenu child) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -846,7 +846,8 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
 
   /**
    * True when {@code parentId} is already in {@code node}'s existing descendant graph (design-WS
-   * children and/or Hibernate nested tree).
+   * children and/or Hibernate nested tree). Walks the in-memory Hibernate index first so cycle
+   * checks do not N+1 {@code loadActions} per descendant.
    */
   boolean descendantContainsParent(PSAction node, int parentId, Set<Integer> seen) {
     if (node == null || node.getId() <= 0 || parentId <= 0 || seen == null) {
@@ -859,15 +860,14 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     if (kids != null) {
       Iterator<?> it = kids.iterator();
       while (it.hasNext()) {
-        int childId = childActionId(it.next());
+        Object next = it.next();
+        int childId = childActionId(next);
         if (childId == parentId) {
           return true;
         }
         if (childId > 0) {
-          PSAction child = findPsActionByKey(Integer.toString(childId));
-          if (child == null) {
-            child = findHibernateActionByKey(Integer.toString(childId));
-          }
+          PSAction child =
+              next instanceof PSAction action ? action : resolveDescendantForCycle(childId);
           if (descendantContainsParent(child, parentId, seen)) {
             return true;
           }
@@ -884,18 +884,28 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
         if (childId == parentId) {
           return true;
         }
-        if (childId > 0) {
-          PSAction loaded = findPsActionByKey(Integer.toString(childId));
-          if (loaded == null) {
-            loaded = psActionFromHibernate(child);
-          }
-          if (descendantContainsParent(loaded, parentId, seen)) {
-            return true;
-          }
+        if (childId > 0
+            && descendantContainsParent(psActionFromHibernate(child), parentId, seen)) {
+          return true;
         }
       }
     }
     return false;
+  }
+
+  /**
+   * Resolve a descendant for cycle walking: Hibernate request index (already loaded) first, then
+   * design-WS only if the nested row is missing from that catalog.
+   */
+  PSAction resolveDescendantForCycle(int childId) {
+    if (childId <= 0) {
+      return null;
+    }
+    PSActionMenu hibernate = requestHibernateIndex().get(Integer.toString(childId));
+    if (hibernate != null) {
+      return psActionFromHibernate(hibernate);
+    }
+    return findPsActionByKey(Integer.toString(childId));
   }
 
   static int childActionId(Object child) {

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ActionMenuAdaptor.java
@@ -27,7 +27,10 @@ import com.percussion.cms.objectstore.PSDbComponentCollection;
 import com.percussion.cms.objectstore.PSMenuModeContextMapping;
 import com.percussion.cms.objectstore.PSAction;
 import com.percussion.rest.Guid;
+import com.percussion.cms.objectstore.PSChildActions;
+import com.percussion.cms.objectstore.PSMenuChild;
 import com.percussion.rest.actions.ActionMenu;
+import com.percussion.rest.actions.ActionMenuList;
 import com.percussion.rest.actions.ActionMenuModeUIContext;
 import com.percussion.rest.actions.ActionMenuParameter;
 import com.percussion.rest.actions.ActionMenuProperty;
@@ -59,6 +62,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
@@ -416,6 +420,55 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
   }
 
   @Override
+  public ActionMenu saveActionMenuChildren(String idOrName, ActionMenuList children) {
+    requireAdmin();
+    requireSessionUserForWrite();
+    if (!isSafeMenuKey(idOrName)) {
+      return null;
+    }
+    IPSGuid id = null;
+    try {
+      PSAction existing = findPsActionByKey(idOrName.trim());
+      if (existing == null) {
+        existing = findHibernateActionByKey(idOrName.trim());
+        if (existing == null) {
+          return null;
+        }
+      }
+      rejectSystemMenuWrite(existing);
+      rejectNonCascadingParent(existing);
+      id = safeGuid(existing);
+      if (id == null) {
+        throw new WebApplicationException(SYSTEM_MENU_WRITE, 409);
+      }
+      List<PSAction> resolved = resolveChildActions(existing, children);
+      String session = currentSession();
+      String user = currentUser();
+      List<PSAction> loaded = service.loadActions(List.of(id), true, false, session, user);
+      if (loaded == null || loaded.isEmpty() || loaded.get(0) == null) {
+        return null;
+      }
+      PSAction domain = loaded.get(0);
+      rejectNonCascadingParent(domain);
+      replaceChildren(domain, resolved);
+      service.saveActions(List.of(domain), true, session, user);
+      return toDtoWithChildren(domain, resolved);
+    } catch (WebApplicationException | IllegalArgumentException e) {
+      throw e;
+    } catch (PSErrorResultsException e) {
+      if (id != null && isNotFound(e, id)) {
+        return null;
+      }
+      throw new WebApplicationException(
+          "Could not update action menu; design lock required or held by another user", 409);
+    } catch (PSErrorsException e) {
+      throw mapSaveOrDeleteFailure("update", e);
+    } finally {
+      clearRequestHibernateIndex();
+    }
+  }
+
+  @Override
   public boolean deleteActionMenu(String idOrName) {
     requireAdmin();
     requireSessionUserForWrite();
@@ -717,6 +770,107 @@ public class ActionMenuAdaptor implements IActionMenuAdaptor {
     } catch (RuntimeException e) {
       return null;
     }
+  }
+
+  static void rejectNonCascadingParent(PSAction parent) {
+    if (parent == null) {
+      return;
+    }
+    if (!parent.isCascadedMenu()) {
+      throw new IllegalArgumentException(
+          "Child associations can only be saved on a cascading MENU");
+    }
+  }
+
+  /**
+   * Resolve child catalog keys to assigned {@link PSAction}s. Unknown child is HTTP 404. Missing
+   * identity on a child row is 400.
+   */
+  List<PSAction> resolveChildActions(PSAction parent, ActionMenuList children) {
+    if (children == null || children.isEmpty()) {
+      return List.of();
+    }
+    int parentId = parent != null ? parent.getId() : -1;
+    List<PSAction> resolved = new ArrayList<>(children.size());
+    for (ActionMenu child : children) {
+      String key = childCatalogKey(child);
+      if (!isSafeMenuKey(key)) {
+        throw new IllegalArgumentException("child name or id is required");
+      }
+      PSAction found = findPsActionByKey(key.trim());
+      if (found == null) {
+        found = findHibernateActionByKey(key.trim());
+      }
+      if (found == null || found.getId() <= 0) {
+        throw new WebApplicationException("Action menu not found", 404);
+      }
+      if (parentId > 0 && found.getId() == parentId) {
+        throw new IllegalArgumentException("a menu cannot be a child of itself");
+      }
+      resolved.add(found);
+    }
+    return resolved;
+  }
+
+  static String childCatalogKey(ActionMenu child) {
+    if (child == null) {
+      return null;
+    }
+    if (StringUtils.isNotBlank(child.getName())) {
+      return child.getName().trim();
+    }
+    if (child.getGuid() != null && StringUtils.isNotBlank(child.getGuid().getStringValue())) {
+      return child.getGuid().getStringValue().trim();
+    }
+    if (child.getId() > 0) {
+      return String.valueOf(child.getId());
+    }
+    return null;
+  }
+
+  static void replaceChildren(PSAction parent, List<PSAction> children) {
+    if (parent == null) {
+      return;
+    }
+    PSChildActions existing = parent.getChildren();
+    List<PSMenuChild> toRemove = new ArrayList<>();
+    Iterator<?> it = existing.iterator();
+    while (it.hasNext()) {
+      Object next = it.next();
+      if (next instanceof PSMenuChild menuChild) {
+        toRemove.add(menuChild);
+      }
+    }
+    for (PSMenuChild menuChild : toRemove) {
+      existing.removeAction(menuChild);
+    }
+    int sort = 1;
+    if (children != null) {
+      for (PSAction child : children) {
+        if (child == null || child.getId() <= 0) {
+          continue;
+        }
+        child.setSortRank(sort++);
+        existing.add(child);
+      }
+    }
+  }
+
+  static ActionMenu toDtoWithChildren(PSAction parent, List<PSAction> children) {
+    ActionMenu menu = toDto(parent);
+    ActionMenuList kids = new ActionMenuList();
+    if (children != null) {
+      int parentId = parent != null ? parent.getId() : 0;
+      for (PSAction child : children) {
+        ActionMenu dto = toDto(child);
+        if (parentId > 0) {
+          dto.setParentId(parentId);
+        }
+        kids.add(dto);
+      }
+    }
+    menu.setChildren(kids);
+    return menu;
   }
 
   static void applyWritableFields(PSAction domain, ActionMenu body) {

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -145,6 +145,8 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <!-- #4123: Admin POST /actions {ActionMenu:{…}} must not JAXB-bind as
                  allowedWorkflowTransitionsRequest (finder is /find/transitions). -->
             <ref bean="actionMenuJsonReader" />
+            <!-- #4204 UI-04: PUT /actions/{id}/children bare array / ActionMenuList wrap. -->
+            <ref bean="actionMenuListJsonReader" />
             <!-- #3905 / #3895 CD-09: PUT /contenttypes/{id}/itemExits wrap can arrive empty
                  under CXF UNWRAP_ROOT_VALUE; bind wrap and flat before jacksonProvider. -->
             <ref bean="contentTypeItemExitsJsonReader" />

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -42,6 +42,7 @@ import com.percussion.services.catalog.PSTypeEnum;
 import com.percussion.services.guidmgr.data.PSGuid;
 import com.percussion.services.menus.PSActionMenu;
 import com.percussion.services.menus.RxmActionMenuConstants;
+import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
@@ -49,6 +50,7 @@ import com.percussion.webservices.PSErrorsException;
 import com.percussion.webservices.ui.IPSUiDesignWs;
 import com.percussion.webservices.ui.data.ActionType;
 import jakarta.ws.rs.WebApplicationException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -319,6 +321,118 @@ class ActionMenuAdaptorWriteTest {
         assertThrows(
             WebApplicationException.class, () -> adaptor.saveActionMenu("MyMenu", new ActionMenu()));
     assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void updateChildren_loadsWithLockNoStealAndSavesOrder() throws Exception {
+    PSAction parent = stubCascadingMenu("MyMenu", 42);
+    PSAction childA = stubAction("ChildA", 100);
+    PSAction childB = stubAction("ChildB", 101);
+    stubCatalogLoad(parent, childA, childB);
+    PSAction locked = stubCascadingMenu("MyMenu", 42);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ActionMenuList children = new ActionMenuList();
+    ActionMenu first = new ActionMenu();
+    first.setName("ChildB");
+    ActionMenu second = new ActionMenu();
+    second.setId(100);
+    children.add(first);
+    children.add(second);
+
+    ActionMenu out = adaptor.saveActionMenuChildren("MyMenu", children);
+
+    assertEquals("MyMenu", out.getName());
+    assertEquals(2, out.getChildren().size());
+    assertEquals("ChildB", out.getChildren().get(0).getName());
+    assertEquals("ChildA", out.getChildren().get(1).getName());
+    assertEquals(2, childCount(locked));
+    assertEquals(1, childB.getSortRank());
+    assertEquals(2, childA.getSortRank());
+    verify(designWs).saveActions(anyList(), eq(true), eq("test-session"), eq("Admin"));
+    verify(designWs).loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void updateChildren_unknownParent_returnsNull() throws Exception {
+    when(designWs.findActions(
+            nullable(String.class), nullable(String.class), nullable(List.class)))
+        .thenReturn(List.of());
+    assertNull(adaptor.saveActionMenuChildren("missing", new ActionMenuList()));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void updateChildren_systemParent_is409() throws Exception {
+    PSAction system = stubAction("Edit", 42);
+    stubCatalogLoad(system);
+    when(designWs.objectIdToPath(any())).thenReturn("//ContentExplorer/Menus/System/Edit");
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.saveActionMenuChildren("Edit", new ActionMenuList()));
+    assertEquals(409, ex.getResponse().getStatus());
+    assertTrue(ex.getMessage().toLowerCase().contains("system"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void updateChildren_nonAdmin_is403() {
+    adaptor = new ActionMenuAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.saveActionMenuChildren("MyMenu", new ActionMenuList()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void updateChildren_unknownChild_is404() throws Exception {
+    PSAction parent = stubCascadingMenu("MyMenu", 42);
+    stubCatalogLoad(parent);
+    PSAction locked = stubCascadingMenu("MyMenu", 42);
+    when(designWs.loadActions(anyList(), eq(true), eq(false), any(), any()))
+        .thenReturn(List.of(locked));
+    ActionMenuList children = new ActionMenuList();
+    ActionMenu missing = new ActionMenu();
+    missing.setName("NoSuchChild");
+    children.add(missing);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.saveActionMenuChildren("MyMenu", children));
+    assertEquals(404, ex.getResponse().getStatus());
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void updateChildren_menuItemParent_is400() throws Exception {
+    PSAction parent = stubAction("MyItem", 42);
+    parent.setMenuType(PSAction.TYPE_MENUITEM);
+    stubCatalogLoad(parent);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> adaptor.saveActionMenuChildren("MyItem", new ActionMenuList()));
+    assertTrue(ex.getMessage().toLowerCase().contains("cascading"));
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void updateChildren_emptyClearsAssociations() throws Exception {
+    PSAction parent = stubCascadingMenu("MyMenu", 42);
+    stubCatalogLoad(parent);
+    PSAction locked = stubCascadingMenu("MyMenu", 42);
+    locked.getChildren().add(stubAction("OldChild", 99));
+    when(designWs.loadActions(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ActionMenu out = adaptor.saveActionMenuChildren("MyMenu", new ActionMenuList());
+
+    assertEquals("MyMenu", out.getName());
+    assertTrue(out.getChildren() == null || out.getChildren().isEmpty());
+    assertEquals(0, childCount(locked));
+    verify(designWs).saveActions(anyList(), eq(true), eq("test-session"), eq("Admin"));
   }
 
   @Test
@@ -613,14 +727,41 @@ class ActionMenuAdaptorWriteTest {
     return action;
   }
 
-  private void stubCatalogLoad(PSAction action) throws Exception {
-    IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
-    when(sum.getGUID()).thenReturn(action.getGUID());
-    when(sum.getName()).thenReturn(action.getName());
+  private PSAction stubCascadingMenu(String name, int id) {
+    PSAction action = stubAction(name, id);
+    action.setMenuType(PSAction.TYPE_MENU);
+    action.setMenuDynamic(false);
+    return action;
+  }
+
+  private static int childCount(PSAction action) {
+    return action == null || action.getChildren() == null ? 0 : action.getChildren().size();
+  }
+
+  private void stubCatalogLoad(PSAction... actions) throws Exception {
+    List<IPSCatalogSummary> sums = new ArrayList<>();
+    Map<Integer, PSAction> byUuid = new HashMap<>();
+    for (PSAction action : actions) {
+      IPSCatalogSummary sum = mock(IPSCatalogSummary.class);
+      when(sum.getGUID()).thenReturn(action.getGUID());
+      when(sum.getName()).thenReturn(action.getName());
+      sums.add(sum);
+      byUuid.put(action.getGUID().getUUID(), action);
+    }
     when(designWs.findActions(
             nullable(String.class), nullable(String.class), nullable(List.class)))
-        .thenReturn(List.of(sum));
+        .thenReturn(sums);
     when(designWs.loadActions(anyList(), eq(false), eq(false), any(), any()))
-        .thenReturn(List.of(action));
+        .thenAnswer(
+            inv -> {
+              List<?> ids = inv.getArgument(0);
+              if (ids == null || ids.isEmpty()) {
+                return List.of();
+              }
+              Object first = ids.get(0);
+              int uuid = first instanceof IPSGuid guid ? guid.getUUID() : -1;
+              PSAction hit = byUuid.get(uuid);
+              return hit == null ? List.of() : List.of(hit);
+            });
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -52,6 +52,7 @@ import com.percussion.webservices.ui.data.ActionType;
 import jakarta.ws.rs.WebApplicationException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -475,6 +476,20 @@ class ActionMenuAdaptorWriteTest {
     assertTrue(ex.getMessage().toLowerCase().contains("cycle"));
     verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
     verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void descendantContainsParent_usesHibernateNestedChildrenWithoutDesignLoad()
+      throws Exception {
+    PSActionMenu menuA = new PSActionMenu("MenuA", "MenuA", PSAction.TYPE_MENU, "", "SERVER", 0);
+    menuA.setActionId(42);
+    PSActionMenu menuB = new PSActionMenu("MenuB", "MenuB", PSAction.TYPE_MENU, "", "SERVER", 0);
+    menuB.setActionId(100);
+    menuB.setChildren(List.of(menuA));
+    adaptor = new ActionMenuAdaptor(designWs, () -> true, () -> List.of(menuB));
+    PSAction nodeB = stubCascadingMenu("MenuB", 100);
+    assertTrue(adaptor.descendantContainsParent(nodeB, 42, new HashSet<>()));
+    verify(designWs, never()).loadActions(anyList(), anyBoolean(), anyBoolean(), any(), any());
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ActionMenuAdaptorWriteTest.java
@@ -388,21 +388,93 @@ class ActionMenuAdaptorWriteTest {
   }
 
   @Test
-  void updateChildren_unknownChild_is404() throws Exception {
+  void updateChildren_unknownChild_is400() throws Exception {
     PSAction parent = stubCascadingMenu("MyMenu", 42);
     stubCatalogLoad(parent);
-    PSAction locked = stubCascadingMenu("MyMenu", 42);
-    when(designWs.loadActions(anyList(), eq(true), eq(false), any(), any()))
-        .thenReturn(List.of(locked));
     ActionMenuList children = new ActionMenuList();
     ActionMenu missing = new ActionMenu();
     missing.setName("NoSuchChild");
     children.add(missing);
-    WebApplicationException ex =
+    IllegalArgumentException ex =
         assertThrows(
-            WebApplicationException.class, () -> adaptor.saveActionMenuChildren("MyMenu", children));
-    assertEquals(404, ex.getResponse().getStatus());
+            IllegalArgumentException.class, () -> adaptor.saveActionMenuChildren("MyMenu", children));
+    assertTrue(ex.getMessage().toLowerCase().contains("unknown"));
     verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void updateChildren_partialUnknownChild_doesNotPersist() throws Exception {
+    PSAction parent = stubCascadingMenu("MyMenu", 42);
+    PSAction childA = stubAction("ChildA", 100);
+    stubCatalogLoad(parent, childA);
+    ActionMenuList children = new ActionMenuList();
+    ActionMenu first = new ActionMenu();
+    first.setName("ChildA");
+    ActionMenu missing = new ActionMenu();
+    missing.setName("NoSuchChild");
+    children.add(first);
+    children.add(missing);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.saveActionMenuChildren("MyMenu", children));
+    assertTrue(ex.getMessage().toLowerCase().contains("unknown"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void updateChildren_duplicateChild_is400() throws Exception {
+    PSAction parent = stubCascadingMenu("MyMenu", 42);
+    PSAction childA = stubAction("ChildA", 100);
+    stubCatalogLoad(parent, childA);
+    ActionMenuList children = new ActionMenuList();
+    ActionMenu first = new ActionMenu();
+    first.setName("ChildA");
+    ActionMenu second = new ActionMenu();
+    second.setId(100);
+    children.add(first);
+    children.add(second);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.saveActionMenuChildren("MyMenu", children));
+    assertTrue(ex.getMessage().toLowerCase().contains("duplicate"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void updateChildren_parentAsOwnChild_is400() throws Exception {
+    PSAction parent = stubCascadingMenu("MyMenu", 42);
+    stubCatalogLoad(parent);
+    ActionMenuList children = new ActionMenuList();
+    ActionMenu self = new ActionMenu();
+    self.setName("MyMenu");
+    children.add(self);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.saveActionMenuChildren("MyMenu", children));
+    assertTrue(ex.getMessage().toLowerCase().contains("cycle"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
+  }
+
+  @Test
+  void updateChildren_transitiveCycle_is400() throws Exception {
+    PSAction parent = stubCascadingMenu("MenuA", 42);
+    PSAction childB = stubCascadingMenu("MenuB", 100);
+    childB.getChildren().add(parent);
+    stubCatalogLoad(parent, childB);
+    ActionMenuList children = new ActionMenuList();
+    ActionMenu b = new ActionMenu();
+    b.setName("MenuB");
+    children.add(b);
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.saveActionMenuChildren("MenuA", children));
+    assertTrue(ex.getMessage().toLowerCase().contains("cycle"));
+    verify(designWs, never()).saveActions(anyList(), anyBoolean(), any(), any());
+    verify(designWs, never()).loadActions(anyList(), eq(true), eq(false), any(), any());
   }
 
   @Test

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -81,6 +81,9 @@ class CatalogRestJaxrsRegistrationTest {
   /** Admin action-menu create POST #4123 — must precede jacksonProvider. */
   private static final String ACTION_MENU_JSON_READER = "actionMenuJsonReader";
 
+  /** UI-04 children PUT #4204 — must precede jacksonProvider. */
+  private static final String ACTION_MENU_LIST_JSON_READER = "actionMenuListJsonReader";
+
   /** CD-18 auto-translation PUT wrap / bare array (#4028) — must precede jacksonProvider. */
   private static final String AUTO_TRANSLATION_ROWS_JSON_READER =
       "autoTranslationRowsJsonReader";
@@ -140,6 +143,8 @@ class CatalogRestJaxrsRegistrationTest {
     int addFolderReader = providerBlock.indexOf("bean=\"" + ADD_FOLDER_JSON_READER + "\"");
     int findTypesReader = providerBlock.indexOf("bean=\"" + FIND_TYPES_JSON_READER + "\"");
     int actionMenuReader = providerBlock.indexOf("bean=\"" + ACTION_MENU_JSON_READER + "\"");
+    int actionMenuListReader =
+        providerBlock.indexOf("bean=\"" + ACTION_MENU_LIST_JSON_READER + "\"");
     int autoTranslationReader =
         providerBlock.indexOf("bean=\"" + AUTO_TRANSLATION_ROWS_JSON_READER + "\"");
     int displayFormatReader =
@@ -186,6 +191,11 @@ class CatalogRestJaxrsRegistrationTest {
             + ACTION_MENU_JSON_READER
             + " (missing → Admin POST /actions JAXB allowedWorkflowTransitionsRequest)");
     assertTrue(
+        actionMenuListReader >= 0,
+        "rest-jax-rs providers must ref "
+            + ACTION_MENU_LIST_JSON_READER
+            + " (missing → Admin PUT /actions/{id}/children ArrayList / bare array 400)");
+    assertTrue(
         autoTranslationReader >= 0,
         "rest-jax-rs providers must ref "
             + AUTO_TRANSLATION_ROWS_JSON_READER
@@ -220,6 +230,9 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(
         actionMenuReader < jackson,
         ACTION_MENU_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        actionMenuListReader < jackson,
+        ACTION_MENU_LIST_JSON_READER + " must be listed before jacksonProvider");
     assertTrue(
         autoTranslationReader < jackson,
         AUTO_TRANSLATION_ROWS_JSON_READER + " must be listed before jacksonProvider");

--- a/rest/README.md
+++ b/rest/README.md
@@ -46,7 +46,7 @@ The module provides 24+ REST resource endpoints organized by functional area:
 ### Workflow & Automation
 
 - **Editions** (`EditionsResource`) - Manage content editions/versions
-- **Action Menus** (`ActionMenuResource`) - UI action menu configuration
+- **Action Menus** (`ActionMenuResource`) - UI action menu configuration (Admin PUT `{id}/children` for cascading MENU associations)
 - **Extensions** (`ExtensionsResource`) - Custom extension management
 
 ### Utilities & Support

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
@@ -17,6 +17,7 @@
 
 package com.percussion.rest.actions;
 
+import com.percussion.rest.Guid;
 import com.percussion.system.utils.PSSiteManageBean;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.Consumes;
@@ -154,7 +155,59 @@ public class ActionMenuJsonReader implements MessageBodyReader<ActionMenu> {
     if (id != null) {
       out.setId(id);
     }
+    Guid guid = guidField(fields.get("guid"));
+    if (guid != null) {
+      out.setGuid(guid);
+    }
+    ActionMenuList children = childrenField(fields.get("children"));
+    if (children != null) {
+      out.setChildren(children);
+    }
     return out;
+  }
+
+  /**
+   * Bind a {@code children} array. Nested {@code ActionMenu} wrap on an element is honored.
+   *
+   * @param node children field; may be null
+   * @return list or {@code null} when the field is absent
+   */
+  static ActionMenuList childrenField(JsonNode node) {
+    if (node == null || node.isNull() || node.isMissingNode()) {
+      return null;
+    }
+    if (!node.isArray()) {
+      throw new WebApplicationException("ActionMenu children must be a JSON array", 400);
+    }
+    ActionMenuList out = new ActionMenuList();
+    for (JsonNode child : node) {
+      if (child == null || child.isNull() || child.isMissingNode()) {
+        continue;
+      }
+      out.add(parseNode(child));
+    }
+    return out;
+  }
+
+  private static Guid guidField(JsonNode node) {
+    if (node == null || node.isNull() || node.isMissingNode() || !node.isObject()) {
+      return null;
+    }
+    String sv = textField(node, "stringValue");
+    if (sv == null) {
+      return null;
+    }
+    Guid guid = new Guid();
+    guid.setStringValue(sv);
+    Integer type = intField(node, "type");
+    if (type != null) {
+      guid.setType(type.shortValue());
+    }
+    Integer uuid = intField(node, "uuid");
+    if (uuid != null) {
+      guid.setUuid(uuid);
+    }
+    return guid;
   }
 
   private static String textField(JsonNode node, String name) {

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuListJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuListJsonReader.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.actions;
+
+import com.percussion.system.utils.PSSiteManageBean;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * JSON reader for Admin {@code PUT /actions/{idOrName}/children} ({@link ActionMenuList}).
+ *
+ * <p>CXF JAXB / {@code UNWRAP_ROOT_VALUE} rejects a bare array and can drop {@code
+ * ActionMenuList} ArrayList subclasses. This reader binds wrap, {@code children}, and flat
+ * arrays before {@code jacksonProvider}.
+ *
+ * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code jacksonProvider}.
+ */
+@Provider
+@Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})
+@Priority(Priorities.USER - 100)
+@PSSiteManageBean("actionMenuListJsonReader")
+public class ActionMenuListJsonReader implements MessageBodyReader<ActionMenuList> {
+
+  /** Mapper without UNWRAP_ROOT_VALUE so wrap vs array is inspected explicitly. */
+  private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+  /** Logger for malformed JSON (details stay off the 400 body). */
+  private static final Logger log = LogManager.getLogger(ActionMenuListJsonReader.class);
+
+  /** Client 400 for malformed JSON; Jackson parse details stay server-side. */
+  static final String INVALID_JSON = "Invalid ActionMenuList JSON";
+
+  /** No-op constructor. */
+  public ActionMenuListJsonReader() {}
+
+  @Override
+  public boolean isReadable(
+      Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    if (type == null || !ActionMenuList.class.isAssignableFrom(type)) {
+      return false;
+    }
+    return mediaType == null || ActionMenuJsonReader.isJsonCompatible(mediaType);
+  }
+
+  @Override
+  public ActionMenuList readFrom(
+      Class<ActionMenuList> type,
+      Type genericType,
+      Annotation[] annotations,
+      MediaType mediaType,
+      MultivaluedMap<String, String> httpHeaders,
+      InputStream entityStream)
+      throws IOException {
+    if (entityStream == null) {
+      return new ActionMenuList();
+    }
+    byte[] raw = entityStream.readAllBytes();
+    if (raw.length == 0) {
+      return new ActionMenuList();
+    }
+    return parse(new String(raw, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Bind children PUT JSON. Empty / whitespace is an empty list (clears associations).
+   *
+   * @param json request body; may be null
+   * @return non-null list
+   */
+  public static ActionMenuList parse(String json) {
+    if (json == null || json.isBlank()) {
+      return new ActionMenuList();
+    }
+    JsonNode root;
+    try {
+      root = MAPPER.readTree(json);
+    } catch (JacksonException e) {
+      log.debug(INVALID_JSON, e);
+      throw new WebApplicationException(INVALID_JSON, 400);
+    }
+    return parseNode(root);
+  }
+
+  /**
+   * Bind a parsed JSON tree to {@link ActionMenuList}.
+   *
+   * @param root parsed body; may be null
+   * @return non-null list
+   */
+  public static ActionMenuList parseNode(JsonNode root) {
+    if (root == null || root.isNull() || root.isMissingNode()) {
+      return new ActionMenuList();
+    }
+    if (root.isArray()) {
+      return ActionMenuJsonReader.childrenField(root);
+    }
+    if (!root.isObject()) {
+      throw new WebApplicationException("ActionMenuList body must be a JSON array or object", 400);
+    }
+    JsonNode nested = firstArray(root, "ActionMenuList", "actionMenuList", "children");
+    if (nested != null) {
+      return ActionMenuJsonReader.childrenField(nested);
+    }
+    JsonNode menu = root.get("ActionMenu");
+    if (menu != null && menu.isObject()) {
+      ActionMenuList fromMenu = ActionMenuJsonReader.childrenField(menu.get("children"));
+      return fromMenu != null ? fromMenu : new ActionMenuList();
+    }
+    ActionMenuList fromFlat = ActionMenuJsonReader.childrenField(root.get("children"));
+    return fromFlat != null ? fromFlat : new ActionMenuList();
+  }
+
+  private static JsonNode firstArray(JsonNode root, String... names) {
+    for (String name : names) {
+      JsonNode n = root.get(name);
+      if (n != null && n.isArray()) {
+        return n;
+      }
+    }
+    return null;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuListJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuListJsonReader.java
@@ -61,6 +61,13 @@ public class ActionMenuListJsonReader implements MessageBodyReader<ActionMenuLis
   /** Client 400 for malformed JSON; Jackson parse details stay server-side. */
   static final String INVALID_JSON = "Invalid ActionMenuList JSON";
 
+  /**
+   * Client 400 when the object is not a children envelope. Unrecognized objects must not bind as
+   * an empty list (that would silently clear associations on PUT).
+   */
+  static final String UNRECOGNIZED_ENVELOPE =
+      "ActionMenuList body must be a JSON array or a recognized children envelope";
+
   /** No-op constructor. */
   public ActionMenuListJsonReader() {}
 
@@ -137,8 +144,10 @@ public class ActionMenuListJsonReader implements MessageBodyReader<ActionMenuLis
       ActionMenuList fromMenu = ActionMenuJsonReader.childrenField(menu.get("children"));
       return fromMenu != null ? fromMenu : new ActionMenuList();
     }
-    ActionMenuList fromFlat = ActionMenuJsonReader.childrenField(root.get("children"));
-    return fromFlat != null ? fromFlat : new ActionMenuList();
+    if (root.has("children")) {
+      return ActionMenuJsonReader.childrenField(root.get("children"));
+    }
+    throw new WebApplicationException(UNRECOGNIZED_ENVELOPE, 400);
   }
 
   private static JsonNode firstArray(JsonNode root, String... names) {

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -310,18 +310,24 @@ public class ActionMenuResource {
               + " string (same catalog keys as GET). Array order is persisted (child SORTORDER"
               + " plus RXMENUACTIONRELATION). Other child fields are ignored. Empty array"
               + " clears children. Parent PUT /actions/{idOrName} does not honor children."
-              + " System parent is 409. Non-cascading parent is 400. Unknown parent or child"
-              + " is 404. Loads with a design lock (overrideLock=false) and releases on save.",
+              + " Cycle (parent as its own child, or A→B→A), unknown child, or duplicate child"
+              + " in one payload is 400 and is not persisted. System parent is 409. Non-Admin"
+              + " is 403. Missing parent is 404. Non-cascading parent is 400. Loads with a"
+              + " design lock (overrideLock=false) and releases on save.",
       responses = {
         @ApiResponse(
             responseCode = "200",
             description = "Updated parent with children in request order",
             content = @Content(schema = @Schema(implementation = ActionMenu.class))),
-        @ApiResponse(responseCode = "400", description = "Invalid input or parent is not a cascading MENU"),
+        @ApiResponse(
+            responseCode = "400",
+            description =
+                "Invalid input, unknown/duplicate child, cascading cycle, or parent is not a"
+                    + " cascading MENU"),
         @ApiResponse(
             responseCode = "403",
             description = "Admin role required, or request has no session/user"),
-        @ApiResponse(responseCode = "404", description = "Parent or child action menu not found"),
+        @ApiResponse(responseCode = "404", description = "Parent action menu not found"),
         @ApiResponse(
             responseCode = "409",
             description =

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuResource.java
@@ -71,8 +71,9 @@ public class ActionMenuResource {
       summary = "List action menus (catalog)",
       description =
           "Lists CX action menus for the Developer module. Admin create/save/delete user menus"
-              + " via POST/PUT/DELETE on this resource. Cascading children composition and"
-              + " usage/command/visibility tabs remain later slices.",
+              + " via POST/PUT/DELETE on this resource. Ordered child associations on a user"
+              + " cascading MENU use PUT /actions/{idOrName}/children. Usage/command/visibility"
+              + " tabs remain a later slice.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -100,9 +101,9 @@ public class ActionMenuResource {
   @Operation(
       summary = "Get action menu detail",
       description =
-          "Loads one action menu by name or numeric id. Admin PUT/DELETE use"
-              + " /services/actions/{idOrName}. Cascading entry composition remains a later"
-              + " slice.",
+          "Loads one action menu by name or numeric id. Nested children come from"
+              + " RXMENUACTIONRELATION. Admin PUT of ordered children is"
+              + " /services/actions/{idOrName}/children.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -214,7 +215,8 @@ public class ActionMenuResource {
               + " (#4123). Name is required, unique (case-insensitive), and must not contain"
               + " whitespace or wildcards. Optional label, description, menuType, and url (GET"
               + " detail fields) are applied before save. Duplicate name is 409. System menus"
-              + " are not created here. Cascading children composition is a later slice.",
+              + " are not created here. Ordered child associations use PUT"
+              + " /actions/{idOrName}/children after create.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -258,7 +260,8 @@ public class ActionMenuResource {
               + " Name is the catalog key and is not renamed on PUT. Loads with a design lock"
               + " (overrideLock=false) and releases on save. Unknown id is 404. Lock/dependency"
               + " conflict is 409. System menus are 409 (not mutated; the lock is not stolen)."
-              + " Cascading children composition is a later slice.",
+              + " Nested children on this body are ignored; ordered child associations use PUT"
+              + " /actions/{idOrName}/children.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -283,6 +286,55 @@ public class ActionMenuResource {
         throw new IllegalArgumentException("body is required");
       }
       ActionMenu updated = requireAdaptor().saveActionMenu(idOrName, body);
+      if (updated == null) {
+        throw new WebApplicationException("Action menu not found", 404);
+      }
+      return updated;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}/children")
+  @Consumes({MediaType.APPLICATION_JSON})
+  @Produces({MediaType.APPLICATION_JSON})
+  @Operation(
+      summary = "Replace action menu children",
+      description =
+          "Admin. Replaces ordered child associations on a user cascading MENU (type MENU with"
+              + " blank URL). Body is ActionMenuList: a JSON array, {\"ActionMenuList\":[…]},"
+              + " or {\"children\":[…]}. Each child is identified by name, numeric id, or GUID"
+              + " string (same catalog keys as GET). Array order is persisted (child SORTORDER"
+              + " plus RXMENUACTIONRELATION). Other child fields are ignored. Empty array"
+              + " clears children. Parent PUT /actions/{idOrName} does not honor children."
+              + " System parent is 409. Non-cascading parent is 400. Unknown parent or child"
+              + " is 404. Loads with a design lock (overrideLock=false) and releases on save.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated parent with children in request order",
+            content = @Content(schema = @Schema(implementation = ActionMenu.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input or parent is not a cascading MENU"),
+        @ApiResponse(
+            responseCode = "403",
+            description = "Admin role required, or request has no session/user"),
+        @ApiResponse(responseCode = "404", description = "Parent or child action menu not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description =
+                "Design lock, dependency conflict, or system menu cannot be mutated"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  /** Admin replace of ordered child associations on a user cascading MENU. */
+  public ActionMenu updateActionMenuChildren(
+      @PathParam("idOrName") String idOrName, ActionMenuList children) {
+    try {
+      ActionMenuList body = children != null ? children : new ActionMenuList();
+      ActionMenu updated = requireAdaptor().saveActionMenuChildren(idOrName, body);
       if (updated == null) {
         throw new WebApplicationException("Action menu not found", 404);
       }

--- a/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
@@ -59,6 +59,18 @@ public interface IActionMenuAdaptor {
   ActionMenu saveActionMenu(String idOrName, ActionMenu body);
 
   /**
+   * Admin. Replace ordered child associations on a user cascading {@code MENU} ({@code loadActions}
+   * lock, {@code saveActions} release). Does not steal another user's lock. System parents are not
+   * mutated. Child identity is {@code name}, numeric {@code id}, or GUID string (same rules as
+   * {@link #findMenuByKey}); array order is the persisted order.
+   *
+   * @param idOrName parent catalog key
+   * @param children ordered children; {@code null} or empty clears associations
+   * @return the persisted parent with children, or {@code null} when the parent is missing/unsafe
+   */
+  ActionMenu saveActionMenuChildren(String idOrName, ActionMenuList children);
+
+  /**
    * Admin. Delete a user action menu by name or GUID ({@code deleteActions}, {@code
    * ignoreDependencies=false}). Does not steal another user's lock. System menus return conflict
    * (not deleted).

--- a/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/actions/IActionMenuAdaptor.java
@@ -62,7 +62,8 @@ public interface IActionMenuAdaptor {
    * Admin. Replace ordered child associations on a user cascading {@code MENU} ({@code loadActions}
    * lock, {@code saveActions} release). Does not steal another user's lock. System parents are not
    * mutated. Child identity is {@code name}, numeric {@code id}, or GUID string (same rules as
-   * {@link #findMenuByKey}); array order is the persisted order.
+   * {@link #findMenuByKey}); array order is the persisted order. Unknown, duplicate, or cyclic
+   * children are rejected without persisting a partial graph.
    *
    * @param idOrName parent catalog key
    * @param children ordered children; {@code null} or empty clears associations

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuJsonReaderTest.java
@@ -76,6 +76,17 @@ class ActionMenuJsonReaderTest {
   }
 
   @Test
+  void parse_childrenArrayHonorsNameAndId() {
+    ActionMenu menu =
+        ActionMenuJsonReader.parse(
+            "{\"name\":\"Parent\",\"children\":[{\"name\":\"ChildA\"},{\"id\":12}]}");
+    assertEquals("Parent", menu.getName());
+    assertEquals(2, menu.getChildren().size());
+    assertEquals("ChildA", menu.getChildren().get(0).getName());
+    assertEquals(12, menu.getChildren().get(1).getId());
+  }
+
+  @Test
   void isReadable_actionMenuJsonOnly() {
     ActionMenuJsonReader reader = new ActionMenuJsonReader();
     assertTrue(

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuListJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuListJsonReaderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.rest.actions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+/** UI-04: wrap, children, and bare-array ActionMenuList JSON for children PUT. */
+class ActionMenuListJsonReaderTest {
+
+  @Test
+  void parse_bareArrayHonorsOrder() {
+    ActionMenuList list =
+        ActionMenuListJsonReader.parse("[{\"name\":\"ChildA\"},{\"name\":\"ChildB\"}]");
+    assertEquals(2, list.size());
+    assertEquals("ChildA", list.get(0).getName());
+    assertEquals("ChildB", list.get(1).getName());
+  }
+
+  @Test
+  void parse_wrappedActionMenuList() {
+    ActionMenuList list =
+        ActionMenuListJsonReader.parse(
+            "{\"ActionMenuList\":[{\"name\":\"A\"},{\"id\":9}]}");
+    assertEquals(2, list.size());
+    assertEquals("A", list.get(0).getName());
+    assertEquals(9, list.get(1).getId());
+  }
+
+  @Test
+  void parse_childrenEnvelope() {
+    ActionMenuList list =
+        ActionMenuListJsonReader.parse("{\"children\":[{\"name\":\"Nested\"}]}");
+    assertEquals(1, list.size());
+    assertEquals("Nested", list.get(0).getName());
+  }
+
+  @Test
+  void parse_emptyIsEmptyList() {
+    assertTrue(ActionMenuListJsonReader.parse("  ").isEmpty());
+    assertTrue(ActionMenuListJsonReader.parse("[]").isEmpty());
+  }
+
+  @Test
+  void parse_invalidJsonIs400() {
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> ActionMenuListJsonReader.parse("{"));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertEquals(ActionMenuListJsonReader.INVALID_JSON, ex.getMessage());
+    String jacksonHint = ex.getMessage() == null ? "" : ex.getMessage().toLowerCase();
+    assertFalse(jacksonHint.contains("unexpected"));
+  }
+
+  @Test
+  void isReadable_actionMenuListJsonOnly() {
+    ActionMenuListJsonReader reader = new ActionMenuListJsonReader();
+    assertTrue(
+        reader.isReadable(
+            ActionMenuList.class, ActionMenuList.class, null, MediaType.APPLICATION_JSON_TYPE));
+    assertFalse(
+        reader.isReadable(
+            ActionMenu.class, ActionMenu.class, null, MediaType.APPLICATION_JSON_TYPE));
+  }
+}

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuListJsonReaderTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuListJsonReaderTest.java
@@ -57,6 +57,31 @@ class ActionMenuListJsonReaderTest {
   }
 
   @Test
+  void parse_actionMenuEnvelopeChildren() {
+    ActionMenuList list =
+        ActionMenuListJsonReader.parse(
+            "{\"ActionMenu\":{\"children\":[{\"name\":\"FromMenu\"},{\"id\":11}]}}");
+    assertEquals(2, list.size());
+    assertEquals("FromMenu", list.get(0).getName());
+    assertEquals(11, list.get(1).getId());
+  }
+
+  @Test
+  void parse_actionMenuEnvelopeOmitsChildrenIsEmpty() {
+    assertTrue(ActionMenuListJsonReader.parse("{\"ActionMenu\":{}}").isEmpty());
+  }
+
+  @Test
+  void parse_unrecognizedObjectIs400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> ActionMenuListJsonReader.parse("{\"foo\":\"bar\"}"));
+    assertEquals(400, ex.getResponse().getStatus());
+    assertEquals(ActionMenuListJsonReader.UNRECOGNIZED_ENVELOPE, ex.getMessage());
+  }
+
+  @Test
   void parse_emptyIsEmptyList() {
     assertTrue(ActionMenuListJsonReader.parse("  ").isEmpty());
     assertTrue(ActionMenuListJsonReader.parse("[]").isEmpty());

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -314,13 +314,46 @@ public class ActionMenuResourceTest {
   }
 
   @Test
-  public void updateActionMenuChildrenUnknownIs404() {
+  public void updateActionMenuChildrenUnknownParentIs404() {
     when(adaptor.saveActionMenuChildren(eq("missing"), any())).thenReturn(null);
     WebApplicationException ex =
         assertThrows(
             WebApplicationException.class,
             () -> resource.updateActionMenuChildren("missing", new ActionMenuList()));
     assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateActionMenuChildrenUnknownChildIs400() {
+    when(adaptor.saveActionMenuChildren(eq("MyMenu"), any()))
+        .thenThrow(new IllegalArgumentException("unknown child action menu"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateActionMenuChildren("MyMenu", new ActionMenuList()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateActionMenuChildrenDuplicateIs400() {
+    when(adaptor.saveActionMenuChildren(eq("MyMenu"), any()))
+        .thenThrow(new IllegalArgumentException("duplicate child in payload"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateActionMenuChildren("MyMenu", new ActionMenuList()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateActionMenuChildrenCycleIs400() {
+    when(adaptor.saveActionMenuChildren(eq("MyMenu"), any()))
+        .thenThrow(new IllegalArgumentException("cascading menu cycle"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateActionMenuChildren("MyMenu", new ActionMenuList()));
+    assertEquals(400, ex.getResponse().getStatus());
   }
 
   @Test

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuResourceTest.java
@@ -279,6 +279,75 @@ public class ActionMenuResourceTest {
   }
 
   @Test
+  public void updateActionMenuChildrenDelegates() {
+    ActionMenuList children = new ActionMenuList();
+    ActionMenu child = new ActionMenu();
+    child.setName("ChildA");
+    children.add(child);
+    ActionMenu updated = new ActionMenu();
+    updated.setName("MyMenu");
+    updated.setChildren(children);
+    when(adaptor.saveActionMenuChildren(eq("MyMenu"), eq(children))).thenReturn(updated);
+
+    ActionMenu out = resource.updateActionMenuChildren("MyMenu", children);
+
+    assertEquals("MyMenu", out.getName());
+    assertEquals(1, out.getChildren().size());
+    assertEquals("ChildA", out.getChildren().get(0).getName());
+    verify(adaptor).saveActionMenuChildren("MyMenu", children);
+  }
+
+  @Test
+  public void updateActionMenuChildrenNullBodyClears() {
+    ActionMenu updated = new ActionMenu();
+    updated.setName("MyMenu");
+    updated.setChildren(new ActionMenuList());
+    when(adaptor.saveActionMenuChildren(eq("MyMenu"), any())).thenReturn(updated);
+
+    ActionMenu out = resource.updateActionMenuChildren("MyMenu", null);
+
+    assertEquals("MyMenu", out.getName());
+    assertTrue(out.getChildren().isEmpty());
+    ArgumentCaptor<ActionMenuList> captor = ArgumentCaptor.forClass(ActionMenuList.class);
+    verify(adaptor).saveActionMenuChildren(eq("MyMenu"), captor.capture());
+    assertTrue(captor.getValue().isEmpty());
+  }
+
+  @Test
+  public void updateActionMenuChildrenUnknownIs404() {
+    when(adaptor.saveActionMenuChildren(eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateActionMenuChildren("missing", new ActionMenuList()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateActionMenuChildrenNonAdminIs403() {
+    when(adaptor.saveActionMenuChildren(eq("MyMenu"), any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateActionMenuChildren("MyMenu", new ActionMenuList()));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateActionMenuChildrenSystemIs409() {
+    when(adaptor.saveActionMenuChildren(eq("Edit"), any()))
+        .thenThrow(
+            new WebApplicationException(
+                "System action menus cannot be updated or deleted via this API", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateActionMenuChildren("Edit", new ActionMenuList()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void updateActionMenuSystemIs409() {
     when(adaptor.saveActionMenu(eq("Edit"), any()))
         .thenThrow(

--- a/rest/src/test/java/com/percussion/rest/actions/ActionsTestAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionsTestAdaptor.java
@@ -64,6 +64,14 @@ public class ActionsTestAdaptor implements IActionMenuAdaptor {
   }
 
   @Override
+  public ActionMenu saveActionMenuChildren(String idOrName, ActionMenuList children) {
+    ActionMenu parent = new ActionMenu();
+    parent.setName(idOrName);
+    parent.setChildren(children);
+    return parent;
+  }
+
+  @Override
   public boolean deleteActionMenu(String idOrName) {
     return false;
   }

--- a/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsActionPersistTest.java
+++ b/system/src/test/java/com/percussion/webservices/ui/impl/PSUiDesignWsActionPersistTest.java
@@ -176,6 +176,40 @@ class PSUiDesignWsActionPersistTest {
         ins.setString(2, "sys_contentid");
         ins.executeUpdate();
       }
+      PSAction parent = newAction(2048, "QaH2Am");
+      parent.setLabel("QA H2 AM");
+      PSAction childA = newAction(3001, "ChildA");
+      childA.setLabel("Child A");
+      PSAction childB = newAction(3002, "ChildB");
+      childB.setLabel("Child B");
+      PSUiDesignWs.insertActionRow(conn, PSUiDesignWs.actionRowSpec(childA));
+      PSUiDesignWs.insertActionRow(conn, PSUiDesignWs.actionRowSpec(childB));
+      parent.getChildren().add(childA);
+      parent.getChildren().add(childB);
+      PSUiDesignWs.persistActionRelationsOn(conn, parent);
+      try (var rs =
+          conn.prepareStatement(
+                  "SELECT CHILDACTIONID FROM RXMENUACTIONRELATION WHERE ACTIONID = 2048 ORDER BY CHILDACTIONID")
+              .executeQuery()) {
+        assertTrue(rs.next());
+        assertEquals(3001, rs.getInt(1));
+        assertTrue(rs.next());
+        assertEquals(3002, rs.getInt(1));
+        assertFalse(rs.next());
+      }
+      try (var rs =
+          conn.prepareStatement("SELECT SORTORDER FROM RXMENUACTION WHERE ACTIONID = 3001")
+              .executeQuery()) {
+        assertTrue(rs.next());
+        assertEquals(1, rs.getInt(1));
+      }
+      try (var rs =
+          conn.prepareStatement("SELECT SORTORDER FROM RXMENUACTION WHERE ACTIONID = 3002")
+              .executeQuery()) {
+        assertTrue(rs.next());
+        assertEquals(2, rs.getInt(1));
+      }
+
       PSUiDesignWs.deleteActionRow(conn, spec.actionId);
       assertFalse(PSUiDesignWs.actionRowExists(conn, spec.actionId, spec.name));
       assertTrue(PSUiDesignWs.actionRowExists(conn, 2049, "Victim"));
@@ -320,6 +354,8 @@ class PSUiDesignWsActionPersistTest {
               + "VERSION INTEGER NOT NULL)");
       st.execute(
           "CREATE TABLE RXMENUACTIONPROPERTIES (ACTIONID INTEGER NOT NULL, PROPNAME VARCHAR(100) NOT NULL, PROPVALUE VARCHAR(4000), DESCRIPTION VARCHAR(255), PRIMARY KEY (ACTIONID, PROPNAME))");
+      st.execute(
+          "CREATE TABLE RXMENUACTIONRELATION (ACTIONID INTEGER NOT NULL, CHILDACTIONID INTEGER NOT NULL)");
     }
     return conn;
   }

--- a/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
+++ b/system/webservices/src/com/percussion/webservices/ui/impl/PSUiDesignWs.java
@@ -27,6 +27,7 @@ import com.percussion.cms.objectstore.PSDisplayFormat;
 import com.percussion.cms.objectstore.PSDFColumns;
 import com.percussion.cms.objectstore.PSDFMultiProperty;
 import com.percussion.cms.objectstore.PSKey;
+import com.percussion.cms.objectstore.PSMenuChild;
 import com.percussion.cms.objectstore.PSSearch;
 import com.percussion.cms.objectstore.PSVersionableDbComponent;
 import com.percussion.data.PSIdGenerator;
@@ -2908,6 +2909,70 @@ public class PSUiDesignWs extends PSUiBaseWs implements IPSUiDesignWs
          ensureRestUserMenuProperty(conn, spec.actionId);
       else
          clearRestUserMenuProperty(conn, spec.actionId);
+      persistActionRelationsOn(conn, action);
+   }
+
+   /**
+    * Rewrite {@code RXMENUACTIONRELATION} for a parent whose child collection is dirty so GET
+    * {@code findActionMenusTree} round-trips REST children PUT on the H2 JDBC fallback path
+    * (locator {@code updateActions} can skip the XML graph). Unmodified empty children are
+    * skipped so label PUT does not wipe existing associations.
+    */
+   static void persistActionRelationsOn(Connection conn, PSAction action) throws SQLException
+   {
+      if (conn == null || action == null || action.getChildren() == null)
+         return;
+      if (action.getChildren().getState() == IPSDbComponent.DBSTATE_UNMODIFIED)
+         return;
+      int parentId = action.getId();
+      if (parentId <= 0)
+         return;
+      try (PreparedStatement del = conn.prepareStatement("DELETE FROM RXMENUACTIONRELATION WHERE ACTIONID = ?"))
+      {
+         del.setInt(1, parentId);
+         del.executeUpdate();
+      }
+      String insertSql = "INSERT INTO RXMENUACTIONRELATION (ACTIONID, CHILDACTIONID) VALUES (?, ?)";
+      String sortSql = "UPDATE RXMENUACTION SET SORTORDER = ? WHERE ACTIONID = ?";
+      int sort = 1;
+      Iterator<?> it = action.getChildren().iterator();
+      while (it.hasNext())
+      {
+         int childId = relationChildId(it.next());
+         if (childId <= 0)
+            continue;
+         try (PreparedStatement ins = conn.prepareStatement(insertSql))
+         {
+            ins.setInt(1, parentId);
+            ins.setInt(2, childId);
+            ins.executeUpdate();
+         }
+         try (PreparedStatement sortPs = conn.prepareStatement(sortSql))
+         {
+            sortPs.setInt(1, sort);
+            sortPs.setInt(2, childId);
+            sortPs.executeUpdate();
+         }
+         sort++;
+      }
+   }
+
+   static int relationChildId(Object node)
+   {
+      if (node instanceof PSMenuChild child)
+      {
+         try
+         {
+            return Integer.parseInt(StringUtils.trimToEmpty(child.getChildActionId()));
+         }
+         catch (NumberFormatException e)
+         {
+            return -1;
+         }
+      }
+      if (node instanceof PSAction child)
+         return child.getId();
+      return -1;
    }
 
    static void ensureActionRowPersisted(PSAction action)


### PR DESCRIPTION
## Summary

Admin **children write** on a user cascading `MENU` fails closed for illegal graphs (parent #1690 FR UI-04 / slice #4205). Stacks on persist slice #4204 / PR #4208.

- `PUT /services/actions/{idOrName}/children` returns **400** for: cascading **cycle** (parent listed as its own child, or A→B→A through existing descendants), **unknown child** id/name, **duplicate child** in one payload (same key or same resolved id).
- **409** system parent, **403** non-Admin, **404** missing parent (unchanged).
- Illegal payloads do **not** persist a partial association list (`saveActions` / lock load are not called).
- Parent `PUT /services/actions/{idOrName}` still ignores nested `children`. SPA composer chrome remains #4206.

Fixes #4205. Parent: #1690.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. Mockito `ActionMenuResourceTest`: children PUT 400 (cycle / unknown child / duplicate), 404 missing parent, 403 non-Admin, 409 system.
2. Adaptor `ActionMenuAdaptorWriteTest`: unknown child 400, partial unknown does not persist, duplicate 400, parent-as-own-child 400, transitive A→B→A 400, system 409, non-Admin 403, missing parent null/404 path.
3. Confirm happy-path ordered persist tests from #4208 still pass.

## Checklist

- [x] **Product documentation** — `product-docs/8.2/developer/rest.md` Action menus children error cases; `product-docs/8.2/admin/developer-action-menus.md` REST table
- [x] **Unit / module tests** — behavioral tests; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; REST only)
- [x] **Build gates** — standalone clean install of `rest`, `projects/sitemanage` (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 1048, Failures: 0, Errors: 0, Skipped: 0
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS; Tests run: 2257, Failures: 0, Errors: 0, Skipped: 125
- **downstream_checked:** C2 signature change did not apply (`saveActionMenuChildren` unchanged). Still grepped `implements IActionMenuAdaptor` and ran standalone sitemanage clean install (production `ActionMenuAdaptor` + rest `ActionsTestAdaptor`).

### C5 UI proof

N/A — public REST + apibridge; no WebUI/Playwright surface.

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
