### PR TITLE
feat(WebUI): custom search URL editor on Developer Searches (#4222)

### DIFF
--- a/WebUI/src/main/ts/api/developer/searchesApi.ts
+++ b/WebUI/src/main/ts/api/developer/searchesApi.ts
@@ -212,9 +212,27 @@ export function isValidSearchName(name: string | undefined | null): boolean {
 
 /** True when the REST / SPA type is a custom URL search. */
 export function isCustomSearchType(type: string | undefined | null): boolean {
-  const t = (type ?? "").trim();
+  const t = (type ?? "").trim().toLowerCase();
   if (!t) return false;
-  return t === SEARCH_TYPE_CUSTOM || t.toLowerCase() === "custom";
+  return t === SEARCH_TYPE_CUSTOM.toLowerCase() || t === "custom" || t === "_custom";
+}
+
+/**
+ * Canonical REST type for persist. Aliases {@code custom} / {@code CustomSearch}
+ * become {@link SEARCH_TYPE_CUSTOM} so dirty/compare matches GET.
+ */
+export function canonicalSearchType(type: string | undefined | null): string {
+  const t = (type ?? "").trim();
+  if (!t) return SEARCH_TYPE_STANDARD;
+  if (isCustomSearchType(t)) return SEARCH_TYPE_CUSTOM;
+  const lower = t.toLowerCase();
+  if (lower === SEARCH_TYPE_STANDARD.toLowerCase() || lower === "standard" || lower === "_standard") {
+    return SEARCH_TYPE_STANDARD;
+  }
+  if (lower === "search" || lower === "user" || lower === "usersearch") {
+    return "Search";
+  }
+  return t;
 }
 
 /** Trim a custom search URL. Empty / null becomes "". */
@@ -223,14 +241,35 @@ export function normalizeSearchUrl(url: string | undefined | null): string {
 }
 
 /**
- * True when the URL is a non-blank URI string (relative or absolute). Whitespace
- * is rejected; the server stores the string as-is after trim.
+ * True when the URL is a safe custom-search target: {@code http}/{@code https}
+ * or a site-relative path starting with {@code /} (not protocol-relative
+ * {@code //}). {@code javascript:}, {@code data:}, and other schemes are
+ * rejected.
  */
 export function isValidSearchUrl(url: string | undefined | null): boolean {
   const key = normalizeSearchUrl(url);
   if (!key) return false;
   if (containsWhitespace(key)) return false;
-  return true;
+  const lower = key.toLowerCase();
+  if (
+    lower.startsWith("javascript:") ||
+    lower.startsWith("data:") ||
+    lower.startsWith("vbscript:")
+  ) {
+    return false;
+  }
+  if (/^https?:\/\//i.test(key)) {
+    try {
+      const parsed = new URL(key);
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+      return false;
+    }
+  }
+  if (key.startsWith("//")) {
+    return false;
+  }
+  return key.startsWith("/");
 }
 
 /**

--- a/WebUI/src/main/ts/api/developer/searchesApi.ts
+++ b/WebUI/src/main/ts/api/developer/searchesApi.ts
@@ -27,10 +27,11 @@ import type {
 /**
  * Writable identity fields for POST/PUT /services/searches. Name is the catalog
  * key (not renamed on PUT). When {@code fields} is present it replaces criteria.
+ * Custom URL searches send {@code url} and {@code customSearch}.
  */
 export type SearchWriteBody = Pick<
   SearchDef,
-  "name" | "label" | "description" | "type" | "displayFormatId"
+  "name" | "label" | "description" | "type" | "displayFormatId" | "url" | "customSearch"
 > & {
   /** Omit to leave stored criteria unchanged. Empty array clears criteria. */
   fields?: SearchDef["fields"];
@@ -41,6 +42,9 @@ export const SEARCH_DEF_ROOT = "SearchDef";
 
 /** REST default type on create ({@code PSSearch.TYPE_STANDARDSEARCH}). */
 export const SEARCH_TYPE_STANDARD = "StandardSearch";
+
+/** REST custom-URL type ({@code PSSearch.TYPE_CUSTOMSEARCH}). */
+export const SEARCH_TYPE_CUSTOM = "CustomSearch";
 
 /** {@code PSSearch.INTERNALNAME_LENGTH} — create name max. */
 export const SEARCH_NAME_MAX = 128;
@@ -206,10 +210,48 @@ export function isValidSearchName(name: string | undefined | null): boolean {
   return isSafeSearchName(key);
 }
 
-/** Save is enabled when the search name is valid (create) or already loaded (edit). */
-export function isSearchWriteReady(opts: { isNew: boolean; name: string }): boolean {
-  if (opts.isNew) return isValidSearchName(opts.name);
-  return Boolean(normalizeSearchName(opts.name));
+/** True when the REST / SPA type is a custom URL search. */
+export function isCustomSearchType(type: string | undefined | null): boolean {
+  const t = (type ?? "").trim();
+  if (!t) return false;
+  return t === SEARCH_TYPE_CUSTOM || t.toLowerCase() === "custom";
+}
+
+/** Trim a custom search URL. Empty / null becomes "". */
+export function normalizeSearchUrl(url: string | undefined | null): string {
+  return url == null ? "" : url.trim();
+}
+
+/**
+ * True when the URL is a non-blank URI string (relative or absolute). Whitespace
+ * is rejected; the server stores the string as-is after trim.
+ */
+export function isValidSearchUrl(url: string | undefined | null): boolean {
+  const key = normalizeSearchUrl(url);
+  if (!key) return false;
+  if (containsWhitespace(key)) return false;
+  return true;
+}
+
+/**
+ * Save is enabled when the search name is valid (create) or already loaded (edit).
+ * Custom URL searches also require a non-blank URL.
+ */
+export function isSearchWriteReady(opts: {
+  isNew: boolean;
+  name: string;
+  type?: string;
+  url?: string;
+}): boolean {
+  if (opts.isNew) {
+    if (!isValidSearchName(opts.name)) return false;
+  } else if (!normalizeSearchName(opts.name)) {
+    return false;
+  }
+  if (isCustomSearchType(opts.type) && !isValidSearchUrl(opts.url)) {
+    return false;
+  }
+  return true;
 }
 
 /** Wire JSON for POST/PUT — a flat body fails JAXB root unwrap. */

--- a/WebUI/src/main/ts/developer/SearchDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SearchDetailPanel.tsx
@@ -18,12 +18,16 @@ import React, { useEffect, useRef, useState } from "react";
 import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import {
+  SEARCH_TYPE_CUSTOM,
   SEARCH_TYPE_STANDARD,
   createSearch,
   deleteSearch,
   getSearchDetail,
+  isCustomSearchType,
   isSearchWriteReady,
+  isValidSearchUrl,
   normalizeSearchName,
+  normalizeSearchUrl,
   saveSearch,
   type SearchWriteBody,
 } from "../api/developer/searchesApi";
@@ -78,7 +82,7 @@ const actionButton: React.CSSProperties = {
 
 const TYPE_OPTIONS: { value: string; kind: "standard" | "custom" | "user" }[] = [
   { value: SEARCH_TYPE_STANDARD, kind: "standard" },
-  { value: "CustomSearch", kind: "custom" },
+  { value: SEARCH_TYPE_CUSTOM, kind: "custom" },
   { value: "Search", kind: "user" },
 ];
 
@@ -90,7 +94,7 @@ function typeLabel(kind: "standard" | "custom" | "user"): string {
 
 function typeFromDetail(detail: SearchDef | null, fallback: string): string {
   if (detail?.type && detail.type.trim()) return detail.type.trim();
-  if (detail?.customSearch) return "CustomSearch";
+  if (detail?.customSearch) return SEARCH_TYPE_CUSTOM;
   if (detail?.userSearch) return "Search";
   if (detail?.standardSearch) return SEARCH_TYPE_STANDARD;
   return fallback;
@@ -115,6 +119,7 @@ export function SearchDetailPanel({
   const [label, setLabel] = useState("");
   const [description, setDescription] = useState("");
   const [type, setType] = useState(SEARCH_TYPE_STANDARD);
+  const [url, setUrl] = useState("");
   const [displayFormatId, setDisplayFormatId] = useState("");
   const [draftFields, setDraftFields] = useState<SearchFieldSummary[]>([]);
   const [addSource, setAddSource] = useState("");
@@ -144,6 +149,7 @@ export function SearchDetailPanel({
         setLabel(d.label || "");
         setDescription(d.description || "");
         setType(typeFromDetail(d, SEARCH_TYPE_STANDARD));
+        setUrl(d.url || "");
         setDisplayFormatId(d.displayFormatId || "");
         const fields = normalizeSearchFields(d.fields);
         setDraftFields(fields);
@@ -165,21 +171,27 @@ export function SearchDetailPanel({
   const loadedLabel = detail?.label || "";
   const loadedDescription = detail?.description || "";
   const loadedType = typeFromDetail(detail, SEARCH_TYPE_STANDARD);
+  const loadedUrl = detail?.url || "";
   const loadedDf = detail?.displayFormatId || "";
+  const customUrl = isCustomSearchType(type);
+  const writeKey = idOrName || createdKey || normalizeSearchName(name);
+  const packaged = isPackagedSearch(idOrName || createdKey || name);
   const dirty =
     isNew ||
     normalizeSearchName(name) !== loadedName ||
     label !== loadedLabel ||
     description !== loadedDescription ||
     type !== loadedType ||
+    normalizeSearchUrl(url) !== normalizeSearchUrl(loadedUrl) ||
     displayFormatId !== loadedDf;
-  const canSave = !busy && dirty && isSearchWriteReady({ isNew, name });
-  const writeKey = idOrName || createdKey || normalizeSearchName(name);
-  const packaged = isPackagedSearch(idOrName || createdKey || name);
+  const canSave =
+    !busy && dirty && !packaged && isSearchWriteReady({ isNew, name, type, url });
   const loadedFields = normalizeSearchFields(detail?.fields);
-  const fields = packaged ? loadedFields : draftFields;
+  const hideFieldEditor = packaged || customUrl;
+  const fields = hideFieldEditor ? loadedFields : draftFields;
   const availableFields = catalogFieldsNotInUse(draftFields);
-  const fieldsDirty = !packaged && !isNew && !fieldCriteriaEqual(draftFields, loadedFields);
+  const fieldsDirty =
+    !hideFieldEditor && !isNew && !fieldCriteriaEqual(draftFields, loadedFields);
   const canSaveFields = !busy && fieldsDirty && detail != null;
 
   function writeBody(): SearchWriteBody {
@@ -188,16 +200,33 @@ export function SearchDetailPanel({
       label,
       description,
       type,
+      customSearch: customUrl,
     };
     if (displayFormatId.trim()) {
       body.displayFormatId = displayFormatId.trim();
+    }
+    if (customUrl) {
+      body.url = normalizeSearchUrl(url);
     }
     return body;
   }
 
   function saveFallback(err: unknown): string {
     if (isApiError(err) && err.status === 409 && isNew) return DEV_MSG.SR_DUPLICATE;
-    if (isApiError(err) && err.status === 400) return DEV_MSG.SR_INVALID_NAME;
+    if (isApiError(err) && err.status === 400) {
+      if (customUrl) {
+        const raw =
+          typeof err.body === "string"
+            ? err.body
+            : err.body && typeof err.body === "object" && "message" in err.body
+              ? String((err.body as { message?: unknown }).message ?? "")
+              : "";
+        if (!isValidSearchUrl(url) || /url/i.test(raw)) {
+          return DEV_MSG.SR_INVALID_URL;
+        }
+      }
+      return DEV_MSG.SR_INVALID_NAME;
+    }
     if (isApiError(err) && err.status === 403) return DEV_MSG.SR_FORBIDDEN;
     if (isApiError(err) && err.status === 404) return DEV_MSG.SR_NOT_FOUND;
     return DEV_MSG.SR_SAVE_ERROR;
@@ -212,7 +241,7 @@ export function SearchDetailPanel({
   }
 
   function handleAddField(): void {
-    if (packaged || busy || isNew || !isValidSearchFieldName(addSource)) {
+    if (hideFieldEditor || busy || isNew || !isValidSearchFieldName(addSource)) {
       return;
     }
     const next = addSearchFieldCriterion(draftFields, addSource, addOperator, addValue);
@@ -223,7 +252,7 @@ export function SearchDetailPanel({
   }
 
   async function handleSaveFields(): Promise<void> {
-    if (!canSaveFields || inflight.current || packaged || !writeKey) {
+    if (!canSaveFields || inflight.current || hideFieldEditor || !writeKey) {
       return;
     }
     inflight.current = true;
@@ -254,7 +283,11 @@ export function SearchDetailPanel({
   }
 
   async function handleSave(): Promise<void> {
-    if (!canSave || inflight.current) return;
+    if (!canSave || inflight.current || packaged) return;
+    if (customUrl && !isValidSearchUrl(url)) {
+      setError(DEV_MSG.SR_INVALID_URL);
+      return;
+    }
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -272,6 +305,7 @@ export function SearchDetailPanel({
       setLabel(saved.label || "");
       setDescription(saved.description || "");
       setType(typeFromDetail(saved, type));
+      setUrl(saved.url || url);
       setDisplayFormatId(saved.displayFormatId || "");
       const savedFields = normalizeSearchFields(saved.fields);
       setDraftFields(savedFields);
@@ -403,7 +437,7 @@ export function SearchDetailPanel({
               data-testid="developer-sr-label"
               style={inputStyle}
               value={label}
-              disabled={busy}
+              disabled={busy || packaged}
               onChange={(e) => setLabel(e.target.value)}
             />
           </div>
@@ -414,7 +448,7 @@ export function SearchDetailPanel({
               data-testid="developer-sr-description"
               style={inputStyle}
               value={description}
-              disabled={busy}
+              disabled={busy || packaged}
               onChange={(e) => setDescription(e.target.value)}
             />
           </div>
@@ -425,7 +459,7 @@ export function SearchDetailPanel({
               data-testid="developer-sr-type"
               style={inputStyle}
               value={type}
-              disabled={busy}
+              disabled={busy || packaged}
               onChange={(e) => setType(e.target.value)}
             >
               {TYPE_OPTIONS.map((opt) => (
@@ -435,6 +469,23 @@ export function SearchDetailPanel({
               ))}
             </select>
           </div>
+          {customUrl ? (
+            <div style={fieldStyle}>
+              <label htmlFor="sr-url">{DEV_MSG.SR_FORM_URL}</label>
+              <input
+                id="sr-url"
+                data-testid="developer-sr-url"
+                style={{ ...inputStyle, fontFamily: "monospace" }}
+                value={url}
+                disabled={busy || packaged}
+                onChange={(e) => setUrl(e.target.value)}
+                autoComplete="off"
+              />
+              <span style={{ color: catalogColors.muted, fontSize: "0.85rem" }}>
+                {DEV_MSG.SR_URL_HINT}
+              </span>
+            </div>
+          ) : null}
           <div style={fieldStyle}>
             <label htmlFor="sr-df">{DEV_MSG.SR_FORM_DF}</label>
             <input
@@ -442,7 +493,7 @@ export function SearchDetailPanel({
               data-testid="developer-sr-display-format"
               style={{ ...inputStyle, fontFamily: "monospace" }}
               value={displayFormatId}
-              disabled={busy}
+              disabled={busy || packaged}
               onChange={(e) => setDisplayFormatId(e.target.value)}
               autoComplete="off"
             />
@@ -509,9 +560,19 @@ export function SearchDetailPanel({
                 <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.SR_FIELDS}</h3>
                 <p
                   style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
-                  data-testid={packaged ? "developer-sr-fields-readonly" : undefined}
+                  data-testid={
+                    customUrl
+                      ? "developer-sr-fields-custom-url"
+                      : packaged
+                        ? "developer-sr-fields-readonly"
+                        : undefined
+                  }
                 >
-                  {packaged ? DEV_MSG.SR_FIELDS_READONLY : DEV_MSG.SR_FIELDS_HINT}
+                  {customUrl
+                    ? DEV_MSG.SR_FIELDS_CUSTOM_URL
+                    : packaged
+                      ? DEV_MSG.SR_FIELDS_READONLY
+                      : DEV_MSG.SR_FIELDS_HINT}
                 </p>
                 {fields.length === 0 ? (
                   <p style={{ color: catalogColors.empty }} data-testid="developer-sr-fields-empty">
@@ -529,7 +590,7 @@ export function SearchDetailPanel({
                           <th style={{ padding: "8px" }}>{DEV_MSG.SR_COL_OP}</th>
                           <th style={{ padding: "8px" }}>{DEV_MSG.SR_COL_VALUE}</th>
                           <th style={{ padding: "8px" }}>{DEV_MSG.SR_COL_FTYPE}</th>
-                          {!packaged ? (
+                          {!hideFieldEditor ? (
                             <th style={{ padding: "8px" }}>{DEV_MSG.SR_COL_ACTIONS}</th>
                           ) : null}
                         </tr>
@@ -546,7 +607,7 @@ export function SearchDetailPanel({
                               {f.fieldName || f.displayName || "—"}
                             </td>
                             <td style={{ padding: "8px" }}>
-                              {!packaged ? (
+                              {!hideFieldEditor ? (
                                 <select
                                   data-testid={`developer-sr-field-op-${i}`}
                                   style={inputStyle}
@@ -571,7 +632,7 @@ export function SearchDetailPanel({
                               )}
                             </td>
                             <td style={{ padding: "8px" }}>
-                              {!packaged ? (
+                              {!hideFieldEditor ? (
                                 <input
                                   data-testid={`developer-sr-field-value-${i}`}
                                   style={inputStyle}
@@ -590,7 +651,7 @@ export function SearchDetailPanel({
                               )}
                             </td>
                             <td style={{ padding: "8px" }}>{f.fieldType || "—"}</td>
-                            {!packaged ? (
+                            {!hideFieldEditor ? (
                               <td style={{ padding: "8px" }}>
                                 <div style={{ display: "flex", gap: "4px", flexWrap: "wrap" }}>
                                   <button
@@ -638,7 +699,7 @@ export function SearchDetailPanel({
                     </table>
                   </div>
                 )}
-                {!packaged && !isNew ? (
+                {!hideFieldEditor && !isNew ? (
                   <div
                     style={{
                       marginTop: "12px",

--- a/WebUI/src/main/ts/developer/SearchDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/SearchDetailPanel.tsx
@@ -20,6 +20,7 @@ import { isApiError } from "../api/client";
 import {
   SEARCH_TYPE_CUSTOM,
   SEARCH_TYPE_STANDARD,
+  canonicalSearchType,
   createSearch,
   deleteSearch,
   getSearchDetail,
@@ -181,7 +182,7 @@ export function SearchDetailPanel({
     normalizeSearchName(name) !== loadedName ||
     label !== loadedLabel ||
     description !== loadedDescription ||
-    type !== loadedType ||
+    canonicalSearchType(type) !== canonicalSearchType(loadedType) ||
     normalizeSearchUrl(url) !== normalizeSearchUrl(loadedUrl) ||
     displayFormatId !== loadedDf;
   const canSave =
@@ -199,13 +200,13 @@ export function SearchDetailPanel({
       name: isNew ? normalizeSearchName(name) : detail?.name || normalizeSearchName(name),
       label,
       description,
-      type,
-      customSearch: customUrl,
+      type: canonicalSearchType(type),
     };
     if (displayFormatId.trim()) {
       body.displayFormatId = displayFormatId.trim();
     }
     if (customUrl) {
+      body.customSearch = true;
       body.url = normalizeSearchUrl(url);
     }
     return body;
@@ -221,7 +222,11 @@ export function SearchDetailPanel({
             : err.body && typeof err.body === "object" && "message" in err.body
               ? String((err.body as { message?: unknown }).message ?? "")
               : "";
-        if (!isValidSearchUrl(url) || /url/i.test(raw)) {
+        if (
+          !isValidSearchUrl(url) ||
+          /\burl is required\b/i.test(raw) ||
+          /invalid url/i.test(raw)
+        ) {
           return DEV_MSG.SR_INVALID_URL;
         }
       }

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -983,7 +983,7 @@ export const DEV_MSG_KEYS = {
   SR_EMPTY: "perc.ui.developer@No searches returned.",
   SR_ERROR: "perc.ui.developer@Could not load searches.",
   SR_HINT:
-    "perc.ui.developer@Create or delete Content Explorer searches (name required, no spaces). On a user or standard search, add, remove, or reorder field criteria and save. Views are a separate catalog.",
+    "perc.ui.developer@Create or delete Content Explorer searches (name required, no spaces). Custom searches require a URL. On a user or standard search, add, remove, or reorder field criteria and save. Views are a separate catalog.",
   SR_NEW: "perc.ui.developer@New search",
   SR_EDIT: "perc.ui.developer@Edit",
   SR_SAVE: "perc.ui.developer@Save",
@@ -993,7 +993,12 @@ export const DEV_MSG_KEYS = {
   SR_FORM_LABEL: "perc.ui.developer@Label",
   SR_FORM_DESCRIPTION: "perc.ui.developer@Description",
   SR_FORM_TYPE: "perc.ui.developer@Type",
+  SR_FORM_URL: "perc.ui.developer@URL",
   SR_FORM_DF: "perc.ui.developer@Display format id",
+  SR_URL_HINT:
+    "perc.ui.developer@Required for a custom search. Relative or absolute URI, no spaces.",
+  SR_INVALID_URL:
+    "perc.ui.developer@Custom search URL is required. Enter a URI without spaces.",
   SR_NAME_HINT:
     "perc.ui.developer@Required. Unique, no spaces, wildcards, or path characters.",
   SR_NAME_READONLY: "perc.ui.developer@Name cannot be changed after the search is created.",
@@ -1024,6 +1029,8 @@ export const DEV_MSG_KEYS = {
   SR_FIELDS: "perc.ui.developer@Field criteria",
   SR_FIELDS_HINT:
     "perc.ui.developer@Search field conditions. On a user or standard search, add, remove, or reorder criteria and save.",
+  SR_FIELDS_CUSTOM_URL:
+    "perc.ui.developer@Custom URL searches do not use field criteria. Edit the URL instead.",
   SR_FIELDS_READONLY:
     "perc.ui.developer@This packaged/system search is read-only. Field add, remove, and reorder are available on user and standard searches only.",
   SR_FIELDS_ADD: "perc.ui.developer@Add criterion",

--- a/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
@@ -528,6 +528,153 @@ describe("SearchDetailPanel", () => {
     });
     expect(screen.queryByTestId("developer-sr-field-editor")).toBeNull();
     expect(screen.queryByTestId("developer-sr-fields-save")).toBeNull();
+    expect((screen.getByTestId("developer-sr-label") as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-sr-type") as HTMLSelectElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-sr-save") as HTMLButtonElement).disabled).toBe(true);
     expect(saveSearch).not.toHaveBeenCalled();
+  });
+
+  it("requires a URL before saving a CustomSearch", () => {
+    render(<SearchDetailPanel idOrName={null} onBack={() => undefined} />);
+    fireEvent.change(screen.getByTestId("developer-sr-name"), {
+      target: { value: "MyCustom" },
+    });
+    fireEvent.change(screen.getByTestId("developer-sr-type"), {
+      target: { value: "CustomSearch" },
+    });
+    expect(screen.getByTestId("developer-sr-url")).toBeTruthy();
+    expect((screen.getByTestId("developer-sr-save") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(screen.getByTestId("developer-sr-url"), {
+      target: { value: "   " },
+    });
+    expect((screen.getByTestId("developer-sr-save") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(screen.getByTestId("developer-sr-url"), {
+      target: { value: "app/has space.xml" },
+    });
+    expect((screen.getByTestId("developer-sr-save") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(screen.getByTestId("developer-sr-url"), {
+      target: { value: "/Rhythmyx/sys_cxSupport/custom.xml" },
+    });
+    expect((screen.getByTestId("developer-sr-save") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("creates a custom URL search with url and customSearch", async () => {
+    createSearch.mockResolvedValue({
+      name: "MyCustom",
+      label: "My Custom",
+      description: "Created via SPA",
+      type: "CustomSearch",
+      customSearch: true,
+      url: "/Rhythmyx/sys_cxSupport/custom.xml",
+      fields: [],
+    });
+    const onSaved = vi.fn();
+    render(<SearchDetailPanel idOrName={null} onBack={() => undefined} onSaved={onSaved} />);
+    fireEvent.change(screen.getByTestId("developer-sr-name"), {
+      target: { value: "MyCustom" },
+    });
+    fireEvent.change(screen.getByTestId("developer-sr-label"), {
+      target: { value: "My Custom" },
+    });
+    fireEvent.change(screen.getByTestId("developer-sr-type"), {
+      target: { value: "CustomSearch" },
+    });
+    fireEvent.change(screen.getByTestId("developer-sr-url"), {
+      target: { value: "/Rhythmyx/sys_cxSupport/custom.xml" },
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-save"));
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalled();
+    });
+    expect(createSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "MyCustom",
+        label: "My Custom",
+        type: "CustomSearch",
+        customSearch: true,
+        url: "/Rhythmyx/sys_cxSupport/custom.xml",
+      }),
+    );
+    expect(onSaved.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        url: "/Rhythmyx/sys_cxSupport/custom.xml",
+        customSearch: true,
+      }),
+    );
+    expect(screen.queryByTestId("developer-sr-field-editor")).toBeNull();
+    expect(screen.getByTestId("developer-sr-fields-custom-url")).toBeTruthy();
+  });
+
+  it("surfaces 400 missing URL on custom create", async () => {
+    createSearch.mockRejectedValue({
+      status: 400,
+      statusText: "Bad Request",
+      body: { message: "url is required for CustomSearch" },
+    });
+    const onSaved = vi.fn();
+    render(<SearchDetailPanel idOrName={null} onBack={() => undefined} onSaved={onSaved} />);
+    fireEvent.change(screen.getByTestId("developer-sr-name"), {
+      target: { value: "MyCustom" },
+    });
+    fireEvent.change(screen.getByTestId("developer-sr-type"), {
+      target: { value: "CustomSearch" },
+    });
+    fireEvent.change(screen.getByTestId("developer-sr-url"), {
+      target: { value: "/Rhythmyx/app/custom.xml" },
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-sr-detail-error").textContent).toContain(
+      DEV_MSG.SR_INVALID_URL,
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("saves URL changes on an existing custom search", async () => {
+    const customDetail = {
+      name: "qa4222custom",
+      label: "Custom URL search",
+      description: "URL search",
+      type: "CustomSearch",
+      customSearch: true,
+      url: "/Rhythmyx/old.xml",
+      displayFormatId: "Default",
+      guid: { stringValue: "0-26-99" },
+      fields: [],
+    };
+    getSearchDetail.mockResolvedValue(customDetail);
+    saveSearch.mockResolvedValue({
+      ...customDetail,
+      url: "/Rhythmyx/new.xml",
+    });
+    const onSaved = vi.fn();
+    render(
+      <SearchDetailPanel idOrName="qa4222custom" onBack={() => undefined} onSaved={onSaved} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-sr-url")).toBeTruthy();
+    });
+    expect((screen.getByTestId("developer-sr-url") as HTMLInputElement).value).toBe(
+      "/Rhythmyx/old.xml",
+    );
+    expect(screen.queryByTestId("developer-sr-field-editor")).toBeNull();
+    fireEvent.change(screen.getByTestId("developer-sr-url"), {
+      target: { value: "/Rhythmyx/new.xml" },
+    });
+    fireEvent.click(screen.getByTestId("developer-sr-save"));
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalled();
+    });
+    expect(saveSearch).toHaveBeenCalledWith(
+      "qa4222custom",
+      expect.objectContaining({
+        name: "qa4222custom",
+        type: "CustomSearch",
+        customSearch: true,
+        url: "/Rhythmyx/new.xml",
+      }),
+    );
   });
 });

--- a/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/SearchDetailPanel.test.tsx
@@ -321,6 +321,8 @@ describe("SearchDetailPanel", () => {
         displayFormatId: "1",
       }),
     );
+    expect(createSearch.mock.calls[0][0]).not.toHaveProperty("customSearch");
+    expect(createSearch.mock.calls[0][0]).not.toHaveProperty("url");
     expect(screen.getByTestId("developer-sr-editor-notice").textContent).toBe(DEV_MSG.SR_SAVED);
   });
 

--- a/WebUI/src/test/ts/developer/searchesApi.test.ts
+++ b/WebUI/src/test/ts/developer/searchesApi.test.ts
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SEARCH_DESIGN_GAPS,
   SEARCH_TYPE_CUSTOM,
+  canonicalSearchType,
   createSearch,
   deleteSearch,
   executeSearch,
@@ -297,10 +298,17 @@ describe("search name validation", () => {
     expect(isCustomSearchType(SEARCH_TYPE_CUSTOM)).toBe(true);
     expect(isCustomSearchType("custom")).toBe(true);
     expect(isCustomSearchType("StandardSearch")).toBe(false);
+    expect(canonicalSearchType("custom")).toBe(SEARCH_TYPE_CUSTOM);
+    expect(canonicalSearchType("CustomSearch")).toBe(SEARCH_TYPE_CUSTOM);
+    expect(canonicalSearchType("standard")).toBe("StandardSearch");
     expect(normalizeSearchUrl("  /app/x.xml  ")).toBe("/app/x.xml");
     expect(isValidSearchUrl("")).toBe(false);
     expect(isValidSearchUrl("   ")).toBe(false);
     expect(isValidSearchUrl("app/has space.xml")).toBe(false);
+    expect(isValidSearchUrl("javascript:alert(1)")).toBe(false);
+    expect(isValidSearchUrl("data:text/html,<script>")).toBe(false);
+    expect(isValidSearchUrl("//evil.example/x")).toBe(false);
+    expect(isValidSearchUrl("not a uri at all")).toBe(false);
     expect(isValidSearchUrl("/Rhythmyx/sys_cxSupport/custom.xml")).toBe(true);
     expect(isValidSearchUrl("https://example.invalid/search")).toBe(true);
     expect(

--- a/WebUI/src/test/ts/developer/searchesApi.test.ts
+++ b/WebUI/src/test/ts/developer/searchesApi.test.ts
@@ -17,15 +17,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SEARCH_DESIGN_GAPS,
+  SEARCH_TYPE_CUSTOM,
   createSearch,
   deleteSearch,
   executeSearch,
   getSearchDetail,
+  isCustomSearchType,
   isSearchWriteReady,
   isValidSearchName,
+  isValidSearchUrl,
   listExplorerSavedSearches,
   listSearches,
   normalizeSearchName,
+  normalizeSearchUrl,
   saveSearch,
   unwrapSearchDef,
   unwrapSearchDefList,
@@ -288,6 +292,42 @@ describe("search name validation", () => {
     expect(isSearchWriteReady({ isNew: false, name: "MySearch" })).toBe(true);
     expect(isSearchWriteReady({ isNew: false, name: "" })).toBe(false);
   });
+
+  it("requires a non-blank URL for CustomSearch writes", () => {
+    expect(isCustomSearchType(SEARCH_TYPE_CUSTOM)).toBe(true);
+    expect(isCustomSearchType("custom")).toBe(true);
+    expect(isCustomSearchType("StandardSearch")).toBe(false);
+    expect(normalizeSearchUrl("  /app/x.xml  ")).toBe("/app/x.xml");
+    expect(isValidSearchUrl("")).toBe(false);
+    expect(isValidSearchUrl("   ")).toBe(false);
+    expect(isValidSearchUrl("app/has space.xml")).toBe(false);
+    expect(isValidSearchUrl("/Rhythmyx/sys_cxSupport/custom.xml")).toBe(true);
+    expect(isValidSearchUrl("https://example.invalid/search")).toBe(true);
+    expect(
+      isSearchWriteReady({
+        isNew: true,
+        name: "MyCustom",
+        type: SEARCH_TYPE_CUSTOM,
+        url: "",
+      }),
+    ).toBe(false);
+    expect(
+      isSearchWriteReady({
+        isNew: true,
+        name: "MyCustom",
+        type: SEARCH_TYPE_CUSTOM,
+        url: "/Rhythmyx/app.xml",
+      }),
+    ).toBe(true);
+    expect(
+      isSearchWriteReady({
+        isNew: true,
+        name: "MySearch",
+        type: "StandardSearch",
+        url: "",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("search wire wrap", () => {
@@ -307,6 +347,21 @@ describe("search wire wrap", () => {
         description: "Created via REST",
         type: "StandardSearch",
         displayFormatId: "1",
+      },
+    });
+    expect(
+      wrapSearchDefForWire({
+        name: "MyCustom",
+        type: "CustomSearch",
+        customSearch: true,
+        url: "/Rhythmyx/sys_cxSupport/custom.xml",
+      }),
+    ).toEqual({
+      SearchDef: {
+        name: "MyCustom",
+        type: "CustomSearch",
+        customSearch: true,
+        url: "/Rhythmyx/sys_cxSupport/custom.xml",
       },
     });
   });

--- a/modules/perc-qa-automation/frontend/tests/developer-search-custom-url.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-search-custom-url.spec.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Searches custom URL editor (#4222 UI-06 / parent #1690).
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   python docker/scripts/perc-devctl.py qa-health
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=…
+ *     npm run test:surface -- --path tests/developer-search-custom-url.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
+
+function developerSearchesUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "searches",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+/** REST-safe unique search name (no spaces, wildcards, or path characters). */
+function uniqueSearchName() {
+  const a = Date.now().toString(36).replace(/[^a-z0-9]/g, "").slice(-4);
+  const b = Math.random().toString(36).replace(/[^a-z0-9]/g, "").slice(2, 6);
+  const suffix = `${a}${b}`.slice(0, 8);
+  return `qa4222${suffix || "x"}`;
+}
+
+async function openSearchesCatalog(page) {
+  await page.goto(developerSearchesUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+  const panel = page.locator('[data-testid="developer-sr-panel"]');
+  const empty = page.locator('[data-testid="developer-sr-empty"]');
+  const listError = page.locator('[data-testid="developer-sr-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer searches catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  await expect(page.locator('[data-testid="developer-sr-new"]')).toBeVisible();
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(
+    unexpectedConsole,
+    `console error: ${unexpectedConsole.join(" | ")}`,
+  ).toEqual([]);
+}
+
+test.describe("Developer search custom URL editor (#4222 / UI-06)", () => {
+  test("Admin can create and delete a custom URL search", async ({ page }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+    await loginAsAdmin(page);
+    await openSearchesCatalog(page);
+
+    const searchName = uniqueSearchName();
+    const searchUrl = `/Rhythmyx/sys_cxSupport/${searchName}.xml`;
+
+    await page.locator('[data-testid="developer-sr-new"]').click();
+    await expect(page.locator('[data-testid="developer-sr-detail"]')).toBeVisible();
+    const saveBtn = page.locator('[data-testid="developer-sr-save"]');
+    await page.locator('[data-testid="developer-sr-name"]').fill(searchName);
+    await page.locator('[data-testid="developer-sr-type"]').selectOption("CustomSearch");
+    await expect(page.locator('[data-testid="developer-sr-url"]')).toBeVisible();
+    await expect(saveBtn).toBeDisabled();
+    await page.locator('[data-testid="developer-sr-url"]').fill(searchUrl);
+    await expect(saveBtn).toBeEnabled();
+    await saveBtn.click();
+
+    const notice = page.locator('[data-testid="developer-sr-editor-notice"]');
+    const saveError = page.locator('[data-testid="developer-sr-detail-error"]');
+    await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+    if (await saveError.isVisible()) {
+      throw new Error(`Create failed: ${(await saveError.innerText()).trim()}`);
+    }
+
+    await expect(page.locator('[data-testid="developer-sr-url"]')).toHaveValue(searchUrl);
+    await expect(page.locator('[data-testid="developer-sr-fields-custom-url"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-sr-field-editor"]')).toHaveCount(0);
+
+    await page.locator('[data-testid="developer-sr-back"]').click();
+    await expect(page.locator('[data-testid="developer-sr-panel"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    const createdRow = page.locator(`[data-sr-name="${searchName}"]`);
+    await expect(createdRow).toHaveCount(1, { timeout: 20_000 });
+
+    await createdRow.click();
+    await expect(page.locator('[data-testid="developer-sr-detail"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-sr-url"]')).toHaveValue(searchUrl);
+    await page.locator('[data-testid="developer-sr-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
+    await expect(page.locator('[data-testid="developer-sr-panel"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator(`[data-sr-name="${searchName}"]`)).toHaveCount(0, {
+      timeout: 20_000,
+    });
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});

--- a/product-docs/8.2/admin/developer-searches.md
+++ b/product-docs/8.2/admin/developer-searches.md
@@ -34,8 +34,10 @@ full Workbench FTS query designer.
 3. Click **New search**. Enter a **name**. Save stays disabled until the name
    is valid (no spaces, no `*` / `%`, no `/` or `..`). Optional: label,
    description, type (`StandardSearch` default, `CustomSearch`, or user
-   `Search`), and display format id. For **Custom**, enter a **URL** (relative
-   or absolute URI, no spaces). Save stays disabled until the URL is present.
+   `Search`), and display format id. For **Custom**, enter a **URL**: `http` /
+   `https`, or a site-relative path starting with `/` (typically `/Rhythmyx/…`).
+   Spaces, `javascript:` / `data:` schemes, and protocol-relative `//` URLs are
+   rejected. Save stays disabled until the URL is valid.
 4. Click **Save**. A duplicate name is **409** and the editor shows that the
    search already exists. An invalid name is **400**. A missing or invalid
    custom URL is **400** and the editor shows that a URL is required. A

--- a/product-docs/8.2/admin/developer-searches.md
+++ b/product-docs/8.2/admin/developer-searches.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-searches
 title: Developer Searches
-description: Create, delete, and edit field criteria for Content Explorer searches from Developer Searches chrome
+description: Create, delete, edit field criteria, and set a custom search URL for Content Explorer searches from Developer Searches chrome
 version: "8.2"
 order: 46
 tags: [admin, developer, searches]
@@ -20,11 +20,13 @@ not deleted from this catalog).
 
 Admins can add, remove, and reorder **field criteria** on a user or standard
 search from this chrome. Packaged/system searches (for example
-`Default_Search` and `RC_Search`) stay read-only for field criteria. Custom-URL
-searches are listed but are not executed from this chrome. This is **not** the
+`Default_Search` and `RC_Search`) stay read-only (identity and field criteria).
+When **Type** is **Custom**, a required **URL** field is shown; field criteria
+are hidden because the search is a custom URL, not a field query. Custom-URL
+searches are not executed from this chrome. This is **not** the
 full Workbench FTS query designer.
 
-## Product path — create, delete, field criteria
+## Product path — create, delete, field criteria, custom URL
 
 1. Sign in as **Admin** (write calls require the Admin role).
 2. Open **Developer → Searches**, or deep-link
@@ -32,19 +34,23 @@ full Workbench FTS query designer.
 3. Click **New search**. Enter a **name**. Save stays disabled until the name
    is valid (no spaces, no `*` / `%`, no `/` or `..`). Optional: label,
    description, type (`StandardSearch` default, `CustomSearch`, or user
-   `Search`), and display format id.
+   `Search`), and display format id. For **Custom**, enter a **URL** (relative
+   or absolute URI, no spaces). Save stays disabled until the URL is present.
 4. Click **Save**. A duplicate name is **409** and the editor shows that the
-   search already exists. An invalid name is **400**. A non-Admin session is
-   **403**. After a successful create, the name field is read-only and the
-   catalog lists the new search (the save is persisted immediately; leaving
-   and returning to the list still shows the row).
-5. Optional: change label, description, type, or display format id and
-   **Save** again.
+   search already exists. An invalid name is **400**. A missing or invalid
+   custom URL is **400** and the editor shows that a URL is required. A
+   non-Admin session is **403**. After a successful create, the name field is
+   read-only and the catalog lists the new search (the save is persisted
+   immediately; leaving and returning to the list still shows the row). A
+   custom search round-trips `url` and `customSearch` on GET.
+5. Optional: change label, description, type, URL (custom only), or display
+   format id and **Save** again.
 6. On a user or standard search, use **Field criteria** to add a field, set
    operator and value, reorder with **Move up** / **Move down**, or **Remove**.
    Click **Save field criteria**. An unknown field name is **400**. A
    packaged/system search does not show the editor (PUT of `fields` is **409**
-   and does not steal another user's design lock).
+   and does not steal another user's design lock). A custom URL search hides
+   the field-criteria editor.
 7. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
    The catalog no longer lists that search.
    Delete of a missing search is **404**. A search still used as a dependent,
@@ -55,9 +61,10 @@ Existing **execute** of standard searches (Explorer Search panel) is unchanged.
 ## Limits
 
 - Name is immutable after create.
-- Packaged/system searches cannot be field-edited from this catalog.
+- Packaged/system searches cannot be edited from this catalog.
 - Views are a separate Developer catalog (UI-07).
-- Custom URL is not collected or executed on write.
+- Custom URL is collected on create/save (`url` + `customSearch`) and is not
+  executed from this chrome.
 
 ## REST
 
@@ -67,8 +74,8 @@ The chrome calls:
 |--------|---------|
 | List | `GET /services/searches` (views omitted) |
 | Load | `GET /services/searches/{idOrName}` |
-| Create | `POST /services/searches` (`name` required; unique, no spaces) |
-| Save | `PUT /services/searches/{idOrName}` (label, description, type, display format; `fields` replaces criteria when present) |
+| Create | `POST /services/searches` (`name` required; unique, no spaces; CustomSearch also sends `url` and `customSearch`) |
+| Save | `PUT /services/searches/{idOrName}` (label, description, type, display format, custom `url`; `fields` replaces criteria when present) |
 | Delete | `DELETE /services/searches/{idOrName}` (`204` on success) |
 
 Writes lock the search for the request and release it on save.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1828,8 +1828,8 @@ CX design **searches** (and optionally **views** on GET/execute) are exposed und
 `/services/searches`. Admin **write** (UI-06) persists through `IPSUiDesignWs`
 (`createSearches` / `loadSearches` / `saveSearches` / `deleteSearches`) — the same design
 web service SOAP uses. There is no new SOAP surface. **Developer → Searches** chrome
-creates and deletes searches (and saves label / description / type / display format)
-and field criteria on user/standard searches — see
+creates and deletes searches (and saves label / description / type / display format /
+custom `url`) and field criteria on user/standard searches — see
 [Developer Searches](id:admin-developer-searches).
 
 | Method | Path | Purpose |
@@ -1838,7 +1838,7 @@ and field criteria on user/standard searches — see
 | `GET` | `/services/searches?includeViews=true` | List searches **and** views (Explorer saved-search picker) |
 | `GET` | `/services/searches/{idOrName}` | Load one search or view by name, label, GUID, or numeric id |
 | `POST` | `/services/searches` | **Admin.** Create a search (`createSearches` then `saveSearches`) |
-| `PUT` | `/services/searches/{idOrName}` | **Admin.** Update label, description, type, display format, and/or field criteria |
+| `PUT` | `/services/searches/{idOrName}` | **Admin.** Update label, description, type, display format, custom `url`, and/or field criteria |
 | `DELETE` | `/services/searches/{idOrName}` | **Admin.** Delete a search (`deleteSearches`, `ignoreDependencies=false`) |
 | `POST` | `/services/searches/{idOrName}/execute` | Execute a standard/user search or view (not a custom URL) |
 
@@ -1859,9 +1859,11 @@ updating, or deleting a search.
 
 Create (`POST /services/searches`) persists immediately (Workbench Finish, not an unsaved
 stub). JSON body requires `name` (unique across searches **and** views, case-insensitive;
-**no whitespace** or wildcards). Optional `label`, `description`, `type`, and
-`displayFormatId` are applied before save. Default `type` is `StandardSearch`. Accepted
-types: `StandardSearch` (`standard`), `CustomSearch` (`custom`), `Search` (user search).
+**no whitespace** or wildcards). Optional `label`, `description`, `type`,
+`displayFormatId`, `url`, and `customSearch` are applied before save. Default `type` is
+`StandardSearch`. Accepted types: `StandardSearch` (`standard`), `CustomSearch`
+(`custom`), `Search` (user search). When `type` is `CustomSearch`, send a non-blank
+`url` (URI string) and `customSearch: true`. GET round-trips `url` and `customSearch`.
 `View` is **400** — views stay on `/services/views`. Duplicate name is **409**. Blank /
 whitespace / wildcard names are **400**. Missing request session/user is **403**.
 Non-Admin is **403**. The new search is then `GET /services/searches/{name}` **200**
@@ -1870,11 +1872,11 @@ with the same name is **409**).
 
 Update (`PUT /services/searches/{idOrName}`) loads with a design lock (`overrideLock=false`)
 and releases it on save. Name is not renamed on PUT. Omitted label / description / type /
-display format leave stored values unchanged. When `fields` is present it replaces field
-criteria in order (`fieldName`, `operator`, `fieldValue`, `position`). Omitted `fields`
-leaves stored criteria unchanged; an empty array clears them. Unknown / invalid field
-name is **400**. Packaged/system searches (`Default_Search`, `RC_Search`) reject field
-mutation with **409** (the lock is not stolen). Unknown id/name is
+display format / `url` leave stored values unchanged. When `fields` is present it replaces
+field criteria in order (`fieldName`, `operator`, `fieldValue`, `position`). Omitted
+`fields` leaves stored criteria unchanged; an empty array clears them. Unknown / invalid
+field name is **400**. Packaged/system searches (`Default_Search`, `RC_Search`) reject
+field mutation with **409** (the lock is not stolen). Unknown id/name is
 **404**. A view key is **400**. Locked-by-another-user is **409**. Non-Admin is **403**.
 
 Delete (`DELETE /services/searches/{idOrName}`) returns **204** when removed; a following
@@ -1902,11 +1904,25 @@ Example create body:
 }
 ```
 
+Example custom URL create:
+
+```json
+{
+  "SearchDef": {
+    "name": "MyCustom",
+    "label": "My Custom",
+    "type": "CustomSearch",
+    "customSearch": true,
+    "url": "/Rhythmyx/sys_cxSupport/custom.xml"
+  }
+}
+```
+
 | Status | Typical meaning |
 |--------|-----------------|
 | `200` | List / get / create / update success |
 | `204` | Delete success |
-| `400` | Invalid input (missing name, whitespace/wildcard name, invalid or View type, unknown field) |
+| `400` | Invalid input (missing name, whitespace/wildcard name, invalid or View type, unknown field, missing custom `url`) |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | Search not found |
 | `409` | Duplicate name, packaged/system field mutation, design lock held by another user, or dependents |

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1863,7 +1863,9 @@ stub). JSON body requires `name` (unique across searches **and** views, case-ins
 `displayFormatId`, `url`, and `customSearch` are applied before save. Default `type` is
 `StandardSearch`. Accepted types: `StandardSearch` (`standard`), `CustomSearch`
 (`custom`), `Search` (user search). When `type` is `CustomSearch`, send a non-blank
-`url` (URI string) and `customSearch: true`. GET round-trips `url` and `customSearch`.
+`url` (`http`/`https` or a site-relative path starting with `/`, typically
+`/Rhythmyx/…`) and `customSearch: true`. Omit `url` / `customSearch` on
+non-custom writes. GET round-trips `url` and `customSearch`.
 `View` is **400** — views stay on `/services/views`. Duplicate name is **409**. Blank /
 whitespace / wildcard names are **400**. Missing request session/user is **403**.
 Non-Admin is **403**. The new search is then `GET /services/searches/{name}` **200**


### PR DESCRIPTION
## Summary

Developer → Searches can now author **custom URL** searches (parent #1690 FR UI-06). When type is CustomSearch, SearchDetailPanel shows a required URL field, persists `url` + `customSearch` on POST/PUT, hides field-criteria editing, and keeps packaged/system searches immutable. Missing or whitespace URLs disable Save and surface in the editor.

Fixes #4222. Slice of #1690.

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd WebUI && ../mvnw.cmd clean install` (standalone; tests included).
2. Vitest: SearchDetailPanel custom URL create/save, missing URL 400, packaged immutable; searchesApi URL write-ready.
3. QA H2: reuse `perc-matrix-cms-h2`, `python docker/scripts/hot-deploy-webui-modern.py`, `perc-devctl.py qa-health` with published host port, then `npm run test:surface -- --path tests/developer-search-custom-url.spec.js`.
4. Admin: New search → Type Custom → URL required → Save → GET round-trip shows URL; field criteria hidden; Default_Search still read-only.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-searches.md` and REST custom `url` notes in `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — WebUI Vitest + standalone `mvnw clean install`
- [x] **WebUI + Playwright** — `modules/perc-qa-automation/frontend/tests/developer-search-custom-url.spec.js`
- [x] **Build gates** — WebUI standalone clean install; no public Java API shape change
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 evidence

- modules_built: WebUI
- build_evidence: `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS; Vitest Test Files 416 passed, Tests 3769 passed
- downstream_checked: none (C2 did not apply — no final/sealed/public Java signature change)

## C5 UI proof

- Existing QA cell `perc-matrix-cms-h2` (healthy); hot-deploy `python docker/scripts/hot-deploy-webui-modern.py` (134 files)
- `python docker/scripts/perc-devctl.py qa-health --timeout-seconds 60` → RESULT:OK HTTP:200 HEALTH:healthy URL:http://127.0.0.1:<published>/Rhythmyx/rest/mimetypes
- `npm run test:surface -- --path tests/developer-search-custom-url.spec.js` → 1 passed (console-clean=yes via spec guards)
- server.log-clean=yes (qa-health product-log ERROR scan passed)
- Cell kept (pre-existing; not qa-down)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.