### PR TITLE
fix(rest): bind Admin ActionMenu POST, skip Jettison JAXB (#4171)

### DIFF
--- a/docs/ai-generated/code-reviews/4171-action-menu-post-jaxb-erlang.md
+++ b/docs/ai-generated/code-reviews/4171-action-menu-post-jaxb-erlang.md
@@ -1,0 +1,35 @@
+# Erlang review: #4171 ActionMenu POST JAXB bind
+
+**Scope:** `fix/issue-4171-action-menu-post-jaxb` vs `origin/main` (cherry-pick of closed unmerged #4189 `b2a446b89a`).
+**Change class:** rest-jax-rs JSON provider + ActionMenu create POST bind (CXF skip Jettison default JSON provider).
+**Memory patterns hit:** incomplete change-class closure (rest + sitemanage dual-ship); tests that only grep source strings (registration test is companion to CXF behavioral tests, not sole proof).
+
+## Summary
+
+Admin `POST /services/actions` with `{"ActionMenu":{…}}` was JAXB-bound by CXF’s default Jettison `JSONProvider` as `allowedWorkflowTransitionsRequest` (finder DTO). Re-land skip-default-JSON-provider on `rest-jax-rs`, pin the finder DTO `@XmlRootElement` / `@JsonRootName`, keep `ActionMenuJsonReader` ahead of Jackson, and lock wrapped create POST with `JAXBElementProvider` in the CXF unit test.
+
+Product-docs 8.2 REST already described wrap/flat create; one sentence now states the collection POST is `ActionMenu`, not the finder DTO.
+
+## Recommendation
+
+approve
+
+## Gate
+
+- Bugs: none
+- Behavioral tests: CXF `ActionMenuCreateCxfUnmarshallTest` (wrapped/flat + JAXB provider still invokes `createActionMenu`; Jackson WRAP_ROOT_VALUE binds wrap without custom reader). `CatalogRestJaxrsRegistrationTest` asserts `skip.default.json.provider.registration` and `actionMenuJsonReader` before `jacksonProvider`. Existing `ActionMenuResourceTest` keeps unique name / 400 / 409 / 403.
+- Cross-platform paths: N/A (no new filesystem I/O). Catalog test already uses `Path.of` / `Files`.
+- May commit/push: yes (cherry-pick already on branch; review is of that commit)
+
+## Issues
+
+None.
+
+## Companions
+
+- rest: `ActionMenuJsonReader` javadoc, `AllowedWorkflowTransitionsRequest` root name, CXF unmarshall tests
+- sitemanage: `sitemanage-beans.xml` jaxrs property; registration test
+- product-docs: `product-docs/8.2/developer/rest.md`
+- Playwright spec not weakened (`developer-action-menu-editor.spec.js` still asserts notice + name read-only)
+
+C2: no type made final/sealed; no public signature change. Reverse-dep `projects/sitemanage` is in the change set.

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1506,7 +1506,8 @@ PUT round-trips GET detail fields already exposed (`label`, `description`,
 | `DELETE` | `/services/actions/{idOrName}` | **Admin.** Delete a user action menu (`deleteActions`, `ignoreDependencies=false`) |
 
 JSON may wrap a single item as `ActionMenu`. **Create** `POST /services/actions`
-sends that envelope (or a flat object with `name`). Do not post
+sends that envelope (or a flat object with `name`). The collection POST is bound
+as `ActionMenu` (not JAXB `allowedWorkflowTransitionsRequest`). Do not post
 `allowedWorkflowTransitionsRequest` on the collection path — that finder lives at
 `POST /services/actions/find/transitions`. Integrators should unwrap the
 `ActionMenu` envelope and read `guid.stringValue` (never assume the GUID is

--- a/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
+++ b/projects/sitemanage/src/main/resources/Rhythmyx/AppServer/server/rx/deploy/rxapp.ear/rxapp.war/WEB-INF/config/spring/projects/sitemanage-beans.xml
@@ -160,6 +160,12 @@ http://cxf.apache.org/schemas/jaxrs.xsd">
             <ref bean="jacksonContextResolver" />
             <ref bean="authorizationFilter" />
         </jaxrs:providers>
+        <!-- #4171: do not auto-register Jettison JSONProvider. It JAXB-binds
+             POST /actions as allowedWorkflowTransitionsRequest (finder is
+             /find/transitions). Jackson + ActionMenuJsonReader own JSON. -->
+        <jaxrs:properties>
+            <entry key="skip.default.json.provider.registration" value="true"/>
+        </jaxrs:properties>
         <jaxrs:features>
             <!-- CXF 3.1+/4.x: use LoggingFeature bean (requires cxf-rt-features-logging).
                  Legacy <cxf:logging/> under core NS has no BeanDefinitionParser without that module. -->

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -226,6 +226,10 @@ class CatalogRestJaxrsRegistrationTest {
     assertTrue(
         displayFormatReader < jackson,
         DISPLAY_FORMAT_JSON_READER + " must be listed before jacksonProvider");
+    assertTrue(
+        restBlock.contains("skip.default.json.provider.registration"),
+        "rest-jax-rs must skip Jettison JSONProvider (POST /actions JAXB "
+            + "allowedWorkflowTransitionsRequest)");
   }
 
   private static Path resolveRepoRoot() {

--- a/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/rest/CatalogRestJaxrsRegistrationTest.java
@@ -227,8 +227,8 @@ class CatalogRestJaxrsRegistrationTest {
         displayFormatReader < jackson,
         DISPLAY_FORMAT_JSON_READER + " must be listed before jacksonProvider");
     assertTrue(
-        restBlock.contains("skip.default.json.provider.registration"),
-        "rest-jax-rs must skip Jettison JSONProvider (POST /actions JAXB "
+        restBlock.contains("skip.default.json.provider.registration\" value=\"true\""),
+        "rest-jax-rs must skip Jettison JSONProvider with value=\"true\" (POST /actions JAXB "
             + "allowedWorkflowTransitionsRequest)");
   }
 

--- a/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
+++ b/rest/src/main/java/com/percussion/rest/actions/ActionMenuJsonReader.java
@@ -46,6 +46,8 @@ import tools.jackson.databind.json.JsonMapper;
  * This reader binds wrap and flat shapes before {@code jacksonProvider}.
  *
  * <p>Must be listed on {@code rest-jax-rs} {@code jaxrs:providers} ahead of {@code jacksonProvider}.
+ * rest-jax-rs also sets {@code skip.default.json.provider.registration} so Jettison JAXB cannot
+ * bind this body as {@code allowedWorkflowTransitionsRequest} (#4171).
  */
 @Provider
 @Consumes({MediaType.APPLICATION_JSON, "text/json", "application/*+json", MediaType.WILDCARD})

--- a/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
+++ b/rest/src/main/java/com/percussion/rest/actions/AllowedWorkflowTransitionsRequest.java
@@ -18,6 +18,7 @@
 package com.percussion.rest.actions;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.Arrays;
 
@@ -27,8 +28,12 @@ import java.util.Arrays;
  * <p>Wire getters return plain nullable types (not {@code Optional}) so Jackson/CXF JSON emits
  * {@code contentIds} and {@code assignmentTypeIds} as JSON arrays, not Optional beans (issue #3388
  * slice 10 / #3432).
+ *
+ * <p>Root name is explicit so JAXB/Jettison cannot treat an {@code ActionMenu} envelope as this
+ * type on {@code POST /actions} (#4171). Finder POST is {@code /actions/find/transitions}.
  */
-@XmlRootElement
+@XmlRootElement(name = "allowedWorkflowTransitionsRequest")
+@JsonRootName("allowedWorkflowTransitionsRequest")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AllowedWorkflowTransitionsRequest {
 

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
@@ -33,8 +33,8 @@ import jakarta.ws.rs.ext.MessageBodyReader;
 import java.io.ByteArrayInputStream;
 import java.lang.annotation.Annotation;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
@@ -114,29 +114,67 @@ public class ActionMenuCreateCxfUnmarshallTest {
 
   @Test
   public void cxfPostWrappedActionMenuInvokesCreate() throws Exception {
-    assertCreatePost(WRAPPED, "cxfN1", "local://issue-4123-actions-wrap");
+    assertCreatePost(WRAPPED, "cxfN1", "local://issue-4123-actions-wrap", true);
   }
 
   @Test
   public void cxfPostFlatActionMenuInvokesCreate() throws Exception {
-    assertCreatePost(FLAT, "cxfFlat", "local://issue-4123-actions-flat");
+    assertCreatePost(FLAT, "cxfFlat", "local://issue-4123-actions-flat", true);
   }
 
+  /**
+   * Jackson + JAXBElementProvider without {@link ActionMenuJsonReader} must still POST wrapped
+   * {@code ActionMenu} (#4171). Distinct from {@link #cxfPostWrappedActionMenuInvokesCreate}:
+   * production skip.default.json.provider.registration means Jackson unwrap wins, not Jettison
+   * JAXB. {@link #startServer} always registers JAXBElementProvider; omitting the custom reader
+   * is the unique path.
+   */
   @Test
-  public void cxfPostWrappedActionMenuWithJaxbProviderStillInvokesCreate() throws Exception {
-    assertCreatePost(WRAPPED, "cxfN1", "local://issue-4171-actions-jaxb");
+  public void cxfPostWrappedActionMenuWithoutCustomReaderInvokesCreate() throws Exception {
+    assertCreatePost(WRAPPED, "cxfN1", "local://issue-4171-actions-jackson-only", false);
   }
 
+  /**
+   * CXF provider chain (Jackson then JAXBElementProvider, no {@link ActionMenuJsonReader}) must
+   * select Jackson for {@code application/json} ActionMenu and bind the wrapped envelope.
+   */
   @Test
-  public void jacksonBarrierBindsWrappedActionMenuWithoutCustomReader() {
+  public void jacksonBarrierBindsWrappedActionMenuWithoutCustomReader() throws Exception {
+    ServerProviderFactory factory = ServerProviderFactory.createInstance(null);
+    JacksonJsonProvider jackson = new JacksonJsonProvider();
+    jackson.setMapper(
+        (tools.jackson.databind.json.JsonMapper)
+            new JacksonContextResolver().getContext(ActionMenu.class));
+    factory.setUserProviders(
+        Arrays.asList(jackson, new JacksonContextResolver(), new JAXBElementProvider<>()));
+
+    MessageImpl message = new MessageImpl();
+    MessageBodyReader<ActionMenu> selected =
+        factory.createMessageBodyReader(
+            ActionMenu.class,
+            ActionMenu.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            message);
+    assertNotNull(selected, "CXF must find a MessageBodyReader for ActionMenu");
+    assertTrue(
+        JacksonJsonProvider.class.isAssignableFrom(selected.getClass()),
+        () -> "Jackson must win the JSON chain, got " + selected.getClass().getName());
+
     ActionMenu menu =
-        new JacksonContextResolver()
-            .getContext(ActionMenu.class)
-            .readValue(WRAPPED, ActionMenu.class);
+        selected.readFrom(
+            ActionMenu.class,
+            ActionMenu.class,
+            new Annotation[0],
+            MediaType.APPLICATION_JSON_TYPE,
+            null,
+            new ByteArrayInputStream(WRAPPED.getBytes(StandardCharsets.UTF_8)));
     assertEquals("cxfN1", menu.getName());
   }
 
-  private void assertCreatePost(String json, String expectedName, String address) throws Exception {
+  private void assertCreatePost(
+      String json, String expectedName, String address, boolean includeActionMenuJsonReader)
+      throws Exception {
     AtomicReference<ActionMenu> captured = new AtomicReference<>();
     IActionMenuAdaptor adaptor = mock(IActionMenuAdaptor.class);
     when(adaptor.createActionMenu(any()))
@@ -156,7 +194,7 @@ public class ActionMenuCreateCxfUnmarshallTest {
     field.setAccessible(true);
     field.set(resource, adaptor);
 
-    server = startServer(resource, address);
+    server = startServer(resource, address, includeActionMenuJsonReader);
 
     WebClient client =
         WebClient.create(address)
@@ -172,7 +210,8 @@ public class ActionMenuCreateCxfUnmarshallTest {
     verify(adaptor).createActionMenu(any());
   }
 
-  private static Server startServer(ActionMenuResource resource, String address) {
+  private static Server startServer(
+      ActionMenuResource resource, String address, boolean includeActionMenuJsonReader) {
     JacksonJsonProvider jackson = new JacksonJsonProvider();
     jackson.setMapper(
         (tools.jackson.databind.json.JsonMapper)
@@ -180,14 +219,16 @@ public class ActionMenuCreateCxfUnmarshallTest {
     JAXRSServerFactoryBean sf = new JAXRSServerFactoryBean();
     sf.setAddress(address);
     sf.setServiceBean(resource);
-    sf.setProviders(
-        List.of(
-            new ActionMenuJsonReader(),
-            new AllowedContentTypeMenusRequestJsonReader(),
-            jackson,
-            new JacksonContextResolver(),
-            new JAXBElementProvider<>(),
-            new WebApplicationExceptionMapper()));
+    ArrayList<Object> providers = new ArrayList<>();
+    if (includeActionMenuJsonReader) {
+      providers.add(new ActionMenuJsonReader());
+    }
+    providers.add(new AllowedContentTypeMenusRequestJsonReader());
+    providers.add(jackson);
+    providers.add(new JacksonContextResolver());
+    providers.add(new JAXBElementProvider<>());
+    providers.add(new WebApplicationExceptionMapper());
+    sf.setProviders(providers);
     Server created = sf.create();
     assertNotNull(created, "CXF local server must start");
     return created;

--- a/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
+++ b/rest/src/test/java/com/percussion/rest/actions/ActionMenuCreateCxfUnmarshallTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.cxf.endpoint.Server;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 import org.apache.cxf.jaxrs.client.WebClient;
+import org.apache.cxf.jaxrs.provider.JAXBElementProvider;
 import org.apache.cxf.jaxrs.provider.ServerProviderFactory;
 import org.apache.cxf.message.MessageImpl;
 import org.junit.jupiter.api.AfterEach;
@@ -79,7 +80,9 @@ public class ActionMenuCreateCxfUnmarshallTest {
     jackson.setMapper(
         (tools.jackson.databind.json.JsonMapper)
             new JacksonContextResolver().getContext(ActionMenu.class));
-    factory.setUserProviders(Arrays.asList(custom, jackson, new JacksonContextResolver()));
+    factory.setUserProviders(
+        Arrays.asList(
+            custom, jackson, new JacksonContextResolver(), new JAXBElementProvider<>()));
 
     MessageImpl message = new MessageImpl();
     MessageBodyReader<ActionMenu> selected =
@@ -117,6 +120,20 @@ public class ActionMenuCreateCxfUnmarshallTest {
   @Test
   public void cxfPostFlatActionMenuInvokesCreate() throws Exception {
     assertCreatePost(FLAT, "cxfFlat", "local://issue-4123-actions-flat");
+  }
+
+  @Test
+  public void cxfPostWrappedActionMenuWithJaxbProviderStillInvokesCreate() throws Exception {
+    assertCreatePost(WRAPPED, "cxfN1", "local://issue-4171-actions-jaxb");
+  }
+
+  @Test
+  public void jacksonBarrierBindsWrappedActionMenuWithoutCustomReader() {
+    ActionMenu menu =
+        new JacksonContextResolver()
+            .getContext(ActionMenu.class)
+            .readValue(WRAPPED, ActionMenu.class);
+    assertEquals("cxfN1", menu.getName());
   }
 
   private void assertCreatePost(String json, String expectedName, String address) throws Exception {
@@ -169,6 +186,7 @@ public class ActionMenuCreateCxfUnmarshallTest {
             new AllowedContentTypeMenusRequestJsonReader(),
             jackson,
             new JacksonContextResolver(),
+            new JAXBElementProvider<>(),
             new WebApplicationExceptionMapper()));
     Server created = sf.create();
     assertNotNull(created, "CXF local server must start");


### PR DESCRIPTION
## Summary

Cycle Verify residual for Developer Action Menus create (`tests/developer-action-menu-editor.spec.js`). Live Admin `POST /services/actions` failed with JAXB `unexpected element ActionMenu; expected allowedWorkflowTransitionsRequest` when CXF’s default Jettison JSON provider bound the collection POST as the workflow-transitions finder DTO.

This PR re-lands the bind (closed unmerged #4189 / cluster #4203 are **not** treated as coverage):

- Sets `skip.default.json.provider.registration` on `rest-jax-rs` so Jackson + `ActionMenuJsonReader` own JSON (finder stays at `POST /actions/find/transitions`).
- Pins `@XmlRootElement` / `@JsonRootName` on `AllowedWorkflowTransitionsRequest` to `allowedWorkflowTransitionsRequest`.
- CXF tests include `JAXBElementProvider` and lock wrapped/flat create POST to `createActionMenu`.
- Integrator note in `product-docs/8.2/developer/rest.md`.

REST create contract is unchanged: unique name, no spaces/wildcards, 409 duplicate, 400 invalid, system menus immutable.

H2 QA must dual-ship **rest + sitemanage + perc-system** (and exploded `sitemanage-beans.xml`) into the WAR — `--then-qa-deploy-webui` alone is not enough.

Operator: Grok: night-issue-prs (model grok-4.6)

Fixes #4171
Partial #4112
Parent #1690

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 1035, Failures: 0).
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2174, Failures: 0, Errors: 0, Skipped: 125).
3. H2 QA: `python docker/scripts/perc-devctl.py qa-up --skip-image-build` → `TEST_CMS_URL=http://127.0.0.1:9993` → `qa-health` RESULT:OK HTTP:200 HEALTH:healthy.
4. Hot-copy `rest-8.2.0-SNAPSHOT.jar`, `sitemanage-8.2.0-SNAPSHOT.jar`, exploded `sitemanage-beans.xml`, `perc-system-8.2.0-SNAPSHOT.jar` into `Rhythmyx/WEB-INF/lib`; in-cell StopJetty/StartJetty; `qa-health` again.
5. `npm run test:surface -- --path tests/developer-action-menu-editor.spec.js` — **3 passed**. Spec not weakened (create POST notice + name read-only). console-clean=yes (spec guards). server.log-clean=yes (no ActionMenu JAXB ERROR/FATAL).
6. `python docker/scripts/perc-devctl.py qa-down` — RESULT:OK.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` (Action menus create POST is `ActionMenu`, not `allowedWorkflowTransitionsRequest`)
- [x] **Unit / module tests** — CXF unmarshall + CatalogRestJaxrsRegistrationTest; rest and sitemanage standalone `clean install`
- [x] **WebUI + Playwright** — existing spec not weakened; H2 surface path **3 passed**
- [x] **Build gates** — rest + sitemanage standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A (no new filesystem path I/O)

### C3 evidence

- **modules_built:** rest, projects/sitemanage
- **build_evidence:** `cd rest && ../mvnw.cmd clean install` BUILD SUCCESS Tests run: 1035 Failures: 0; `cd projects/sitemanage && ../../mvnw.cmd clean install` BUILD SUCCESS Tests run: 2174 Failures: 0 Errors: 0 Skipped: 125
- **downstream_checked:** sitemanage (depends on rest) standalone clean install; no `extends ActionMenu` subclasses (only `ActionMenuList` collection ctor)

### C5 UI proof

- qa-up `--skip-image-build`; TEST_CMS_URL=`http://127.0.0.1:9993`
- Dual-ship rest + sitemanage + perc-system WAR jars + exploded beans.xml
- Playwright: `npm run test:surface -- --path tests/developer-action-menu-editor.spec.js` — 3 passed
- console-clean=yes; server.log-clean=yes

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
