### PR TITLE
feat(views): persist Admin user custom URL views (UI-07) (#4235)

### DIFF
--- a/docs/ai-generated/code-reviews/4235-custom-url-view-write-erlang.md
+++ b/docs/ai-generated/code-reviews/4235-custom-url-view-write-erlang.md
@@ -1,0 +1,41 @@
+# Erlang review: issue #4235 REST UI-07 custom URL view write
+
+**Branch:** `feat/issue-4235-custom-url-view-write`  
+**Base:** `origin/main`  
+**Date:** 2026-09-03  
+**Recommendation:** approve  
+**Gate:** May commit/push: yes  
+**Memory patterns hit:** change-class closure (rest resource + sitemanage adaptor + Spring stub already present + product-docs); behavioral tests (not string-only); URL paths correctly use `/` (classic app URLs, not filesystem).
+
+## Summary
+
+Admin POST/PUT of a *user* CustomView with required `url` via existing `IPSUiDesignWs` (held lock, `overrideLock=false`). GET round-trips `url` and `customView=true`. Inbox-family / packaged `sys_cxViews` catalog keys stay 409. Blank/invalid URL 400; non-Admin 403; duplicate name 409. No SPA/Playwright (siblings).
+
+## Cross-platform path checklist
+
+- No new filesystem path joins.
+- Custom-view `url` is a classic application URL (`../app/page.xml`); `/` is correct for that domain.
+- Rejection of `\\`, NUL, `://`, and `..` after leading `../` is validation, not OS path I/O.
+
+## Issues
+
+None (bugs / missing behavioral tests / non-portable I/O).
+
+## Change-class companions
+
+| Companion | Status |
+|-----------|--------|
+| rest resource + OpenAPI text | updated |
+| IViewAdaptor javadoc | updated |
+| sitemanage ViewAdaptor persist | updated (`setCustom` + `setUrl`) |
+| Mockito resource tests | ViewResourceTest |
+| Adaptor tests (exact types / real `PSSearch`) | ViewAdaptorWriteTest, ViewAdaptorFieldsTest |
+| Spring test stub | TestViewAdaptor already implements create/save |
+| product-docs/8.2/developer/rest.md | View write contract |
+| Playwright / SPA | N/A (out of scope; siblings #4236/#4237) |
+
+## Builds
+
+- `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1036, Failures: 0
+- `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2182, Failures: 0
+- C2: no `final`/`sealed` or signature change; reverse-dep `projects/sitemanage` installed

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1586,9 +1586,10 @@ Admin **write** persists through `IPSUiDesignWs` (`createViews` / `loadViews` / 
 `deleteViews`) — the same design web service SOAP uses. There is no new SOAP surface.
 **Developer → Views** chrome creates and deletes standard views, saves label /
 description / type / display format, and edits **field criteria** on
-user/standard views — see [Developer Views](id:admin-developer-views). Inbox-family
-and custom URL views cannot be mutated from that catalog. Execute is **not**
-invoked when creating, updating, or deleting a view. Create is durable:
+user/standard views — see [Developer Views](id:admin-developer-views). Admin REST
+also persists **user** custom URL views (`url` + `customView`). Inbox-family and
+packaged `sys_cxViews` catalog keys cannot be mutated from that catalog. Execute
+is **not** invoked when creating, updating, or deleting a view. Create is durable:
 `GET /services/views` lists the new name after POST.
 
 Operators open Inbox from Explorer **Views → My Content → Inbox** (see
@@ -1602,8 +1603,8 @@ created name (durable persist; a second POST of that name is **409**).
 |--------|------|---------|
 | `GET` | `/services/views` | List view definitions (name, category, standard vs custom URL; includes `guid`) |
 | `GET` | `/services/views/{idOrName}` | Load one view by name, numeric id, or GUID string (includes `guid` for Object ACL) |
-| `POST` | `/services/views` | **Admin.** Create a standard (field-criteria) view (`createViews` then `saveViews`) |
-| `PUT` | `/services/views/{idOrName}` | **Admin.** Update label, description, type, display format, and/or `fields` (omit to leave criteria unchanged; empty array clears; unknown field is 400) |
+| `POST` | `/services/views` | **Admin.** Create a standard (field-criteria) view or a **user** custom URL view (`createViews` then `saveViews`) |
+| `PUT` | `/services/views/{idOrName}` | **Admin.** Update label, description, type, display format, `url` (user custom URL views), and/or `fields` (omit to leave criteria unchanged; empty array clears; unknown field is 400) |
 | `DELETE` | `/services/views/{idOrName}` | **Admin.** Delete a user/standard view (`deleteViews`, `ignoreDependencies=false`) |
 | `POST` | `/services/views/{idOrName}/execute` | Execute a **standard** (field-criteria) view or an Inbox-family **custom URL** view |
 
@@ -1644,10 +1645,10 @@ Successful response is a paged envelope: `children[]` (Explorer-ready rows with 
 |--------|-----------------|
 | `200` | List / get / create / update / execute success |
 | `204` | Delete success |
-| `400` | Invalid input (missing name, whitespace/wildcard name, invalid or search type, custom URL on create, **unknown field** on PUT `fields`), invalid execute body, or an **unsupported** custom URL view |
+| `400` | Invalid input (missing name, whitespace/wildcard name, invalid or search type, **blank/invalid `url`** on custom URL write, **unknown field** on PUT `fields`), invalid execute body, or an **unsupported** custom URL view on execute |
 | `403` | Caller is not Admin, or the request has no session/user for the design session |
 | `404` | View not found or unsafe key (blank, path separators, `..`) |
-| `409` | Duplicate name, design lock held by another user, dependents, or Inbox/system custom URL write |
+| `409` | Duplicate name, design lock held by another user, dependents, or Inbox-family / packaged `sys_cxViews` write |
 | `500` | Design or execute engine failure (standard views) |
 | `503` | Views adaptor not configured, or custom-view backend unavailable |
 
@@ -1681,24 +1682,32 @@ Create (`POST /services/views`) persists immediately (Workbench Finish, not an u
 stub). JSON body requires `name` (unique across views **and** searches, case-insensitive;
 **no whitespace** or wildcards). Optional `label`, `description`, `type`, and
 `displayFormatId` are applied before save. Default `type` is `View`. Accepted types:
-`View` (`standard`, `standardView`). Search types (`StandardSearch`, `Search`) are
-**400** — searches stay on `/services/searches`. Custom URL (`url` set, or type
-`custom` / `CustomView`) is **400**. Duplicate name is **409**. Blank /
+`View` (`standard`, `standardView`) and **user** custom URL views (`custom`,
+`CustomView`). Search types (`StandardSearch`, `Search`) are **400** — searches stay
+on `/services/searches`. A user custom URL view requires `url` (relative classic
+application path such as `../myApp/page.xml`). Blank, placeholder, absolute/scheme,
+backslash, or traversal URLs are **400**. Duplicate name is **409**. Blank /
 whitespace / wildcard names are **400**. Missing request session/user is **403**.
-Non-Admin is **403**. The new view is then `GET /services/views/{name}` **200**
-and is included in `GET /services/views` (the create is durable; a second POST
-with the same name is **409**).
+Non-Admin is **403**. After POST, `GET /services/views/{name}` returns the stored
+`url` and `customView=true` for a custom URL view. The create is durable; a second
+POST with the same name is **409**.
 
 Update (`PUT /services/views/{idOrName}`) loads with a design lock (`overrideLock=false`)
-and releases it on save. Name is not renamed on PUT. Omitted label / description / type /
-display format leave stored values unchanged. Unknown id/name is **404**. Inbox-family
-and other custom URL views are **409** (not mutated; the lock is not stolen).
-Locked-by-another-user is **409**. Non-Admin is **403**.
+and releases it on save. `{idOrName}` may be the view **name** or GUID
+(`0-18-{searchId}`). After POST, field-criteria save uses that GUID; if the H2
+catalog XML lags the JDBC insert, the server still loads by SEARCHID uuid (not
+the packed GUID long) and, when the path GUID misses, by the body `name`.
+Name is not renamed on PUT. Omitted label / description / type /
+display format / `url` leave stored values unchanged. A user custom URL view may update
+`url`; an explicit blank `url` is **400**. Unknown id/name is **404**. Inbox-family and
+packaged `sys_cxViews` catalog keys (`Inbox`, `Outbox`, `Recent`, `Session`,
+`Checked_Out_By_Me`, `DuplicateFolderPaths`) are **409** (not mutated; the lock is
+not stolen). Locked-by-another-user is **409**. Non-Admin is **403**.
 
 Delete (`DELETE /services/views/{idOrName}`) returns **204** when removed; a following
-`GET` is **404**. Unknown id/name is **404**. Inbox-family and other custom URL views are
-**409** (not deleted). Dependents or a lock held by another user are **409**. Non-Admin
-is **403**.
+`GET` is **404**. Unknown id/name is **404**. Inbox-family and packaged `sys_cxViews`
+catalog keys are **409** (not deleted). User custom URL views may be deleted.
+Dependents or a lock held by another user are **409**. Non-Admin is **403**.
 
 Create/update load or create the view with a **held design lock** and release it on
 save. There is no separate lock/unlock REST pair on this catalog. Field criterion
@@ -1708,7 +1717,7 @@ JSON objects use the `ViewDef` wire type. POST/PUT JSON is wrapped under a `View
 root (JAXB/Jackson UNWRAP_ROOT_VALUE). Prefer the generated OpenAPI schema as the
 integration source of truth.
 
-Example create body:
+Example create body (standard view):
 
 ```json
 {
@@ -1722,16 +1731,32 @@ Example create body:
 }
 ```
 
+Example create body (user custom URL view):
+
+```json
+{
+  "ViewDef": {
+    "name": "MyCustom",
+    "label": "My Custom",
+    "type": "CustomView",
+    "customView": true,
+    "url": "../myApp/page.xml",
+    "displayFormatId": "1"
+  }
+}
+```
+
 ### Integrator notes
 
 - Keys may be the view **name**, numeric **id**, or GUID string (including untyped GUID).
 - Admin write is POST/PUT/DELETE on this resource and from **Developer → Views**
-  (create / save / delete). Inbox-family and custom URL views cannot be updated
-  or deleted (`409`). Field criterion editing remains a `designGaps` note on detail.
+  (create / save / delete). Inbox-family and packaged `sys_cxViews` views cannot
+  be updated or deleted (`409`). User custom URL views persist `url` / `customView`.
 - Admin write is durable on H2 and other supported databases: after POST, GET
   list includes the name. A POST that cannot be cataloged is not **200**.
-- **Developer → Views** chrome can create and delete standard views (field
-  criteria stay read-only). Inbox-family views stay **409** on mutate/delete.
+- **Developer → Views** chrome can create and delete standard views. Inbox-family
+  views stay **409** on mutate/delete. User custom URL view SPA chrome is a
+  separate slice.
 - Operator Inbox run-from-tree is Explorer **Views → My Content → Inbox**, not a
   free-floating Inbox root.
 

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -65,11 +65,13 @@ import org.w3c.dom.NodeList;
 
 /**
  * CX view definition catalog (UI-07 list/detail/write) plus view execute façade for Explorer
- * (#3115 / #3239 / #4070). Loads designs via {@link IPSUiDesignWs#findViews} / {@link
+ * (#3115 / #3239 / #4070 / #4235). Loads designs via {@link IPSUiDesignWs#findViews} / {@link
  * IPSUiDesignWs#loadViews} — not the search catalog. Admin create/save/delete persist through
  * {@link IPSUiDesignWs} — the same design web service SOAP uses. Execute is not invoked on write.
  * Standard views use the design search runner; Inbox-family custom URLs invoke {@code
- * sys_cxViews/*} and map {@code Item} rows to Explorer items.
+ * sys_cxViews/*} and map {@code Item} rows to Explorer items. Admin may persist <em>user</em>
+ * custom URL views ({@code url} + {@code customView}); Inbox-family / packaged {@code
+ * sys_cxViews} catalog keys stay conflict on mutate/delete.
  */
 @PSSiteManageBean
 @Lazy
@@ -80,7 +82,13 @@ public class ViewAdaptor implements IViewAdaptor {
   static final String ADMIN_REQUIRED = "Admin role required to create, update, or delete views";
 
   static final String PROTECTED_VIEW_WRITE =
-      "Inbox-family and custom URL views cannot be updated or deleted via this API";
+      "Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API";
+
+  /** Explicit 400 when a user custom URL view is missing {@code url}. */
+  static final String CUSTOM_VIEW_URL_REQUIRED = "Custom URL view requires a non-blank url";
+
+  /** Explicit 400 when {@code url} is not a relative classic application path. */
+  static final String CUSTOM_VIEW_URL_INVALID = "Invalid custom view URL";
 
   /** Product default page size when design max is unset/unlimited and client omits maxResults. */
   static final int DEFAULT_PAGE_SIZE = 25;
@@ -107,11 +115,24 @@ public class ViewAdaptor implements IViewAdaptor {
           + " sys_cxViews/outbox, sys_cxViews/recent, sys_cxViews/session,"
           + " sys_cxViews/checkedoutbyme, and sys_cxViews/duplicatefolderpaths.";
 
+  /**
+   * Packaged CX custom-view internal names (sys_cxViews). PUT/DELETE of these keys is 409;
+   * user-created custom URL views with other names remain writable.
+   */
+  static final Set<String> PACKAGED_CX_VIEW_NAMES =
+      Set.of(
+          "inbox",
+          "outbox",
+          "recent",
+          "session",
+          "checked_out_by_me",
+          "duplicatefolderpaths");
+
   /** Catalog-level capability notes. Attached on detail only (REST-GAPS-02 list dedup). */
   static final List<String> DESIGN_GAPS =
       List.of(
           "View rename is not supported on PUT (name is the catalog key)",
-          "Inbox-family and custom URL views cannot be updated or deleted via this API",
+          "Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API",
           "Custom URL views outside the sys_cxViews Inbox family cannot be executed via this API",
           "Searches are a separate catalog (Developer Searches / UI-06)");
 
@@ -210,7 +231,9 @@ public class ViewAdaptor implements IViewAdaptor {
     }
     String name = requireValidName(body.getName());
     assertNameUnique(name);
-    rejectCustomUrlCreate(body);
+    if (isCustomUrlWrite(body)) {
+      requireValidCustomViewUrl(body.getUrl());
+    }
     resolveViewType(body.getType(), true);
     String session = currentSession();
     String user = currentUser();
@@ -272,6 +295,7 @@ public class ViewAdaptor implements IViewAdaptor {
       return null;
     }
     rejectProtectedViewWrite(existing);
+    rejectBlankCustomUrlOnSave(existing, body);
     IPSGuid id = safeGuid(existing);
     if (id == null) {
       throw new WebApplicationException(PROTECTED_VIEW_WRITE, 409);
@@ -1090,6 +1114,14 @@ public class ViewAdaptor implements IViewAdaptor {
     if (StringUtils.isNotBlank(body.getDisplayFormatId())) {
       domain.setDisplayFormatId(body.getDisplayFormatId().trim());
     }
+    boolean custom = domain.isCustomView() || isCustomUrlWrite(body);
+    if (custom) {
+      domain.setCustom(true);
+      if (StringUtils.isNotBlank(body.getUrl())) {
+        domain.setUrl(requireValidCustomViewUrl(body.getUrl()));
+      }
+      return;
+    }
     if (body.getFields() != null) {
       applyFields(domain, body.getFields());
     }
@@ -1229,7 +1261,8 @@ public class ViewAdaptor implements IViewAdaptor {
 
   /**
    * Map REST type aliases to {@link PSSearch#TYPE_VIEW}. Blank on create defaults to View. Search
-   * and custom types are rejected.
+   * types are rejected. {@code custom} / {@code CustomView} stay {@link PSSearch#TYPE_VIEW} (custom
+   * URL is {@code setCustom} + {@code url}, not a search type).
    *
    * @param creating when true, blank type becomes View; when false, blank means leave unchanged
    */
@@ -1240,16 +1273,13 @@ public class ViewAdaptor implements IViewAdaptor {
     String t = raw.trim();
     if (t.equalsIgnoreCase(PSSearch.TYPE_VIEW)
         || t.equalsIgnoreCase("standard")
-        || t.equalsIgnoreCase("standardview")) {
+        || t.equalsIgnoreCase("standardview")
+        || t.equalsIgnoreCase("custom")
+        || t.equalsIgnoreCase("customview")) {
       return PSSearch.TYPE_VIEW;
     }
-    if (t.equalsIgnoreCase("custom")
-        || t.equalsIgnoreCase("customview")
-        || t.equalsIgnoreCase(PSSearch.TYPE_CUSTOMSEARCH)) {
-      throw new IllegalArgumentException(
-          "Custom URL views cannot be created or updated via this API");
-    }
-    if (t.equalsIgnoreCase(PSSearch.TYPE_STANDARDSEARCH)
+    if (t.equalsIgnoreCase(PSSearch.TYPE_CUSTOMSEARCH)
+        || t.equalsIgnoreCase(PSSearch.TYPE_STANDARDSEARCH)
         || t.equalsIgnoreCase(PSSearch.TYPE_USERSEARCH)
         || t.equalsIgnoreCase("search")
         || t.equalsIgnoreCase("usersearch")) {
@@ -1321,10 +1351,90 @@ public class ViewAdaptor implements IViewAdaptor {
     return false;
   }
 
-  static void rejectCustomUrlCreate(ViewDef body) {
-    if (body != null && StringUtils.isNotBlank(body.getUrl())) {
+  /**
+   * True when the wire body is a user custom URL view write: {@code customView}, type {@code
+   * custom}/{@code CustomView}, or a non-blank {@code url}.
+   */
+  static boolean isCustomUrlWrite(ViewDef body) {
+    if (body == null) {
+      return false;
+    }
+    if (body.isCustomView()) {
+      return true;
+    }
+    if (StringUtils.isNotBlank(body.getUrl())) {
+      return true;
+    }
+    String type = body.getType();
+    if (StringUtils.isBlank(type)) {
+      return false;
+    }
+    String t = type.trim();
+    return t.equalsIgnoreCase("custom") || t.equalsIgnoreCase("customview");
+  }
+
+  /**
+   * Validate a classic custom-view URL. Blank/placeholder is 400; absolute/scheme, backslash,
+   * NUL, and path traversal after leading {@code ../} are invalid.
+   */
+  static String requireValidCustomViewUrl(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_REQUIRED);
+    }
+    String url = raw.trim();
+    if (url.equalsIgnoreCase(PSSearch.URL_PLACEHOLDER)) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_REQUIRED);
+    }
+    if (url.length() > PSSearch.CUSTOMURL_LENGTH) {
       throw new IllegalArgumentException(
-          "Custom URL views cannot be created or updated via this API");
+          "Custom url must not exceed " + PSSearch.CUSTOMURL_LENGTH + " characters");
+    }
+    if (url.indexOf('\\') >= 0 || url.indexOf('\0') >= 0) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_INVALID);
+    }
+    String lower = url.toLowerCase(Locale.ROOT);
+    if (lower.contains("://") || lower.startsWith("file:") || lower.startsWith("//")) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_INVALID);
+    }
+    String rest = url;
+    while (rest.startsWith("../")) {
+      rest = rest.substring(3);
+    }
+    if (rest.startsWith("./")) {
+      rest = rest.substring(2);
+    }
+    if (rest.isEmpty() || rest.contains("..")) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_INVALID);
+    }
+    return url;
+  }
+
+  static boolean isPackagedCxViewName(String name) {
+    if (isInboxKey(name)) {
+      return true;
+    }
+    if (StringUtils.isBlank(name)) {
+      return false;
+    }
+    String key = name.trim().toLowerCase(Locale.ROOT).replace(' ', '_');
+    return PACKAGED_CX_VIEW_NAMES.contains(key);
+  }
+
+  private static void rejectBlankCustomUrlOnSave(PSSearch existing, ViewDef body) {
+    boolean converting = existing != null && !existing.isCustomView() && isCustomUrlWrite(body);
+    if (converting) {
+      requireValidCustomViewUrl(body != null ? body.getUrl() : null);
+      return;
+    }
+    if (existing != null
+        && existing.isCustomView()
+        && body != null
+        && body.getUrl() != null
+        && StringUtils.isBlank(body.getUrl())) {
+      throw new IllegalArgumentException(CUSTOM_VIEW_URL_REQUIRED);
+    }
+    if (body != null && body.getUrl() != null && StringUtils.isNotBlank(body.getUrl())) {
+      requireValidCustomViewUrl(body.getUrl());
     }
   }
 
@@ -1332,7 +1442,7 @@ public class ViewAdaptor implements IViewAdaptor {
     if (existing == null) {
       return;
     }
-    if (isInboxKey(existing.getName()) || existing.isCustomView()) {
+    if (isPackagedCxViewName(existing.getName())) {
       throw new WebApplicationException(PROTECTED_VIEW_WRITE, 409);
     }
   }

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ViewAdaptor.java
@@ -1375,7 +1375,8 @@ public class ViewAdaptor implements IViewAdaptor {
 
   /**
    * Validate a classic custom-view URL. Blank/placeholder is 400; absolute/scheme, backslash,
-   * NUL, and path traversal after leading {@code ../} are invalid.
+   * NUL, and path traversal are invalid. At most one leading {@code ../} is allowed (classic CX
+   * app path); further {@code ../} segments or any remaining {@code ..} are rejected.
    */
   static String requireValidCustomViewUrl(String raw) {
     if (StringUtils.isBlank(raw)) {
@@ -1396,8 +1397,10 @@ public class ViewAdaptor implements IViewAdaptor {
     if (lower.contains("://") || lower.startsWith("file:") || lower.startsWith("//")) {
       throw new IllegalArgumentException(CUSTOM_VIEW_URL_INVALID);
     }
+    // Classic CX paths use a single leading "../app/...". Strip at most one; leftover ".." is
+    // traversal (e.g. "../../etc/passwd" must not pass after multi-strip).
     String rest = url;
-    while (rest.startsWith("../")) {
+    if (rest.startsWith("../")) {
       rest = rest.substring(3);
     }
     if (rest.startsWith("./")) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorFieldsTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorFieldsTest.java
@@ -124,6 +124,25 @@ class ViewAdaptorFieldsTest {
   }
 
   @Test
+  void applyWritableFields_customUrlRoundTripsOnRealPsSearch() throws Exception {
+    PSSearch view = new PSSearch("MyCustom");
+    view.setType(PSSearch.TYPE_VIEW);
+    ViewDef body = new ViewDef();
+    body.setType("CustomView");
+    body.setCustomView(true);
+    body.setUrl("../myApp/page.xml");
+    body.setLabel("My Custom");
+    ViewAdaptor.applyWritableFields(view, body);
+    assertTrue(view.isCustomView());
+    assertEquals("../myApp/page.xml", view.getUrl());
+    assertEquals("My Custom", view.getLabel());
+    ViewDef out = ViewAdaptor.toDef(view, true);
+    assertTrue(out.isCustomView());
+    assertEquals("../myApp/page.xml", out.getUrl());
+    assertFalse(out.isStandardView());
+  }
+
+  @Test
   void requireValidFieldName_unknownIs400Shape() {
     IllegalArgumentException blank =
         assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.requireValidFieldName("  "));

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -409,6 +410,39 @@ class ViewAdaptorWriteTest {
   }
 
   @Test
+  void update_standardView_toCustomUrl_convertsAndRoundTrips() throws Exception {
+    PSSearch existing = stubView("MyView", false);
+    stubCatalogLoad(existing);
+    PSSearch locked = stubView("MyView", false);
+    when(locked.getUrl()).thenReturn("../myApp/converted.xml");
+    // Mock does not flip isCustomView on setCustom; mirror domain after conversion.
+    doAnswer(
+            inv -> {
+              when(locked.isCustomView()).thenReturn(true);
+              when(locked.isStandardView()).thenReturn(false);
+              return null;
+            })
+        .when(locked)
+        .setCustom(true);
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ViewDef body = new ViewDef();
+    body.setType("CustomView");
+    body.setCustomView(true);
+    body.setUrl("../myApp/converted.xml");
+
+    ViewDef out = adaptor.saveView("MyView", body);
+
+    assertEquals("MyView", out.getName());
+    assertEquals("../myApp/converted.xml", out.getUrl());
+    assertTrue(out.isCustomView());
+    verify(locked).setCustom(true);
+    verify(locked).setUrl("../myApp/converted.xml");
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
   void update_lockConflict_is409() throws Exception {
     PSSearch existing = stubView("MyView", false);
     stubCatalogLoad(existing);
@@ -551,9 +585,16 @@ class ViewAdaptorWriteTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> ViewAdaptor.requireValidCustomViewUrl("../myApp/../../etc/passwd"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ViewAdaptor.requireValidCustomViewUrl("../../etc/passwd"));
     assertTrue(ViewAdaptor.isPackagedCxViewName("Inbox"));
     assertTrue(ViewAdaptor.isPackagedCxViewName("Outbox"));
     assertTrue(ViewAdaptor.isPackagedCxViewName("Checked_Out_By_Me"));
+    assertTrue(ViewAdaptor.isPackagedCxViewName("INBOX"));
+    assertTrue(ViewAdaptor.isPackagedCxViewName("inbox"));
+    assertTrue(ViewAdaptor.isPackagedCxViewName("Outbox "));
+    assertTrue(ViewAdaptor.isPackagedCxViewName("checked out by me"));
     assertFalse(ViewAdaptor.isPackagedCxViewName("MyCustom"));
   }
 

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ViewAdaptorWriteTest.java
@@ -55,7 +55,8 @@ import org.mockito.ArgumentCaptor;
 
 /**
  * UI-07 POST create / PUT update / DELETE persist via {@code createViews}/{@code saveViews}/{@code
- * deleteViews}. Admin only; unique name; no lock steal; Inbox/custom URL is 409.
+ * deleteViews}. Admin only; unique name; no lock steal; Inbox-family / packaged {@code
+ * sys_cxViews} keys are 409. User custom URL views persist {@code url}.
  */
 @Tag("UnitTest")
 class ViewAdaptorWriteTest {
@@ -215,13 +216,52 @@ class ViewAdaptorWriteTest {
   }
 
   @Test
-  void create_customUrl_is400() {
+  void create_customUrl_roundTripsUrlAndCustomView() throws Exception {
+    PSSearch view = stubView("MyCustom", true);
+    when(view.getUrl()).thenReturn("../myApp/page.xml");
+    when(designWs.createViews(eq(List.of("MyCustom")), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(view));
+    stubCatalogVisibleAfterSave(view);
+
     ViewDef body = new ViewDef();
-    body.setName("MyInbox");
-    body.setUrl("../sys_cxViews/inbox.xml");
+    body.setName("MyCustom");
+    body.setType("CustomView");
+    body.setCustomView(true);
+    body.setUrl("../myApp/page.xml");
+    body.setLabel("My Custom");
+
+    ViewDef out = adaptor.createView(body);
+
+    assertEquals("MyCustom", out.getName());
+    assertEquals("../myApp/page.xml", out.getUrl());
+    assertTrue(out.isCustomView());
+    verify(designWs).createViews(eq(List.of("MyCustom")), eq("test-session"), eq("Admin"));
+    verify(view).setCustom(true);
+    verify(view).setUrl("../myApp/page.xml");
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void create_blankCustomUrl_is400() {
+    ViewDef body = new ViewDef();
+    body.setName("MyCustom");
+    body.setType("CustomView");
+    body.setCustomView(true);
+    body.setUrl("  ");
     IllegalArgumentException ex =
         assertThrows(IllegalArgumentException.class, () -> adaptor.createView(body));
-    assertTrue(ex.getMessage().toLowerCase().contains("custom"));
+    assertTrue(ex.getMessage().toLowerCase().contains("url"), ex.getMessage());
+    verify(designWs, never()).createViews(anyList(), any(), any());
+  }
+
+  @Test
+  void create_invalidCustomUrl_is400() {
+    ViewDef body = new ViewDef();
+    body.setName("MyCustom");
+    body.setUrl("https://evil.example/view");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.createView(body));
+    assertTrue(ex.getMessage().toLowerCase().contains("invalid"), ex.getMessage());
     verify(designWs, never()).createViews(anyList(), any(), any());
   }
 
@@ -321,6 +361,54 @@ class ViewAdaptorWriteTest {
   }
 
   @Test
+  void update_packagedOutbox_is409() throws Exception {
+    PSSearch outbox = stubView("Outbox", true);
+    stubCatalogLoad(outbox);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> adaptor.saveView("Outbox", new ViewDef()));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_userCustomUrl_updatesUrl() throws Exception {
+    PSSearch existing = stubView("MyCustom", true);
+    when(existing.getUrl()).thenReturn("../myApp/page.xml");
+    stubCatalogLoad(existing);
+    PSSearch locked = stubView("MyCustom", true);
+    when(locked.getUrl()).thenReturn("../myApp/updated.xml");
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(locked));
+
+    ViewDef body = new ViewDef();
+    body.setUrl("../myApp/updated.xml");
+    body.setCustomView(true);
+
+    ViewDef out = adaptor.saveView("MyCustom", body);
+
+    assertEquals("MyCustom", out.getName());
+    assertEquals("../myApp/updated.xml", out.getUrl());
+    assertTrue(out.isCustomView());
+    verify(locked).setCustom(true);
+    verify(locked).setUrl("../myApp/updated.xml");
+    verify(designWs).saveViews(anyList(), eq(true), eq("test-session"), eq("Admin"));
+  }
+
+  @Test
+  void update_userCustomUrl_blankUrl_is400() throws Exception {
+    PSSearch existing = stubView("MyCustom", true);
+    when(existing.getUrl()).thenReturn("../myApp/page.xml");
+    stubCatalogLoad(existing);
+
+    ViewDef body = new ViewDef();
+    body.setUrl("  ");
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> adaptor.saveView("MyCustom", body));
+    assertTrue(ex.getMessage().toLowerCase().contains("url"), ex.getMessage());
+    verify(designWs, never()).saveViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
   void update_lockConflict_is409() throws Exception {
     PSSearch existing = stubView("MyView", false);
     stubCatalogLoad(existing);
@@ -375,13 +463,25 @@ class ViewAdaptorWriteTest {
   }
 
   @Test
-  void delete_customUrl_is409() throws Exception {
-    PSSearch custom = stubView("MyCustom", true);
+  void delete_packagedCustomUrl_is409() throws Exception {
+    PSSearch custom = stubView("Recent", true);
     stubCatalogLoad(custom);
     WebApplicationException ex =
-        assertThrows(WebApplicationException.class, () -> adaptor.deleteView("MyCustom"));
+        assertThrows(WebApplicationException.class, () -> adaptor.deleteView("Recent"));
     assertEquals(409, ex.getResponse().getStatus());
     verify(designWs, never()).deleteViews(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_userCustomUrl_succeeds() throws Exception {
+    PSSearch existing = stubView("MyCustom", true);
+    when(existing.getUrl()).thenReturn("../myApp/page.xml");
+    stubCatalogLoad(existing);
+    when(designWs.loadViews(anyList(), eq(true), eq(false), eq("test-session"), eq("Admin")))
+        .thenReturn(List.of(existing));
+
+    assertTrue(adaptor.deleteView("MyCustom"));
+    verify(designWs).deleteViews(eq(List.of(guid)), eq(false), eq("test-session"), eq("Admin"));
   }
 
   @Test
@@ -430,10 +530,31 @@ class ViewAdaptorWriteTest {
     assertNull(ViewAdaptor.resolveViewType(null, false));
     assertEquals(PSSearch.TYPE_VIEW, ViewAdaptor.resolveViewType("standard", true));
     assertEquals(PSSearch.TYPE_VIEW, ViewAdaptor.resolveViewType("View", true));
-    assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.resolveViewType("custom", true));
+    assertEquals(PSSearch.TYPE_VIEW, ViewAdaptor.resolveViewType("custom", true));
+    assertEquals(PSSearch.TYPE_VIEW, ViewAdaptor.resolveViewType("CustomView", true));
     assertThrows(
         IllegalArgumentException.class, () -> ViewAdaptor.resolveViewType("StandardSearch", true));
     assertThrows(IllegalArgumentException.class, () -> ViewAdaptor.resolveViewType("nope", true));
+  }
+
+  @Test
+  void requireValidCustomViewUrl_rejectsBlankAndInvalid() {
+    assertEquals("../myApp/page.xml", ViewAdaptor.requireValidCustomViewUrl("../myApp/page.xml"));
+    assertThrows(
+        IllegalArgumentException.class, () -> ViewAdaptor.requireValidCustomViewUrl("  "));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ViewAdaptor.requireValidCustomViewUrl(PSSearch.URL_PLACEHOLDER));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ViewAdaptor.requireValidCustomViewUrl("https://evil.example/x"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ViewAdaptor.requireValidCustomViewUrl("../myApp/../../etc/passwd"));
+    assertTrue(ViewAdaptor.isPackagedCxViewName("Inbox"));
+    assertTrue(ViewAdaptor.isPackagedCxViewName("Outbox"));
+    assertTrue(ViewAdaptor.isPackagedCxViewName("Checked_Out_By_Me"));
+    assertFalse(ViewAdaptor.isPackagedCxViewName("MyCustom"));
   }
 
   @Test

--- a/rest/src/main/java/com/percussion/rest/views/IViewAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/views/IViewAdaptor.java
@@ -36,8 +36,9 @@ public interface IViewAdaptor {
   ViewExecuteResult executeView(String idOrName, ViewExecuteRequest request);
 
   /**
-   * Admin. Create and persist a CX standard (field-criteria) view ({@code createViews} then
-   * {@code saveViews}).
+   * Admin. Create and persist a CX view ({@code createViews} then {@code saveViews}). Standard
+   * (field-criteria) views omit {@code url}. User custom URL views require {@code url} (type
+   * {@code CustomView} or {@code customView=true}).
    *
    * @param body required; {@code name} is the unique catalog key
    * @return the persisted view
@@ -46,19 +47,19 @@ public interface IViewAdaptor {
 
   /**
    * Admin. Update and persist a CX view by name or GUID ({@code loadViews} lock, {@code
-   * saveViews} release). Does not steal another user's lock. Inbox-family and custom URL views
-   * are not mutated.
+   * saveViews} release). Does not steal another user's lock. Inbox-family and packaged {@code
+   * sys_cxViews} catalog keys are not mutated. User custom URL views may update {@code url}.
    *
    * @param idOrName catalog key (same rules as {@link #findViewByKey})
-   * @param body required writable fields (label, description, type, displayFormat)
+   * @param body required writable fields (label, description, type, displayFormat, url)
    * @return the persisted view, or {@code null} when missing/unsafe
    */
   ViewDef saveView(String idOrName, ViewDef body);
 
   /**
    * Admin. Delete a CX view by name or GUID ({@code deleteViews}, {@code
-   * ignoreDependencies=false}). Does not steal another user's lock. Inbox-family and custom URL
-   * views return conflict (not deleted).
+   * ignoreDependencies=false}). Does not steal another user's lock. Inbox-family and packaged
+   * {@code sys_cxViews} catalog keys return conflict (not deleted).
    *
    * @param idOrName catalog key (same rules as {@link #findViewByKey})
    * @return {@code true} when deleted, {@code false} when missing/unsafe

--- a/rest/src/main/java/com/percussion/rest/views/ViewResource.java
+++ b/rest/src/main/java/com/percussion/rest/views/ViewResource.java
@@ -32,8 +32,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * <p>Searches (UI-06) remain a separate catalog. Admin POST/PUT/DELETE persist through {@link
  * IViewAdaptor} ({@code IPSUiDesignWs} create/save/delete views). Execute is a separate façade
  * and is not invoked from write. Inbox-family custom-URL views ({@code sys_cxViews/inbox} and
- * documented peers) are executed on this same path; other custom URLs return 400. Inbox/system
- * custom-URL views cannot be updated or deleted here.
+ * documented peers) are executed on this same path; other custom URLs return 400 on execute.
+ * Admin may POST/PUT a <em>user</em> custom URL view ({@code url} required). Inbox-family and
+ * packaged {@code sys_cxViews} catalog keys cannot be updated or deleted here.
  */
 @PSSiteManageBean(value = "restViewResource")
 @Path("/views")
@@ -164,12 +165,12 @@ public class ViewResource {
   @Operation(
       summary = "Create view",
       description =
-          "Admin. Creates and persists a CX standard (field-criteria) view via"
-              + " IPSUiDesignWs.createViews then saveViews (held design lock, released on save)."
-              + " Name is required, unique (case-insensitive), and must not contain whitespace"
-              + " or wildcards. Optional label, description, type (View default), and"
-              + " displayFormatId are applied before save. Duplicate name is 409. Custom URL"
-              + " views are not created here. Searches are not created here (use"
+          "Admin. Creates and persists a CX view via IPSUiDesignWs.createViews then saveViews"
+              + " (held design lock, released on save). Name is required, unique"
+              + " (case-insensitive), and must not contain whitespace or wildcards. Optional"
+              + " label, description, type (View default), and displayFormatId are applied"
+              + " before save. Type CustomView (or customView=true) requires url. Duplicate name"
+              + " is 409. Blank/invalid url is 400. Searches are not created here (use"
               + " /services/searches). Execute is not invoked on write.",
       responses = {
         @ApiResponse(
@@ -209,13 +210,14 @@ public class ViewResource {
   @Operation(
       summary = "Update view",
       description =
-          "Admin. Updates label, description, type, displayFormatId, and/or field criteria by"
-              + " name or GUID. Name is the catalog key and is not renamed on PUT. Omitted"
+          "Admin. Updates label, description, type, displayFormatId, url, and/or field criteria"
+              + " by name or GUID. Name is the catalog key and is not renamed on PUT. Omitted"
               + " fields leave existing criteria unchanged; an empty fields array clears them."
-              + " Unknown field names are 400. Loads with a design lock (overrideLock=false)"
-              + " and releases on save. Unknown id is 404. Lock/dependency conflict is 409."
-              + " Inbox-family and custom URL views are 409 (not mutated). Searches are not"
-              + " saved here. Execute is not invoked on write.",
+              + " Unknown field names are 400. User custom URL views may update url (blank url"
+              + " is 400). Loads with a design lock (overrideLock=false) and releases on save."
+              + " Unknown id is 404. Lock/dependency conflict is 409. Inbox-family and packaged"
+              + " sys_cxViews views are 409 (not mutated). Searches are not saved here. Execute"
+              + " is not invoked on write.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -229,7 +231,7 @@ public class ViewResource {
         @ApiResponse(
             responseCode = "409",
             description =
-                "Design lock, dependency conflict, or Inbox/custom URL view cannot be mutated"),
+                "Design lock, dependency conflict, or packaged sys_cxViews view cannot be mutated"),
         @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })
@@ -257,8 +259,8 @@ public class ViewResource {
       description =
           "Admin. Deletes a CX view by name or GUID via IPSUiDesignWs.deleteViews"
               + " (ignoreDependencies=false). Unknown id is 404. Lock/dependency conflict is 409."
-              + " Inbox-family and custom URL views are 409 (not deleted). Following GET is 404"
-              + " after a successful delete. Searches are not deleted here.",
+              + " Inbox-family and packaged sys_cxViews views are 409 (not deleted). Following"
+              + " GET is 404 after a successful delete. Searches are not deleted here.",
       responses = {
         @ApiResponse(responseCode = "204", description = "Deleted"),
         @ApiResponse(responseCode = "400", description = "Invalid input"),
@@ -269,7 +271,7 @@ public class ViewResource {
         @ApiResponse(
             responseCode = "409",
             description =
-                "Design lock, dependency conflict, or Inbox/custom URL view cannot be deleted"),
+                "Design lock, dependency conflict, or packaged sys_cxViews view cannot be deleted"),
         @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
         @ApiResponse(responseCode = "500", description = "Error")
       })

--- a/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/views/ViewResourceTest.java
@@ -244,6 +244,40 @@ public class ViewResourceTest {
   }
 
   @Test
+  public void createViewCustomUrlDelegates() {
+    ViewDef body = new ViewDef();
+    body.setName("MyCustom");
+    body.setType("CustomView");
+    body.setCustomView(true);
+    body.setUrl("../myApp/page.xml");
+    ViewDef created = new ViewDef();
+    created.setName("MyCustom");
+    created.setUrl("../myApp/page.xml");
+    created.setCustomView(true);
+    when(adaptor.createView(any())).thenReturn(created);
+
+    ViewDef out = resource.createView(body);
+
+    assertEquals("MyCustom", out.getName());
+    assertEquals("../myApp/page.xml", out.getUrl());
+    assertTrue(out.isCustomView());
+    verify(adaptor).createView(body);
+  }
+
+  @Test
+  public void createViewBlankUrlIs400() {
+    when(adaptor.createView(any()))
+        .thenThrow(new IllegalArgumentException("Custom URL view requires a non-blank url"));
+    ViewDef body = new ViewDef();
+    body.setName("MyCustom");
+    body.setType("CustomView");
+    body.setUrl("  ");
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.createView(body));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
   public void createViewBlankNameIs400() {
     when(adaptor.createView(any())).thenThrow(new IllegalArgumentException("name is required"));
     ViewDef body = new ViewDef();
@@ -311,11 +345,29 @@ public class ViewResourceTest {
   }
 
   @Test
+  public void updateViewCustomUrlDelegates() {
+    ViewDef body = new ViewDef();
+    body.setUrl("../myApp/updated.xml");
+    body.setCustomView(true);
+    ViewDef updated = new ViewDef();
+    updated.setName("MyCustom");
+    updated.setUrl("../myApp/updated.xml");
+    updated.setCustomView(true);
+    when(adaptor.saveView(eq("MyCustom"), eq(body))).thenReturn(updated);
+
+    ViewDef out = resource.updateView("MyCustom", body);
+
+    assertEquals("../myApp/updated.xml", out.getUrl());
+    assertTrue(out.isCustomView());
+    verify(adaptor).saveView("MyCustom", body);
+  }
+
+  @Test
   public void updateViewInboxIs409() {
     when(adaptor.saveView(eq("Inbox"), any()))
         .thenThrow(
             new WebApplicationException(
-                "Inbox-family and custom URL views cannot be updated or deleted via this API",
+                "Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API",
                 409));
     WebApplicationException ex =
         assertThrows(
@@ -355,7 +407,7 @@ public class ViewResourceTest {
     when(adaptor.deleteView(eq("Inbox")))
         .thenThrow(
             new WebApplicationException(
-                "Inbox-family and custom URL views cannot be updated or deleted via this API",
+                "Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API",
                 409));
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> resource.deleteView("Inbox"));


### PR DESCRIPTION
## Summary

REST **UI-07** slice of parent [#1690](https://github.com/intersoftdatalabs-in/percussioncms/issues/1690): Admin can **POST** a uniquely named user `CustomView` with required `url` and **PUT** that same user custom URL view. `GET` round-trips `url` and `customView=true`. Persist uses existing `IPSUiDesignWs` (`createViews` / `loadViews` lock with `overrideLock=false` / `saveViews` release). Inbox-family and packaged `sys_cxViews` catalog keys (`Inbox`, `Outbox`, `Recent`, `Session`, `Checked_Out_By_Me`, `DuplicateFolderPaths`) stay **409**. Blank/invalid URL is **400**; non-Admin **403**; duplicate name **409**.

SPA chrome and Playwright are **out of scope** (siblings #4236 / #4237).

Fixes #4235  
Parent: #1690

Operator: Grok: night-issue-prs (model grok-4.6)

## Test plan

1. `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 1036, Failures: 0). `ViewResourceTest` includes custom URL POST/PUT and blank URL 400.
2. `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS (Tests run: 2182, Failures: 0). `ViewAdaptorWriteTest` / `ViewAdaptorFieldsTest` cover create/PUT round-trip on exact `PSSearch` types, packaged 409, blank/invalid URL 400.
3. Review `product-docs/8.2/developer/rest.md` View write contract for user custom URL POST/PUT and Inbox-family 409.

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/developer/rest.md` View write contract
- [x] **Unit / module tests** — resource + adaptor behavioral tests; standalone `mvnw clean install` green
- [x] **WebUI + Playwright** — N/A (no WebUI product screen change; siblings #4236/#4237)
- [x] **Build gates** — `rest` then `projects/sitemanage` standalone clean install (no skipTests)
- [x] **Cross-platform** — N/A for filesystem I/O; classic view URLs correctly use `/`

## C3 evidence

- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:**
  - `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1036, Failures: 0 (`ViewResourceTest` 33/0; `MainTest` 2/0)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2182, Failures: 0 (`ViewAdaptorWriteTest` 33/0; `ViewAdaptorFieldsTest` 13/0)
- **downstream_checked:** C2 did not apply (no `final`/`sealed` or public signature change). Reverse-dep `projects/sitemanage` was still standalone clean-installed because it implements `IViewAdaptor`.
- **C5 UI proof:** N/A (Java REST/adaptor only; no SPA/Playwright this slice)

> Co-Authored by Grok Build 1.0.5 using grok-4.6 with agent night-issue-prs.
