### PR TITLE
feat(rest): SY-01 extension register/update/delete (#4239)

### DIFF
--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1827,6 +1827,85 @@ Example create body:
 | `500` | Control manager or file I/O failure |
 | `503` | Control adaptor not configured |
 
+## Extensions (catalog)
+
+Server **extension** registrations (Workbench / Developer **Extension Registration**, SY-01) are
+exposed under `/services/extensions`. List and detail include system (`global/percussion/...`),
+handler-owned, and user (`user/`) extensions. Backing is **ALT** — `IPSExtensionService` /
+`IPSExtensionManager` — there is no SOAP design twin and this API does not invent one.
+
+Admin **write** registers, updates, and deletes **user** extensions only. New registrations are
+forced under context `user/`. Packaged **system** extensions (`global/percussion/...`) and
+**handler-owned** extensions (`ExtensionHandler` / `Handlers`) are read-only (**409** on mutate).
+**Do not** treat this as a Developer Extensions SPA; create/edit chrome is a later sibling.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/extensions/catalog` | List registered extensions |
+| `GET` | `/services/extensions/catalog/item?key=` | Load one extension by FQN or short name |
+| `POST` | `/services/extensions` | **Admin.** Register (install) a user extension under `user/` |
+| `PUT` | `/services/extensions/catalog/item?key=` | **Admin.** Update mutable fields of a user extension |
+| `DELETE` | `/services/extensions/catalog/item?key=` | **Admin.** Delete a user extension |
+| `POST` | `/services/extensions/list` | Filtered list (`ExtensionFilterOptions` body) |
+
+JSON objects use the `Extension` wire type. POST/PUT JSON is wrapped under an `Extension`
+root (JAXB/Jackson UNWRAP_ROOT_VALUE). Prefer the generated OpenAPI schema as the
+integration source of truth. Detail and write keys use a **query** parameter (`key`) because
+FQNs contain `/`.
+
+### Extension write contract (Admin)
+
+Register (`POST /services/extensions`) persists immediately via `IPSExtensionService.installExtension`.
+JSON body requires `extensionName` (valid Java identifier) and at least one
+`supportedInterfaces` entry. `handlerName` defaults to `Java`. Context is forced to `user/`
+(attempting `global/percussion/...` or handler context is **409**; other non-`user/` contexts
+are **400**). For Java handlers, `initParameters.className` is required. Duplicate FQN is
+**409**. Blank / invalid names or missing interfaces are **400**. Non-Admin is **403**. The
+new extension is then `GET /services/extensions/catalog/item?key=<FQN-or-name>` **200** and
+appears on `GET /services/extensions/catalog`.
+
+Update (`PUT /services/extensions/catalog/item?key=`) updates mutable fields of a **user**
+extension (init parameters, interfaces, runtime parameters, resource lists, deprecated /
+restore-on-error flags, version). Identity (`handlerName` / `context` / `extensionName`) is
+not renamed on PUT — round-trip GET then PUT for boolean flags. Unknown key is **404**. A
+**system** or **handler-owned** extension is **409**. Non-Admin is **403**.
+
+Delete (`DELETE /services/extensions/catalog/item?key=`) returns **204** when a user
+extension is removed; a following `GET` is **404**. Unknown key is **404**. A **system** or
+**handler-owned** extension is **409** (not deleted). Non-Admin is **403**.
+
+There is **no** Developer SPA extensions create/edit/delete in this slice — operators and
+integrators call the REST path (or Workbench).
+
+Example register body:
+
+```json
+{
+  "Extension": {
+    "extensionName": "my_user_ext",
+    "handlerName": "Java",
+    "supportedInterfaces": [
+      "com.percussion.extension.IPSUdfProcessor"
+    ],
+    "initParameters": {
+      "className": "com.example.MyUserExtension",
+      "com.percussion.user.description": "Created via REST"
+    }
+  }
+}
+```
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | List / get / register / update success |
+| `204` | Delete success |
+| `400` | Invalid input (missing name/interfaces/className, invalid handler/context/URLs) |
+| `403` | Caller is not Admin |
+| `404` | User extension not found |
+| `409` | Duplicate FQN, or attempt to mutate/delete a system or handler-owned extension |
+| `500` | Extension manager failure |
+| `503` | Extension adaptor not configured |
+
 ## Searches catalog and execute
 
 CX design **searches** (and optionally **views** on GET/execute) are exposed under

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/ExtensionAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/ExtensionAdaptor.java
@@ -17,27 +17,80 @@
 
 package com.percussion.apibridge;
 
+import com.percussion.design.objectstore.PSExtensionParamDef;
+import com.percussion.error.PSNonUniqueException;
 import com.percussion.error.PSNotFoundException;
-import com.percussion.extension.*;
+import com.percussion.extension.IPSExtensionDef;
+import com.percussion.extension.IPSExtensionHandler;
+import com.percussion.extension.PSExtensionDef;
+import com.percussion.extension.PSExtensionException;
+import com.percussion.extension.PSExtensionRef;
 import com.percussion.extensions.IPSExtensionService;
-import com.percussion.rest.extensions.*;
+import com.percussion.rest.extensions.Extension;
+import com.percussion.rest.extensions.ExtensionFilterOptions;
+import com.percussion.rest.extensions.ExtensionMethod;
+import com.percussion.rest.extensions.ExtensionParameter;
+import com.percussion.rest.extensions.IExtensionAdaptor;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.net.MalformedURLException;
 import java.net.URI;
-import java.util.*;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.BooleanSupplier;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
-/** Adaptor for managing Extensions in Percussion CMS. */
+/**
+ * Adaptor for Extension catalog and Admin user-extension write (SY-01) over {@link
+ * IPSExtensionService}. System ({@code global/percussion/...}) and handler-owned extensions are
+ * never mutated. New registrations are forced under context {@code user/}.
+ */
 @PSSiteManageBean
 public class ExtensionAdaptor implements IExtensionAdaptor {
 
+  private static final Logger log = LogManager.getLogger(ExtensionAdaptor.class);
+
+  static final String ADMIN_REQUIRED =
+      "Admin role required to register, update, or delete user extensions";
+
+  static final String IMMUTABLE_EXTENSION =
+      "System or handler-owned extensions cannot be updated or deleted";
+
+  /** Canonical context for Admin-registered user extensions (Workbench convention). */
+  static final String USER_CONTEXT = "user/";
+
+  static final String DEFAULT_HANDLER = "Java";
+
   private final IPSExtensionService extensionService;
-  private final Logger log = LogManager.getLogger(ExtensionAdaptor.class);
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   @Autowired
   public ExtensionAdaptor(IPSExtensionService extensionService) {
+    this(extensionService, null);
+  }
+
+  /** Package-visible for unit tests. */
+  ExtensionAdaptor(IPSExtensionService extensionService, BooleanSupplier adminChecker) {
     this.extensionService = extensionService;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   private Extension copyExtensionRef(PSExtensionRef ref) {
@@ -46,6 +99,7 @@ public class ExtensionAdaptor implements IExtensionAdaptor {
     ret.setContext(ref.getContext());
     ret.setExtensionName(ref.getExtensionName());
     ret.setHandlerName(ref.getHandlerName());
+    ret.setFqn(ref.getFQN());
 
     try {
       var def = extensionService.getExtensionDef(ref);
@@ -53,10 +107,11 @@ public class ExtensionAdaptor implements IExtensionAdaptor {
       ret.setDeprecated(def.isDeprecated());
       ret.setJexlExtension(def.isJexlExtension());
       ret.setVersion(def.getVersion());
+      ret.setRestoreRequestParamsOnError(def.isRestoreRequestParamsOnError());
 
       // Copy interfaces
       var interfaces = new ArrayList<String>();
-      def.getInterfaces().forEachRemaining(o -> interfaces.add(o));
+      def.getInterfaces().forEachRemaining(interfaces::add);
       ret.setSupportedInterfaces(interfaces);
 
       // Init params
@@ -69,8 +124,7 @@ public class ExtensionAdaptor implements IExtensionAdaptor {
       var methods = new HashMap<String, ExtensionMethod>();
       def.getMethods()
           .forEachRemaining(
-              methodObj -> {
-                var defMethod = methodObj;
+              defMethod -> {
                 var meth = new ExtensionMethod();
                 meth.setName(defMethod.getName());
                 meth.setDescription(defMethod.getDescription());
@@ -79,8 +133,7 @@ public class ExtensionAdaptor implements IExtensionAdaptor {
                 defMethod
                     .getParameters()
                     .forEachRemaining(
-                        paramObj -> {
-                          var emp = paramObj;
+                        emp -> {
                           var ep = new ExtensionParameter();
                           ep.setDataType(emp.getType());
                           ep.setDescription(emp.getDescription());
@@ -104,7 +157,10 @@ public class ExtensionAdaptor implements IExtensionAdaptor {
 
       // Supplied resources
       var supplied = new ArrayList<String>();
-      def.getSuppliedResources().forEachRemaining(res -> supplied.add(res.toString()));
+      Iterator<URL> suppliedIt = def.getSuppliedResources();
+      if (suppliedIt != null) {
+        suppliedIt.forEachRemaining(res -> supplied.add(res.toString()));
+      }
       ret.setSuppliedResources(supplied);
 
       // Runtime parameters
@@ -172,6 +228,461 @@ public class ExtensionAdaptor implements IExtensionAdaptor {
       }
     }
     return null;
+  }
+
+  @Override
+  public Extension registerExtension(URI baseURI, Extension body) {
+    requireAdmin();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String extensionName = requireValidExtensionName(body.getExtensionName());
+    String handlerName = resolveHandlerName(body.getHandlerName());
+    String category = StringUtils.defaultString(body.getCategory());
+    List<String> interfaces = requireInterfaces(body.getSupportedInterfaces());
+    rejectImmutableRegistrationContext(body.getContext());
+
+    PSExtensionRef ref = new PSExtensionRef(category, handlerName, USER_CONTEXT, extensionName);
+    assertRefAvailable(ref);
+    if ("Java".equalsIgnoreCase(handlerName)) {
+      requireJavaClassName(body.getInitParameters());
+    }
+
+    PSExtensionDef def =
+        buildDef(
+            ref,
+            interfaces,
+            body.getInitParameters(),
+            body.getRuntimeParameters(),
+            body.getResourceLocations(),
+            body.getSuppliedResources(),
+            body.getRequiredApplications(),
+            body.isDeprecated(),
+            body.isRestoreRequestParamsOnError(),
+            body.getVersion());
+
+    try {
+      extensionService.installExtension(def, Collections.emptyIterator());
+    } catch (PSNonUniqueException e) {
+      throw new WebApplicationException("Extension already exists: " + ref.getFQN(), 409);
+    } catch (PSNotFoundException e) {
+      throw new IllegalArgumentException("Extension handler not found: " + handlerName, e);
+    } catch (PSExtensionException e) {
+      throw new IllegalStateException("Failed to register extension: " + e.getMessage(), e);
+    }
+
+    Extension created = findExtensionByKey(baseURI, ref.getFQN());
+    if (created == null) {
+      created = copyExtensionRef(ref);
+    }
+    return created;
+  }
+
+  @Override
+  public Extension updateExtension(URI baseURI, String idOrName, Extension body) {
+    requireAdmin();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    if (!isSafeExtensionKey(idOrName)) {
+      return null;
+    }
+    Extension existing = findExtensionByKey(baseURI, idOrName);
+    if (existing == null) {
+      return null;
+    }
+    rejectImmutableMutation(existing);
+
+    PSExtensionRef ref = refFromExtension(existing);
+    IPSExtensionDef current;
+    try {
+      current = extensionService.getExtensionDef(ref);
+    } catch (PSNotFoundException e) {
+      return null;
+    } catch (PSExtensionException e) {
+      throw new IllegalStateException("Failed to load extension: " + e.getMessage(), e);
+    }
+
+    List<String> interfaces =
+        body.getSupportedInterfaces() != null && !body.getSupportedInterfaces().isEmpty()
+            ? requireInterfaces(body.getSupportedInterfaces())
+            : collectInterfaces(current);
+    Map<String, String> initParams =
+        mergeInitParams(current, body.getInitParameters());
+    if ("Java".equalsIgnoreCase(ref.getHandlerName())) {
+      requireJavaClassName(initParams);
+    }
+    List<ExtensionParameter> runtimeParams =
+        body.getRuntimeParameters() != null
+            ? body.getRuntimeParameters()
+            : copyRuntimeParams(current);
+    List<String> resourceLocations =
+        body.getResourceLocations() != null
+            ? body.getResourceLocations()
+            : copyUrlList(current.getResourceLocations());
+    List<String> suppliedResources =
+        body.getSuppliedResources() != null
+            ? body.getSuppliedResources()
+            : copyUrlList(current.getSuppliedResources());
+    List<String> requiredApps =
+        body.getRequiredApplications() != null
+            ? body.getRequiredApplications()
+            : copyRequiredApps(current);
+
+    // Wire booleans are primitives — clients should round-trip GET then PUT.
+    boolean deprecated = body.isDeprecated();
+    boolean restoreOnError = body.isRestoreRequestParamsOnError();
+    long version = body.getVersion() > 0 ? body.getVersion() : current.getVersion();
+
+    PSExtensionDef def =
+        buildDef(
+            ref,
+            interfaces,
+            initParams,
+            runtimeParams,
+            resourceLocations,
+            suppliedResources,
+            requiredApps,
+            deprecated,
+            restoreOnError,
+            version);
+
+    try {
+      extensionService.updateExtension(def, Collections.emptyIterator());
+    } catch (PSNotFoundException e) {
+      return null;
+    } catch (PSExtensionException e) {
+      throw new IllegalStateException("Failed to update extension: " + e.getMessage(), e);
+    }
+
+    Extension updated = findExtensionByKey(baseURI, ref.getFQN());
+    if (updated == null) {
+      updated = copyExtensionRef(ref);
+    }
+    return updated;
+  }
+
+  @Override
+  public boolean deleteExtension(URI baseURI, String idOrName) {
+    requireAdmin();
+    if (!isSafeExtensionKey(idOrName)) {
+      return false;
+    }
+    Extension existing = findExtensionByKey(baseURI, idOrName);
+    if (existing == null) {
+      return false;
+    }
+    rejectImmutableMutation(existing);
+    PSExtensionRef ref = refFromExtension(existing);
+    try {
+      extensionService.removeExtension(ref);
+      return true;
+    } catch (PSNotFoundException e) {
+      return false;
+    } catch (PSExtensionException e) {
+      throw new IllegalStateException("Failed to delete extension: " + e.getMessage(), e);
+    }
+  }
+
+  private PSExtensionDef buildDef(
+      PSExtensionRef ref,
+      List<String> interfaces,
+      Map<String, String> initParameters,
+      List<ExtensionParameter> runtimeParameters,
+      List<String> resourceLocations,
+      List<String> suppliedResources,
+      List<String> requiredApplications,
+      boolean deprecated,
+      boolean restoreRequestParamsOnError,
+      long version) {
+    Properties initProps = new Properties();
+    if (initParameters != null) {
+      for (Map.Entry<String, String> e : initParameters.entrySet()) {
+        if (e.getKey() != null && e.getValue() != null) {
+          initProps.setProperty(e.getKey(), e.getValue());
+        }
+      }
+    }
+    if (version > 0) {
+      initProps.setProperty(IPSExtensionDef.INIT_PARAM_VERSION, Long.toString(version));
+    }
+
+    List<PSExtensionParamDef> runtime = new ArrayList<>();
+    if (runtimeParameters != null) {
+      for (ExtensionParameter p : runtimeParameters) {
+        if (p == null || StringUtils.isBlank(p.getName())) {
+          continue;
+        }
+        PSExtensionParamDef pd =
+            new PSExtensionParamDef(
+                p.getName().trim(),
+                StringUtils.defaultIfBlank(p.getDataType(), "java.lang.String"));
+        if (p.getDescription() != null) {
+          pd.setDescription(p.getDescription());
+        }
+        runtime.add(pd);
+      }
+    }
+
+    List<URL> resourceUrls = toUrls(resourceLocations, "resourceLocations");
+    List<URL> suppliedUrls = toUrls(suppliedResources, "suppliedResources");
+
+    PSExtensionDef def =
+        new PSExtensionDef(
+            ref,
+            interfaces.iterator(),
+            resourceUrls.iterator(),
+            initProps,
+            runtime.iterator(),
+            suppliedUrls.iterator(),
+            deprecated,
+            restoreRequestParamsOnError);
+
+    if (requiredApplications != null && !requiredApplications.isEmpty()) {
+      List<PSExtensionRef> apps = new ArrayList<>();
+      for (String app : requiredApplications) {
+        if (StringUtils.isBlank(app)) {
+          continue;
+        }
+        try {
+          apps.add(new PSExtensionRef(app.trim()));
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException("invalid requiredApplications entry: " + app, e);
+        }
+      }
+      def.setRequiredApplications(apps.iterator());
+    }
+    return def;
+  }
+
+  private void assertRefAvailable(PSExtensionRef ref) {
+    try {
+      if (extensionService.exists(ref)) {
+        throw new WebApplicationException("Extension already exists: " + ref.getFQN(), 409);
+      }
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSExtensionException e) {
+      throw new IllegalStateException("Failed to check extension existence: " + e.getMessage(), e);
+    }
+  }
+
+  private static void rejectImmutableRegistrationContext(String context) {
+    if (StringUtils.isBlank(context)) {
+      return;
+    }
+    String normalized = PSExtensionRef.canonicalizeContext(context.trim());
+    if (isImmutableContext(normalized)) {
+      throw new WebApplicationException(
+          "Cannot register extensions under system or handler context", 409);
+    }
+    // Non-user contexts are rejected for Admin REST create; force user/.
+    if (!USER_CONTEXT.equalsIgnoreCase(normalized)
+        && !"user".equalsIgnoreCase(context.trim())) {
+      throw new IllegalArgumentException(
+          "context must be user/ for Admin registration (got " + context + ")");
+    }
+  }
+
+  private void rejectImmutableMutation(Extension existing) {
+    if (isImmutableExtension(existing)) {
+      throw new WebApplicationException(IMMUTABLE_EXTENSION, 409);
+    }
+  }
+
+  static boolean isImmutableExtension(Extension e) {
+    if (e == null) {
+      return false;
+    }
+    if (IPSExtensionHandler.HANDLER_HANDLER.equalsIgnoreCase(
+        StringUtils.defaultString(e.getHandlerName()))) {
+      return true;
+    }
+    return isImmutableContext(e.getContext());
+  }
+
+  static boolean isImmutableContext(String context) {
+    if (context == null || context.isBlank()) {
+      return false;
+    }
+    String c = context.trim().toLowerCase(Locale.ROOT);
+    if (!c.endsWith("/")) {
+      c = c + "/";
+    }
+    if (c.startsWith("handlers/")) {
+      return true;
+    }
+    return c.startsWith("global/percussion/");
+  }
+
+  static String requireValidExtensionName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      throw new IllegalArgumentException("extensionName is required");
+    }
+    String name = raw.trim();
+    if (!PSExtensionRef.isValidExtensionName(name)) {
+      throw new IllegalArgumentException("invalid extensionName");
+    }
+    return name;
+  }
+
+  static String resolveHandlerName(String raw) {
+    if (StringUtils.isBlank(raw)) {
+      return DEFAULT_HANDLER;
+    }
+    String handler = raw.trim();
+    if (!PSExtensionRef.isValidExtensionName(handler)) {
+      throw new IllegalArgumentException("invalid handlerName");
+    }
+    if (IPSExtensionHandler.HANDLER_HANDLER.equalsIgnoreCase(handler)) {
+      throw new WebApplicationException("Cannot register handler-owned extensions", 409);
+    }
+    return handler;
+  }
+
+  static List<String> requireInterfaces(List<String> interfaces) {
+    if (interfaces == null || interfaces.isEmpty()) {
+      throw new IllegalArgumentException("supportedInterfaces is required");
+    }
+    List<String> out = new ArrayList<>();
+    for (String iface : interfaces) {
+      if (StringUtils.isBlank(iface)) {
+        continue;
+      }
+      out.add(iface.trim());
+    }
+    if (out.isEmpty()) {
+      throw new IllegalArgumentException("supportedInterfaces is required");
+    }
+    return out;
+  }
+
+  static void requireJavaClassName(Map<String, String> initParams) {
+    if (initParams == null
+        || StringUtils.isBlank(initParams.get(IPSExtensionDef.INIT_PARAM_CLASSNAME))) {
+      throw new IllegalArgumentException(
+          "initParameters.className is required for Java extensions");
+    }
+  }
+
+  private static PSExtensionRef refFromExtension(Extension e) {
+    String category = StringUtils.defaultString(e.getCategory());
+    String handler = e.getHandlerName();
+    String context = e.getContext();
+    String name = e.getExtensionName();
+    if (StringUtils.isAnyBlank(handler, context, name)) {
+      if (StringUtils.isNotBlank(e.getFqn())) {
+        return new PSExtensionRef(e.getFqn());
+      }
+      throw new IllegalStateException("extension identity incomplete");
+    }
+    return new PSExtensionRef(category, handler, context, name);
+  }
+
+  private static List<String> collectInterfaces(IPSExtensionDef def) {
+    List<String> out = new ArrayList<>();
+    def.getInterfaces().forEachRemaining(out::add);
+    return out;
+  }
+
+  private static Map<String, String> mergeInitParams(
+      IPSExtensionDef current, Map<String, String> bodyParams) {
+    Map<String, String> merged = new HashMap<>();
+    current
+        .getInitParameterNames()
+        .forEachRemaining(name -> merged.put(name, current.getInitParameter(name)));
+    if (bodyParams != null) {
+      for (Map.Entry<String, String> e : bodyParams.entrySet()) {
+        if (e.getKey() == null) {
+          continue;
+        }
+        if (e.getValue() == null) {
+          merged.remove(e.getKey());
+        } else {
+          merged.put(e.getKey(), e.getValue());
+        }
+      }
+    }
+    return merged;
+  }
+
+  private static List<ExtensionParameter> copyRuntimeParams(IPSExtensionDef def) {
+    List<ExtensionParameter> out = new ArrayList<>();
+    def.getRuntimeParameterNames()
+        .forEachRemaining(
+            name -> {
+              var p = def.getRuntimeParameter(name);
+              ExtensionParameter ep = new ExtensionParameter();
+              ep.setName(p.getName());
+              ep.setDescription(p.getDescription());
+              ep.setDataType(p.getDataType());
+              out.add(ep);
+            });
+    return out;
+  }
+
+  private static List<String> copyUrlList(Iterator<URL> it) {
+    List<String> out = new ArrayList<>();
+    if (it == null) {
+      return out;
+    }
+    it.forEachRemaining(u -> out.add(u.toString()));
+    return out;
+  }
+
+  private static List<String> copyRequiredApps(IPSExtensionDef def) {
+    List<String> out = new ArrayList<>();
+    def.getRequiredApplications().forEachRemaining(app -> out.add(app.toString()));
+    return out;
+  }
+
+  private static List<URL> toUrls(List<String> locations, String field) {
+    List<URL> out = new ArrayList<>();
+    if (locations == null) {
+      return out;
+    }
+    for (String loc : locations) {
+      if (StringUtils.isBlank(loc)) {
+        continue;
+      }
+      try {
+        out.add(URI.create(loc.trim()).toURL());
+      } catch (IllegalArgumentException | MalformedURLException e) {
+        throw new IllegalArgumentException("invalid " + field + " URL: " + loc, e);
+      }
+    }
+    return out;
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
   }
 
   /** Allow FQN-style keys (may contain '/'). Reject traversal and backslash/null. */

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ExtensionAdaptorSafeKeyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ExtensionAdaptorSafeKeyTest.java
@@ -24,4 +24,12 @@ class ExtensionAdaptorSafeKeyTest {
     assertFalse(ExtensionAdaptor.isSafeExtensionKey("a\u0000b"));
     assertFalse(ExtensionAdaptor.isSafeExtensionKey(null));
   }
+
+  @Test
+  void isImmutableContext_systemAndHandlers() {
+    assertTrue(ExtensionAdaptor.isImmutableContext("global/percussion/exit"));
+    assertTrue(ExtensionAdaptor.isImmutableContext("Handlers"));
+    assertFalse(ExtensionAdaptor.isImmutableContext("user/"));
+    assertFalse(ExtensionAdaptor.isImmutableContext(null));
+  }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/ExtensionAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/ExtensionAdaptorWriteTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.error.PSNonUniqueException;
+import com.percussion.error.PSNotFoundException;
+import com.percussion.extension.IPSExtensionDef;
+import com.percussion.extension.IPSExtensionHandler;
+import com.percussion.extension.PSExtensionDef;
+import com.percussion.extension.PSExtensionException;
+import com.percussion.extension.PSExtensionRef;
+import com.percussion.extensions.IPSExtensionService;
+import com.percussion.rest.extensions.Extension;
+import jakarta.ws.rs.WebApplicationException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * SY-01 Admin POST register / PUT update / DELETE user extensions via {@code
+ * IPSExtensionService}. Admin only; system/handler-owned are 409.
+ */
+@Tag("UnitTest")
+class ExtensionAdaptorWriteTest {
+
+  private static final URI BASE = URI.create("http://localhost/");
+
+  private IPSExtensionService extensionService;
+  private ExtensionAdaptor adaptor;
+  private final Map<String, IPSExtensionDef> installed = new HashMap<>();
+
+  @BeforeEach
+  void setUp() throws Exception {
+    extensionService = mock(IPSExtensionService.class);
+    adaptor = new ExtensionAdaptor(extensionService, () -> true);
+
+    when(extensionService.getExtensionNames(any(), any(), any(), any()))
+        .thenAnswer(inv -> installed.values().stream().map(IPSExtensionDef::getRef).iterator());
+    when(extensionService.exists(any()))
+        .thenAnswer(
+            inv -> {
+              PSExtensionRef ref = inv.getArgument(0);
+              return ref != null && installed.containsKey(ref.getFQN());
+            });
+    when(extensionService.getExtensionDef(any()))
+        .thenAnswer(
+            inv -> {
+              PSExtensionRef ref = inv.getArgument(0);
+              if (ref == null) {
+                throw new PSNotFoundException("null");
+              }
+              IPSExtensionDef def = installed.get(ref.getFQN());
+              if (def == null) {
+                throw new PSNotFoundException(ref.getFQN());
+              }
+              return def;
+            });
+    doAnswer(
+            inv -> {
+              IPSExtensionDef def = inv.getArgument(0);
+              if (def != null) {
+                installed.put(def.getRef().getFQN(), def);
+              }
+              return null;
+            })
+        .when(extensionService)
+        .installExtension(any(), any());
+    doAnswer(
+            inv -> {
+              IPSExtensionDef def = inv.getArgument(0);
+              if (def != null) {
+                installed.put(def.getRef().getFQN(), def);
+              }
+              return null;
+            })
+        .when(extensionService)
+        .updateExtension(any(), any());
+    doAnswer(
+            inv -> {
+              PSExtensionRef ref = inv.getArgument(0);
+              if (ref != null) {
+                installed.remove(ref.getFQN());
+              }
+              return null;
+            })
+        .when(extensionService)
+        .removeExtension(any());
+  }
+
+  @Test
+  void register_installsUnderUserContext() throws Exception {
+    Extension body = userBody("my_user_ext");
+
+    Extension out = adaptor.registerExtension(BASE, body);
+
+    assertEquals("my_user_ext", out.getExtensionName());
+    assertEquals("user/", out.getContext());
+    assertEquals("Java", out.getHandlerName());
+    assertTrue(out.getFqn().contains("/user/"));
+    assertTrue(installed.containsKey(out.getFqn()));
+
+    ArgumentCaptor<IPSExtensionDef> cap = ArgumentCaptor.forClass(IPSExtensionDef.class);
+    verify(extensionService).installExtension(cap.capture(), any());
+    assertEquals(ExtensionAdaptor.USER_CONTEXT, cap.getValue().getRef().getContext());
+  }
+
+  @Test
+  void register_thenFindByKeyRoundTrips() {
+    Extension body = userBody("my_user_ext");
+    Extension created = adaptor.registerExtension(BASE, body);
+    Extension fetched = adaptor.findExtensionByKey(BASE, created.getFqn());
+    assertNotNull(fetched);
+    assertEquals("my_user_ext", fetched.getExtensionName());
+    assertEquals(
+        "com.example.MyExt",
+        fetched.getInitParameters().get(IPSExtensionDef.INIT_PARAM_CLASSNAME));
+  }
+
+  @Test
+  void register_duplicateIs409() throws Exception {
+    adaptor.registerExtension(BASE, userBody("my_user_ext"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.registerExtension(BASE, userBody("my_user_ext")));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void register_systemContextIs409() throws Exception {
+    Extension body = userBody("my_user_ext");
+    body.setContext("global/percussion/exit");
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.registerExtension(BASE, body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(extensionService, never()).installExtension(any(), any());
+  }
+
+  @Test
+  void register_blankNameThrows400() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.registerExtension(BASE, null));
+    Extension blank = new Extension();
+    blank.setExtensionName("  ");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.registerExtension(BASE, blank));
+    assertTrue(ex.getMessage().contains("extensionName is required"));
+  }
+
+  @Test
+  void register_missingInterfacesThrows() {
+    Extension body = userBody("my_user_ext");
+    body.setSupportedInterfaces(List.of());
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.registerExtension(BASE, body));
+    assertTrue(ex.getMessage().contains("supportedInterfaces"));
+  }
+
+  @Test
+  void register_missingClassNameForJavaThrows() {
+    Extension body = userBody("my_user_ext");
+    body.setInitParameters(Map.of());
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.registerExtension(BASE, body));
+    assertTrue(ex.getMessage().contains("className"));
+  }
+
+  @Test
+  void register_nonAdminIs403() {
+    ExtensionAdaptor denied = new ExtensionAdaptor(extensionService, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> denied.registerExtension(BASE, userBody("my_user_ext")));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void update_mutatesInitParams() {
+    adaptor.registerExtension(BASE, userBody("my_user_ext"));
+    Extension body = userBody("my_user_ext");
+    body.setInitParameters(
+        Map.of(
+            IPSExtensionDef.INIT_PARAM_CLASSNAME,
+            "com.example.MyExt",
+            IPSExtensionDef.INIT_PARAM_DESCRIPTION,
+            "updated via REST"));
+    body.setDeprecated(true);
+
+    Extension out = adaptor.updateExtension(BASE, "my_user_ext", body);
+
+    assertTrue(out.isDeprecated());
+    assertEquals("updated via REST", out.getInitParameters().get(IPSExtensionDef.INIT_PARAM_DESCRIPTION));
+  }
+
+  @Test
+  void update_systemExtensionIs409() throws Exception {
+    seedSystemExtension();
+    Extension body = userBody("sys_add");
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.updateExtension(BASE, "sys_add", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(extensionService, never()).updateExtension(any(IPSExtensionDef.class), any());
+  }
+
+  @Test
+  void update_handlerOwnedIs409() throws Exception {
+    seedHandlerExtension();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.updateExtension(BASE, "Java", userBody("Java")));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void update_unknownReturnsNull() {
+    assertEquals(null, adaptor.updateExtension(BASE, "missing", userBody("missing")));
+  }
+
+  @Test
+  void delete_removesUserExtension() {
+    adaptor.registerExtension(BASE, userBody("my_user_ext"));
+    assertTrue(adaptor.deleteExtension(BASE, "my_user_ext"));
+    assertEquals(null, adaptor.findExtensionByKey(BASE, "my_user_ext"));
+  }
+
+  @Test
+  void delete_systemIs409() throws Exception {
+    seedSystemExtension();
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.deleteExtension(BASE, "sys_add"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(extensionService, never()).removeExtension(any(PSExtensionRef.class));
+  }
+
+  @Test
+  void delete_unknownReturnsFalse() {
+    assertFalse(adaptor.deleteExtension(BASE, "missing"));
+  }
+
+  @Test
+  void isImmutableHelpers() {
+    Extension system = new Extension();
+    system.setHandlerName("Java");
+    system.setContext("global/percussion/exit/");
+    system.setExtensionName("sys_add");
+    assertTrue(ExtensionAdaptor.isImmutableExtension(system));
+    assertTrue(ExtensionAdaptor.isImmutableContext("global/percussion/generic"));
+
+    Extension user = new Extension();
+    user.setHandlerName("Java");
+    user.setContext("user/");
+    user.setExtensionName("my_user_ext");
+    assertFalse(ExtensionAdaptor.isImmutableExtension(user));
+
+    Extension handler = new Extension();
+    handler.setHandlerName(IPSExtensionHandler.HANDLER_HANDLER);
+    handler.setContext(IPSExtensionHandler.HANDLER_CONTEXT);
+    handler.setExtensionName("Java");
+    assertTrue(ExtensionAdaptor.isImmutableExtension(handler));
+  }
+
+  @Test
+  void register_nonUniqueFromServiceIs409() throws Exception {
+    // Fresh service so doThrow is not layered over the setUp install Answer (Mockito null probe).
+    IPSExtensionService svc = mock(IPSExtensionService.class);
+    when(svc.exists(any())).thenReturn(false);
+    doThrow(new PSNonUniqueException(1, "dup")).when(svc).installExtension(any(), any());
+    ExtensionAdaptor local = new ExtensionAdaptor(svc, () -> true);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> local.registerExtension(BASE, userBody("my_user_ext")));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  private void seedSystemExtension() throws Exception {
+    PSExtensionRef ref =
+        new PSExtensionRef("Java", "global/percussion/generic/", "sys_add");
+    Properties init = new Properties();
+    init.setProperty(IPSExtensionDef.INIT_PARAM_CLASSNAME, "com.percussion.generic.PSAdd");
+    PSExtensionDef def =
+        new PSExtensionDef(
+            ref,
+            List.of("com.percussion.extension.IPSUdfProcessor").iterator(),
+            Collections.emptyIterator(),
+            init,
+            Collections.emptyIterator());
+    installed.put(ref.getFQN(), def);
+  }
+
+  private void seedHandlerExtension() throws Exception {
+    PSExtensionRef ref =
+        new PSExtensionRef(
+            IPSExtensionHandler.HANDLER_HANDLER,
+            IPSExtensionHandler.HANDLER_CONTEXT + "/",
+            "Java");
+    Properties init = new Properties();
+    init.setProperty(IPSExtensionDef.INIT_PARAM_CLASSNAME, "com.percussion.extension.PSJavaExtensionHandler");
+    PSExtensionDef def =
+        new PSExtensionDef(
+            ref,
+            List.of("com.percussion.extension.IPSExtensionHandler").iterator(),
+            Collections.emptyIterator(),
+            init,
+            Collections.emptyIterator());
+    installed.put(ref.getFQN(), def);
+  }
+
+  private static Extension userBody(String name) {
+    Extension e = new Extension();
+    e.setExtensionName(name);
+    e.setHandlerName("Java");
+    e.setSupportedInterfaces(List.of("com.percussion.extension.IPSUdfProcessor"));
+    e.setInitParameters(Map.of(IPSExtensionDef.INIT_PARAM_CLASSNAME, "com.example.MyExt"));
+    return e;
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/extensions/ExtensionsResource.java
+++ b/rest/src/main/java/com/percussion/rest/extensions/ExtensionsResource.java
@@ -28,8 +28,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
@@ -43,13 +45,16 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * REST resource for Extension operations. Sunny Sal: "Extension operations? Bas yahi toh mera kaam
- * hai!"
+ * REST resource for Extension catalog and Admin user-extension write (SY-01).
+ *
+ * <p>Admin POST/PUT/DELETE persist <strong>user</strong> extensions through {@link
+ * IExtensionAdaptor} ({@code IPSExtensionService}). System and handler-owned extensions are
+ * read-only. This resource is REST only — it does not add Developer SPA chrome.
  */
 @PSSiteManageBean(value = "restExtensionsResource")
 @Path("/extensions")
 @XmlRootElement
-@Tag(name = "Extensions", description = "Extension operations")
+@Tag(name = "Extensions", description = "Extension catalog and user-extension write")
 public class ExtensionsResource {
 
   private final IExtensionAdaptor adaptor;
@@ -86,8 +91,9 @@ public class ExtensionsResource {
   @Operation(
       summary = "List extensions (catalog)",
       description =
-          "Lists registered server extensions for the Developer module. Install/remove remain"
-              + " later slices.",
+          "Lists registered server extensions for the Developer module. Admin"
+              + " register/update/delete of user extensions are POST/PUT/DELETE on this"
+              + " resource. System and handler-owned extensions remain read-only.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -116,8 +122,9 @@ public class ExtensionsResource {
   @Operation(
       summary = "Get extension detail",
       description =
-          "Loads one extension by FQN or extension name (query param key). Write remains"
-              + " unsupported.",
+          "Loads one extension by FQN or extension name (query param key). Admin write of user"
+              + " extensions is POST/PUT/DELETE on this resource. System and handler-owned"
+              + " extensions cannot be mutated.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -145,13 +152,123 @@ public class ExtensionsResource {
     }
   }
 
-  private IExtensionAdaptor requireAdaptor() {
-    if (adaptor == null) {
-      // Misconfiguration — not a transient handler failure (align with View/Slots/Locales peers)
-      throw new WebApplicationException(
-          "Extension adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Register user extension",
+      description =
+          "Admin. Registers (installs) a user extension via IPSExtensionService under context"
+              + " user/. extensionName and at least one supportedInterfaces entry are required."
+              + " handlerName defaults to Java. Duplicate FQN is 409. System/handler contexts"
+              + " cannot be registered (409). This is REST only — there is no Developer SPA"
+              + " create chrome.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = Extension.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "Extension already exists or immutable context"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Extension registerExtension(Extension body) {
+    try {
+      Extension created = requireAdaptor().registerExtension(uriInfo.getBaseUri(), body);
+      if (created == null) {
+        throw new WebApplicationException("Failed to register extension", 500);
+      }
+      return created;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
     }
-    return adaptor;
+  }
+
+  @PUT
+  @Path("/catalog/item")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Update user extension",
+      description =
+          "Admin. Updates mutable fields of a user extension by FQN or extension name (query"
+              + " param key). Identity (handler/context/name) is not renamed on PUT. System and"
+              + " handler-owned extensions are 409. Unknown key is 404.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = Extension.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Extension not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "System or handler-owned extension cannot be mutated"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Extension updateExtension(
+      @Parameter(name = "key", required = true, description = "FQN or extension name")
+          @QueryParam("key")
+          String key,
+      Extension body) {
+    try {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      Extension updated = requireAdaptor().updateExtension(uriInfo.getBaseUri(), key, body);
+      if (updated == null) {
+        throw new WebApplicationException("Extension not found", 404);
+      }
+      return updated;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/catalog/item")
+  @Operation(
+      summary = "Delete user extension",
+      description =
+          "Admin. Deletes a user extension by FQN or extension name (query param key). System"
+              + " and handler-owned extensions are 409 (not deleted). Unknown key is 404."
+              + " Following GET is 404 after a successful delete.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Extension not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "System or handler-owned extension cannot be deleted"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteExtension(
+      @Parameter(name = "key", required = true, description = "FQN or extension name")
+          @QueryParam("key")
+          String key) {
+    try {
+      boolean deleted = requireAdaptor().deleteExtension(uriInfo.getBaseUri(), key);
+      if (!deleted) {
+        throw new WebApplicationException("Extension not found", 404);
+      }
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
   }
 
   /**
@@ -190,5 +307,28 @@ public class ExtensionsResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Admin 403, duplicate 409, and immutable 409 are
+   * already {@link WebApplicationException}s from the adaptor.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    return new WebApplicationException(e, 500);
+  }
+
+  private IExtensionAdaptor requireAdaptor() {
+    if (adaptor == null) {
+      // Misconfiguration — not a transient handler failure (align with View/Slots/Locales peers)
+      throw new WebApplicationException(
+          "Extension adaptor not configured", Response.Status.SERVICE_UNAVAILABLE);
+    }
+    return adaptor;
   }
 }

--- a/rest/src/main/java/com/percussion/rest/extensions/IExtensionAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/extensions/IExtensionAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,13 @@ package com.percussion.rest.extensions;
 import java.net.URI;
 import java.util.List;
 
-/** Adaptor interface for Extension operations. Sunny Sal: "Adaptor pattern FTW!" */
+/**
+ * Adaptor interface for Extension catalog and Admin user-extension write (SY-01).
+ *
+ * <p>Write methods persist <strong>user</strong> extensions through {@code IPSExtensionService} /
+ * {@code IPSExtensionManager}. System ({@code global/percussion/...}) and handler-owned
+ * extensions are immutable.
+ */
 public interface IExtensionAdaptor {
 
   /**
@@ -39,4 +45,34 @@ public interface IExtensionAdaptor {
 
   /** Resolve by FQN or extension name; null if missing/unsafe. */
   Extension findExtensionByKey(URI baseURI, String idOrName);
+
+  /**
+   * Admin. Register (install) a user extension under context {@code user/}.
+   *
+   * @param baseURI Base URI for the request
+   * @param body required; {@code extensionName} and at least one supported interface
+   * @return the persisted extension
+   */
+  Extension registerExtension(URI baseURI, Extension body);
+
+  /**
+   * Admin. Update mutable fields of a user extension identified by FQN or short name. Does not
+   * mutate system or handler-owned extensions.
+   *
+   * @param baseURI Base URI for the request
+   * @param idOrName FQN or extension name (same rules as {@link #findExtensionByKey})
+   * @param body required writable fields
+   * @return the persisted extension, or {@code null} when missing/unsafe
+   */
+  Extension updateExtension(URI baseURI, String idOrName, Extension body);
+
+  /**
+   * Admin. Delete a user extension by FQN or short name. Does not mutate system or handler-owned
+   * extensions.
+   *
+   * @param baseURI Base URI for the request
+   * @param idOrName FQN or extension name (same rules as {@link #findExtensionByKey})
+   * @return {@code true} when deleted, {@code false} when missing/unsafe
+   */
+  boolean deleteExtension(URI baseURI, String idOrName);
 }

--- a/rest/src/test/java/com/percussion/rest/extensions/ExtensionsResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/extensions/ExtensionsResourceTest.java
@@ -11,10 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.List;
@@ -127,5 +129,149 @@ public class ExtensionsResourceTest {
             WebApplicationException.class, () -> resource.getExtensionCatalogItem("sys_add"));
     assertEquals(500, ex.getResponse().getStatus());
     assertSame(boom, ex.getCause());
+  }
+
+  @Test
+  public void registerExtensionDelegates() {
+    Extension body = userBody("my_user_ext");
+    Extension created = userBody("my_user_ext");
+    created.setContext("user/");
+    when(adaptor.registerExtension(any(), eq(body))).thenReturn(created);
+
+    Extension out = resource.registerExtension(body);
+
+    assertEquals("my_user_ext", out.getExtensionName());
+    assertEquals("user/", out.getContext());
+    verify(adaptor).registerExtension(any(), eq(body));
+  }
+
+  @Test
+  public void registerExtensionBlankNameIs400() {
+    when(adaptor.registerExtension(any(), any()))
+        .thenThrow(new IllegalArgumentException("extensionName is required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.registerExtension(new Extension()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void registerExtensionDuplicateIs409() {
+    when(adaptor.registerExtension(any(), any()))
+        .thenThrow(new WebApplicationException("Extension already exists: Java/user/my_user_ext", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.registerExtension(userBody("my_user_ext")));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void registerExtensionNonAdminIs403() {
+    when(adaptor.registerExtension(any(), any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.registerExtension(userBody("my_user_ext")));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateExtensionDelegates() {
+    Extension body = userBody("my_user_ext");
+    body.setDeprecated(true);
+    Extension updated = userBody("my_user_ext");
+    updated.setDeprecated(true);
+    when(adaptor.updateExtension(any(), eq("my_user_ext"), eq(body))).thenReturn(updated);
+
+    Extension out = resource.updateExtension("my_user_ext", body);
+
+    assertTrue(out.isDeprecated());
+    verify(adaptor).updateExtension(any(), eq("my_user_ext"), eq(body));
+  }
+
+  @Test
+  public void updateExtensionUnknownIs404() {
+    when(adaptor.updateExtension(any(), eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateExtension("missing", new Extension()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateExtensionNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateExtension("my_user_ext", null));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).updateExtension(any(), any(), any());
+  }
+
+  @Test
+  public void updateExtensionSystemIs409() {
+    when(adaptor.updateExtension(any(), eq("sys_add"), any()))
+        .thenThrow(new WebApplicationException("System or handler-owned extensions cannot be updated", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateExtension("sys_add", new Extension()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteExtensionNoContent() {
+    when(adaptor.deleteExtension(any(), eq("my_user_ext"))).thenReturn(true);
+
+    Response r = resource.deleteExtension("my_user_ext");
+
+    assertEquals(204, r.getStatus());
+    verify(adaptor).deleteExtension(any(), eq("my_user_ext"));
+  }
+
+  @Test
+  public void deleteExtensionUnknownIs404() {
+    when(adaptor.deleteExtension(any(), eq("missing"))).thenReturn(false);
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteExtension("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteExtensionSystemIs409() {
+    when(adaptor.deleteExtension(any(), eq("sys_add")))
+        .thenThrow(new WebApplicationException("System or handler-owned extensions cannot be deleted", 409));
+    WebApplicationException ex =
+        assertThrows(WebApplicationException.class, () -> resource.deleteExtension("sys_add"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteExtensionNonAdminIs403() {
+    when(adaptor.deleteExtension(any(), eq("my_user_ext")))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteExtension("my_user_ext"));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void missingAdaptorReturnsServiceUnavailableOnRegister() {
+    ExtensionsResource bare = new ExtensionsResource();
+    bare.setUriInfo(uriInfo);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> bare.registerExtension(userBody("x")));
+    assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  private static Extension userBody(String name) {
+    Extension e = new Extension();
+    e.setExtensionName(name);
+    e.setHandlerName("Java");
+    e.setSupportedInterfaces(List.of("com.percussion.extension.IPSUdfProcessor"));
+    e.setInitParameters(java.util.Map.of("className", "com.example.MyExt"));
+    return e;
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestExtensionAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestExtensionAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 1999-2025 Percussion Software, Inc.
+ * Copyright 1999-2026 Percussion Software, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.net.URI;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
-/** Test adaptor for Extension API bridge. */
+/** Test adaptor for Extension API bridge (MainTest Spring context). */
 @Component
 public class TestExtensionAdaptor implements IExtensionAdaptor {
 
@@ -43,5 +43,20 @@ public class TestExtensionAdaptor implements IExtensionAdaptor {
   @Override
   public List<Extension> getExtensions(URI baseURI, ExtensionFilterOptions filter) {
     return null;
+  }
+
+  @Override
+  public Extension registerExtension(URI baseURI, Extension body) {
+    return body;
+  }
+
+  @Override
+  public Extension updateExtension(URI baseURI, String idOrName, Extension body) {
+    return body;
+  }
+
+  @Override
+  public boolean deleteExtension(URI baseURI, String idOrName) {
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

Implements **SY-01 Admin REST write** for user extensions (slice of Parent #1690 / issue #4239).

- `IExtensionAdaptor` + `ExtensionsResource`: `POST /services/extensions`, `PUT/DELETE /services/extensions/catalog/item?key=`
- `ExtensionAdaptor` (sitemanage): `IPSExtensionService.installExtension` / `updateExtension` / `removeExtension`; Admin gate; force `user/` context; system (`global/percussion/...`) and handler-owned → **409**; non-Admin → **403**; unknown → **404**; bad payload → **400**
- Mockito `ExtensionsResourceTest`, `ExtensionAdaptorWriteTest`, Spring `TestExtensionAdaptor` stub
- `product-docs/8.2/developer/rest.md` Extensions catalog write contract

Out of scope (sibling slices): SPA #4240, Playwright #4241.

Operator: Grok: night-issue-prs (model grok-4.5)
Parent tracker: #1690

## Test plan

- [x] `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1050, Failures: 0; `ExtensionsResourceTest` 22/0
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2273, Failures: 0, Errors: 0; `ExtensionAdaptorWriteTest` 17/0; `ExtensionAdaptorSafeKeyTest` 2/0
- [x] Downstream: sitemanage standalone install (implements rest adaptor surface)
- [x] C5 UI Playwright: N/A (REST-only; SPA/Playwright are #4240/#4241)

## Product documentation

- [x] Updated pages under `product-docs/` (`product-docs/8.2/developer/rest.md` Extensions catalog write)

## C3 evidence

- modules_built=rest,projects/sitemanage
- build_evidence=`cd rest; ../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 1050); `cd projects/sitemanage; ../../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 2273, Failures: 0, Errors: 0)
- downstream_checked=projects/sitemanage (implements `IExtensionAdaptor`; standalone clean install green)

Fixes #4239

> Co-Authored by Grok Build 1.0.5 using grok-4.5 with agent night-issue-prs.
