### PR TITLE
feat(rest): Admin SY-03 relationship type create/update/delete (#4251)

### DIFF
--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1891,6 +1891,97 @@ Example create body:
 | `500` | Control manager or file I/O failure |
 | `503` | Control adaptor not configured |
 
+## Relationship types (catalog)
+
+Server **relationship type** definitions (Workbench / Developer **System Design → Relationship
+Types**, SY-03) are exposed under `/services/relationshiptypes`. List and detail include
+**system** and **user** types with category, cloning/revision flags, properties, and effects.
+Backing is `IPSSystemDesignWs` (`findRelationshipTypes` / `loadRelationshipTypes` /
+`createRelationshipTypes` / `saveRelationshipTypes` / `deleteRelationshipTypes`) — the same
+design web service SOAP uses. There is no new SOAP surface.
+
+Admin **write** creates, updates, and deletes **user** relationship types only. Packaged
+**system** types are read-only (**409** on mutate/delete). **Do not** treat this as a Developer
+Relationship Types SPA; create/edit chrome is a later sibling.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/services/relationshiptypes` | List relationship types |
+| `GET` | `/services/relationshiptypes/{idOrName}` | Load one type by name or GUID string |
+| `POST` | `/services/relationshiptypes` | **Admin.** Create a user relationship type (optional `copyFrom`) |
+| `PUT` | `/services/relationshiptypes/{idOrName}` | **Admin.** Update mutable fields of a user type |
+| `DELETE` | `/services/relationshiptypes/{idOrName}` | **Admin.** Delete a user relationship type |
+
+JSON objects use the `RelationshipType` wire type. Prefer the generated OpenAPI schema as the
+integration source of truth. Detail and write keys use a **path** parameter (`idOrName`) —
+names must not contain `/` or whitespace.
+
+### Relationship type write contract (Admin)
+
+Create (`POST /services/relationshiptypes`) persists immediately via
+`createRelationshipTypes` + `saveRelationshipTypes`. JSON body requires `name` (no whitespace,
+no wildcards). Provide either:
+
+* `category` — category **code** (`rs_activeassembly`, `rs_copy`, `rs_promotable`,
+  `rs_translation`, …) or **label** (`Active Assembly`, `New Copy`, …), or
+* `copyFrom` — name or GUID of an existing type whose mutable fields (label, description,
+  cloning/revision flags, user properties, effects) are copied onto the new **user** type
+  (Workbench copy-from-system).
+
+`label` defaults to `name` when omitted. Duplicate name is **409**. Blank / invalid name or
+missing category (when `copyFrom` is absent) is **400**. Unknown `copyFrom` is **400**.
+Non-Admin is **403**. The new type is then `GET /services/relationshiptypes/{name}` **200** and
+appears on `GET /services/relationshiptypes`.
+
+Update (`PUT /services/relationshiptypes/{idOrName}`) updates mutable fields of a **user** type
+(label, description, category, `allowCloning` / revision flags, user properties). Identity
+(`name`) is not renamed on PUT — round-trip GET then PUT for boolean flags. Effect
+condition/execution-context editing and cloning field-override editor are not supported via
+this API (see `designGaps` on detail). Unknown key is **404**. A **system** type is **409**.
+Non-Admin is **403**. Lock conflicts are **409**.
+
+Delete (`DELETE /services/relationshiptypes/{idOrName}`) returns **204** when a user type is
+removed; a following `GET` is **404**. Unknown key is **404**. A **system** type is **409**
+(not deleted). Non-Admin is **403**.
+
+There is **no** Developer SPA relationship-type create/edit/delete in this slice — operators
+and integrators call the REST path (or Workbench).
+
+Example create body:
+
+```json
+{
+  "RelationshipType": {
+    "name": "MyUserRel",
+    "label": "My User Rel",
+    "category": "rs_activeassembly",
+    "description": "Created via REST"
+  }
+}
+```
+
+Example copy-from-system body:
+
+```json
+{
+  "RelationshipType": {
+    "name": "CopiedRel",
+    "copyFrom": "ActiveAssembly"
+  }
+}
+```
+
+| Status | Typical meaning |
+|--------|-----------------|
+| `200` | List / get / create / update success |
+| `204` | Delete success |
+| `400` | Invalid input (missing name/category, whitespace/wildcard name, unknown copyFrom) |
+| `403` | Caller is not Admin |
+| `404` | User relationship type not found |
+| `409` | Duplicate name, system type immutable, or design lock conflict |
+| `500` | Design WS failure |
+| `503` | Relationship type adaptor not configured |
+
 ## Extensions (catalog)
 
 Server **extension** registrations (Workbench / Developer **Extension Registration**, SY-01) are

--- a/projects/sitemanage/src/main/java/com/percussion/apibridge/RelationshipTypeAdaptor.java
+++ b/projects/sitemanage/src/main/java/com/percussion/apibridge/RelationshipTypeAdaptor.java
@@ -20,6 +20,8 @@ package com.percussion.apibridge;
 import com.percussion.design.objectstore.PSConditionalEffect;
 import com.percussion.design.objectstore.PSEntry;
 import com.percussion.design.objectstore.PSExtensionCall;
+import com.percussion.design.objectstore.PSProperty;
+import com.percussion.design.objectstore.PSPropertySet;
 import com.percussion.design.objectstore.PSRelationshipConfig;
 import com.percussion.rest.Guid;
 import com.percussion.rest.relationshiptypes.IRelationshipTypeAdaptor;
@@ -27,44 +29,74 @@ import com.percussion.rest.relationshiptypes.RelationshipType;
 import com.percussion.rest.relationshiptypes.RelationshipTypeEffect;
 import com.percussion.rest.relationshiptypes.RelationshipTypeProperty;
 import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.share.service.exception.PSDataServiceException;
 import com.percussion.system.utils.PSSiteManageBean;
+import com.percussion.user.data.PSCurrentUser;
+import com.percussion.user.service.IPSUserService;
 import com.percussion.utils.guid.IPSGuid;
 import com.percussion.utils.request.PSRequestInfo;
 import com.percussion.webservices.PSErrorException;
 import com.percussion.webservices.PSErrorResultsException;
+import com.percussion.webservices.PSErrorsException;
+import com.percussion.webservices.PSLockErrorException;
 import com.percussion.webservices.system.IPSSystemDesignWs;
 import com.percussion.webservices.system.PSSystemWsLocator;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
-/** Design catalog adaptor for relationship types (SY-03 read). */
+/**
+ * Design catalog adaptor for relationship types and Admin user-type write (SY-03) over {@link
+ * IPSSystemDesignWs}. System relationship types are never mutated.
+ */
 @PSSiteManageBean
 @Lazy
 public class RelationshipTypeAdaptor implements IRelationshipTypeAdaptor {
 
   private static final Logger log = LogManager.getLogger(RelationshipTypeAdaptor.class);
 
+  static final String ADMIN_REQUIRED =
+      "Admin role required to create, update, or delete user relationship types";
+
+  static final String IMMUTABLE_TYPE = "System relationship types cannot be updated or deleted";
+
   /** Catalog-level capability notes. Attached on detail only (REST-GAPS-02 list dedup). */
   static final List<String> DESIGN_GAPS =
       List.of(
-          "Relationship type create / update / delete not supported via this API",
           "Cloning field override editor not supported via this API",
           "Effect condition and execution-context edit not supported via this API");
 
   private final IPSSystemDesignWs designWs;
+  private final BooleanSupplier adminChecker;
+
+  /** Injected by Spring in production; unused when {@link #adminChecker} is overridden in tests. */
+  @Autowired(required = false)
+  private IPSUserService userService;
 
   public RelationshipTypeAdaptor() {
-    this(PSSystemWsLocator.getSystemDesignWebservice());
+    this(PSSystemWsLocator.getSystemDesignWebservice(), null);
   }
 
   /** Package-visible for unit tests. */
   RelationshipTypeAdaptor(IPSSystemDesignWs designWs) {
+    this(designWs, null);
+  }
+
+  /** Package-visible for unit tests. */
+  RelationshipTypeAdaptor(IPSSystemDesignWs designWs, BooleanSupplier adminChecker) {
     this.designWs = designWs;
+    this.adminChecker = adminChecker != null ? adminChecker : this::isCurrentUserAdmin;
   }
 
   @Override
@@ -83,8 +115,8 @@ public class RelationshipTypeAdaptor implements IRelationshipTypeAdaptor {
       if (guids.isEmpty()) {
         return List.of();
       }
-      String user = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
-      String session = (String) PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+      String user = currentUser();
+      String session = currentSession();
       List<PSRelationshipConfig> configs =
           designWs.loadRelationshipTypes(guids, false, false, session, user);
       List<RelationshipType> out = new ArrayList<>();
@@ -107,44 +139,532 @@ public class RelationshipTypeAdaptor implements IRelationshipTypeAdaptor {
     if (!isSafeRelationshipTypeKey(idOrName)) {
       return null;
     }
-    String key = idOrName.trim();
-    // Single catalog load — avoid N+1 find/load round-trips on detail.
-    List<RelationshipType> all = listRelationshipTypes();
-    if (all == null || all.isEmpty()) {
+    PSRelationshipConfig cfg = resolveConfig(idOrName.trim(), false);
+    return cfg != null ? withDesignGaps(copyConfig(cfg, false)) : null;
+  }
+
+  @Override
+  public RelationshipType createRelationshipType(RelationshipType body) {
+    requireAdmin();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    String name = requireValidName(body.getName());
+    requireSessionUserForDesignWrite();
+    String session = currentSession();
+    String user = currentUser();
+    assertNameUnique(name);
+
+    String copyFrom = StringUtils.trimToNull(body.getCopyFrom());
+    PSRelationshipConfig source = null;
+    String category;
+    if (copyFrom != null) {
+      if (!isSafeRelationshipTypeKey(copyFrom)) {
+        throw new IllegalArgumentException("copyFrom is invalid");
+      }
+      source = resolveConfig(copyFrom, false);
+      if (source == null) {
+        throw new IllegalArgumentException("copyFrom relationship type not found: " + copyFrom);
+      }
+      category = source.getCategory();
+    } else {
+      category = resolveCategoryCode(body.getCategory());
+      if (category == null) {
+        throw new IllegalArgumentException(
+            "category is required when copyFrom is not set (code or label, e.g."
+                + " rs_activeassembly or Active Assembly)");
+      }
+    }
+
+    try {
+      List<PSRelationshipConfig> created =
+          designWs.createRelationshipTypes(
+              Collections.singletonList(name),
+              Collections.singletonList(category),
+              session,
+              user);
+      if (created == null || created.isEmpty() || created.get(0) == null) {
+        throw new IllegalStateException("Design WS createRelationshipTypes returned empty");
+      }
+      PSRelationshipConfig config = created.get(0);
+      if (source != null) {
+        copyMutableFromSource(config, source);
+      }
+      applyCreateOverrides(config, body, name);
+      designWs.saveRelationshipTypes(Collections.singletonList(config), true, session, user);
+      PSRelationshipConfig reloaded = resolveConfig(name, false);
+      return reloaded != null
+          ? withDesignGaps(copyConfig(reloaded, false))
+          : withDesignGaps(copyConfig(config, false));
+    } catch (WebApplicationException | IllegalStateException | IllegalArgumentException e) {
+      throw e;
+    } catch (PSLockErrorException e) {
+      throw new WebApplicationException(
+          "Could not create relationship type; design lock required or held by another user",
+          409);
+    } catch (PSErrorsException e) {
+      throw mapPersistFailure(name, e, "Failed to save new relationship type");
+    } catch (PSErrorException e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("Relationship type already exists: " + name, 409);
+      }
+      throw mapPersistFailure(name, e, "Failed to create relationship type");
+    } catch (Exception e) {
+      if (isAlreadyExistsFailure(e)) {
+        throw new WebApplicationException("Relationship type already exists: " + name, 409);
+      }
+      log.error("Failed to create relationship type {}: {}", name, e.getMessage(), e);
+      throw new IllegalStateException("Failed to create relationship type", e);
+    }
+  }
+
+  @Override
+  public RelationshipType updateRelationshipType(String idOrName, RelationshipType body) {
+    requireAdmin();
+    if (body == null) {
+      throw new IllegalArgumentException("body is required");
+    }
+    if (!isSafeRelationshipTypeKey(idOrName)) {
       return null;
     }
-    for (RelationshipType t : all) {
-      if (t == null) {
+    requireSessionUserForDesignWrite();
+    String session = currentSession();
+    String user = currentUser();
+    String key = idOrName.trim();
+    try {
+      PSRelationshipConfig unlocked = resolveConfig(key, false);
+      if (unlocked == null) {
+        return null;
+      }
+      rejectImmutableMutation(unlocked);
+      PSRelationshipConfig locked;
+      try {
+        locked = resolveConfig(key, true);
+      } catch (RuntimeException e) {
+        if (e.getCause() instanceof PSErrorResultsException
+            || e instanceof WebApplicationException) {
+          throw lockConflict("Could not update relationship type");
+        }
+        throw e;
+      }
+      if (locked == null) {
+        throw lockConflict("Could not update relationship type");
+      }
+      rejectImmutableMutation(locked);
+      applyUpdateFields(locked, body);
+      designWs.saveRelationshipTypes(Collections.singletonList(locked), true, session, user);
+      PSRelationshipConfig reloaded = resolveConfig(locked.getName(), false);
+      return reloaded != null
+          ? withDesignGaps(copyConfig(reloaded, false))
+          : withDesignGaps(copyConfig(locked, false));
+    } catch (WebApplicationException | IllegalArgumentException | IllegalStateException e) {
+      throw e;
+    } catch (PSErrorsException e) {
+      if (isLockFailure(e)) {
+        throw lockConflict("Could not update relationship type");
+      }
+      throw mapPersistFailure(key, e, "Failed to update relationship type");
+    } catch (PSErrorException e) {
+      throw mapPersistFailure(key, e, "Failed to update relationship type");
+    } catch (Exception e) {
+      log.error("Failed to update relationship type {}: {}", key, e.getMessage(), e);
+      throw new IllegalStateException("Failed to update relationship type", e);
+    }
+  }
+
+  @Override
+  public boolean deleteRelationshipType(String idOrName) {
+    requireAdmin();
+    if (!isSafeRelationshipTypeKey(idOrName)) {
+      return false;
+    }
+    requireSessionUserForDesignWrite();
+    String session = currentSession();
+    String user = currentUser();
+    String key = idOrName.trim();
+    try {
+      PSRelationshipConfig current = resolveConfig(key, false);
+      if (current == null) {
+        return false;
+      }
+      rejectImmutableMutation(current);
+      if (current.getGUID() == null) {
+        throw new IllegalStateException(
+            "Relationship type '" + key + "' has no GUID; cannot delete");
+      }
+      PSRelationshipConfig locked;
+      try {
+        locked = resolveConfig(key, true);
+      } catch (RuntimeException e) {
+        throw lockConflict("Could not delete relationship type");
+      }
+      if (locked == null || locked.getGUID() == null) {
+        throw lockConflict("Could not delete relationship type");
+      }
+      rejectImmutableMutation(locked);
+      try {
+        designWs.deleteRelationshipTypes(
+            Collections.singletonList(locked.getGUID()), false, session, user);
+      } catch (PSErrorsException e) {
+        if (isLockFailure(e)) {
+          throw lockConflict("Could not delete relationship type");
+        }
+        String details = formatErrors(e);
+        throw new IllegalArgumentException("Could not delete relationship type: " + details, e);
+      }
+      return true;
+    } catch (IllegalArgumentException | IllegalStateException | WebApplicationException e) {
+      throw e;
+    } catch (PSErrorException e) {
+      throw mapPersistFailure(key, e, "Failed to delete relationship type");
+    } catch (Exception e) {
+      log.error("Failed to delete relationship type {}: {}", key, e.getMessage(), e);
+      throw new IllegalStateException("Failed to delete relationship type", e);
+    }
+  }
+
+  private PSRelationshipConfig resolveConfig(String idOrName, boolean lock) {
+    if (!isSafeRelationshipTypeKey(idOrName)) {
+      return null;
+    }
+    String key = idOrName.trim();
+    try {
+      // Prefer exact name lookup via find summaries.
+      List<IPSCatalogSummary> byName = designWs.findRelationshipTypes(key, null);
+      IPSGuid guid = null;
+      if (byName != null) {
+        for (IPSCatalogSummary s : byName) {
+          if (s != null && key.equalsIgnoreCase(StringUtils.defaultString(s.getName()))) {
+            guid = s.getGUID();
+            break;
+          }
+        }
+      }
+      if (guid == null) {
+        // GUID string path
+        try {
+          var parsed = new com.percussion.services.guidmgr.data.PSGuid(key);
+          List<IPSCatalogSummary> all = designWs.findRelationshipTypes(null, null);
+          if (all != null) {
+            int uuid = parsed.getUUID();
+            short type = parsed.getType();
+            for (IPSCatalogSummary s : all) {
+              if (s != null
+                  && s.getGUID() != null
+                  && s.getGUID().getUUID() == uuid
+                  && s.getGUID().getType() == type) {
+                guid = s.getGUID();
+                break;
+              }
+            }
+          }
+        } catch (IllegalArgumentException e) {
+          log.debug("Invalid relationship type GUID syntax: {}", e.getMessage());
+        }
+      }
+      if (guid == null) {
+        return null;
+      }
+      String session = currentSession();
+      String user = currentUser();
+      List<PSRelationshipConfig> loaded =
+          designWs.loadRelationshipTypes(
+              Collections.singletonList(guid), lock, false, session, user);
+      if (loaded == null || loaded.isEmpty()) {
+        return null;
+      }
+      return loaded.get(0);
+    } catch (PSErrorResultsException e) {
+      if (lock) {
+        throw new WebApplicationException(
+            "Could not lock relationship type; design lock required or held by another user",
+            409);
+      }
+      throw new RuntimeException("Failed to load relationship type: " + key, e);
+    } catch (PSErrorException e) {
+      throw new RuntimeException("Failed to resolve relationship type: " + key, e);
+    }
+  }
+
+  private void applyCreateOverrides(PSRelationshipConfig config, RelationshipType body, String name) {
+    if (StringUtils.isNotBlank(body.getLabel())) {
+      config.setLabel(body.getLabel().trim());
+    } else if (StringUtils.isBlank(config.getLabel())) {
+      // Keep copyFrom source label when present; otherwise default to name.
+      config.setLabel(name);
+    }
+    if (body.getDescription() != null) {
+      config.setDescription(body.getDescription());
+    }
+    if (body.getUserProperties() != null && !body.getUserProperties().isEmpty()) {
+      applyUserProperties(config, body.getUserProperties());
+    }
+  }
+
+  private void applyUpdateFields(PSRelationshipConfig config, RelationshipType body) {
+    if (StringUtils.isNotBlank(body.getLabel())) {
+      config.setLabel(body.getLabel().trim());
+    }
+    if (body.getDescription() != null) {
+      config.setDescription(body.getDescription());
+    }
+    if (StringUtils.isNotBlank(body.getCategory())) {
+      String category = resolveCategoryCode(body.getCategory());
+      if (category == null) {
+        throw new IllegalArgumentException("invalid category: " + body.getCategory());
+      }
+      config.setCategory(category);
+    }
+    // Wire booleans are primitives — clients should round-trip GET then PUT.
+    setBooleanSysProp(config, PSRelationshipConfig.RS_ALLOWCLONING, body.isAllowCloning());
+    setBooleanSysProp(config, PSRelationshipConfig.RS_USEOWNERREVISION, body.isUseOwnerRevision());
+    setBooleanSysProp(
+        config, PSRelationshipConfig.RS_USEDEPENDENTREVISION, body.isUseDependentRevision());
+    if (body.getUserProperties() != null) {
+      applyUserProperties(config, body.getUserProperties());
+    }
+  }
+
+  private static void copyMutableFromSource(
+      PSRelationshipConfig dest, PSRelationshipConfig source) {
+    if (StringUtils.isNotBlank(source.getLabel())) {
+      dest.setLabel(source.getLabel());
+    }
+    dest.setDescription(source.getDescription());
+    // Copy system property values (cloning / revision flags, etc.)
+    for (Object nameObj : PSRelationshipConfig.RS_PROPERTY_NAME_ENUM) {
+      if (!(nameObj instanceof String pname)) {
         continue;
       }
-      if (key.equalsIgnoreCase(t.getName())) {
-        return withDesignGaps(t);
-      }
-      if (t.getGuid() != null) {
-        String guidStr = t.getGuid().getStringValue();
-        if (guidStr != null && key.equalsIgnoreCase(guidStr)) {
-          return withDesignGaps(t);
-        }
+      PSProperty srcProp = source.getSysProperty(pname);
+      PSProperty destProp = dest.getSysProperty(pname);
+      if (srcProp != null && destProp != null && !destProp.isLocked()) {
+        destProp.setValue(srcProp.getValue());
       }
     }
-    // Fallback: parse as type-host-uuid. Guid.getUuid()/IPSGuid.getUUID() are ints (not
-    // java.util.UUID), so value equality uses == on the primitive fields.
+    // Copy user-defined properties
+    PSPropertySet userProps = new PSPropertySet();
+    Iterator<?> userIt = source.getUserDefProperties();
+    while (userIt.hasNext()) {
+      Object o = userIt.next();
+      if (o instanceof PSProperty p) {
+        userProps.add((PSProperty) p.clone());
+      }
+    }
+    dest.setUserDefProperties(userProps.iterator());
+    // Copy effects (cloned)
+    List<PSConditionalEffect> effects = new ArrayList<>();
+    Iterator<?> effectIt = source.getEffects();
+    while (effectIt.hasNext()) {
+      Object o = effectIt.next();
+      if (o instanceof PSConditionalEffect ce) {
+        effects.add((PSConditionalEffect) ce.clone());
+      }
+    }
+    dest.setEffects(effects.iterator());
+  }
+
+  private static void applyUserProperties(
+      PSRelationshipConfig config, List<RelationshipTypeProperty> props) {
+    PSPropertySet set = new PSPropertySet();
+    if (props != null) {
+      for (RelationshipTypeProperty p : props) {
+        if (p == null || StringUtils.isBlank(p.getName())) {
+          continue;
+        }
+        PSProperty prop = new PSProperty(p.getName().trim());
+        prop.setValue(p.getValue());
+        set.add(prop);
+      }
+    }
+    config.setUserDefProperties(set.iterator());
+  }
+
+  private static void setBooleanSysProp(
+      PSRelationshipConfig config, String propName, boolean value) {
+    PSProperty prop = config.getSysProperty(propName);
+    if (prop == null) {
+      return;
+    }
+    if (prop.isLocked()) {
+      return;
+    }
+    prop.setValue(Boolean.valueOf(value));
+    // Keep the string map used by isCloningAllowed / getSystemProperty in sync.
+    String str = value ? PSProperty.XML_BOOL_YES : PSProperty.XML_BOOL_NO;
+    config.getSystemProperties().put(propName, str);
+  }
+
+  private void assertNameUnique(String name) {
     try {
-      var parsed = new com.percussion.services.guidmgr.data.PSGuid(key);
-      int uuid = parsed.getUUID();
-      short type = parsed.getType();
-      for (RelationshipType t : all) {
-        if (t != null
-            && t.getGuid() != null
-            && t.getGuid().getUuid() == uuid
-            && t.getGuid().getType() == type) {
-          return withDesignGaps(t);
+      List<IPSCatalogSummary> existing = designWs.findRelationshipTypes(name, null);
+      if (existing == null) {
+        return;
+      }
+      for (IPSCatalogSummary summary : existing) {
+        if (summary != null
+            && name.equalsIgnoreCase(StringUtils.defaultString(summary.getName()))) {
+          throw new WebApplicationException("Relationship type already exists: " + name, 409);
         }
       }
-    } catch (IllegalArgumentException e) {
-      log.debug("Invalid relationship type GUID syntax: {}", e.getMessage());
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (PSErrorException e) {
+      throw new IllegalStateException("Failed to check relationship type existence", e);
+    }
+  }
+
+  private static void rejectImmutableMutation(PSRelationshipConfig config) {
+    if (config != null && config.isSystem()) {
+      throw new WebApplicationException(IMMUTABLE_TYPE, 409);
+    }
+  }
+
+  static String resolveCategoryCode(String categoryOrLabel) {
+    if (StringUtils.isBlank(categoryOrLabel)) {
+      return null;
+    }
+    String key = categoryOrLabel.trim();
+    for (PSEntry entry : PSRelationshipConfig.CATEGORY_ENUM) {
+      if (entry == null) {
+        continue;
+      }
+      if (key.equalsIgnoreCase(entry.getValue())) {
+        return entry.getValue();
+      }
+      if (entry.getLabel() != null
+          && entry.getLabel().getText() != null
+          && key.equalsIgnoreCase(entry.getLabel().getText())) {
+        return entry.getValue();
+      }
     }
     return null;
+  }
+
+  static String requireValidName(String name) {
+    if (StringUtils.isBlank(name)) {
+      throw new IllegalArgumentException("name is required");
+    }
+    String trimmed = name.trim();
+    for (int i = 0; i < trimmed.length(); i++) {
+      if (Character.isWhitespace(trimmed.charAt(i))) {
+        throw new IllegalArgumentException("name cannot contain whitespace");
+      }
+    }
+    if (trimmed.contains("*")) {
+      throw new IllegalArgumentException("name must not contain wildcards");
+    }
+    if (!isSafeRelationshipTypeKey(trimmed)) {
+      throw new IllegalArgumentException("name is invalid");
+    }
+    return trimmed;
+  }
+
+  private void requireAdmin() {
+    boolean allowed;
+    try {
+      allowed = adminChecker.getAsBoolean();
+    } catch (WebApplicationException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.debug("Admin check failed: {}", e.getMessage());
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+    if (!allowed) {
+      throw new WebApplicationException(ADMIN_REQUIRED, Response.Status.FORBIDDEN);
+    }
+  }
+
+  boolean isCurrentUserAdmin() {
+    if (userService == null) {
+      return false;
+    }
+    try {
+      PSCurrentUser current = userService.getCurrentUser();
+      if (current == null || StringUtils.isBlank(current.getName())) {
+        return false;
+      }
+      return userService.isAdminUser(current.getName());
+    } catch (PSDataServiceException e) {
+      log.debug("Unable to resolve current user for Admin check: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  private static void requireSessionUserForDesignWrite() {
+    if (StringUtils.isBlank(currentSession()) || StringUtils.isBlank(currentUser())) {
+      throw new WebApplicationException(
+          "Request session/user required for relationship type design session",
+          Response.Status.FORBIDDEN);
+    }
+  }
+
+  private static String currentSession() {
+    Object session = PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_JSESSIONID);
+    return session != null ? session.toString() : null;
+  }
+
+  private static String currentUser() {
+    Object user = PSRequestInfo.getRequestInfo(PSRequestInfo.KEY_USER);
+    return user != null ? user.toString() : null;
+  }
+
+  private static WebApplicationException lockConflict(String prefix) {
+    return new WebApplicationException(
+        prefix + "; design lock required or held by another user", 409);
+  }
+
+  private static RuntimeException mapPersistFailure(String name, Exception e, String prefix) {
+    log.error("{} {}: {}", prefix, name, e.getMessage(), e);
+    if (e instanceof PSErrorsException pe && isLockFailure(pe)) {
+      return lockConflict(prefix);
+    }
+    return new IllegalStateException(prefix + ": " + e.getMessage(), e);
+  }
+
+  private static boolean isLockFailure(PSErrorsException e) {
+    if (e == null || e.getErrors() == null) {
+      return false;
+    }
+    for (Object err : e.getErrors().values()) {
+      if (err == null) {
+        continue;
+      }
+      String msg = err.toString().toLowerCase(Locale.ROOT);
+      if (msg.contains("lock") || err instanceof PSLockErrorException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isAlreadyExistsFailure(Throwable e) {
+    Throwable cur = e;
+    while (cur != null) {
+      String msg = StringUtils.defaultString(cur.getMessage()).toLowerCase(Locale.ROOT);
+      if (msg.contains("must be unique") || msg.contains("already exists")) {
+        return true;
+      }
+      cur = cur.getCause();
+    }
+    return false;
+  }
+
+  private static String formatErrors(PSErrorsException e) {
+    if (e == null || e.getErrors() == null || e.getErrors().isEmpty()) {
+      return e != null ? StringUtils.defaultString(e.getMessage()) : "";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (Object err : e.getErrors().values()) {
+      if (err == null) {
+        continue;
+      }
+      if (sb.length() > 0) {
+        sb.append("; ");
+      }
+      sb.append(err);
+    }
+    return sb.toString();
   }
 
   private RelationshipType copyConfig(PSRelationshipConfig cfg, boolean includeDesignGaps) {

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/RelationshipTypeAdaptorSafeKeyTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/RelationshipTypeAdaptorSafeKeyTest.java
@@ -4,7 +4,9 @@
 
 package com.percussion.apibridge;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Tag;
@@ -24,5 +26,16 @@ class RelationshipTypeAdaptorSafeKeyTest {
     assertFalse(RelationshipTypeAdaptor.isSafeRelationshipTypeKey("   "));
     assertFalse(RelationshipTypeAdaptor.isSafeRelationshipTypeKey("a\u0000b"));
     assertFalse(RelationshipTypeAdaptor.isSafeRelationshipTypeKey(null));
+  }
+
+  @Test
+  void requireValidName_rejectsWhitespaceAndWildcards() {
+    assertEquals("MyRel", RelationshipTypeAdaptor.requireValidName("MyRel"));
+    assertThrows(
+        IllegalArgumentException.class, () -> RelationshipTypeAdaptor.requireValidName(" "));
+    assertThrows(
+        IllegalArgumentException.class, () -> RelationshipTypeAdaptor.requireValidName("My Rel"));
+    assertThrows(
+        IllegalArgumentException.class, () -> RelationshipTypeAdaptor.requireValidName("My*Rel"));
   }
 }

--- a/projects/sitemanage/src/test/java/com/percussion/apibridge/RelationshipTypeAdaptorWriteTest.java
+++ b/projects/sitemanage/src/test/java/com/percussion/apibridge/RelationshipTypeAdaptorWriteTest.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.percussion.apibridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.percussion.design.objectstore.PSRelationshipConfig;
+import com.percussion.rest.relationshiptypes.RelationshipType;
+import com.percussion.rest.relationshiptypes.RelationshipTypeProperty;
+import com.percussion.services.catalog.IPSCatalogSummary;
+import com.percussion.services.catalog.data.PSObjectSummary;
+import com.percussion.utils.guid.IPSGuid;
+import com.percussion.utils.request.PSRequestInfo;
+import com.percussion.webservices.system.IPSSystemDesignWs;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * SY-03 Admin POST create / PUT update / DELETE user relationship types via {@code
+ * IPSSystemDesignWs}. Admin only; system types are 409.
+ */
+@Tag("UnitTest")
+class RelationshipTypeAdaptorWriteTest {
+
+  private IPSSystemDesignWs designWs;
+  private RelationshipTypeAdaptor adaptor;
+  private final Map<String, PSRelationshipConfig> store = new HashMap<>();
+  private final AtomicInteger nextId = new AtomicInteger(100);
+
+  @BeforeEach
+  void setUp() throws Exception {
+    PSRequestInfo.resetRequestInfo();
+    PSRequestInfo.initRequestInfo(new HashMap<String, Object>());
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_JSESSIONID, "test-session");
+    PSRequestInfo.setRequestInfo(PSRequestInfo.KEY_USER, "Admin");
+
+    designWs = mock(IPSSystemDesignWs.class);
+    adaptor = new RelationshipTypeAdaptor(designWs, () -> true);
+
+    when(designWs.findRelationshipTypes(any(), isNull()))
+        .thenAnswer(
+            inv -> {
+              String name = inv.getArgument(0);
+              List<IPSCatalogSummary> out = new ArrayList<>();
+              for (PSRelationshipConfig cfg : store.values()) {
+                if (cfg == null) {
+                  continue;
+                }
+                if (name == null
+                    || name.isBlank()
+                    || name.equalsIgnoreCase(cfg.getName())) {
+                  out.add(toSummary(cfg));
+                }
+              }
+              return out;
+            });
+
+    when(designWs.loadRelationshipTypes(anyList(), anyBoolean(), anyBoolean(), any(), any()))
+        .thenAnswer(
+            inv -> {
+              List<IPSGuid> ids = inv.getArgument(0);
+              List<PSRelationshipConfig> out = new ArrayList<>();
+              for (IPSGuid id : ids) {
+                for (PSRelationshipConfig cfg : store.values()) {
+                  if (cfg.isAssinedId() && cfg.getGUID().equals(id)) {
+                    out.add(cfg);
+                    break;
+                  }
+                }
+              }
+              return out;
+            });
+
+    when(designWs.createRelationshipTypes(anyList(), anyList(), any(), any()))
+        .thenAnswer(
+            inv -> {
+              List<String> names = inv.getArgument(0);
+              List<String> categories = inv.getArgument(1);
+              List<PSRelationshipConfig> created = new ArrayList<>();
+              for (int i = 0; i < names.size(); i++) {
+                PSRelationshipConfig cfg =
+                    new PSRelationshipConfig(
+                        names.get(i),
+                        PSRelationshipConfig.RS_TYPE_USER,
+                        categories.get(i));
+                cfg.setId(nextId.getAndIncrement());
+                store.put(cfg.getName().toLowerCase(), cfg);
+                created.add(cfg);
+              }
+              return created;
+            });
+
+    doAnswer(
+            inv -> {
+              List<PSRelationshipConfig> configs = inv.getArgument(0);
+              for (PSRelationshipConfig cfg : configs) {
+                if (cfg != null && cfg.getName() != null) {
+                  store.put(cfg.getName().toLowerCase(), cfg);
+                }
+              }
+              return null;
+            })
+        .when(designWs)
+        .saveRelationshipTypes(anyList(), anyBoolean(), any(), any());
+
+    doAnswer(
+            inv -> {
+              List<IPSGuid> ids = inv.getArgument(0);
+              store
+                  .entrySet()
+                  .removeIf(
+                      e -> {
+                        PSRelationshipConfig cfg = e.getValue();
+                        if (cfg == null || !cfg.isAssinedId()) {
+                          return false;
+                        }
+                        for (IPSGuid id : ids) {
+                          if (cfg.getGUID().equals(id)) {
+                            return true;
+                          }
+                        }
+                        return false;
+                      });
+              return null;
+            })
+        .when(designWs)
+        .deleteRelationshipTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @AfterEach
+  void tearDown() {
+    PSRequestInfo.resetRequestInfo();
+  }
+
+  @Test
+  void create_persistsUserTypeAndRoundTrips() throws Exception {
+    RelationshipType body = userBody("MyUserRel");
+    body.setLabel("My User Rel");
+    body.setDescription("created via REST");
+
+    RelationshipType out = adaptor.createRelationshipType(body);
+
+    assertEquals("MyUserRel", out.getName());
+    assertEquals("My User Rel", out.getLabel());
+    assertEquals("created via REST", out.getDescription());
+    assertTrue(out.isUserType());
+    assertFalse(out.isSystemType());
+    assertEquals(PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY, out.getCategory());
+
+    RelationshipType fetched = adaptor.findRelationshipType("MyUserRel");
+    assertNotNull(fetched);
+    assertEquals("My User Rel", fetched.getLabel());
+
+    ArgumentCaptor<List> namesCap = ArgumentCaptor.forClass(List.class);
+    ArgumentCaptor<List> catsCap = ArgumentCaptor.forClass(List.class);
+    verify(designWs).createRelationshipTypes(namesCap.capture(), catsCap.capture(), any(), any());
+    assertEquals(List.of("MyUserRel"), namesCap.getValue());
+    assertEquals(
+        List.of(PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY), catsCap.getValue());
+  }
+
+  @Test
+  void create_acceptsCategoryLabel() {
+    RelationshipType body = userBody("MyUserRel");
+    body.setCategory("Active Assembly");
+    RelationshipType out = adaptor.createRelationshipType(body);
+    assertEquals(PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY, out.getCategory());
+  }
+
+  @Test
+  void create_copyFromSystemCopiesMutableFields() {
+    PSRelationshipConfig system =
+        new PSRelationshipConfig(
+            "ActiveAssembly",
+            PSRelationshipConfig.RS_TYPE_SYSTEM,
+            PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY);
+    system.setId(1);
+    system.setLabel("Active Assembly");
+    system.setDescription("system desc");
+    store.put(system.getName().toLowerCase(), system);
+
+    RelationshipType body = new RelationshipType();
+    body.setName("CopiedRel");
+    body.setCopyFrom("ActiveAssembly");
+
+    RelationshipType out = adaptor.createRelationshipType(body);
+
+    assertEquals("CopiedRel", out.getName());
+    assertTrue(out.isUserType());
+    assertFalse(out.isSystemType());
+    assertEquals("Active Assembly", out.getLabel());
+    assertEquals("system desc", out.getDescription());
+    assertEquals(PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY, out.getCategory());
+  }
+
+  @Test
+  void create_duplicateIs409() {
+    seedUser("MyUserRel");
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.createRelationshipType(userBody("MyUserRel")));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).createRelationshipTypes(anyList(), anyList(), any(), any());
+  }
+
+  @Test
+  void create_blankNameThrows400() {
+    assertThrows(IllegalArgumentException.class, () -> adaptor.createRelationshipType(null));
+    RelationshipType blank = new RelationshipType();
+    blank.setName("  ");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.createRelationshipType(blank));
+    assertTrue(ex.getMessage().contains("name is required"));
+  }
+
+  @Test
+  void create_missingCategoryThrows() {
+    RelationshipType body = new RelationshipType();
+    body.setName("MyUserRel");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> adaptor.createRelationshipType(body));
+    assertTrue(ex.getMessage().contains("category"));
+  }
+
+  @Test
+  void create_nonAdminIs403() {
+    RelationshipTypeAdaptor denied = new RelationshipTypeAdaptor(designWs, () -> false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> denied.createRelationshipType(userBody("MyUserRel")));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  void update_mutatesLabelDescriptionAndFlags() {
+    seedUser("MyUserRel");
+    RelationshipType body = new RelationshipType();
+    body.setLabel("Updated Label");
+    body.setDescription("updated desc");
+    body.setAllowCloning(false);
+    body.setUseOwnerRevision(true);
+    body.setUseDependentRevision(false);
+    body.setUserProperties(List.of(new RelationshipTypeProperty("custom", "v1")));
+
+    RelationshipType out = adaptor.updateRelationshipType("MyUserRel", body);
+
+    assertEquals("Updated Label", out.getLabel());
+    assertEquals("updated desc", out.getDescription());
+    assertFalse(out.isAllowCloning());
+    RelationshipType fetched = adaptor.findRelationshipType("MyUserRel");
+    assertEquals("Updated Label", fetched.getLabel());
+    assertTrue(
+        fetched.getUserProperties().stream()
+            .anyMatch(p -> "custom".equals(p.getName()) && "v1".equals(p.getValue())));
+  }
+
+  @Test
+  void update_systemTypeIs409() {
+    PSRelationshipConfig system =
+        new PSRelationshipConfig(
+            "ActiveAssembly",
+            PSRelationshipConfig.RS_TYPE_SYSTEM,
+            PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY);
+    system.setId(1);
+    store.put(system.getName().toLowerCase(), system);
+
+    RelationshipType body = new RelationshipType();
+    body.setLabel("Nope");
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> adaptor.updateRelationshipType("ActiveAssembly", body));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).saveRelationshipTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void update_unknownReturnsNull() {
+    RelationshipType body = new RelationshipType();
+    body.setLabel("x");
+    assertEquals(null, adaptor.updateRelationshipType("missing", body));
+  }
+
+  @Test
+  void delete_removesUserType() {
+    seedUser("MyUserRel");
+    assertTrue(adaptor.deleteRelationshipType("MyUserRel"));
+    assertEquals(null, adaptor.findRelationshipType("MyUserRel"));
+  }
+
+  @Test
+  void delete_systemTypeIs409() {
+    PSRelationshipConfig system =
+        new PSRelationshipConfig(
+            "ActiveAssembly",
+            PSRelationshipConfig.RS_TYPE_SYSTEM,
+            PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY);
+    system.setId(1);
+    store.put(system.getName().toLowerCase(), system);
+
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> adaptor.deleteRelationshipType("ActiveAssembly"));
+    assertEquals(409, ex.getResponse().getStatus());
+    verify(designWs, never()).deleteRelationshipTypes(anyList(), anyBoolean(), any(), any());
+  }
+
+  @Test
+  void delete_unknownReturnsFalse() {
+    assertFalse(adaptor.deleteRelationshipType("missing"));
+  }
+
+  @Test
+  void resolveCategoryCode_mapsLabelAndCode() {
+    assertEquals(
+        PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY,
+        RelationshipTypeAdaptor.resolveCategoryCode("Active Assembly"));
+    assertEquals(
+        PSRelationshipConfig.CATEGORY_TRANSLATION,
+        RelationshipTypeAdaptor.resolveCategoryCode("rs_translation"));
+    assertEquals(null, RelationshipTypeAdaptor.resolveCategoryCode("nope"));
+  }
+
+  private void seedUser(String name) {
+    PSRelationshipConfig cfg =
+        new PSRelationshipConfig(
+            name,
+            PSRelationshipConfig.RS_TYPE_USER,
+            PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY);
+    cfg.setId(nextId.getAndIncrement());
+    cfg.setLabel(name);
+    store.put(cfg.getName().toLowerCase(), cfg);
+  }
+
+  private static RelationshipType userBody(String name) {
+    RelationshipType t = new RelationshipType();
+    t.setName(name);
+    t.setCategory(PSRelationshipConfig.CATEGORY_ACTIVE_ASSEMBLY);
+    return t;
+  }
+
+  private static IPSCatalogSummary toSummary(PSRelationshipConfig cfg) {
+    return new PSObjectSummary(cfg.getGUID(), cfg.getName());
+  }
+}

--- a/rest/src/main/java/com/percussion/rest/relationshiptypes/IRelationshipTypeAdaptor.java
+++ b/rest/src/main/java/com/percussion/rest/relationshiptypes/IRelationshipTypeAdaptor.java
@@ -19,7 +19,12 @@ package com.percussion.rest.relationshiptypes;
 
 import java.util.List;
 
-/** Adaptor for relationship type design catalog (SY-03 read). */
+/**
+ * Adaptor for relationship type design catalog and Admin user-type write (SY-03).
+ *
+ * <p>Write methods persist <strong>user</strong> relationship types through {@code
+ * IPSSystemDesignWs}. System relationship types are immutable.
+ */
 public interface IRelationshipTypeAdaptor {
 
   /**
@@ -36,4 +41,30 @@ public interface IRelationshipTypeAdaptor {
    * @return type, or null when not found / unsafe key
    */
   RelationshipType findRelationshipType(String idOrName);
+
+  /**
+   * Admin. Create a user relationship type, optionally copying mutable fields from an existing
+   * type ({@code copyFrom}).
+   *
+   * @param body required; {@code name} required; {@code category} or {@code copyFrom} required
+   * @return the persisted relationship type
+   */
+  RelationshipType createRelationshipType(RelationshipType body);
+
+  /**
+   * Admin. Update mutable fields of a user relationship type. Does not mutate system types.
+   *
+   * @param idOrName name or GUID string (same rules as {@link #findRelationshipType})
+   * @param body required writable fields
+   * @return the persisted type, or {@code null} when missing/unsafe
+   */
+  RelationshipType updateRelationshipType(String idOrName, RelationshipType body);
+
+  /**
+   * Admin. Delete a user relationship type. Does not mutate system types.
+   *
+   * @param idOrName name or GUID string (same rules as {@link #findRelationshipType})
+   * @return {@code true} when deleted, {@code false} when missing/unsafe
+   */
+  boolean deleteRelationshipType(String idOrName);
 }

--- a/rest/src/main/java/com/percussion/rest/relationshiptypes/RelationshipType.java
+++ b/rest/src/main/java/com/percussion/rest/relationshiptypes/RelationshipType.java
@@ -24,10 +24,10 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Design-time relationship type (PSRelationshipConfig) catalog projection. */
+/** Design-time relationship type (PSRelationshipConfig) catalog / Admin write projection. */
 @XmlRootElement(name = "RelationshipType")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(description = "Relationship type design object (read-only catalog)")
+@Schema(description = "Relationship type design object (catalog + Admin user-type write)")
 public class RelationshipType {
 
   @Schema(description = "Relationship type GUID")
@@ -45,7 +45,7 @@ public class RelationshipType {
   @Schema(description = "Type discriminator (system or user)")
   private String type;
 
-  @Schema(description = "Category code (e.g. rs_activeassembly)")
+  @Schema(description = "Category code (e.g. rs_activeassembly) or label (e.g. Active Assembly)")
   private String category;
 
   @Schema(description = "Human-readable category label when known")
@@ -66,6 +66,12 @@ public class RelationshipType {
   @Schema(description = "Use dependent revision flag")
   private boolean useDependentRevision;
 
+  @Schema(
+      description =
+          "On POST only: name or GUID of an existing type to copy mutable fields from"
+              + " (Workbench copy-from-system). Ignored on GET/PUT.")
+  private String copyFrom;
+
   @Schema(description = "Conditional effects")
   private List<RelationshipTypeEffect> effects = new ArrayList<>();
 
@@ -77,9 +83,8 @@ public class RelationshipType {
 
   @Schema(
       description =
-          "Honest design gaps for this read-only surface. Present on detail GET; typically"
-              + " omitted on list rows to avoid repeating the same catalog-level array"
-              + " (REST-GAPS-02)")
+          "Honest design gaps for this surface. Present on detail GET; typically omitted on"
+              + " list rows to avoid repeating the same catalog-level array (REST-GAPS-02)")
   private List<String> designGaps = new ArrayList<>();
 
   public RelationshipType() {}
@@ -178,6 +183,14 @@ public class RelationshipType {
 
   public void setUseDependentRevision(boolean useDependentRevision) {
     this.useDependentRevision = useDependentRevision;
+  }
+
+  public String getCopyFrom() {
+    return copyFrom;
+  }
+
+  public void setCopyFrom(String copyFrom) {
+    this.copyFrom = copyFrom;
   }
 
   public List<RelationshipTypeEffect> getEffects() {

--- a/rest/src/main/java/com/percussion/rest/relationshiptypes/RelationshipTypeResource.java
+++ b/rest/src/main/java/com/percussion/rest/relationshiptypes/RelationshipTypeResource.java
@@ -24,7 +24,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -36,14 +40,18 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Read-only relationship type catalog for the Developer module (SY-03 list/detail).
+ * Relationship type catalog and Admin user-type write for the Developer module (SY-03).
  *
- * <p>Create/edit/delete remain later slices.
+ * <p>Admin POST/PUT/DELETE persist <strong>user</strong> relationship types through {@link
+ * IRelationshipTypeAdaptor} ({@code IPSSystemDesignWs}). System relationship types are read-only
+ * (**409**). This resource is REST only — it does not add Developer SPA chrome.
  */
 @PSSiteManageBean(value = "restRelationshipTypeResource")
 @Path("/relationshiptypes")
 @XmlRootElement
-@Tag(name = "Relationship Types", description = "Relationship type design catalog (read-only)")
+@Tag(
+    name = "Relationship Types",
+    description = "Relationship type design catalog and user-type write")
 public class RelationshipTypeResource {
 
   private final IRelationshipTypeAdaptor adaptor;
@@ -68,7 +76,7 @@ public class RelationshipTypeResource {
       summary = "List relationship types",
       description =
           "Lists system and user relationship types with category, properties, and effects."
-              + " Create/edit/delete are later slices.",
+              + " Admin create/update/delete of user types are POST/PUT/DELETE on this resource.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -98,8 +106,8 @@ public class RelationshipTypeResource {
   @Operation(
       summary = "Get relationship type detail",
       description =
-          "Loads one relationship type by name or GUID string (type-host-uuid). Write remains"
-              + " unsupported.",
+          "Loads one relationship type by name or GUID string (type-host-uuid). Admin write of"
+              + " user types is POST/PUT/DELETE on this resource. System types cannot be mutated.",
       responses = {
         @ApiResponse(
             responseCode = "200",
@@ -122,6 +130,130 @@ public class RelationshipTypeResource {
     } catch (Exception e) {
       throw new WebApplicationException(e, 500);
     }
+  }
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Create user relationship type",
+      description =
+          "Admin. Creates a user relationship type via IPSSystemDesignWs.createRelationshipTypes"
+              + " + save. name is required (no whitespace). Provide category (code or label) or"
+              + " copyFrom (existing name/GUID to copy mutable fields from — Workbench"
+              + " copy-from-system). Duplicate name is 409. System types cannot be created as"
+              + " system (always user). This is REST only — there is no Developer SPA create"
+              + " chrome.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Created",
+            content = @Content(schema = @Schema(implementation = RelationshipType.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "409", description = "Name already exists"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public RelationshipType createRelationshipType(RelationshipType body) {
+    try {
+      RelationshipType created = requireAdaptor().createRelationshipType(body);
+      if (created == null) {
+        throw new WebApplicationException("Failed to create relationship type", 500);
+      }
+      return created;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @PUT
+  @Path("/{idOrName}")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Operation(
+      summary = "Update user relationship type",
+      description =
+          "Admin. Updates mutable fields of a user relationship type (label, description,"
+              + " category, cloning/revision flags, user properties). Name is not renamed on PUT."
+              + " System types are 409. Unknown key is 404. Prefer round-trip GET then PUT for"
+              + " boolean flags.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Updated",
+            content = @Content(schema = @Schema(implementation = RelationshipType.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Relationship type not found"),
+        @ApiResponse(responseCode = "409", description = "System relationship type cannot be mutated"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public RelationshipType updateRelationshipType(
+      @PathParam("idOrName") String idOrName, RelationshipType body) {
+    try {
+      if (body == null) {
+        throw new IllegalArgumentException("body is required");
+      }
+      RelationshipType updated = requireAdaptor().updateRelationshipType(idOrName, body);
+      if (updated == null) {
+        throw new WebApplicationException("Relationship type not found", 404);
+      }
+      return updated;
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  @DELETE
+  @Path("/{idOrName}")
+  @Operation(
+      summary = "Delete user relationship type",
+      description =
+          "Admin. Deletes a user relationship type by name or GUID. System types are 409 (not"
+              + " deleted). Unknown key is 404. Following GET is 404 after a successful delete.",
+      responses = {
+        @ApiResponse(responseCode = "204", description = "Deleted"),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "403", description = "Admin role required"),
+        @ApiResponse(responseCode = "404", description = "Relationship type not found"),
+        @ApiResponse(
+            responseCode = "409",
+            description = "System relationship type cannot be deleted"),
+        @ApiResponse(responseCode = "503", description = "Adaptor not configured"),
+        @ApiResponse(responseCode = "500", description = "Error")
+      })
+  public Response deleteRelationshipType(@PathParam("idOrName") String idOrName) {
+    try {
+      boolean deleted = requireAdaptor().deleteRelationshipType(idOrName);
+      if (!deleted) {
+        throw new WebApplicationException("Relationship type not found", 404);
+      }
+      return Response.noContent().build();
+    } catch (RuntimeException e) {
+      throw mapWriteFailure(e);
+    } catch (Exception e) {
+      throw new WebApplicationException(e, 500);
+    }
+  }
+
+  /**
+   * Map adaptor write failures to HTTP status. Admin 403, duplicate 409, and immutable 409 are
+   * already {@link WebApplicationException}s from the adaptor.
+   */
+  static WebApplicationException mapWriteFailure(RuntimeException e) {
+    if (e instanceof WebApplicationException wae) {
+      return wae;
+    }
+    if (e instanceof IllegalArgumentException) {
+      return new WebApplicationException(e.getMessage(), 400);
+    }
+    return new WebApplicationException(e, 500);
   }
 
   private IRelationshipTypeAdaptor requireAdaptor() {

--- a/rest/src/test/java/com/percussion/rest/relationshiptypes/RelationshipTypeResourceTest.java
+++ b/rest/src/test/java/com/percussion/rest/relationshiptypes/RelationshipTypeResourceTest.java
@@ -21,12 +21,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -132,5 +135,135 @@ public class RelationshipTypeResourceTest {
     WebApplicationException ex =
         assertThrows(WebApplicationException.class, () -> bare.getRelationshipType("any"));
     assertEquals(503, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createRelationshipTypeDelegates() {
+    RelationshipType body = userBody("MyUserRel");
+    RelationshipType created = userBody("MyUserRel");
+    created.setUserType(true);
+    when(adaptor.createRelationshipType(eq(body))).thenReturn(created);
+
+    RelationshipType out = resource.createRelationshipType(body);
+
+    assertEquals("MyUserRel", out.getName());
+    assertTrue(out.isUserType());
+    verify(adaptor).createRelationshipType(eq(body));
+  }
+
+  @Test
+  public void createRelationshipTypeBlankNameIs400() {
+    when(adaptor.createRelationshipType(any()))
+        .thenThrow(new IllegalArgumentException("name is required"));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.createRelationshipType(new RelationshipType()));
+    assertEquals(400, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createRelationshipTypeDuplicateIs409() {
+    when(adaptor.createRelationshipType(any()))
+        .thenThrow(new WebApplicationException("Relationship type already exists: MyUserRel", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.createRelationshipType(userBody("MyUserRel")));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void createRelationshipTypeNonAdminIs403() {
+    when(adaptor.createRelationshipType(any()))
+        .thenThrow(new WebApplicationException("Admin role required", Response.Status.FORBIDDEN));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.createRelationshipType(userBody("MyUserRel")));
+    assertEquals(403, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateRelationshipTypeDelegates() {
+    RelationshipType body = userBody("MyUserRel");
+    body.setLabel("Updated");
+    RelationshipType updated = userBody("MyUserRel");
+    updated.setLabel("Updated");
+    when(adaptor.updateRelationshipType(eq("MyUserRel"), eq(body))).thenReturn(updated);
+
+    RelationshipType out = resource.updateRelationshipType("MyUserRel", body);
+
+    assertEquals("Updated", out.getLabel());
+    verify(adaptor).updateRelationshipType(eq("MyUserRel"), eq(body));
+  }
+
+  @Test
+  public void updateRelationshipTypeUnknownIs404() {
+    when(adaptor.updateRelationshipType(eq("missing"), any())).thenReturn(null);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateRelationshipType("missing", new RelationshipType()));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void updateRelationshipTypeNullBodyIs400() {
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.updateRelationshipType("MyUserRel", null));
+    assertEquals(400, ex.getResponse().getStatus());
+    verify(adaptor, never()).updateRelationshipType(any(), any());
+  }
+
+  @Test
+  public void updateRelationshipTypeSystemIs409() {
+    when(adaptor.updateRelationshipType(eq("ActiveAssembly"), any()))
+        .thenThrow(
+            new WebApplicationException(
+                "System relationship types cannot be updated or deleted", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class,
+            () -> resource.updateRelationshipType("ActiveAssembly", new RelationshipType()));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteRelationshipTypeDelegates() {
+    when(adaptor.deleteRelationshipType(eq("MyUserRel"))).thenReturn(true);
+    Response resp = resource.deleteRelationshipType("MyUserRel");
+    assertEquals(204, resp.getStatus());
+    verify(adaptor).deleteRelationshipType("MyUserRel");
+  }
+
+  @Test
+  public void deleteRelationshipTypeUnknownIs404() {
+    when(adaptor.deleteRelationshipType(eq("missing"))).thenReturn(false);
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteRelationshipType("missing"));
+    assertEquals(404, ex.getResponse().getStatus());
+  }
+
+  @Test
+  public void deleteRelationshipTypeSystemIs409() {
+    when(adaptor.deleteRelationshipType(eq("ActiveAssembly")))
+        .thenThrow(
+            new WebApplicationException(
+                "System relationship types cannot be updated or deleted", 409));
+    WebApplicationException ex =
+        assertThrows(
+            WebApplicationException.class, () -> resource.deleteRelationshipType("ActiveAssembly"));
+    assertEquals(409, ex.getResponse().getStatus());
+  }
+
+  private static RelationshipType userBody(String name) {
+    RelationshipType t = new RelationshipType();
+    t.setName(name);
+    t.setCategory("rs_activeassembly");
+    t.setLabel(name);
+    return t;
   }
 }

--- a/rest/src/test/java/com/percussion/rest/test/apibridge/TestRelationshipTypeAdaptor.java
+++ b/rest/src/test/java/com/percussion/rest/test/apibridge/TestRelationshipTypeAdaptor.java
@@ -22,7 +22,7 @@ import com.percussion.rest.relationshiptypes.RelationshipType;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
-/** Test adaptor for Relationship Type API bridge. */
+/** Test adaptor for Relationship Type API bridge (MainTest Spring context). */
 @Component
 public class TestRelationshipTypeAdaptor implements IRelationshipTypeAdaptor {
 
@@ -34,5 +34,20 @@ public class TestRelationshipTypeAdaptor implements IRelationshipTypeAdaptor {
   @Override
   public RelationshipType findRelationshipType(String idOrName) {
     return null;
+  }
+
+  @Override
+  public RelationshipType createRelationshipType(RelationshipType body) {
+    return body;
+  }
+
+  @Override
+  public RelationshipType updateRelationshipType(String idOrName, RelationshipType body) {
+    return body;
+  }
+
+  @Override
+  public boolean deleteRelationshipType(String idOrName) {
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
Parent: #1690 (FR SY-03). Implements Admin REST write for **user** relationship types:

- `POST /services/relationshiptypes` — create user type (`category` or `copyFrom`)
- `PUT /services/relationshiptypes/{idOrName}` — update mutable fields
- `DELETE /services/relationshiptypes/{idOrName}` — delete user type
- System types return **409**; non-Admin **403**; validation **400**
- Backing: `IPSSystemDesignWs` (same design WS as Workbench SOAP)
- Spring test stub + Mockito resource tests + sitemanage adaptor write tests
- `product-docs/8.2/developer/rest.md` write contract

No SPA / Playwright in this slice (siblings later).

## Test plan
- [x] `cd rest && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 1086, Failures: 0
- [x] `cd projects/sitemanage && ../../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 2322, Failures: 0, Skipped: 125
- [x] Resource tests: create/update/delete 400/403/404/409 mapping
- [x] Adaptor tests: create, copyFrom, update flags/props, system 409, delete

## Product documentation
- [x] Updated pages under `product-docs/` (`product-docs/8.2/developer/rest.md` — Relationship types write contract)

## C3 build evidence
- **modules_built:** `rest`, `projects/sitemanage`
- **build_evidence:** standalone `mvnw clean install` in each module dir (rest first, then sitemanage); BUILD SUCCESS; rest Tests run: 1086 Failures: 0; sitemanage Tests run: 2322 Failures: 0 Skipped: 125
- **downstream_checked:** sitemanage standalone clean install (implements new `IRelationshipTypeAdaptor` write methods). No `final`/`sealed` API changes. Grep N/A for subclass blast radius.

## C5 UI proof
- [x] N/A — REST/backend only; no WebUI / Playwright in this slice

## Operator
Operator: Grok: night-issue-prs (model grok-4.5)

Fixes #4251

> Co-Authored by Grok Build 1.0.5 using grok-4.5 with agent night-issue-prs.