### PR TITLE
feat(WebUI): SPA custom URL view editor (UI-07) (#4236)

### DIFF
--- a/WebUI/src/main/ts/api/developer/viewsApi.ts
+++ b/WebUI/src/main/ts/api/developer/viewsApi.ts
@@ -26,10 +26,11 @@ export { resolveViewObjectGuid };
  * Writable identity fields for POST/PUT /services/views. Name is the catalog
  * key (not renamed on PUT). Field criteria are included on PUT when the SPA
  * saves the criterion list (omitted fields leave existing criteria unchanged).
+ * Custom URL writes send {@code url} + {@code customView} instead of fields.
  */
 export type ViewWriteBody = Pick<
   ViewDef,
-  "name" | "label" | "description" | "type" | "displayFormatId" | "fields"
+  "name" | "label" | "description" | "type" | "displayFormatId" | "fields" | "url" | "customView"
 >;
 
 /** Jackson / JAXB root for ViewDef (UNWRAP_ROOT_VALUE on POST/PUT). */
@@ -38,8 +39,14 @@ export const VIEW_DEF_ROOT = "ViewDef";
 /** REST default type on create ({@code PSSearch.TYPE_VIEW}). */
 export const VIEW_TYPE_STANDARD = "View";
 
+/** REST custom URL type alias used by Developer Views chrome ({@code CustomView}). */
+export const VIEW_TYPE_CUSTOM = "CustomView";
+
 /** {@code PSSearch.INTERNALNAME_LENGTH} — create name max. */
 export const VIEW_NAME_MAX = 128;
+
+/** {@code PSSearch.CUSTOMURL_LENGTH} — custom URL max. */
+export const VIEW_URL_MAX = 255;
 
 /** Seed / DCE internal name for the operator Inbox view. */
 export const INBOX_VIEW_NAME = "Inbox";
@@ -48,14 +55,28 @@ export const INBOX_VIEW_NAME = "Inbox";
 export const INBOX_DCE_PATH = "//Views//MyContent/Inbox";
 
 /**
+ * Packaged {@code sys_cxViews} catalog keys (REST {@code PACKAGED_CX_VIEW_NAMES}).
+ * PUT/DELETE of these names is 409; user-created custom URL views stay writable.
+ */
+export const PACKAGED_CX_VIEW_NAMES = new Set([
+  "inbox",
+  "outbox",
+  "recent",
+  "session",
+  "checked_out_by_me",
+  "duplicatefolderpaths",
+]);
+
+/**
  * Catalog-level design gaps (REST-GAPS-02). Server omits these on list rows;
  * detail re-attaches or SPA falls back via this constant.
  *
- * <p>Create / save / delete and field-criterion write are supported (UI-07 / UI-08).
- * Inbox-family mutate remains REST-protected.</p>
+ * <p>Create / save / delete, field-criterion write, and user custom URL write are
+ * supported (UI-07). Inbox-family / packaged {@code sys_cxViews} mutate remains
+ * REST-protected.</p>
  */
 export const VIEW_DESIGN_GAPS: string[] = [
-  "Inbox-family and custom URL views cannot be updated or deleted via this API",
+  "Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API",
   "Searches are a separate catalog (Developer Searches / UI-06)",
 ];
 
@@ -100,30 +121,116 @@ export function isValidViewName(name: string | undefined | null): boolean {
   return isSafeViewName(key);
 }
 
-/** Save is enabled when the view name is valid (create) or already loaded (edit). */
-export function isViewWriteReady(opts: { isNew: boolean; name: string }): boolean {
-  if (opts.isNew) return isValidViewName(opts.name);
-  return Boolean(normalizeViewName(opts.name));
+/** True when the REST / SPA type is a custom URL view. */
+export function isCustomViewType(type: string | undefined | null): boolean {
+  const t = (type ?? "").trim().toLowerCase();
+  if (!t) return false;
+  return t === VIEW_TYPE_CUSTOM.toLowerCase() || t === "custom";
 }
 
 /**
- * True when REST will 409 on PUT/DELETE (Inbox family or custom URL).
- * Catalog chrome must not delete these rows.
+ * Canonical REST type for persist. Aliases {@code custom} / {@code CustomView}
+ * become {@link VIEW_TYPE_CUSTOM} so dirty/compare matches GET.
+ */
+export function canonicalViewType(type: string | undefined | null): string {
+  const t = (type ?? "").trim();
+  if (!t) return VIEW_TYPE_STANDARD;
+  if (isCustomViewType(t)) return VIEW_TYPE_CUSTOM;
+  const lower = t.toLowerCase();
+  if (lower === VIEW_TYPE_STANDARD.toLowerCase() || lower === "standard" || lower === "_standard") {
+    return VIEW_TYPE_STANDARD;
+  }
+  return t;
+}
+
+/** Trim a custom view URL. Empty / null becomes "". */
+export function normalizeViewUrl(url: string | undefined | null): string {
+  return url == null ? "" : url.trim();
+}
+
+/**
+ * True when the URL is accepted by REST custom-view write
+ * ({@code ViewAdaptor.requireValidCustomViewUrl}): non-blank classic relative
+ * path, at most one leading {@code ../}, no schemes / backslash / remaining
+ * {@code ..}, max {@link VIEW_URL_MAX}.
+ */
+export function isValidViewUrl(url: string | undefined | null): boolean {
+  const key = normalizeViewUrl(url);
+  if (!key) return false;
+  if (key.length > VIEW_URL_MAX) return false;
+  if (containsWhitespace(key)) return false;
+  if (key.includes("\\") || key.includes("\0")) return false;
+  const lower = key.toLowerCase();
+  if (lower === "<enter url>") return false;
+  if (lower.includes("://") || lower.startsWith("file:") || lower.startsWith("//")) {
+    return false;
+  }
+  let rest = key;
+  if (rest.startsWith("../")) {
+    rest = rest.slice(3);
+  }
+  if (rest.startsWith("./")) {
+    rest = rest.slice(2);
+  }
+  if (!rest || rest.includes("..")) return false;
+  return true;
+}
+
+/**
+ * Save is enabled when the view name is valid (create) or already loaded (edit).
+ * Custom URL views also require a non-blank URL.
+ */
+export function isViewWriteReady(opts: {
+  isNew: boolean;
+  name: string;
+  type?: string;
+  url?: string;
+}): boolean {
+  if (opts.isNew) {
+    if (!isValidViewName(opts.name)) return false;
+  } else if (!normalizeViewName(opts.name)) {
+    return false;
+  }
+  if (isCustomViewType(opts.type) && !isValidViewUrl(opts.url)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * True when REST will 409 on PUT/DELETE for the Inbox design row (name or DCE
+ * path). Prefer {@link isPackagedCxViewName} for the full packaged set.
  */
 export function isInboxViewName(name: string | undefined | null): boolean {
   const n = normalizeViewName(name).replace(/\\/g, "/");
   if (!n) return false;
-  return n.toLowerCase() === INBOX_VIEW_NAME.toLowerCase() || n.toLowerCase() === INBOX_DCE_PATH.toLowerCase();
+  return (
+    n.toLowerCase() === INBOX_VIEW_NAME.toLowerCase() ||
+    n.toLowerCase() === INBOX_DCE_PATH.toLowerCase()
+  );
 }
 
-/** Inbox-family / custom-URL / system views are not deleted from this catalog. */
+/**
+ * True when the catalog key is an Inbox-family / packaged {@code sys_cxViews}
+ * name (REST {@code isPackagedCxViewName}). Spaces become underscores.
+ */
+export function isPackagedCxViewName(name: string | undefined | null): boolean {
+  if (isInboxViewName(name)) return true;
+  const key = normalizeViewName(name).toLowerCase().replace(/ /g, "_");
+  if (!key) return false;
+  return PACKAGED_CX_VIEW_NAMES.has(key);
+}
+
+/**
+ * Inbox-family / packaged {@code sys_cxViews} views are not mutated from this
+ * catalog. User-created custom URL views ({@code customView} with a non-packaged
+ * name) remain writable.
+ */
 export function isProtectedViewWrite(
   view: Pick<ViewDef, "name" | "customView" | "url"> | null | undefined,
 ): boolean {
   if (view == null) return false;
-  if (view.customView) return true;
-  if (view.url != null && String(view.url).trim()) return true;
-  return isInboxViewName(view.name);
+  return isPackagedCxViewName(view.name);
 }
 
 /** Wire JSON for POST/PUT — a flat body fails JAXB root unwrap. */
@@ -172,6 +279,7 @@ export function unwrapViewDefList(payload: unknown): ViewDef[] {
 const STALE_WRITE_GAPS = new Set([
   "View create / update / delete not supported via this API",
   "View field criterion editing not supported via this API",
+  "Inbox-family and custom URL views cannot be updated or deleted via this API",
 ]);
 
 /** Drop the pre-UI-07 write gap when REST still attaches it on GET detail. */

--- a/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
@@ -20,13 +20,18 @@ import { captureDialogOpener } from "../architecture/useDialogEscape";
 import { isApiError } from "../api/client";
 import { resolveViewObjectGuid } from "../api/displayFormatGuid";
 import {
+  VIEW_TYPE_CUSTOM,
   VIEW_TYPE_STANDARD,
+  canonicalViewType,
   createView,
   deleteView,
   getViewDetail,
+  isCustomViewType,
   isProtectedViewWrite,
+  isValidViewUrl,
   isViewWriteReady,
   normalizeViewName,
+  normalizeViewUrl,
   saveView,
   type ViewWriteBody,
 } from "../api/developer/viewsApi";
@@ -82,10 +87,10 @@ const actionButton: React.CSSProperties = {
 };
 
 function typeFromDetail(detail: ViewDef | null, fallback: string): string {
-  if (detail?.type && detail.type.trim()) return detail.type.trim();
-  if (detail?.customView) return "CustomView";
+  if (detail?.type && detail.type.trim()) return canonicalViewType(detail.type);
+  if (detail?.customView) return VIEW_TYPE_CUSTOM;
   if (detail?.standardView) return VIEW_TYPE_STANDARD;
-  return fallback;
+  return canonicalViewType(fallback);
 }
 
 /** CX view GUID wire shape {@code host-18-uuid} used after create catalog lag. */
@@ -116,6 +121,7 @@ export function ViewDetailPanel({
   const [label, setLabel] = useState("");
   const [description, setDescription] = useState("");
   const [type, setType] = useState(VIEW_TYPE_STANDARD);
+  const [url, setUrl] = useState("");
   const [displayFormatId, setDisplayFormatId] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -148,6 +154,7 @@ export function ViewDetailPanel({
         setLabel(d.label || "");
         setDescription(d.description || "");
         setType(typeFromDetail(d, VIEW_TYPE_STANDARD));
+        setUrl(d.url || "");
         setDisplayFormatId(d.displayFormatId || "");
         const nextFields = normalizeViewFields(d.fields);
         setDraftFields(nextFields);
@@ -171,23 +178,31 @@ export function ViewDetailPanel({
   const loadedLabel = detail?.label || "";
   const loadedDescription = detail?.description || "";
   const loadedType = typeFromDetail(detail, VIEW_TYPE_STANDARD);
+  const loadedUrl = detail?.url || "";
   const loadedDf = detail?.displayFormatId || "";
+  const customUrl = isCustomViewType(type) || Boolean(detail?.customView);
   const protectedWrite = isProtectedViewWrite(detail);
   const dirty =
     isNew ||
     normalizeViewName(name) !== loadedName ||
     label !== loadedLabel ||
     description !== loadedDescription ||
-    type !== loadedType ||
+    canonicalViewType(type) !== canonicalViewType(loadedType) ||
+    normalizeViewUrl(url) !== normalizeViewUrl(loadedUrl) ||
     displayFormatId !== loadedDf;
-  const canSave = !busy && !protectedWrite && dirty && isViewWriteReady({ isNew, name });
+  const canSave =
+    !busy &&
+    !protectedWrite &&
+    dirty &&
+    isViewWriteReady({ isNew, name, type, url });
   const objectGuid = resolveViewObjectGuid(detail, catalogGuid);
   const writeKey = objectGuid || idOrName || createdKey || normalizeViewName(name);
   const loadedFields = useMemo(
     () => (detail != null ? normalizeViewFields(detail.fields) : []),
     [detail],
   );
-  const fieldsEditable = !protectedWrite && !isNew && detail != null;
+  const hideFieldEditor = protectedWrite || customUrl;
+  const fieldsEditable = !hideFieldEditor && !isNew && detail != null;
   const fields = fieldsEditable ? draftFields : loadedFields;
   const availableFields = catalogViewFieldsNotInUse(draftFields);
   const fieldsDirty = fieldsEditable && !viewFieldsEqual(draftFields, loadedFields);
@@ -199,10 +214,14 @@ export function ViewDetailPanel({
       name: isNew ? normalizeViewName(name) : detail?.name || normalizeViewName(name),
       label: label == null ? "" : String(label),
       description: description == null ? "" : String(description),
-      type: type == null ? "" : String(type),
+      type: canonicalViewType(type),
     };
     if (df.trim()) {
       body.displayFormatId = df.trim();
+    }
+    if (isCustomViewType(type)) {
+      body.customView = true;
+      body.url = normalizeViewUrl(url);
     }
     return body;
   }
@@ -210,7 +229,25 @@ export function ViewDetailPanel({
   function saveFallback(err: unknown): string {
     if (isApiError(err) && err.status === 409 && isNew) return DEV_MSG.VW_DUPLICATE;
     if (isApiError(err) && err.status === 409) return DEV_MSG.VW_PROTECTED;
-    if (isApiError(err) && err.status === 400) return DEV_MSG.VW_INVALID_NAME;
+    if (isApiError(err) && err.status === 400) {
+      if (isCustomViewType(type)) {
+        const raw =
+          typeof err.body === "string"
+            ? err.body
+            : err.body && typeof err.body === "object" && "message" in err.body
+              ? String((err.body as { message?: unknown }).message ?? "")
+              : "";
+        if (
+          !isValidViewUrl(url) ||
+          /\burl is required\b/i.test(raw) ||
+          /custom url/i.test(raw) ||
+          /invalid url/i.test(raw)
+        ) {
+          return DEV_MSG.VW_INVALID_URL;
+        }
+      }
+      return DEV_MSG.VW_INVALID_NAME;
+    }
     if (isApiError(err) && err.status === 403) return DEV_MSG.VW_FORBIDDEN;
     if (isApiError(err) && err.status === 404) return DEV_MSG.VW_NOT_FOUND;
     return DEV_MSG.VW_SAVE_ERROR;
@@ -284,7 +321,11 @@ export function ViewDetailPanel({
   }
 
   async function handleSave(): Promise<void> {
-    if (!canSave || inflight.current) return;
+    if (!canSave || inflight.current || protectedWrite) return;
+    if (isCustomViewType(type) && !isValidViewUrl(url)) {
+      setError(DEV_MSG.VW_INVALID_URL);
+      return;
+    }
     inflight.current = true;
     setBusy(true);
     setError(null);
@@ -302,6 +343,7 @@ export function ViewDetailPanel({
       setLabel(saved.label || "");
       setDescription(saved.description || "");
       setType(typeFromDetail(saved, type));
+      setUrl(saved.url || url);
       setDisplayFormatId(saved.displayFormatId || "");
       const nextFields = normalizeViewFields(saved.fields);
       setDraftFields(nextFields);
@@ -465,18 +507,31 @@ export function ViewDetailPanel({
               id="vw-type"
               data-testid="developer-vw-type"
               style={inputStyle}
-              value={type}
+              value={canonicalViewType(type)}
               disabled={busy || protectedWrite || !isNew}
               onChange={(e) => setType(e.target.value)}
             >
               <option value={VIEW_TYPE_STANDARD}>{DEV_MSG.VW_KIND_STANDARD}</option>
-              {type && type !== VIEW_TYPE_STANDARD ? (
-                <option value={type}>
-                  {detail?.customView ? DEV_MSG.VW_KIND_CUSTOM : type}
-                </option>
-              ) : null}
+              <option value={VIEW_TYPE_CUSTOM}>{DEV_MSG.VW_KIND_CUSTOM}</option>
             </select>
           </div>
+          {isCustomViewType(type) ? (
+            <div style={fieldStyle}>
+              <label htmlFor="vw-url">{DEV_MSG.VW_FORM_URL}</label>
+              <input
+                id="vw-url"
+                data-testid="developer-vw-url"
+                style={{ ...inputStyle, fontFamily: "monospace" }}
+                value={url}
+                disabled={busy || protectedWrite}
+                onChange={(e) => setUrl(e.target.value)}
+                autoComplete="off"
+              />
+              <span style={{ color: catalogColors.muted, fontSize: "0.85rem" }}>
+                {DEV_MSG.VW_URL_HINT}
+              </span>
+            </div>
+          ) : null}
           <div style={fieldStyle}>
             <label htmlFor="vw-df">{DEV_MSG.VW_FORM_DF}</label>
             <input
@@ -560,9 +615,19 @@ export function ViewDetailPanel({
                 <h3 style={{ fontSize: "1rem" }}>{DEV_MSG.VW_FIELDS}</h3>
                 <p
                   style={{ color: catalogColors.muted, fontSize: "0.9rem" }}
-                  data-testid={protectedWrite ? "developer-vw-fields-readonly" : undefined}
+                  data-testid={
+                    protectedWrite
+                      ? "developer-vw-fields-readonly"
+                      : customUrl
+                        ? "developer-vw-fields-custom-url"
+                        : undefined
+                  }
                 >
-                  {protectedWrite ? DEV_MSG.VW_FIELDS_READONLY : DEV_MSG.VW_FIELDS_HINT}
+                  {protectedWrite
+                    ? DEV_MSG.VW_FIELDS_READONLY
+                    : customUrl
+                      ? DEV_MSG.VW_FIELDS_CUSTOM_URL
+                      : DEV_MSG.VW_FIELDS_HINT}
                 </p>
                 {fields.length === 0 ? (
                   <p style={{ color: catalogColors.empty }} data-testid="developer-vw-fields-empty">

--- a/WebUI/src/main/ts/developer/messages.ts
+++ b/WebUI/src/main/ts/developer/messages.ts
@@ -1169,7 +1169,12 @@ export const DEV_MSG_KEYS = {
   VW_FORM_LABEL: "perc.ui.developer@Label",
   VW_FORM_DESCRIPTION: "perc.ui.developer@Description",
   VW_FORM_TYPE: "perc.ui.developer@Type",
+  VW_FORM_URL: "perc.ui.developer@URL",
   VW_FORM_DF: "perc.ui.developer@Display format id",
+  VW_URL_HINT:
+    "perc.ui.developer@Required for a custom URL view. Classic relative path (for example ../sys_cxViews/myapp.xml), no spaces or schemes.",
+  VW_INVALID_URL:
+    "perc.ui.developer@Custom view URL is required. Enter a classic relative path without spaces or schemes.",
   VW_NAME_HINT:
     "perc.ui.developer@Required. Unique, no spaces, wildcards, or path characters.",
   VW_NAME_READONLY: "perc.ui.developer@Name cannot be changed after the view is created.",
@@ -1184,7 +1189,7 @@ export const DEV_MSG_KEYS = {
   VW_FORBIDDEN: "perc.ui.developer@Admin role required to change views.",
   VW_NOT_FOUND: "perc.ui.developer@View not found.",
   VW_PROTECTED:
-    "perc.ui.developer@Inbox-family and custom URL views cannot be updated or deleted from this catalog.",
+    "perc.ui.developer@Inbox-family and packaged sys_cxViews views cannot be updated or deleted from this catalog.",
   VW_COL_NAME: "perc.ui.developer@Name",
   VW_COL_LABEL: "perc.ui.developer@Label",
   VW_COL_KIND: "perc.ui.developer@Kind",
@@ -1201,9 +1206,11 @@ export const DEV_MSG_KEYS = {
   VW_DETAIL_ERROR: "perc.ui.developer@Could not load view.",
   VW_FIELDS: "perc.ui.developer@Field criteria",
   VW_FIELDS_HINT:
-    "perc.ui.developer@Add, remove, or reorder field conditions on this view. Inbox-family and custom URL views stay read-only.",
+    "perc.ui.developer@Add, remove, or reorder field conditions on this view. Packaged Inbox-family views stay read-only.",
+  VW_FIELDS_CUSTOM_URL:
+    "perc.ui.developer@Custom URL views do not use field criteria. Edit the URL instead.",
   VW_FIELDS_READONLY:
-    "perc.ui.developer@Field criteria cannot be edited on Inbox-family or custom URL views.",
+    "perc.ui.developer@Field criteria cannot be edited on Inbox-family or packaged sys_cxViews views.",
   VW_FIELDS_ADD: "perc.ui.developer@Add field",
   VW_FIELDS_REMOVE: "perc.ui.developer@Remove",
   VW_FIELDS_MOVE_UP: "perc.ui.developer@Move up",
@@ -1224,7 +1231,7 @@ export const DEV_MSG_KEYS = {
   VW_GAPS: "perc.ui.developer@Design gaps (not in this API yet)",
   VW_GAP_FIELDS: "perc.ui.developer@View field criterion editing not supported via this API",
   VW_GAP_PROTECTED:
-    "perc.ui.developer@Inbox-family and custom URL views cannot be updated or deleted via this API",
+    "perc.ui.developer@Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API",
   VW_GAP_SEARCHES: "perc.ui.developer@Searches are a separate catalog (Developer Searches / UI-06)",
   EX_LOADING: "perc.ui.developer@Loading extensions...",
   EX_EMPTY: "perc.ui.developer@No extensions returned.",

--- a/WebUI/src/test/ts/api/developer/viewsApi.test.ts
+++ b/WebUI/src/test/ts/api/developer/viewsApi.test.ts
@@ -18,14 +18,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   VIEW_DESIGN_GAPS,
+  VIEW_TYPE_CUSTOM,
+  VIEW_TYPE_STANDARD,
   createView,
   deleteView,
   getViewDetail,
+  isCustomViewType,
   isInboxViewName,
+  isPackagedCxViewName,
   isProtectedViewWrite,
   isValidViewName,
+  isValidViewUrl,
   isViewWriteReady,
   normalizeViewName,
+  normalizeViewUrl,
   saveView,
   unwrapViewDef,
   unwrapViewDefList,
@@ -108,6 +114,57 @@ describe("view name validation", () => {
     expect(isViewWriteReady({ isNew: false, name: "MyView" })).toBe(true);
     expect(isViewWriteReady({ isNew: false, name: "" })).toBe(false);
   });
+
+  it("requires a classic relative URL for CustomView writes", () => {
+    expect(
+      isViewWriteReady({
+        isNew: true,
+        name: "MyCustom",
+        type: VIEW_TYPE_CUSTOM,
+        url: "",
+      }),
+    ).toBe(false);
+    expect(
+      isViewWriteReady({
+        isNew: true,
+        name: "MyCustom",
+        type: VIEW_TYPE_CUSTOM,
+        url: "../sys_cxViews/myapp.xml",
+      }),
+    ).toBe(true);
+    expect(
+      isViewWriteReady({
+        isNew: false,
+        name: "MyCustom",
+        type: "custom",
+        url: "sys_cxViews/myapp.xml",
+      }),
+    ).toBe(true);
+    expect(isViewWriteReady({ isNew: true, name: "MyView", type: VIEW_TYPE_STANDARD })).toBe(
+      true,
+    );
+  });
+});
+
+describe("custom view URL validation", () => {
+  it("detects CustomView type aliases", () => {
+    expect(isCustomViewType(VIEW_TYPE_CUSTOM)).toBe(true);
+    expect(isCustomViewType("custom")).toBe(true);
+    expect(isCustomViewType(VIEW_TYPE_STANDARD)).toBe(false);
+    expect(isCustomViewType("")).toBe(false);
+  });
+
+  it("accepts classic relative URLs and rejects schemes / traversal", () => {
+    expect(normalizeViewUrl("  ../sys_cxViews/myapp.xml  ")).toBe("../sys_cxViews/myapp.xml");
+    expect(isValidViewUrl("../sys_cxViews/myapp.xml")).toBe(true);
+    expect(isValidViewUrl("sys_cxViews/myapp.xml")).toBe(true);
+    expect(isValidViewUrl("")).toBe(false);
+    expect(isValidViewUrl("https://example.com/x")).toBe(false);
+    expect(isValidViewUrl("//host/path")).toBe(false);
+    expect(isValidViewUrl("../../etc/passwd")).toBe(false);
+    expect(isValidViewUrl("has space")).toBe(false);
+    expect(isValidViewUrl("<enter url>")).toBe(false);
+  });
 });
 
 describe("protected view write", () => {
@@ -118,11 +175,22 @@ describe("protected view write", () => {
     expect(isInboxViewName("MyView")).toBe(false);
   });
 
-  it("does not allow delete of Inbox-family or custom URL views", () => {
+  it("protects packaged sys_cxViews keys but not user custom URL views", () => {
+    expect(isPackagedCxViewName("Inbox")).toBe(true);
+    expect(isPackagedCxViewName("Outbox")).toBe(true);
+    expect(isPackagedCxViewName("Checked Out By Me")).toBe(true);
+    expect(isPackagedCxViewName("MyCustom")).toBe(false);
     expect(isProtectedViewWrite({ name: "Inbox" })).toBe(true);
     expect(isProtectedViewWrite({ name: "Outbox", customView: true })).toBe(true);
     expect(isProtectedViewWrite({ name: "Recent", url: "../sys_cxViews/recent.xml" })).toBe(true);
     expect(isProtectedViewWrite({ name: "MyView" })).toBe(false);
+    expect(
+      isProtectedViewWrite({
+        name: "MyCustom",
+        customView: true,
+        url: "../sys_cxViews/myapp.xml",
+      }),
+    ).toBe(false);
   });
 });
 
@@ -151,28 +219,52 @@ describe("view wire wrap", () => {
     expect(VIEW_DESIGN_GAPS.some((g) => /create/i.test(g))).toBe(false);
     expect(VIEW_DESIGN_GAPS.some((g) => /field criterion/i.test(g))).toBe(false);
     expect(VIEW_DESIGN_GAPS.some((g) => /Inbox-family/i.test(g))).toBe(true);
+    expect(VIEW_DESIGN_GAPS.some((g) => /packaged sys_cxViews/i.test(g))).toBe(true);
   });
 
-  it("filters a stale REST write and field-criterion gap on GET detail", () => {
+  it("filters a stale REST write, field-criterion, and pre-UI-07 custom URL gap on GET detail", () => {
     expect(
       withoutStaleViewWriteGap([
         "View create / update / delete not supported via this API",
         "View field criterion editing not supported via this API",
         "Inbox-family and custom URL views cannot be updated or deleted via this API",
+        "Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API",
       ]),
-    ).toEqual(["Inbox-family and custom URL views cannot be updated or deleted via this API"]);
+    ).toEqual([
+      "Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API",
+    ]);
   });
 
   it("does not drop a similar substring that is not the exact stale gap", () => {
     expect(
       withoutStaleViewWriteGap([
         "View create / update / delete must run in sequence",
-        "Inbox-family and custom URL views cannot be updated or deleted via this API",
+        "Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API",
       ]),
     ).toEqual([
       "View create / update / delete must run in sequence",
-      "Inbox-family and custom URL views cannot be updated or deleted via this API",
+      "Inbox-family and packaged sys_cxViews views cannot be updated or deleted via this API",
     ]);
+  });
+
+  it("wraps custom URL create body with url and customView", () => {
+    expect(
+      wrapViewDefForWire({
+        name: "MyCustom",
+        label: "My Custom",
+        type: VIEW_TYPE_CUSTOM,
+        customView: true,
+        url: "../sys_cxViews/myapp.xml",
+      }),
+    ).toEqual({
+      ViewDef: {
+        name: "MyCustom",
+        label: "My Custom",
+        type: VIEW_TYPE_CUSTOM,
+        customView: true,
+        url: "../sys_cxViews/myapp.xml",
+      },
+    });
   });
 });
 
@@ -211,6 +303,36 @@ describe("viewsApi write paths", () => {
     expect(String(fetchMock.mock.calls[0][0])).toContain(PATHS.VIEWS);
     expect(JSON.parse(String(init.body))).toEqual({
       ViewDef: { name: "MyView", label: "My View", type: "View" },
+    });
+  });
+
+  it("POSTs custom URL create with url and customView", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        name: "MyCustom",
+        label: "My Custom",
+        type: VIEW_TYPE_CUSTOM,
+        customView: true,
+        url: "../sys_cxViews/myapp.xml",
+      }),
+    );
+    const saved = await createView({
+      name: "MyCustom",
+      label: "My Custom",
+      type: VIEW_TYPE_CUSTOM,
+      customView: true,
+      url: "../sys_cxViews/myapp.xml",
+    });
+    expect(saved.customView).toBe(true);
+    expect(saved.url).toBe("../sys_cxViews/myapp.xml");
+    expect(JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body))).toEqual({
+      ViewDef: {
+        name: "MyCustom",
+        label: "My Custom",
+        type: VIEW_TYPE_CUSTOM,
+        customView: true,
+        url: "../sys_cxViews/myapp.xml",
+      },
     });
   });
 

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -222,6 +222,121 @@ describe("ViewDetailPanel", () => {
     expect(save.disabled).toBe(false);
   });
 
+  it("creates a user CustomView with URL and hides field criteria", async () => {
+    createView.mockResolvedValue({
+      name: "MyCustom",
+      label: "My Custom",
+      type: "CustomView",
+      customView: true,
+      url: "../sys_cxViews/myapp.xml",
+      guid: { stringValue: "0-18-77" },
+      fields: [],
+    });
+    const onSaved = vi.fn();
+    render(<ViewDetailPanel idOrName={null} onBack={() => undefined} onSaved={onSaved} />);
+    fireEvent.change(screen.getByTestId("developer-vw-name"), {
+      target: { value: "MyCustom" },
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-type"), {
+      target: { value: "CustomView" },
+    });
+    expect(screen.getByTestId("developer-vw-url")).toBeTruthy();
+    expect((screen.getByTestId("developer-vw-save") as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(screen.getByTestId("developer-vw-url"), {
+      target: { value: "../sys_cxViews/myapp.xml" },
+    });
+    expect((screen.getByTestId("developer-vw-save") as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(screen.getByTestId("developer-vw-save"));
+    await waitFor(() => {
+      expect(createView).toHaveBeenCalled();
+    });
+    expect(createView.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        name: "MyCustom",
+        type: "CustomView",
+        customView: true,
+        url: "../sys_cxViews/myapp.xml",
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-editor-notice").textContent).toBe(DEV_MSG.VW_SAVED);
+    });
+    expect(screen.getByTestId("developer-vw-fields-custom-url")).toBeTruthy();
+    expect(screen.queryByTestId("developer-vw-field-editor")).toBeNull();
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it("surfaces missing custom URL as invalid URL (client and 400)", async () => {
+    render(<ViewDetailPanel idOrName={null} onBack={() => undefined} />);
+    fireEvent.change(screen.getByTestId("developer-vw-name"), {
+      target: { value: "MyCustom" },
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-type"), {
+      target: { value: "CustomView" },
+    });
+    expect((screen.getByTestId("developer-vw-save") as HTMLButtonElement).disabled).toBe(true);
+
+    createView.mockRejectedValue({
+      status: 400,
+      statusText: "Bad Request",
+      body: { message: "Custom url is required" },
+    });
+    fireEvent.change(screen.getByTestId("developer-vw-url"), {
+      target: { value: "../sys_cxViews/myapp.xml" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-save"));
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-detail-error")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-detail-error").textContent).toContain(
+      DEV_MSG.VW_INVALID_URL,
+    );
+  });
+
+  it("updates URL on an existing user CustomView", async () => {
+    getViewDetail.mockResolvedValue({
+      name: "MyCustom",
+      label: "My Custom",
+      type: "CustomView",
+      customView: true,
+      url: "../sys_cxViews/old.xml",
+      guid: { stringValue: "0-18-88" },
+      fields: [],
+    });
+    saveView.mockResolvedValue({
+      name: "MyCustom",
+      label: "My Custom",
+      type: "CustomView",
+      customView: true,
+      url: "../sys_cxViews/new.xml",
+      guid: { stringValue: "0-18-88" },
+      fields: [],
+    });
+    render(<ViewDetailPanel idOrName="MyCustom" onBack={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-url")).toBeTruthy();
+    });
+    expect(screen.getByTestId("developer-vw-fields-custom-url")).toBeTruthy();
+    expect(screen.queryByTestId("developer-vw-field-editor")).toBeNull();
+    fireEvent.change(screen.getByTestId("developer-vw-url"), {
+      target: { value: "../sys_cxViews/new.xml" },
+    });
+    fireEvent.click(screen.getByTestId("developer-vw-save"));
+    await waitFor(() => {
+      expect(saveView).toHaveBeenCalled();
+    });
+    expect(saveView.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        type: "CustomView",
+        customView: true,
+        url: "../sys_cxViews/new.xml",
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("developer-vw-editor-notice").textContent).toBe(DEV_MSG.VW_SAVED);
+    });
+  });
+
   it("keeps name read-only on edit", async () => {
     getViewDetail.mockResolvedValue(sampleDetail);
     render(<ViewDetailPanel idOrName="My View" onBack={() => undefined} />);
@@ -444,10 +559,11 @@ describe("ViewDetailPanel", () => {
     expect(screen.queryByTestId("developer-vw-delete")).toBeNull();
   });
 
-  it("does not delete Inbox-family or custom URL views", async () => {
+  it("does not mutate Inbox-family packaged views", async () => {
     getViewDetail.mockResolvedValue({
       ...sampleDetail,
       name: "Inbox",
+      type: "CustomView",
       customView: true,
       url: "../sys_cxViews/inbox.xml",
     });
@@ -457,6 +573,7 @@ describe("ViewDetailPanel", () => {
     });
     expect(screen.queryByTestId("developer-vw-delete")).toBeNull();
     expect((screen.getByTestId("developer-vw-save") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("developer-vw-url") as HTMLInputElement).disabled).toBe(true);
     expect(deleteView).not.toHaveBeenCalled();
   });
 

--- a/product-docs/8.2/admin/developer-views.md
+++ b/product-docs/8.2/admin/developer-views.md
@@ -1,7 +1,7 @@
 ---
 id: admin-developer-views
 title: Developer Views
-description: Create, delete, and edit field criteria on Content Explorer views from Developer Views chrome
+description: Create, delete, and edit field criteria or custom URLs on Content Explorer views from Developer Views chrome
 version: "8.2"
 order: 47
 tags: [admin, developer, views]
@@ -10,19 +10,22 @@ tags: [admin, developer, views]
 # Developer Views
 
 **Developer → Views** lists Content Explorer view definitions (Workbench
-**View** editor: unique name, label, type, display format, and field
-criteria). Admins can **create** a standard (field-criteria) view, **delete**
-a user view, and **add / remove / reorder field criteria** on a
-user/standard view from this chrome. The **name** is required, must be unique
+**View** editor: unique name, label, type, display format, field criteria, or
+a classic custom URL). Admins can **create** a standard (field-criteria) view
+or a **user custom URL** view (`CustomView`), **delete** a user view, **edit
+field criteria** on a user/standard view, and **update the URL** on a user
+custom URL view from this chrome. The **name** is required, must be unique
 across views **and** searches (case-insensitive), and must not contain
 spaces, wildcards (`*` / `%`), or path characters. Name cannot be renamed
 after create. Searches stay on **Developer → Searches**. Inbox-family and
-other custom URL views are listed but **cannot** be updated, deleted, or
-field-edited from this catalog.
+other packaged `sys_cxViews` catalog keys (Inbox, Outbox, Recent, Session,
+Checked Out By Me, Duplicate Folder Paths) are listed but **cannot** be
+updated, deleted, or field-edited from this catalog.
 
 The field picker uses the same CX system-field catalog as **Developer →
-Display Formats** columns. Custom-URL views (Inbox, Outbox, Recent, and the
-rest of the `sys_cxViews` family) stay protected.
+Display Formats** columns. Packaged custom-URL views in the `sys_cxViews`
+family stay protected. User-created custom URL views hide the field-criteria
+editor and collect a **URL** instead.
 
 ## Product path — create, delete
 
@@ -31,26 +34,32 @@ rest of the `sys_cxViews` family) stay protected.
    `spa.jsp?entry=developer&section=views`.
 3. Click **New view**. Enter a **name**. Save stays disabled until the name
    is valid (no spaces, no `*` / `%`, no `/` or `..`). Optional: label,
-   description, type (`View` default), and display format id.
-4. Click **Save**. A duplicate name is **409** and the editor shows that the
+   description, type (`View` default or `CustomView`), and display format id.
+4. For a **CustomView**, enter a classic relative **URL** (for example
+   `../sys_cxViews/myapp.xml`). Save stays disabled until the URL is
+   non-blank and valid (no schemes, no multi-segment `../` traversal). Field
+   criteria are not collected for custom URL views.
+5. Click **Save**. A duplicate name is **409** and the editor shows that the
    view already exists (including when the name is already in the catalog
-   list). An invalid name is **400**. A non-Admin session is **403**. After a
-   successful create, the name field is read-only and the catalog lists the
-   new view immediately (the save is persisted to the views catalog; leaving
-   and returning to the list still shows the row). A second **New view**
-   using that same name stays on the editor with the duplicate error.
-5. Optional: change label, description, type, or display format id and
-   **Save** again.
-6. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
+   list). An invalid name is **400**. A blank or invalid custom URL is
+   **400** and the editor shows that a URL is required. A non-Admin session
+   is **403**. After a successful create, the name field is read-only and the
+   catalog lists the new view immediately (the save is persisted to the views
+   catalog; leaving and returning to the list still shows the row). A second
+   **New view** using that same name stays on the editor with the duplicate
+   error. A custom URL create round-trips `url` and `customView` on GET.
+6. Optional: change label, description, type (on create only), display format
+   id, or (for a user custom URL view) the URL, then **Save** again.
+7. Click **Delete** and confirm in the in-app dialog (not a browser prompt).
    The catalog no longer lists that view.
-   Delete of a missing view is **404**. Inbox-family / custom URL views have
-   no Delete control. A view still used as a dependent, or locked by another
-   user, is **409**.
+   Delete of a missing view is **404**. Inbox-family / packaged `sys_cxViews`
+   views have no Delete control. A view still used as a dependent, or locked
+   by another user, is **409**.
 
 ## Product path — field criteria
 
 1. Open a **user/standard** view from the catalog (not Inbox or another
-   custom-URL view).
+   packaged custom-URL view, and not a user custom URL view).
 2. In **Field criteria**, choose a field from the picker, optional operator
    and value, then **Add field**. Use **Move up** / **Move down** to reorder
    and **Remove** to drop a row.
@@ -59,9 +68,10 @@ rest of the `sys_cxViews` family) stay protected.
    that lookup is **404**, retries by name. `GET /services/views/{name}` then
    lists those criteria in the same order. An unknown field is **400**. A
    non-Admin session is **403**.
-4. Inbox-family and custom URL views show the criteria table **read-only**
-   (no add/remove/reorder/save). This chrome does **not** mutate Inbox
-   custom-URL views.
+4. Inbox-family / packaged `sys_cxViews` views show the criteria table
+   **read-only** (no add/remove/reorder/save). User custom URL views hide the
+   field editor and show a note to edit the URL instead. This chrome does
+   **not** mutate Inbox packaged views.
 
 Existing **execute** of standard views and Inbox-family custom URL views
 (Explorer Views tree) is unchanged.
@@ -73,8 +83,9 @@ Existing **execute** of standard views and Inbox-family custom URL views
   (same picker as display-format columns). Unknown field names are rejected.
 - Searches are a separate Developer catalog (UI-06); search field-selection
   is not this chrome.
-- Custom URL is not collected or executed on write.
-- Inbox-family and custom URL views cannot be updated, deleted, or
+- User custom URL views collect and persist `url` (+ `customView`) from this
+  chrome; field criteria are not used on those rows.
+- Inbox-family and packaged `sys_cxViews` views cannot be updated, deleted, or
   field-edited here.
 
 ## REST
@@ -85,12 +96,13 @@ The chrome calls:
 |--------|---------|
 | List | `GET /services/views` |
 | Load | `GET /services/views/{idOrName}` |
-| Create | `POST /services/views` (`name` required; unique, no spaces) |
-| Save | `PUT /services/views/{idOrName}` (label, description, type, display format; optional `fields`) |
+| Create | `POST /services/views` (`name` required; unique, no spaces; CustomView requires `url`) |
+| Save | `PUT /services/views/{idOrName}` (label, description, type, display format, `url` for user custom URL views; optional `fields`) |
 | Delete | `DELETE /services/views/{idOrName}` (`204` on success) |
 
 Omitted `fields` on PUT leave existing criteria unchanged. An empty `fields`
 array clears them. Writes lock the view for the request and release it on
-save.
+save. Admin REST also persists user custom URL views; see
+[REST API — Views](id:developer-rest).
 
 Integrator notes: [REST API — Views](id:developer-rest).

--- a/product-docs/8.2/developer/rest.md
+++ b/product-docs/8.2/developer/rest.md
@@ -1630,12 +1630,14 @@ and read `guid.stringValue` or synthesize from `id` when the Guid is omitted.
 Admin **write** persists through `IPSUiDesignWs` (`createViews` / `loadViews` / `saveViews` /
 `deleteViews`) — the same design web service SOAP uses. There is no new SOAP surface.
 **Developer → Views** chrome creates and deletes standard views, saves label /
-description / type / display format, and edits **field criteria** on
-user/standard views — see [Developer Views](id:admin-developer-views). Admin REST
-also persists **user** custom URL views (`url` + `customView`). Inbox-family and
-packaged `sys_cxViews` catalog keys cannot be mutated from that catalog. Execute
-is **not** invoked when creating, updating, or deleting a view. Create is durable:
-`GET /services/views` lists the new name after POST.
+description / type / display format, edits **field criteria** on
+user/standard views, and creates/updates **user** custom URL views (`url` +
+`customView`) from the same SPA editor — see
+[Developer Views](id:admin-developer-views). Admin REST persists the same
+shapes. Inbox-family and packaged `sys_cxViews` catalog keys cannot be mutated
+from that catalog. Execute is **not** invoked when creating, updating, or
+deleting a view. Create is durable: `GET /services/views` lists the new name
+after POST.
 
 Operators open Inbox from Explorer **Views → My Content → Inbox** (see
 [Content Explorer](id:admin-content-explorer)). Integrators run the same assignment list


### PR DESCRIPTION
## Summary

Implements SPA **UI-07** custom URL view editor for Developer Views (#4236), parent #1690.

- Stacked on open REST PR #4238 (`feat/issue-4235-custom-url-view-write`) — does **not** re-implement persist.
- `ViewDetailPanel`: type `CustomView` shows required URL; POST/PUT send `url` + `customView`; field-criteria editor hidden for custom URL views; Inbox-family / packaged `sys_cxViews` stay read-only.
- `viewsApi`: `isValidViewUrl` / `isPackagedCxViewName`; `isProtectedViewWrite` only for packaged keys (user custom URL views remain writable).
- Vitest: create/save custom URL, missing URL 400, Inbox immutable.
- Product docs: `product-docs/8.2/admin/developer-views.md` + REST note that SPA chrome exists.

**Out of scope (per slice):** Playwright H2 live proof → #4237; REST persist → #4235/#4238.

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

- [x] `cd WebUI && ../mvnw.cmd clean install` — BUILD SUCCESS; Tests run: 3875, Failures: 0 (Vitest)
- [x] Vitest covers custom URL create/save, missing URL, Inbox packaged immutable
- [ ] Playwright H2 surface (`developer-view-custom-url.spec.js`) deferred to #4237
- [ ] Manual UAT after #4237 + merge of #4238: Admin create CustomView with URL; GET round-trip; Inbox read-only

## Checklist

- [x] **Product documentation** — updated `product-docs/8.2/admin/developer-views.md` and `product-docs/8.2/developer/rest.md`
- [x] **Unit / module tests** — Vitest + WebUI standalone clean install green
- [x] **WebUI + Playwright** — N/A for this slice; Playwright H2 live proof is #4237
- [x] **Build gates** — WebUI `mvnw clean install` BUILD SUCCESS
- [x] **Cross-platform** — N/A (no path/file I/O)

## C3 build evidence

- **modules_built:** `WebUI`
- **build_evidence:** `cd WebUI; ../mvnw.cmd clean install` → BUILD SUCCESS; Test Files 421 passed; Tests 3875 passed
- **downstream_checked:** none (SPA/docs only; no Java API shape change in this commit; REST/sitemanage come from stacked #4238)

## C5 UI live proof

- Deferred to slice #4237 per issue/triage (Playwright UI-07 custom URL H2). Vitest green locally; no `qa-up` Playwright run in this PR.

Fixes #4236

Partial: Playwright remains on #4237; merge after #4238.

> Co-Authored by Grok Build 1.0.5 using grok-4.5 with agent night-issue-prs.
