### PR TITLE
test(qa): Playwright UI-07 custom URL view H2 (#4237)

### DIFF
--- a/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
+++ b/WebUI/src/main/ts/developer/ViewDetailPanel.tsx
@@ -87,8 +87,10 @@ const actionButton: React.CSSProperties = {
 };
 
 function typeFromDetail(detail: ViewDef | null, fallback: string): string {
-  if (detail?.type && detail.type.trim()) return canonicalViewType(detail.type);
+  // REST persists CustomView as type "View" + customView=true + url; prefer the flag
+  // so post-save chrome keeps the URL field (Playwright UI-07 / #4237).
   if (detail?.customView) return VIEW_TYPE_CUSTOM;
+  if (detail?.type && detail.type.trim()) return canonicalViewType(detail.type);
   if (detail?.standardView) return VIEW_TYPE_STANDARD;
   return canonicalViewType(fallback);
 }

--- a/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
+++ b/WebUI/src/test/ts/developer/ViewDetailPanel.test.tsx
@@ -223,10 +223,11 @@ describe("ViewDetailPanel", () => {
   });
 
   it("creates a user CustomView with URL and hides field criteria", async () => {
+    // REST wire type is PSSearch.TYPE_VIEW ("View") with customView=true + url.
     createView.mockResolvedValue({
       name: "MyCustom",
       label: "My Custom",
-      type: "CustomView",
+      type: "View",
       customView: true,
       url: "../sys_cxViews/myapp.xml",
       guid: { stringValue: "0-18-77" },
@@ -261,6 +262,10 @@ describe("ViewDetailPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("developer-vw-editor-notice").textContent).toBe(DEV_MSG.VW_SAVED);
     });
+    expect((screen.getByTestId("developer-vw-type") as HTMLSelectElement).value).toBe("CustomView");
+    expect((screen.getByTestId("developer-vw-url") as HTMLInputElement).value).toBe(
+      "../sys_cxViews/myapp.xml",
+    );
     expect(screen.getByTestId("developer-vw-fields-custom-url")).toBeTruthy();
     expect(screen.queryByTestId("developer-vw-field-editor")).toBeNull();
     expect(onSaved).toHaveBeenCalled();

--- a/modules/perc-qa-automation/frontend/tests/developer-view-custom-url.spec.js
+++ b/modules/perc-qa-automation/frontend/tests/developer-view-custom-url.spec.js
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 Intersoft Data Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Developer Views custom URL editor (#4237 UI-07 / parent #1690).
+ *
+ * Depends on REST #4235 / SPA #4236 (custom URL create/save chrome).
+ * Peer: developer-search-custom-url.spec.js (do not weaken standard view specs).
+ *
+ * Surface-filtered QA:
+ * <pre>
+ *   perc-devctl qa-up
+ *   python docker/scripts/perc-devctl.py qa-health
+ *   cd modules/perc-qa-automation/frontend
+ *   TEST_CMS_URL=… ADMIN_USERNAME=Admin ADMIN_PASSWORD=…
+ *     npm run test:surface -- --path tests/developer-view-custom-url.spec.js
+ *   perc-devctl qa-down
+ * </pre>
+ */
+
+const { test, expect } = require("@playwright/test");
+const { loginAsAdmin, BASE_URL } = require("./helpers/auth");
+const { confirmDeveloperCatalogDelete } = require("./helpers/developer-catalog-confirm");
+
+function developerViewsUrl() {
+  const q = new URLSearchParams({
+    entry: "developer",
+    section: "views",
+    _: String(Date.now()),
+  });
+  return `${BASE_URL}/Rhythmyx/cm/app/spa.jsp?${q.toString()}`;
+}
+
+/** REST-safe unique view name (no spaces, wildcards, or path characters). */
+function uniqueViewName() {
+  const a = Date.now().toString(36).replace(/[^a-z0-9]/g, "").slice(-4);
+  const b = Math.random().toString(36).replace(/[^a-z0-9]/g, "").slice(2, 6);
+  const suffix = `${a}${b}`.slice(0, 8);
+  return `qa4237${suffix || "x"}`;
+}
+
+async function openViewsCatalog(page) {
+  await page.goto(developerViewsUrl(), { waitUntil: "networkidle" });
+  await expect(page.locator('[data-testid="nav-developer"]')).toBeVisible({
+    timeout: 20_000,
+  });
+  const panel = page.locator('[data-testid="developer-vw-panel"]');
+  const empty = page.locator('[data-testid="developer-vw-empty"]');
+  const listError = page.locator('[data-testid="developer-vw-error"]');
+  await expect(panel.or(empty).or(listError).first()).toBeVisible({
+    timeout: 30_000,
+  });
+  if (await listError.isVisible()) {
+    throw new Error(
+      `Developer views catalog error: ${(await listError.innerText()).trim()}`,
+    );
+  }
+  await expect(page.locator('[data-testid="developer-vw-new"]')).toBeVisible();
+}
+
+function attachConsoleGuards(page) {
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(String(err && err.message ? err.message : err));
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      consoleErrors.push(msg.text());
+    }
+  });
+  return { pageErrors, consoleErrors };
+}
+
+function assertConsoleClean(pageErrors, consoleErrors) {
+  expect(pageErrors, `pageerror: ${pageErrors.join(" | ")}`).toEqual([]);
+  const unexpectedConsole = consoleErrors.filter(
+    (t) => !/Failed to load resource/i.test(t) && !/favicon/i.test(t),
+  );
+  expect(
+    unexpectedConsole,
+    `console error: ${unexpectedConsole.join(" | ")}`,
+  ).toEqual([]);
+}
+
+test.describe("Developer view custom URL editor (#4237 / UI-07)", () => {
+  test("Admin can create and delete a custom URL view", async ({ page }) => {
+    test.setTimeout(120_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+    await loginAsAdmin(page);
+    await openViewsCatalog(page);
+
+    const viewName = uniqueViewName();
+    const viewUrl = `../qa4237/${viewName}.xml`;
+
+    await page.locator('[data-testid="developer-vw-new"]').click();
+    await expect(page.locator('[data-testid="developer-vw-detail"]')).toBeVisible();
+    const saveBtn = page.locator('[data-testid="developer-vw-save"]');
+    await page.locator('[data-testid="developer-vw-name"]').fill(viewName);
+    await page.locator('[data-testid="developer-vw-type"]').selectOption("CustomView");
+    await expect(page.locator('[data-testid="developer-vw-url"]')).toBeVisible();
+    await expect(saveBtn).toBeDisabled();
+    await page.locator('[data-testid="developer-vw-url"]').fill(viewUrl);
+    await expect(saveBtn).toBeEnabled();
+    await saveBtn.click();
+
+    const notice = page.locator('[data-testid="developer-vw-editor-notice"]');
+    const saveError = page.locator('[data-testid="developer-vw-detail-error"]');
+    await expect(notice.or(saveError).first()).toBeVisible({ timeout: 20_000 });
+    if (await saveError.isVisible()) {
+      throw new Error(`Create failed: ${(await saveError.innerText()).trim()}`);
+    }
+
+    await expect(page.locator('[data-testid="developer-vw-url"]')).toHaveValue(viewUrl);
+    await expect(page.locator('[data-testid="developer-vw-fields-custom-url"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-vw-field-editor"]')).toHaveCount(0);
+
+    await page.locator('[data-testid="developer-vw-back"]').click();
+    await expect(page.locator('[data-testid="developer-vw-panel"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    const createdRow = page.locator(`[data-vw-name="${viewName}"]`);
+    await expect(createdRow).toHaveCount(1, { timeout: 20_000 });
+
+    await createdRow.click();
+    await expect(page.locator('[data-testid="developer-vw-detail"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-vw-url"]')).toHaveValue(viewUrl);
+    await expect(page.locator('[data-testid="developer-vw-fields-custom-url"]')).toBeVisible();
+    await page.locator('[data-testid="developer-vw-delete"]').click();
+    await confirmDeveloperCatalogDelete(page);
+    await expect(page.locator('[data-testid="developer-vw-panel"]')).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.locator(`[data-vw-name="${viewName}"]`)).toHaveCount(0, {
+      timeout: 20_000,
+    });
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+
+  test("Inbox-family views stay non-mutable from this catalog", async ({ page }) => {
+    test.setTimeout(90_000);
+    const { pageErrors, consoleErrors } = attachConsoleGuards(page);
+
+    await loginAsAdmin(page);
+    await openViewsCatalog(page);
+
+    const inboxOpen = page.locator('[data-vw-name="Inbox"]');
+    await expect(inboxOpen).toHaveCount(1, { timeout: 20_000 });
+    await inboxOpen.click();
+    await expect(page.locator('[data-testid="developer-vw-detail"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-vw-protected-hint"]')).toBeVisible();
+    await expect(page.locator('[data-testid="developer-vw-delete"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="developer-vw-save"]')).toBeDisabled();
+    const urlField = page.locator('[data-testid="developer-vw-url"]');
+    if ((await urlField.count()) > 0) {
+      await expect(urlField).toBeDisabled();
+    }
+    await expect(page.locator('[data-testid="developer-vw-field-editor"]')).toHaveCount(0);
+
+    await page.locator('[data-testid="developer-vw-back"]').click();
+    await expect(page.locator('[data-testid="developer-vw-panel"]')).toBeVisible();
+    await expect(page.locator('[data-vw-name="Inbox"]')).toHaveCount(1);
+
+    assertConsoleClean(pageErrors, consoleErrors);
+  });
+});


### PR DESCRIPTION
## Summary

Parent tracker: **#1690** (FR UI-07). Slice **#4237** — H2 surface-filtered Playwright for Admin custom URL view create/save/delete and Inbox-family immutability.

- Adds `modules/perc-qa-automation/frontend/tests/developer-view-custom-url.spec.js` (peer of `developer-search-custom-url.spec.js`; does not weaken standard view specs).
- Small SPA consume fix: `ViewDetailPanel.typeFromDetail` prefers `customView=true` when REST returns `type: "View"` (`PSSearch.TYPE_VIEW`) so post-save chrome keeps the URL field. Vitest updated to match live wire shape.

**Stacked on** open SPA PR **#4257** (`feat/issue-4236-spa-custom-url-view-editor`, which already includes REST #4235). Retarget base to `main` after #4257 merges. Does not re-implement REST persist.

Fixes #4237

Operator: Grok: night-issue-prs (model grok-4.5)

## Test plan

1. `python docker/scripts/perc-devctl.py qa-up` → note `TEST_CMS_URL` / `ADMIN_PASSWORD`
2. Standalone `mvnw clean install` for `rest`, `projects/sitemanage`, `WebUI` (dependency jars + SPA fix), then `modules/perc-qa-automation`
3. `perc-devctl qa-deploy-war-jars --restart-jetty` + `qa-deploy-webui`; `qa-health` with pinned `QA_CMS_HOST_PORT`
4. From `modules/perc-qa-automation/frontend`:
   `npm run test:surface -- --path tests/developer-view-custom-url.spec.js`
5. Expect 2 passed; browser console clean; no view-related ERROR/FATAL in `server.log`
6. `perc-devctl qa-down`

## Checklist

- [x] **Product documentation** — N/A: Playwright companion + SPA post-save type round-trip fix for already-documented Developer Views custom URL chrome from #4236 / product-docs in PR #4257
- [x] **Unit / module tests** — Vitest `ViewDetailPanel` custom URL create asserts REST `type: View` + `customView` round-trip; Playwright surface green
- [x] **WebUI + Playwright** — `developer-view-custom-url.spec.js`
- [x] **Build gates** — standalone clean install: `modules/perc-qa-automation`, `WebUI` (plus dependency `rest` / `sitemanage` for C5 hot-deploy)
- [x] **Cross-platform** — N/A for path I/O (Playwright selectors / SPA type mapping only)

## C3 build evidence

- **modules_built:** `modules/perc-qa-automation`, `WebUI` (C5 also built/hot-deployed `rest`, `projects/sitemanage`)
- **build_evidence:**
  - `cd modules/perc-qa-automation && ../../mvnw.cmd clean install` → BUILD SUCCESS
  - `cd WebUI && ../mvnw.cmd clean install` → BUILD SUCCESS
  - `cd rest && ../mvnw.cmd clean install` → BUILD SUCCESS (dep for C5)
  - `cd projects/sitemanage && ../../mvnw.cmd clean install` → BUILD SUCCESS (Tests run: 2316, Failures: 0, Skipped: 125)
- **downstream_checked:** none (no `final`/sealed/public API signature change)

## C5 UI proof (H2 QA)

- `perc-devctl qa-up` → `TEST_CMS_URL=http://127.0.0.1:9993` `QA_CONTAINER=perc-matrix-cms-h2`
- Hot-deploy: `qa-deploy-war-jars --restart-jetty` + `qa-deploy-webui`; `qa-health` → `RESULT:OK HTTP:200 HEALTH:healthy`
- `npm run test:surface -- --path tests/developer-view-custom-url.spec.js` → **2 passed**
- console-clean=yes (spec pageerror/console guards)
- server.log-clean=yes (no view/custom URL related ERROR/FATAL in test window)

> Co-Authored by Grok Build 1.0.5 using grok-4.5 with agent night-issue-prs.